### PR TITLE
Possibilité de supprimer des gestionnaires pour une cantine

### DIFF
--- a/api/tests/test_manager_invitations.py
+++ b/api/tests/test_manager_invitations.py
@@ -1,7 +1,6 @@
 from data.factories.managerinvitation import ManagerInvitationFactory
 from django.core import mail
 from django.urls import reverse
-from django.db import transaction
 from django.test.utils import override_settings
 from rest_framework.test import APITestCase
 from rest_framework import status
@@ -11,42 +10,63 @@ from .utils import authenticate
 
 
 class TestManagerInvitationApi(APITestCase):
-    def test_unauthenticated_manager_call(self):
+    def test_unauthenticated_add_manager_call(self):
         """
         When calling this API unauthenticated we expect a 403
         """
         response = self.client.post(reverse("add_manager"), {"canteenId": 999})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_unauthenticated_remove_manager_call(self):
+        """
+        When calling this API unauthenticated we expect a 403
+        """
+        response = self.client.post(reverse("remove_manager"), {"canteenId": 999})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     @authenticate
-    def test_manager_missing_canteen(self):
+    def test_add_manager_missing_canteen(self):
         """
         When calling this API on a nonexistent canteen we expect a 404
         """
-        payload = {
-            "canteenId": 999,
-            "email": "test@example.com"
-        }
+        payload = {"canteenId": 999, "email": "test@example.com"}
         response = self.client.post(reverse("add_manager"), payload)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         with self.assertRaises(ManagerInvitation.DoesNotExist):
             ManagerInvitation.objects.get(canteen__id=999)
 
     @authenticate
-    def test_manager_forbidden_canteen(self):
+    def test_remove_manager_missing_canteen(self):
+        """
+        When calling this API on a nonexistent canteen we expect a 404
+        """
+        payload = {"canteenId": 999, "email": "test@example.com"}
+        response = self.client.post(reverse("remove_manager"), payload)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_add_manager_forbidden_canteen(self):
         """
         When calling this API on a canteen that the user doesn't manage,
         we expect a 404
         """
         canteen = CanteenFactory.create()
-        payload = {
-            "canteenId": canteen.id,
-            "email": "test@example.com"
-        }
+        payload = {"canteenId": canteen.id, "email": "test@example.com"}
         response = self.client.post(reverse("add_manager"), payload)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         with self.assertRaises(ManagerInvitation.DoesNotExist):
             ManagerInvitation.objects.get(canteen__id=canteen.id)
+
+    @authenticate
+    def test_remove_manager_forbidden_canteen(self):
+        """
+        When calling this API on a canteen that the user doesn't manage,
+        we expect a 404
+        """
+        canteen = CanteenFactory.create()
+        payload = {"canteenId": canteen.id, "email": "test@example.com"}
+        response = self.client.post(reverse("remove_manager"), payload)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     @override_settings(DEFAULT_FROM_EMAIL="test-from@example.com")
@@ -58,10 +78,7 @@ class TestManagerInvitationApi(APITestCase):
         """
         canteen = CanteenFactory.create()
         canteen.managers.add(authenticate.user)
-        payload = {
-            "canteenId": canteen.id,
-            "email": "test@example.com"
-        }
+        payload = {"canteenId": canteen.id, "email": "test@example.com"}
         response = self.client.post(reverse("add_manager"), payload)
         body = response.json()
 
@@ -85,10 +102,7 @@ class TestManagerInvitationApi(APITestCase):
         """
         canteen = CanteenFactory.create()
         canteen.managers.add(authenticate.user)
-        payload = {
-            "canteenId": canteen.id,
-            "email": "test@example.com"
-        }
+        payload = {"canteenId": canteen.id, "email": "test@example.com"}
         self.client.post(reverse("add_manager"), payload)
         response = self.client.post(reverse("add_manager"), payload)
 
@@ -110,22 +124,22 @@ class TestManagerInvitationApi(APITestCase):
         canteen1.managers.add(authenticate.user)
         canteen2.managers.add(authenticate.user)
 
