### PR TITLE
Adds product origin info in published canteen card

### DIFF
--- a/frontend/src/components/CanteenIndicators.vue
+++ b/frontend/src/components/CanteenIndicators.vue
@@ -1,5 +1,9 @@
 <template>
   <div>
+    <p class="my-0" v-if="includeProductOrigin && latestDiagnostic">
+      <v-icon small>mdi-food-apple</v-icon>
+      {{ productOriginText }}
+    </p>
     <p class="my-0" v-if="canteen.dailyMealCount">
       <v-icon small>mdi-silverware-fork-knife</v-icon>
       {{ canteen.dailyMealCount }} repas par jour
@@ -16,12 +20,18 @@
 </template>
 
 <script>
+import { lastYear, getPercentage } from "@/utils"
+
 export default {
   name: "CanteenIndicators",
   props: {
     canteen: {
       type: Object,
       required: true,
+    },
+    includeProductOrigin: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {
@@ -31,6 +41,17 @@ export default {
       return this.canteen.sectors
         .map((sectorId) => sectors.find((x) => x.id === sectorId).name.toLowerCase())
         .join(", ")
+    },
+    latestDiagnostic() {
+      return this.canteen.diagnostics.find((x) => x.year === lastYear())
+    },
+    productOriginText() {
+      const bioPercent = getPercentage(this.latestDiagnostic.valueBioHt, this.latestDiagnostic.valueTotalHt)
+      const sustainablePercent = getPercentage(
+        this.latestDiagnostic.valueSustainableHt,
+        this.latestDiagnostic.valueTotalHt
+      )
+      return `${bioPercent} % bio, ${sustainablePercent} % qualité et durables`
     },
   },
 }

--- a/frontend/src/components/CanteenIndicators.vue
+++ b/frontend/src/components/CanteenIndicators.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <p class="my-0" v-if="includeProductOrigin && latestDiagnostic">
+    <p class="my-0" v-if="includeProductOrigin && productOriginDiagnostic">
       <v-icon small>mdi-food-apple</v-icon>
       {{ productOriginText }}
     </p>
@@ -42,14 +42,19 @@ export default {
         .map((sectorId) => sectors.find((x) => x.id === sectorId).name.toLowerCase())
         .join(", ")
     },
-    latestDiagnostic() {
-      return this.canteen.diagnostics.find((x) => x.year === lastYear())
+    productOriginDiagnostic() {
+      const latestDiagnostic = this.canteen.diagnostics.find((x) => x.year === lastYear())
+      if (!latestDiagnostic || !latestDiagnostic.valueBioHt || !latestDiagnostic.valueSustainableHt) return null
+      return latestDiagnostic
     },
     productOriginText() {
-      const bioPercent = getPercentage(this.latestDiagnostic.valueBioHt, this.latestDiagnostic.valueTotalHt)
+      const bioPercent = getPercentage(
+        this.productOriginDiagnostic.valueBioHt,
+        this.productOriginDiagnostic.valueTotalHt
+      )
       const sustainablePercent = getPercentage(
-        this.latestDiagnostic.valueSustainableHt,
-        this.latestDiagnostic.valueTotalHt
+        this.productOriginDiagnostic.valueSustainableHt,
+        this.productOriginDiagnostic.valueTotalHt
       )
       return `${bioPercent} % bio, ${sustainablePercent} % qualité et durables`
     },

--- a/frontend/src/components/CanteenIndicators.vue
+++ b/frontend/src/components/CanteenIndicators.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import { lastYear, getPercentage } from "@/utils"
+import { lastYear, getPercentage, isDiagnosticComplete } from "@/utils"
 
 export default {
   name: "CanteenIndicators",
@@ -44,7 +44,7 @@ export default {
     },
     productOriginDiagnostic() {
       const latestDiagnostic = this.canteen.diagnostics.find((x) => x.year === lastYear())
-      if (!latestDiagnostic || !latestDiagnostic.valueBioHt || !latestDiagnostic.valueSustainableHt) return null
+      if (!latestDiagnostic || !isDiagnosticComplete(latestDiagnostic)) return null
       return latestDiagnostic
     },
     productOriginText() {

--- a/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
+++ b/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
@@ -8,7 +8,7 @@
       {{ canteen.name }}
     </v-card-title>
     <v-card-subtitle v-if="canteen.dailyMealCount || canteen.city">
-      <CanteenIndicators :canteen="canteen" />
+      <CanteenIndicators :canteen="canteen" :includeProductOrigin="true" />
     </v-card-subtitle>
     <v-card-text v-if="Object.keys(earnedBadges).length" class="grey--text text--darken-4 d-flex">
       <v-img


### PR DESCRIPTION
Affiche l'information d'approvisionnement dans la carte d'une cantine publiée si celle-ci a un diagnostic pour l'année dernière.

![image](https://user-images.githubusercontent.com/1225929/135874541-914b75d2-4aa3-4016-9126-7e4fb789f483.png)
