### PR TITLE
Ajouter un commande pour le déploiement à staging

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "stage": "npm run build && surge dist staging-ma-cantine.surge.sh"
   },
   "dependencies": {
     "core-js": "^3.6.5",


### PR DESCRIPTION
Avec ça, on peut écrire `npm run stage` (dans ma-cantine/front-end/) pour déployer à l'environnement staging.