### PR TITLE
Permet la suppression de plusieurs cantines depuis l'admin

### DIFF
--- a/data/admin/softdeletionadmin.py
+++ b/data/admin/softdeletionadmin.py
@@ -1,13 +1,16 @@
 from django.contrib import admin
 
-class SoftDeletionAdmin(admin.ModelAdmin):
 
+class SoftDeletionAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         qs = self.model.all_objects
         ordering = self.get_ordering(request)
         if ordering:
             qs = qs.order_by(*ordering)
         return qs
-        
+
     def delete_model(self, request, obj):
         obj.hard_delete()
+
+    def delete_queryset(self, request, queryset):
+        return queryset.hard_delete()


### PR DESCRIPTION
Vu que les cantines possèdent un mécanisme de suppression intermédiaire, lors de l'implémentation du `SoftDeleteModel` nous avons surchargé la méthode de l'admin qui supprime une cantine : 

```python
# data/admin/softdeletionadmin.py
def delete_model(self, request, obj):
        obj.hard_delete()
```

Néanmoins, cette méthode n'est pas appelé lors qu'on fait une suppression groupée. Il faut donc surcharger la méthode `delete_queryset`. 