### PR TITLE
Suivre la génération du affichage avec matomo

### DIFF
--- a/frontend/src/views/GeneratePosterPage/index.vue
+++ b/frontend/src/views/GeneratePosterPage/index.vue
@@ -214,6 +214,10 @@ export default {
       this.saveDiagnostic()
       this.saveCanteen()
 
+      if (this.$matomo) {
+        this.$matomo.trackEvent("form", "submit", "poster-generator")
+      }
+
       const htmlPoster = document.getElementById("canteen-poster")
       const pdfOptions = {
         filename: "Affiche_convives_2020.pdf",


### PR DESCRIPTION
J'ai pas réussit a tester si l'evenement est visible sur matomo - peut-être parce-que la rêquet (qu'on peut voir dans le network de la page) viens du localhost ?
J'ai choisi les textes pour la fonction appel en suivant les récommendations ici : https://matomo.org/docs/event-tracking/#the-anatomy-of-an-event