### PR TITLE
Ordre alphabétique des cantines dans l'espace utilisateur

### DIFF
--- a/frontend/src/views/ManagementPage/index.vue
+++ b/frontend/src/views/ManagementPage/index.vue
@@ -44,7 +44,7 @@
         </v-btn>
       </div>
 
-      <div v-for="canteen in $store.state.userCanteens" :key="`diag-${canteen.id}`">
+      <div v-for="canteen in canteens" :key="`diag-${canteen.id}`">
         <div v-if="canteen.diagnostics && canteen.diagnostics.length">
           <v-row>
             <v-col cols="12" v-for="diagnostic in sortedDiagnosticsForCanteen(canteen)" :key="diagnostic.id">
@@ -75,7 +75,7 @@ export default {
       return this.$store.state.loggedUser
     },
     canteens() {
-      return this.$store.state.userCanteens
+      return [...this.$store.state.userCanteens].sort((a, b) => (a.name > b.name ? 1 : -1))
     },
     hasDiagnostics() {
       return this.canteens.length && this.canteens.some((c) => !!c.diagnostics.length)


### PR DESCRIPTION
Aujourd'hui l'ordre des cantines affichées dans l'espace client est la date de création. Or, lorsqu'on commence à en avoir plusieurs, c'est difficile de les trouver - surtout dans le cas d'un import. De plus, la date de création n'est pas forcément un critère que les utilisateurs ont en tête lors de l'utilisation du produit.

À terme on pourrait - si besoin - créer des champs de triage des cantines, mais en attendant je me dis que l'ordre alphabétique est plus facile à comprendre pour les utilisateurs. Cette PR met les cantines en ordre alphabétique dans l'espace utilisateur. 