### PR TITLE
Shows only one QR code on PDF poster

### DIFF
--- a/frontend/src/views/GeneratePosterPage/CanteenPoster.vue
+++ b/frontend/src/views/GeneratePosterPage/CanteenPoster.vue
@@ -62,7 +62,10 @@
       <div class="footer-text">
         <p style="margin-bottom: 0px;">En savoir plus de la loi EGAlim :</p>
         <p><a href="https://ma-cantine.beta.gouv.fr/">https://ma-cantine.beta.gouv.fr/</a></p>
-        <qrcode-vue value="https://ma-cantine.beta.gouv.fr"></qrcode-vue>
+        <qrcode-vue
+          v-if="canteen.publicationStatus !== 'published'"
+          value="https://ma-cantine.beta.gouv.fr"
+        ></qrcode-vue>
       </div>
       <div class="footer-text" style="text-align: right;" v-if="canteen.publicationStatus === 'published'">
         <p style="width: 210px;">En savoir plus sur les pratiques mises en oeuvre par l'établissement</p>


### PR DESCRIPTION
Suite à une remarque de Jenn, l'affiche n'aura qu'un seul PDF : celui de la page de la cantine si elle est publiée, sinon celui du site.

![qr-code](https://user-images.githubusercontent.com/1225929/131484561-c8c9a38f-7e6f-43fd-ad4e-6878e7a67e79.gif)
