### PR TITLE
Envoi d'email lors de la publication d'une cantine

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -82,6 +82,23 @@ class UpdateUserCanteenView(UpdateAPIView):
     def patch(self, request, *args, **kwargs):
         return self.partial_update(request, *args, **kwargs)
 
+    def perform_update(self, serializer):
+        previous_publication_status = serializer.instance.data_is_public
+        new_publication_status = serializer.validated_data.get('data_is_public', False)
+
+        if (not previous_publication_status and new_publication_status):
+            cantine = serializer.instance
+            admin_url = "http://%s/admin/data/canteen/%s/change/" % (settings.HOSTNAME, cantine.id,)
+            send_mail(
+                "Cantine publiée sur ma cantine",
+                "La cantine « %s » vient d'être publiée. Plus d'informations sur : %s" % (cantine.name, admin_url),
+                settings.DEFAULT_FROM_EMAIL,
+                [settings.CONTACT_EMAIL],
+            )
+
+        return super(UpdateUserCanteenView, self).perform_update(serializer)
+
+
 
 class DiagnosticCreateView(CreateAPIView):
     permission_classes = [permissions.IsAuthenticated]
@@ -144,7 +161,7 @@ class SubscribeBetaTester(APIView):
                 "measures": key_measures,
             }
             send_mail(
-                "Nouveau Béta-testeur ma canteen",
+                "Nouveau Béta-testeur ma cantine",
                 render_to_string("subscription-beta-tester.txt", context),
                 settings.DEFAULT_FROM_EMAIL,
                 [settings.CONTACT_EMAIL],

--- a/api/views.py
+++ b/api/views.py
@@ -87,11 +87,14 @@ class UpdateUserCanteenView(UpdateAPIView):
         new_publication_status = serializer.validated_data.get('data_is_public', False)
 
         if (not previous_publication_status and new_publication_status):
+            protocol = "https" if settings.SECURE else "http"
             cantine = serializer.instance
-            admin_url = "http://%s/admin/data/canteen/%s/change/" % (settings.HOSTNAME, cantine.id,)
+            admin_url = "%s://%s/admin/data/canteen/%s/change/" % (protocol, settings.HOSTNAME, cantine.id,)
+            canteens_url = "%s://%s/nos-cantines/" % (protocol, settings.HOSTNAME,)
+
             send_mail(
                 "Cantine publiée sur ma cantine",
-                "La cantine « %s » vient d'être publiée. Plus d'informations sur : %s" % (cantine.name, admin_url),
+                "La cantine « %s » vient d'être publiée.\nAdmin : %s\nNos cantines : %s" % (cantine.name, admin_url, canteens_url),
                 settings.DEFAULT_FROM_EMAIL,
                 [settings.CONTACT_EMAIL],
                 fail_silently=True,

--- a/api/views.py
+++ b/api/views.py
@@ -94,10 +94,10 @@ class UpdateUserCanteenView(UpdateAPIView):
                 "La cantine « %s » vient d'être publiée. Plus d'informations sur : %s" % (cantine.name, admin_url),
                 settings.DEFAULT_FROM_EMAIL,
                 [settings.CONTACT_EMAIL],
+                fail_silently=True,
             )
 
         return super(UpdateUserCanteenView, self).perform_update(serializer)
-
 
 
 class DiagnosticCreateView(CreateAPIView):

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -27,6 +27,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv("SECRET")
 SECURE_SSL_REDIRECT = os.getenv("FORCE_HTTPS") == "True"
 
+# The site uses http or https?
+SECURE =  os.getenv("SECURE") == "True"
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG") == "True"
 AUTH_USER_MODEL = "data.User"


### PR DESCRIPTION
:information_source:  **Ce code sera enlevé quand la feature de l'étape _brouillon_, _en validation_, _publié_ sera en place.**

L'envoi d'email est placé dans la _view_ de l'API et non pas le modèle car :
- On veut envoyer ce mail quand l'utilisateur publie la cantine, mais non pas quand nous le faisons depuis le backoffice. 
- Vu que ce code n'a pas vocation à rester, le plus simple c'est d'utiliser le serializer qui contient l'état précédent et ultérieur à un moment précis. Ceci nous permet d'éviter des chantiers plus impactants comme la mise en place d'un système de dirty-fields.

L'email envoyé inclut simplement le nom de la cantine publiée et l'URL du backoffice pour voir plus d'informations.

À noter que l'envoie d'email est un best-effort-approach (d'où le `fail_silently=True`). Nous ne bloquerons pas la sauvegarde en cas d'échec de cet email (par ex. lors que SendInBlue pourrait être down) car nous avons d'autres moyens (Metabase, back-office) d'obtenir cette information, et que l 'utilisateur n'a pas besoin de cette étape pour compléter ses actions.