### PR TITLE
Completer JWT authentication

### DIFF
--- a/api/application/routes/save-diagnostic.js
+++ b/api/application/routes/save-diagnostic.js
@@ -1,0 +1,15 @@
+// example auth route for now - to be replaced by real save diagnostic endpoint
+const saveDiagnosticHandler = async function(request, h) {
+  return h.response({ id: request.auth.credentials.user.id }).code(200);
+};
+
+exports.register = async function(server) {
+  server.route([{
+    method: "GET",
+    path: "/save-diagnostic",
+    handler: saveDiagnosticHandler,
+    options: {
+      auth: 'jwt'
+    }
+  }]);
+};

--- a/api/domain/services/authentication.js
+++ b/api/domain/services/authentication.js
@@ -1,9 +1,15 @@
+require('dotenv').config();
 const crypto = require('crypto');
+const Jwt = require('@hapi/jwt');
 const { sendEmail } = require("./mailer");
 const { saveLoginTokenForUser } = require('../../infrastructure/repositories/login-token')
 
 function generateToken() {
   return crypto.randomBytes(200).toString('base64').slice(0, 255);
+};
+
+function generateJwtForUser(user) {
+  return Jwt.token.generate({ email: user.email }, process.env.JWT_SECRET_KEY);
 };
 
 async function sendLoginLink(user, urlPrefix) {
@@ -29,5 +35,6 @@ function sendSignUpLink(email) {
 
 module.exports = {
   sendLoginLink,
-  sendSignUpLink
+  sendSignUpLink,
+  generateJwtForUser
 }

--- a/api/domain/usecases/complete-login.js
+++ b/api/domain/usecases/complete-login.js
@@ -1,10 +1,9 @@
-require('dotenv').config();
-const jwt = require("jsonwebtoken");
 const { getUserForLoginToken } = require("../../infrastructure/repositories/login-token");
+const { generateJwtForUser } = require("../services/authentication");
 
 exports.completeLogin = async function(loginTokenString) {
   let user = await getUserForLoginToken(loginTokenString);
   return {
-    jwt: jwt.sign({ email: user.email }, process.env.JWT_SECRET_KEY, { expiresIn: '7 days' })
+    jwt: generateJwtForUser(user)
   };
 };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,9 +8,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@hapi/hapi": "^20.1.2",
+        "@hapi/jwt": "^2.0.1",
         "dotenv": "^8.2.0",
         "joi": "^17.4.0",
-        "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.21",
         "node-fetch": "^2.6.1",
         "pg": "^8.5.1",
@@ -611,6 +611,15 @@
         "@hapi/hoek": "9.x.x"
       }
     },
+    "node_modules/@hapi/catbox-object": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-object/-/catbox-object-2.0.0.tgz",
+      "integrity": "sha512-tzTo5q9UVqwqtpNkIz0VNSmJTbaGyD9ZQmw4a91BBWB+YJWYa066KkxOTHGmmWJzjZEhG2CsNYKu34J25pA5aw==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
     "node_modules/@hapi/content": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
@@ -688,6 +697,23 @@
         "@hapi/bourne": "2.x.x",
         "@hapi/cryptiles": "5.x.x",
         "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/jwt": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/jwt/-/jwt-2.0.1.tgz",
+      "integrity": "sha512-6/nX/yOIk9mvs+r72LFhF177yOB4yVv3e0Nqn7cIx2CU+VruBHxMKkHraARXx6oUAtiwNuyhW+trO5QeGm9ESQ==",
+      "dependencies": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/catbox-object": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/wreck": "17.x.x",
+        "ecdsa-sig-formatter": "1.x.x",
+        "joi": "^17.2.1"
       }
     },
     "node_modules/@hapi/mimos": {
@@ -1657,11 +1683,6 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/buffer-from": {
       "version": "1.1.1",
@@ -4207,35 +4228,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4249,25 +4241,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/kind-of": {
@@ -4332,41 +4305,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -7969,6 +7907,15 @@
         "@hapi/hoek": "9.x.x"
       }
     },
+    "@hapi/catbox-object": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-object/-/catbox-object-2.0.0.tgz",
+      "integrity": "sha512-tzTo5q9UVqwqtpNkIz0VNSmJTbaGyD9ZQmw4a91BBWB+YJWYa066KkxOTHGmmWJzjZEhG2CsNYKu34J25pA5aw==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
     "@hapi/content": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
@@ -8040,6 +7987,23 @@
         "@hapi/bourne": "2.x.x",
         "@hapi/cryptiles": "5.x.x",
         "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/jwt": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/jwt/-/jwt-2.0.1.tgz",
+      "integrity": "sha512-6/nX/yOIk9mvs+r72LFhF177yOB4yVv3e0Nqn7cIx2CU+VruBHxMKkHraARXx6oUAtiwNuyhW+trO5QeGm9ESQ==",
+      "requires": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/catbox-object": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/wreck": "17.x.x",
+        "ecdsa-sig-formatter": "1.x.x",
+        "joi": "^17.2.1"
       }
     },
     "@hapi/mimos": {
@@ -8862,11 +8826,6 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
-    },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -10897,30 +10856,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "requires": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -10931,25 +10866,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      }
-    },
-    "jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "requires": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -10999,41 +10915,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-    },
-    "lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-    },
-    "lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
-    "lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "@hapi/hapi": "^20.1.2",
+    "@hapi/jwt": "^2.0.1",
     "dotenv": "^8.2.0",
     "joi": "^17.4.0",
-    "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "pg": "^8.5.1",

