### PR TITLE
N'afficher pas 'null' si on n'a pas une ville pour la cantine après import

### DIFF
--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -208,17 +208,19 @@ export default {
     if (canteen) {
       this.canteen = JSON.parse(JSON.stringify(canteen))
       this.publicationRequested = !!canteen.publicationStatus && canteen.publicationStatus !== "draft"
-      const initialCityAutocomplete = {
-        text: canteen.city,
-        value: {
-          label: canteen.city,
-          citycode: canteen.cityInseeCode,
-          postcode: canteen.postalCode,
-          context: canteen.department,
-        },
+      if (canteen.city) {
+        const initialCityAutocomplete = {
+          text: canteen.city,
+          value: {
+            label: canteen.city,
+            citycode: canteen.cityInseeCode,
+            postcode: canteen.postalCode,
+            context: canteen.department,
+          },
+        }
+        this.communes = [initialCityAutocomplete]
+        this.cityAutocompleteChoice = initialCityAutocomplete.value
       }
-      this.communes = [initialCityAutocomplete]
-      this.cityAutocompleteChoice = initialCityAutocomplete.value
     } else this.$router.push({ name: "NewCanteen" })
   },
   created() {


### PR DESCRIPTION
Le bogue :
![null-city-bug](https://user-images.githubusercontent.com/9282816/127842481-ab05a020-dd25-45e5-ac67-4dba1a61383d.gif)

On doit discuter si ou quand on veut appeler le API d'adresse avec seulement le code postale.