-        self.client.post(reverse("add_manager"), {
-            "canteenId": canteen1.id,
-            "email": "test1@example.com"
-        })
-        self.client.post(reverse("add_manager"), {
-            "canteenId": canteen1.id,
-            "email": "test2@example.com"
-        })
-        self.client.post(reverse("add_manager"), {
-            "canteenId": canteen2.id,
-            "email": "test1@example.com"
-        })
-        self.client.post(reverse("add_manager"), {
-            "canteenId": canteen2.id,
-            "email": "test2@example.com"
-        })
+        self.client.post(
+            reverse("add_manager"),
+            {"canteenId": canteen1.id, "email": "test1@example.com"},
+        )
+        self.client.post(
+            reverse("add_manager"),
+            {"canteenId": canteen1.id, "email": "test2@example.com"},
+        )
+        self.client.post(
+            reverse("add_manager"),
+            {"canteenId": canteen2.id, "email": "test1@example.com"},
+        )
+        self.client.post(
+            reverse("add_manager"),
+            {"canteenId": canteen2.id, "email": "test2@example.com"},
+        )
 
         pms = ManagerInvitation.objects.all()
         self.assertEqual(len(pms), 4)
@@ -140,10 +154,7 @@ class TestManagerInvitationApi(APITestCase):
         canteen = CanteenFactory.create()
         canteen.managers.add(authenticate.user)
         other_user = UserFactory.create()
-        payload = {
-            "canteenId": canteen.id,
-            "email": other_user.email
-        }
+        payload = {"canteenId": canteen.id, "email": other_user.email}
 
         response = self.client.post(reverse("add_manager"), payload)
         body = response.json()
@@ -155,5 +166,67 @@ class TestManagerInvitationApi(APITestCase):
         self.assertEqual(len(mail.outbox), 0)
 
         self.assertEqual(len(body["managers"]), canteen.managers.all().count())
-        self.assertEqual(len(body["managerInvitations"]), canteen.managerinvitation_set.all().count())
+        self.assertEqual(
+            len(body["managerInvitations"]), canteen.managerinvitation_set.all().count()
+        )
 
+    @authenticate
+    def test_authenticated_remove_manager(self):
+        """
+        It should be possible to remove a given manager from a canteen
+        """
+        coworker = UserFactory.create()
+        canteen = CanteenFactory.create()
+        canteen.managers.add(authenticate.user)
+        canteen.managers.add(coworker)
+
+        payload = {"canteenId": canteen.id, "email": coworker.email}
+
+        response = self.client.post(reverse("remove_manager"), payload)
+        body = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(canteen.managers.filter(id=coworker.id).count(), 0)
+        self.assertEqual(canteen.managers.filter(id=authenticate.user.id).count(), 1)
+        self.assertEqual(len(body["managers"]), canteen.managers.all().count())
+
+    @authenticate
+    def test_authenticated_remove_unexistent_manager(self):
+        """
+        When trying to remove a manager that does not manage a canteen, we will
+        respond 200 OK.
+        """
+        coworker = UserFactory.create()
+        canteen = CanteenFactory.create()
+        canteen.managers.add(authenticate.user)
+
+        payload = {"canteenId": canteen.id, "email": coworker.email}
+
+        response = self.client.post(reverse("remove_manager"), payload)
+        body = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(canteen.managers.filter(id=authenticate.user.id).count(), 1)
+        self.assertEqual(len(body["managers"]), canteen.managers.all().count())
+
+    @authenticate
+    @override_settings(DEFAULT_FROM_EMAIL="test-from@example.com")
+    def test_authenticated_delete_invitation(self):
+        """
+        We should be able to remove a pending invitation
+        """
+        invitedManagerEmail = "invited-manager@example.com"
+        canteen = CanteenFactory.create()
+        canteen.managers.add(authenticate.user)
+        invitation = ManagerInvitationFactory.create(
+            canteen=canteen, email=invitedManagerEmail
+        )
+
+        payload = {"canteenId": canteen.id, "email": invitedManagerEmail}
+        self.client.post(reverse("remove_manager"), payload)
+
+        with self.assertRaises(ManagerInvitation.DoesNotExist):
+            ManagerInvitation.objects.get(pk=invitation.id)
+
+        with self.assertRaises(ManagerInvitation.DoesNotExist):
+            ManagerInvitation.objects.get(canteen=canteen, email=invitedManagerEmail)

--- a/api/tests/test_manager_invitations.py
+++ b/api/tests/test_manager_invitations.py
@@ -191,7 +191,7 @@ class TestManagerInvitationApi(APITestCase):
         self.assertEqual(len(body["managers"]), canteen.managers.all().count())
 
     @authenticate