--- a/api/tests/acceptance/save-diagnostic.test.js
+++ b/api/tests/acceptance/save-diagnostic.test.js
@@ -1,0 +1,54 @@
+const { init } = require("../../server");
+const { Canteen } = require("../../infrastructure/models/canteen");
+const { User } = require("../../infrastructure/models/user");
+const { createUserWithCanteen } = require('../../infrastructure/repositories/user');
+const { generateJwtForUser } = require('../../domain/services/authentication');
+const { sequelize } = require("../../infrastructure/postgres-database");
+
+describe('Save diagnostic endpoint /save-diagnostic', () => {
+  let server, user;
+
+  beforeAll(async () => {
+    server = await init();
+    await Canteen.sync({ force: true });
+    await User.sync({ force: true });
+    user = await createUserWithCanteen({
+      email: "test@example.com",
+      firstName: "Camille",
+      lastName: "Dupont",
+    }, {
+      name: "Test canteen",
+      city: "Lyon",
+      sector: "school"
+    })
+    user = user.toJSON();
+  });
+
+  it('returns user data given valid JWT', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/save-diagnostic',
+      headers: {
+        'Authorization': 'Bearer '+generateJwtForUser(user)
+      }
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.result.id).toStrictEqual(user.id);
+  });
+
+  it('returns 401 given JWT with unknown email', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/save-diagnostic',
+      headers: {
+        'Authorization': 'Bearer '+generateJwtForUser({ email: "unknown@email.com" })
+      }
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    await sequelize.close();
+  });
+});

--- a/api/tests/acceptance/subscribe-beta-tester.test.js
+++ b/api/tests/acceptance/subscribe-beta-tester.test.js
@@ -6,7 +6,7 @@ describe("Beta-tester subscription endpoint /subscribe-beta-tester", () => {
   let server;
   let responseBodyJSON = { message: "test" };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     server = await init();
 
     fetch.mockReturnValue({
@@ -15,10 +15,6 @@ describe("Beta-tester subscription endpoint /subscribe-beta-tester", () => {
         return Promise.resolve(responseBodyJSON);
       }
     });
-  });
-
-  afterEach(async () => {
-    await server.stop();
   });
 
   it("returns successful response given valid payload", async () => {
@@ -53,5 +49,9 @@ describe("Beta-tester subscription endpoint /subscribe-beta-tester", () => {
       payload: {}
     });
     expect(res.statusCode).toBe(400);
-  })
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
 });

--- a/api/tests/unit/domain/authentication.test.js
+++ b/api/tests/unit/domain/authentication.test.js
@@ -1,0 +1,19 @@
+require('dotenv').config();
+const { generateJwtForUser } = require("../../../domain/services/authentication");
+
+jest.mock('@hapi/jwt');
+const Jwt = require('@hapi/jwt');
+
+describe('Authentication service', () => {
+  it('uses user email and secret key to generate JWT', () => {
+    const mockedToken = "xxx.yyy.zzz";
+    Jwt.token.generate.mockReturnValue(mockedToken);
+    const email = "example@test.com";
+    const jwt = generateJwtForUser({
+      id: 5,
+      email
+    });
+    expect(Jwt.token.generate).toHaveBeenCalledWith({ email }, process.env.JWT_SECRET_KEY);
+    expect(jwt).toBe(mockedToken);
+  });
+});

--- a/api/tests/unit/domain/complete-login.test.js
+++ b/api/tests/unit/domain/complete-login.test.js
@@ -1,4 +1,4 @@
-const jwt = require('jsonwebtoken');
+const Jwt = require('@hapi/jwt');
 const { completeLogin } = require('../../../domain/usecases/complete-login');
 const { NotFoundError } = require('../../../infrastructure/errors');
 
@@ -11,7 +11,8 @@ describe('Log in completion', () => {
     const user = { email: "some@email.com" };
     getUserForLoginToken.mockReturnValue(user);
     const res = await completeLogin('somelogintoken');
-    expect(jwt.decode(res.jwt).email).toBe(user.email);
+    const decodedEmail = Jwt.token.decode(res.jwt).decoded.payload.email;
+    expect(decodedEmail).toBe(user.email);
   });
 
   it('throws an error given an invalid token', async () => {

--- a/api/tests/unit/domain/complete-login.test.js
+++ b/api/tests/unit/domain/complete-login.test.js
@@ -1,18 +1,24 @@
-const Jwt = require('@hapi/jwt');
 const { completeLogin } = require('../../../domain/usecases/complete-login');
 const { NotFoundError } = require('../../../infrastructure/errors');
 
 jest.mock('../../../infrastructure/repositories/login-token');
 const { getUserForLoginToken } = require('../../../infrastructure/repositories/login-token');
 
+jest.mock('../../../domain/services/authentication');
+const { generateJwtForUser } = require('../../../domain/services/authentication');
+
 describe('Log in completion', () => {
 
   it('generates a JSON web token given a valid login token', async () => {
     const user = { email: "some@email.com" };
     getUserForLoginToken.mockReturnValue(user);
+
+    const testToken = 'xxx.yyy.zzz';
+    generateJwtForUser.mockReturnValue(testToken);
+
     const res = await completeLogin('somelogintoken');
-    const decodedEmail = Jwt.token.decode(res.jwt).decoded.payload.email;
-    expect(decodedEmail).toBe(user.email);
+    expect(generateJwtForUser).toHaveBeenCalledWith(user);
+    expect(res).toStrictEqual({ jwt: testToken });
   });
 
   it('throws an error given an invalid token', async () => {


### PR DESCRIPTION
À noter: on peut éviter générer un JWT dans les tests acceptance en donnant un object `auth` au `server.inject` (https://hapi.dev/api/?v=20.1.2#-await-serverinjectoptions), alors peut-être le refactorisation du generateJwtForUser n'est pas nécessaire, mais j'ai voulu démontrer comment la requête doit être formatée. Qu'est-ce que tu penses ?