### PR TITLE
Ajouter l'autocompletion de commune

### DIFF
--- a/front-end/src/views/GeneratePosterPage/index.vue
+++ b/front-end/src/views/GeneratePosterPage/index.vue
@@ -16,8 +16,27 @@
           Je représente <label for="school">la cantine</label>
           <input id="school" v-model="form.school" class="field" placeholder="nom de l'établissement" required>
           dans <label for="commune">la commune de </label>
-          <input id="commune" v-model="form.commune" class="field" placeholder="nom de la commune" required>.
+          <input id="commune"
+            v-model="form.commune"
+            class="field"
+            placeholder="nom de la commune"
+            required
+            type="search"
+            @input="search"
+            list="communes"
+          >
+          <datalist id="communes">
+            <option v-for="commune in communes" :value="commune.properties.label" :key="commune.properties.id">
+              {{ commune.properties.label }} ({{ commune.properties.context }})
+            </option>
+          </datalist>
+          .
         </p>
+        <!-- TODO: remove after debugging -->
+        <p v-for="commune in communes" :value="commune.properties.label" :key="commune.properties.id">
+          {{ commune.properties.label }} ({{ commune.properties.context }})
+        </p>
+        <!-- END -->
         <p>
           <label for="servings">Nous servons </label>
           <input id="servings"
@@ -96,9 +115,21 @@
     data() {
       return {
         form: {},
+        communes: []
       };
     },
     methods: {
+      async search() {
+        if(!this.form.commune) {
+          this.communes = [];
+          return;
+        }
+        const queryUrl = "https://api-adresse.data.gouv.fr/search/?q="+this.form.commune+"&type=municipality&autocomplete=1";
+        const response = await fetch(queryUrl);
+        const { features: communes } = await response.json();
+        this.communes = communes;
+        console.log(this.communes); // TODO: remove after debugging
+      },
       submit() {
         //this fix an issue where the beginning of the pdf is blank depending on the scroll position
         window.scrollTo({ top: 0 });

--- a/front-end/src/views/GeneratePosterPage/index.vue
+++ b/front-end/src/views/GeneratePosterPage/index.vue
@@ -121,8 +121,7 @@
         }
         const queryUrl = "https://api-adresse.data.gouv.fr/search/?q="+this.form.commune+"&type=municipality&autocomplete=1";
         const response = await fetch(queryUrl);
-        const { features: communes } = await response.json();
-        this.communes = communes;
+        this.communes = (await response.json()).features;
       },
       submit() {
         //this fix an issue where the beginning of the pdf is blank depending on the scroll position

--- a/front-end/src/views/GeneratePosterPage/index.vue
+++ b/front-end/src/views/GeneratePosterPage/index.vue
@@ -32,11 +32,6 @@
           </datalist>
           .
         </p>
-        <!-- TODO: remove after debugging -->
-        <p v-for="commune in communes" :value="commune.properties.label" :key="commune.properties.id">
-          {{ commune.properties.label }} ({{ commune.properties.context }})
-        </p>
-        <!-- END -->
         <p>
           <label for="servings">Nous servons </label>
           <input id="servings"
@@ -128,7 +123,6 @@
         const response = await fetch(queryUrl);
         const { features: communes } = await response.json();
         this.communes = communes;
-        console.log(this.communes); // TODO: remove after debugging
       },
       submit() {
         //this fix an issue where the beginning of the pdf is blank depending on the scroll position


### PR DESCRIPTION
Pour recréer la bogue, c'est pas complètement le même chaque fois mais essaye de taper "Plo" dans le input pour le commune, et vois que l'affichage des communes est différent dans le `datalist` et avec la balise `p`. Je peux démontrer aussi si ça ne marche pas. J'ai vu la bogue dans Safari et Firefox, je n'ai pas testé Chrome.