-    def test_authenticated_remove_unexistent_manager(self):
+    def test_authenticated_remove_nonexistent_manager(self):
         """
         When trying to remove a manager that does not manage a canteen, we will
         respond 200 OK.

--- a/api/urls.py
+++ b/api/urls.py
@@ -4,7 +4,7 @@ from api.views import LoggedUserView, SubscribeBetaTester, SubscribeNewsletter
 from api.views import UpdateUserView, PublishedCanteensView, UserCanteensView
 from api.views import DiagnosticCreateView, UpdateUserCanteenView, DiagnosticUpdateView
 from api.views import BlogPostsView, SectorListView, ChangePasswordView
-from api.views import AddManagerView
+from api.views import AddManagerView, RemoveManagerView
 
 
 urlpatterns = {
@@ -42,6 +42,11 @@ urlpatterns = {
         "addManager/",
         AddManagerView.as_view(),
         name="add_manager",
+    ),
+    path(
+        "removeManager/",
+        RemoveManagerView.as_view(),
+        name="remove_manager",
     ),
 }
 

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -378,6 +378,23 @@ export default new Vuex.Store({
         })
     },
 
+    removeManager(context, { canteenId, email }) {
+      return fetch(`/api/v1/removeManager/`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ canteenId, email }),
+      })
+        .then(verifyResponse)
+        .then((response) => {
+          context.commit("UPDATE_USER_CANTEEN_MANAGERS", { canteenId, data: response })
+          context.commit("SET_CANTEENS_LOADING_STATUS", Constants.LoadingStatus.SUCCESS)
+        })
+        .catch((e) => {
+          context.commit("SET_CANTEENS_LOADING_STATUS", Constants.LoadingStatus.ERROR)
+          throw e
+        })
+    },
+
     notify(context, { title, message, status }) {
       context.commit("SET_NOTIFICATION", { title, message, status })
       setTimeout(() => context.commit("REMOVE_NOTIFICATION", message), 4000)

--- a/frontend/src/views/CanteenEditor/AdminRemovalDialog.vue
+++ b/frontend/src/views/CanteenEditor/AdminRemovalDialog.vue
@@ -14,7 +14,7 @@
       <v-card-text>
         <span v-if="manager.firstName || manager.lastName">{{ manager.firstName }} {{ manager.lastName }}</span>
         <span v-else>Cette personne</span>
-        n'aura plus accès a cette cantine et ne sera plus en mesure d'en apporter des modifications ni de créer des
+        n'aura plus accès à cette cantine et ne sera plus en mesure d'en apporter des modifications ni de créer des
         diagnostics.
       </v-card-text>
 

--- a/frontend/src/views/CanteenEditor/AdminRemovalDialog.vue
+++ b/frontend/src/views/CanteenEditor/AdminRemovalDialog.vue
@@ -1,0 +1,51 @@
+<template>
+  <v-dialog v-model="isOpen" width="500">
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn color="red" x-small fab outlined v-bind="attrs" v-on="on">
+        <v-icon>mdi-trash-can</v-icon>
+      </v-btn>
+    </template>
+
+    <v-card class="text-left">
+      <v-card-title class="font-weight-bold">
+        Voulez-vous enlever {{ manager.email }} de la liste de gestionnaires ?
+      </v-card-title>
+
+      <v-card-text>
+        <span v-if="manager.firstName || manager.lastName">{{ manager.firstName }} {{ manager.lastName }}</span>
+        <span v-else>Cette personne</span>
+        n'aura plus accès a cette cantine et ne sera plus en mesure d'en apporter des modifications ni de créer des
+        diagnostics.
+      </v-card-text>
+
+      <v-divider></v-divider>
+
+      <v-card-actions class="pa-4">
+        <v-spacer></v-spacer>
+        <v-btn outlined text @click="$emit('input', false)" class="mr-2">
+          Non, revenir en arrière
+        </v-btn>
+        <v-btn outlined color="red" text @click="$emit('delete')">
+          Oui, enlever {{ manager.firstName }} {{ manager.lastName }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  name: "AdminRemovalDialog",
+  props: ["value", "manager"],
+  computed: {
+    isOpen: {
+      get() {
+        return this.value
+      },
+      set(newValue) {
+        this.$emit("input", newValue)
+      },
+    },
+  },
+}
+</script>

--- a/frontend/src/views/CanteenEditor/AdminRemovalDialog.vue
+++ b/frontend/src/views/CanteenEditor/AdminRemovalDialog.vue
@@ -2,7 +2,7 @@
   <v-dialog v-model="isOpen" width="500">
     <template v-slot:activator="{ on, attrs }">
       <v-btn color="red" x-small fab outlined v-bind="attrs" v-on="on">
-        <v-icon>mdi-trash-can</v-icon>
+        <v-icon aria-hidden="false" title="Enlever">mdi-trash-can</v-icon>
       </v-btn>
     </template>
 

--- a/frontend/src/views/CanteenEditor/ManagerItem.vue
+++ b/frontend/src/views/CanteenEditor/ManagerItem.vue
@@ -1,23 +1,58 @@
 <template>
-  <v-list-item>
-    <v-list-item-icon>
-      <v-icon :color="color">{{ icon }}</v-icon>
-    </v-list-item-icon>
-    <v-list-item-content>
-      <v-list-item-title
-        v-text="manager.lastName ? `${manager.firstName} ${manager.lastName}` : manager.email"
-      ></v-list-item-title>
-      <v-list-item-subtitle>
-        {{ status }}
-        <span class="mx-2" v-if="status && manager.lastName">-</span>
-        <span v-if="!!manager.lastName">{{ manager.email }}</span>
-      </v-list-item-subtitle>
-    </v-list-item-content>
-  </v-list-item>
+  <div>
+    <v-list-item>
+      <v-list-item-icon>
+        <v-icon :color="isInvitation ? 'secondary' : 'primary'">
+          {{ isInvitation ? "mdi-account-clock-outline" : "mdi-account-check-outline" }}
+        </v-icon>
+      </v-list-item-icon>
+      <v-list-item-content>
+        <v-list-item-title
+          v-text="isInvitation ? manager.email : `${manager.firstName} ${manager.lastName}`"
+        ></v-list-item-title>
+        <v-list-item-subtitle>
+          <span v-if="isInvitation">Invitation envoyée</span>
+          <span v-else-if="$store.state.loggedUser.email === manager.email">
+            Vous êtes gestionnaire de cette cantine
+          </span>
+          <span v-else>{{ manager.email }}</span>
+        </v-list-item-subtitle>
+      </v-list-item-content>
+      <AdminRemovalDialog v-if="showDeleteButton" :manager="manager" v-model="dialog" @delete="deleteManager" />
+    </v-list-item>
+    <v-divider class="my-1"></v-divider>
+  </div>
 </template>
 
 <script>
+import AdminRemovalDialog from "./AdminRemovalDialog"
+
 export default {
-  props: ["manager", "icon", "color", "status"],
+  components: { AdminRemovalDialog },
+  data() {
+    return {
+      dialog: false,
+    }
+  },
+  props: {
+    manager: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    isInvitation() {
+      return !this.manager.lastName
+    },
+    showDeleteButton() {
+      return this.$store.state.loggedUser.email !== this.manager.email
+    },
+  },
+  methods: {
+    deleteManager() {
+      this.$emit("delete", this.manager)
+      this.dialog = false
+    },
+  },
 }
 </script>

--- a/frontend/src/views/CanteenEditor/index.vue
+++ b/frontend/src/views/CanteenEditor/index.vue
@@ -467,8 +467,6 @@ export default {
         })
     },
     deleteManager(manager) {
-      console.log(`should remove manager ${manager.email}`)
-
       this.$store
         .dispatch("removeManager", {
           canteenId: this.canteen.id,

--- a/frontend/src/views/CanteenEditor/index.vue
+++ b/frontend/src/views/CanteenEditor/index.vue
@@ -198,25 +198,19 @@
       <h2 class="font-weight-black text-h5 mt-10">
         Les gestionnaires pour cette cantine
       </h2>
-      <v-list disabled>
-        <v-list-item-group>
-          <ManagerItem
-            v-for="manager in managers"
-            :key="manager.email"
-            :manager="manager"
-            icon="mdi-account-check-outline"
-            color="primary"
-            status=""
-          />
-          <ManagerItem
-            v-for="manager in managerInvitations"
-            :key="manager.email"
-            :manager="manager"
-            icon="mdi-account-clock-outline"
-            color="secondary"
-            status="Invitation envoyée"
-          />
-        </v-list-item-group>
+      <v-list>
+        <ManagerItem @delete="deleteManager" v-for="manager in managers" :key="manager.email" :manager="manager" />
+      </v-list>
+      <v-list>
+        <p class="text-body-1 font-weight-black" v-if="managerInvitations && managerInvitations.length > 0">
+          Invitations en cours
+        </p>
+        <ManagerItem
+          @delete="deleteManager"
+          v-for="manager in managerInvitations"
+          :key="manager.email"
+          :manager="manager"
+        />
       </v-list>
       <v-row>
         <v-col cols="12" sm="10" md="6">
@@ -329,7 +323,10 @@ export default {
       }
     },
     managers() {
-      return this.originalCanteen.managers
+      const managersCopy = [...this.originalCanteen.managers]
+      const loggedUserIndex = managersCopy.findIndex((x) => x.email === this.$store.state.loggedUser.email)
+      managersCopy.splice(0, 0, managersCopy.splice(loggedUserIndex, 1)[0])
+      return managersCopy
     },
     managerInvitations() {
       return this.originalCanteen.managerInvitations
@@ -467,6 +464,25 @@ export default {
         .catch(() => {
           this.$store.dispatch("notifyServerError")
           this.newManagerEmail = undefined
+        })
+    },
+    deleteManager(manager) {
+      console.log(`should remove manager ${manager.email}`)
+
+      this.$store
+        .dispatch("removeManager", {
+          canteenId: this.canteen.id,
+          email: manager.email,
+        })
+        .then(() => {
+          this.$store.dispatch("notify", {
+            title: "Mise à jour prise en compte",
+            message: `${manager.email} n'est plus gestionnaire de cette cantine`,
+            status: "success",
+          })
+        })
+        .catch(() => {
+          this.$store.dispatch("notifyServerError")
         })
     },
   },

--- a/frontend/tests/unit/ManagerItem.spec.js
+++ b/frontend/tests/unit/ManagerItem.spec.js
@@ -1,0 +1,108 @@
+import Vuex from "vuex"
+import VueRouter from "vue-router"
+import Vuetify from "vuetify"
+import { shallowMount, createLocalVue } from "@vue/test-utils"
+import ManagerItem from "@/views/CanteenEditor/ManagerItem"
+
+const localVue = createLocalVue()
+localVue.use(VueRouter)
+
+describe("ManagerItem.vue", () => {
+  let vuetify
+
+  beforeEach(() => {
+    vuetify = new Vuetify()
+  })
+
+  it("Includes delete button if manager is not the authenticated user", () => {
+    const wrapper = shallowMount(ManagerItem, {
+      localVue,
+      propsData: {
+        manager: {
+          email: "invited@example.com",
+        },
+      },
+      vuetify,
+      stubs: ["AdminRemovalDialog"],
+      store: new Vuex.Store({
+        state: {
+          loggedUser: {
+            email: "test@example.com",
+          },
+        },
+      }),
+    })
+    expect(wrapper.find("adminremovaldialog-stub").exists()).toBe(true)
+  })
+
+  it("Hides the delete button if manager is the authenticated user", () => {
+    const wrapper = shallowMount(ManagerItem, {
+      localVue,
+      propsData: {
+        manager: {
+          email: "test@example.com",
+        },
+      },
+      vuetify,
+      stubs: ["AdminRemovalDialog"],
+      store: new Vuex.Store({
+        state: {
+          loggedUser: {
+            email: "test@example.com",
+          },
+        },
+      }),
+    })
+    expect(wrapper.find("adminremovaldialog-stub").exists()).toBe(false)
+  })
+
+  it("Renders an orange icon with a clock when dealing with an invitation", () => {
+    const wrapper = shallowMount(ManagerItem, {
+      localVue,
+      propsData: {
+        manager: {
+          email: "invited@example.com",
+        },
+      },
+      vuetify,
+      stubs: ["AdminRemovalDialog"],
+      store: new Vuex.Store({
+        state: {
+          loggedUser: {
+            email: "test@example.com",
+          },
+        },
+      }),
+    })
+    const iconWrapper = wrapper.find("v-icon-stub")
+    expect(iconWrapper.exists()).toBe(true)
+    expect(iconWrapper.attributes().color).toBe("secondary")
+    expect(iconWrapper.text()).toBe("mdi-account-clock-outline")
+  })
+
+  it("Renders a green icon with a check when dealing with an manager", () => {
+    const wrapper = shallowMount(ManagerItem, {
+      localVue,
+      propsData: {
+        manager: {
+          email: "manager@example.com",
+          firstName: "Manager",
+          lastName: "Doe",
+        },
+      },
+      vuetify,
+      stubs: ["AdminRemovalDialog"],
+      store: new Vuex.Store({
+        state: {
+          loggedUser: {
+            email: "test@example.com",
+          },
+        },
+      }),
+    })
+    const iconWrapper = wrapper.find("v-icon-stub")
+    expect(iconWrapper.exists()).toBe(true)
+    expect(iconWrapper.attributes().color).toBe("primary")
+    expect(iconWrapper.text()).toBe("mdi-account-check-outline")
+  })
+})


### PR DESCRIPTION
À noter que pour l'instant un gestionnaire ne peux pas se supprimer lui-même pour éviter des cantines sans gestionnaires.

![delete-manager](https://user-images.githubusercontent.com/1225929/125827720-cc2fc97d-96bd-4576-9b12-35ed95da70f2.gif)

