### PR TITLE
Fix des erreurs de console lors de la suppression d'une cantine

### DIFF
--- a/frontend/src/components/CanteenNavigation.vue
+++ b/frontend/src/components/CanteenNavigation.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav aria-label="Options de gestion de ma cantine">
+  <nav aria-label="Options de gestion de ma cantine" v-if="canteen">
     <v-card outlined class="mt-4">
       <v-list nav class="text-left">
         <v-list-item-group>

--- a/frontend/src/views/CanteenEditor/CanteenDeletion.vue
+++ b/frontend/src/views/CanteenEditor/CanteenDeletion.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-left pb-10">
+  <div class="text-left pb-10" v-if="originalCanteen">
     <h1 class="font-weight-black text-h4 my-4">
       Supprimer ma cantine
     </h1>
@@ -20,11 +20,10 @@ export default {
   props: {
     originalCanteen: {
       type: Object,
-      required: true,
     },
   },
   created() {
-    document.title = `Supprimer - ${this.originalCanteen.name} - ma-cantine.beta.gouv.fr`
+    document.title = `Supprimer - ${this.originalCanteen?.name || ""} - ma-cantine.beta.gouv.fr`
   },
   data() {
     return {


### PR DESCRIPTION
Les erreurs affichées dans la console lors qu'on supprimait une cantine venaient de deux composants : 

1- `CanteenDeletion.vue`, qui s'attendait à avoir la propriété `originalCanteen` à tout moment, et
2- `CanteenNavigation.vue`, qui utilise sa propriété `canteen` pour afficher certains valeurs

Or, la méthode _deleteCanteen_ fait d'abord la suppression de la cantine, et puis la navigation vers la page de gestion. Donc pendant un petit moment la cantine est supprimée et n'existe plus, alors que les deux composants ci-dessus sont encore à l'écran et s'attendent à pouvoir utiliser ces informations.

Changer l'ordre de la suppression (d'abord faire la redirection vers _gestion_ et puis supprimer la cantine) n'est pas top pour l'utilisateur, car la cantine supprimée sera visible pendant un petit moment dans l'écran de gestion.

Je propose donc d'adapter les deux composants pour faire en sorte que rien ne soit affiché pendant le court moment entre la suppression de la cantine et la navigation vers la page de gestion.