### PR TITLE
Ajouter des champs pour les valeurs de 2021 et 2022

### DIFF
--- a/frontend/src/components/KeyMeasureDiagnostic/QualityMeasure.vue
+++ b/frontend/src/components/KeyMeasureDiagnostic/QualityMeasure.vue
@@ -79,6 +79,86 @@
         v-model="latestDiagnostic.valueFairTradeHt"
       ></v-text-field>
     </div>
+
+    <div class="d-flex flex-column mt-10">
+      <p>En 2021, la valeur prévisionnelle (en HT) de mes achats alimentaires...</p>
+
+      <p class="body-2 mb-1 mt-2">...totale</p>
+      <v-text-field
+        hide-details="auto"
+        type="number"
+        :rules="[validators.positiveNumber]"
+        solo
+        v-model="provisionalYear1Diagnostic.valueTotalHt"
+      ></v-text-field>
+
+      <p class="body-2 mb-1 mt-4">...en produits bio</p>
+      <v-text-field
+        hide-details="auto"
+        type="number"
+        :rules="[validators.positiveNumber]"
+        solo
+        v-model="provisionalYear1Diagnostic.valueBioHt"
+      ></v-text-field>
+
+      <p class="body-2 mb-1 mt-4">...en autres produits de qualité et durables (hors bio)</p>
+      <v-text-field
+        hide-details="auto"
+        type="number"
+        :rules="[validators.positiveNumber]"
+        solo
+        v-model="provisionalYear1Diagnostic.valueSustainableHt"
+      ></v-text-field>
+
+      <p class="body-2 mb-1 mt-4">...en produits issus du commerce équitable</p>
+      <v-text-field
+        hide-details="auto"
+        type="number"
+        :rules="[validators.positiveNumber]"
+        solo
+        v-model="provisionalYear1Diagnostic.valueFairTradeHt"
+      ></v-text-field>
+    </div>
+
+    <div class="d-flex flex-column mt-10">
+      <p>En 2022, la valeur prévisionnelle (en HT) de mes achats alimentaires...</p>
+
+      <p class="body-2 mb-1 mt-2">...totale</p>
+      <v-text-field
+        hide-details="auto"
+        type="number"
+        :rules="[validators.positiveNumber]"
+        solo
+        v-model="provisionalYear2Diagnostic.valueTotalHt"
+      ></v-text-field>
+
+      <p class="body-2 mb-1 mt-4">...en produits bio</p>
+      <v-text-field
+        hide-details="auto"
+        type="number"
+        :rules="[validators.positiveNumber]"
+        solo
+        v-model="provisionalYear2Diagnostic.valueBioHt"
+      ></v-text-field>
+
+      <p class="body-2 mb-1 mt-4">...en autres produits de qualité et durables (hors bio)</p>
+      <v-text-field
+        hide-details="auto"
+        type="number"
+        :rules="[validators.positiveNumber]"
+        solo
+        v-model="provisionalYear2Diagnostic.valueSustainableHt"
+      ></v-text-field>
+
+      <p class="body-2 mb-1 mt-4">...en produits issus du commerce équitable</p>
+      <v-text-field
+        hide-details="auto"
+        type="number"
+        :rules="[validators.positiveNumber]"
+        solo
+        v-model="provisionalYear2Diagnostic.valueFairTradeHt"
+      ></v-text-field>
+    </div>
   </div>
 </template>
 
@@ -93,6 +173,8 @@ export default {
     return {
       latestDiagnostic: this.diagnostics.latest,
       previousDiagnostic: this.diagnostics.previous,
+      provisionalYear1Diagnostic: this.diagnostics.provisionalYear1,
+      provisionalYear2Diagnostic: this.diagnostics.provisionalYear2,
     }
   },
   computed: {

--- a/frontend/src/components/KeyMeasureDiagnostic/index.vue
+++ b/frontend/src/components/KeyMeasureDiagnostic/index.vue
@@ -84,6 +84,8 @@ export default {
     saveInLocalStorage() {
       this.$store.dispatch("saveLocalStorageDiagnostic", this.diagnosticsCopy.latest)
       this.$store.dispatch("saveLocalStorageDiagnostic", this.diagnosticsCopy.previous)
+      this.$store.dispatch("saveLocalStorageDiagnostic", this.diagnosticsCopy.provisionalYear1)
+      this.$store.dispatch("saveLocalStorageDiagnostic", this.diagnosticsCopy.provisionalYear2)
     },
     async submit() {
       await saveDiagnostics(this.diagnostics)

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -259,6 +259,8 @@ export default new Vuex.Store({
         return [
           Object.assign({}, Constants.DefaultDiagnostics, { year: 2019 }),
           Object.assign({}, Constants.DefaultDiagnostics, { year: 2020 }),
+          Object.assign({}, Constants.DefaultDiagnostics, { year: 2021 }),
+          Object.assign({}, Constants.DefaultDiagnostics, { year: 2022 }),
         ]
       }
       return Object.values(JSON.parse(savedDiagnostics))

--- a/frontend/src/views/DiagnosticPage.vue
+++ b/frontend/src/views/DiagnosticPage.vue
@@ -112,6 +112,10 @@ export default {
           diagnostics.find((x) => x.year === 2019) || Object.assign({}, Constants.DefaultDiagnostics, { year: 2019 }),
         latest:
           diagnostics.find((x) => x.year === 2020) || Object.assign({}, Constants.DefaultDiagnostics, { year: 2020 }),
+        provisionalYear1:
+          diagnostics.find((x) => x.year === 2021) || Object.assign({}, Constants.DefaultDiagnostics, { year: 2021 }),
+        provisionalYear2:
+          diagnostics.find((x) => x.year === 2022) || Object.assign({}, Constants.DefaultDiagnostics, { year: 2022 }),
       }
     },
     serverDiagnostics() {

--- a/frontend/src/views/PublishPage/index.vue
+++ b/frontend/src/views/PublishPage/index.vue
@@ -55,6 +55,12 @@ export default {
         latest:
           diagnosticsCopy.find((x) => x.year === 2020) ||
           Object.assign({}, Constants.DefaultDiagnostics, { year: 2020 }),
+        provisionalYear1:
+          diagnosticsCopy.find((x) => x.year === 2021) ||
+          Object.assign({}, Constants.DefaultDiagnostics, { year: 2021 }),
+        provisionalYear2:
+          diagnosticsCopy.find((x) => x.year === 2022) ||
+          Object.assign({}, Constants.DefaultDiagnostics, { year: 2022 }),
       }
       return this.$route.name === "PublishMeasurePage" ? diagnostics : canteenCopy
     },


### PR DESCRIPTION
Il y a pas mal des choses coté UX a améliorer, mais je pense qu'il y a une plus grande question de ça (vois mon commentaire #234) alors je sais pas si on veut prendre le temps pour ça dans cette PR. Par rapport du ancien fonctionalité, le difference entre ça et cette PR, c'est que les champs sont affichés dans un colonne, et pas deux.