### PR TITLE
Ameliorer l'affichage des pourcentages quand on remplis les données appros

### DIFF
--- a/frontend/src/components/MultiYearSummaryStatistics.vue
+++ b/frontend/src/components/MultiYearSummaryStatistics.vue
@@ -19,6 +19,7 @@
 
 <script>
 import VueApexCharts from "vue-apexcharts"
+import { strictIsNaN } from "@/utils"
 
 const VALUE_DESCRIPTION = "Pourcentage d'achats"
 const BIO = "Bio"
@@ -154,10 +155,6 @@ function getPercentage(partialValue, totalValue) {
   } else {
     return Math.round((100 * partialValue) / totalValue)
   }
-}
-
-function strictIsNaN(x) {
-  return Number(x) !== x
 }
 
 function percentageFormatter(val) {

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -144,3 +144,7 @@ export const getObjectDiff = (obj1, obj2, keysToIgnore) => {
 
   return diffs
 }
+
+export const strictIsNaN = (x) => {
+  return Number(x) !== x
+}

--- a/frontend/src/views/DiagnosticEditor/index.vue
+++ b/frontend/src/views/DiagnosticEditor/index.vue
@@ -142,7 +142,7 @@ import DiversificationMeasure from "@/components/KeyMeasureDiagnostic/Diversific
 import NoPlasticMeasure from "@/components/KeyMeasureDiagnostic/NoPlasticMeasure"
 import QualityMeasureValuesInput from "@/components/KeyMeasureDiagnostic/QualityMeasureValuesInput"
 import DiagnosticExpansionPanel from "./DiagnosticExpansionPanel"
-import { getObjectDiff } from "@/utils"
+import { getObjectDiff, strictIsNaN } from "@/utils"
 
 function percentage(part, total) {
   return Math.round((part / total) * 100)
@@ -258,10 +258,10 @@ export default {
     approSummary() {
       if (this.diagnostic.valueTotalHt > 0) {
         let summary = []
-        if (this.diagnostic.valueBioHt) {
+        if (hasValue(this.diagnostic.valueBioHt)) {
           summary.push(`${percentage(this.diagnostic.valueBioHt, this.diagnostic.valueTotalHt)} % bio`)
         }
-        if (this.diagnostic.valueSustainableHt) {
+        if (hasValue(this.diagnostic.valueSustainableHt)) {
           summary.push(
             `${percentage(this.diagnostic.valueSustainableHt, this.diagnostic.valueTotalHt)} % de qualité et durable`
           )
@@ -348,5 +348,13 @@ export default {
     }
     window.confirm(LEAVE_WARNING) ? next() : next(false)
   },
+}
+
+function hasValue(val) {
+  if (typeof val === "string") {
+    return !!val
+  } else {
+    return !strictIsNaN(val)
+  }
 }
 </script>


### PR DESCRIPTION
Avant, quand les valeurs bio et durable était 0, la caption était 'Incomplet', maintenant elle est: 
![Screenshot 2021-08-25 at 13 09 10](https://user-images.githubusercontent.com/9282816/130780389-7e93bc93-7da4-47ea-8e10-eda1ef32ab4a.png)
