### PR TITLE
Hot-fix : Permet de créer une nouvelle cantine avec des images

### DIFF
--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -186,7 +186,7 @@ export default {
   },
   data() {
     return {
-      canteen: {},
+      canteen: { images: [] },
       formIsValid: true,
       bypassLeaveWarning: false,
       deletionDialog: false,


### PR DESCRIPTION
Une nouvelle cantine ne contenait pas le tableau des images qui permet l'éditeur d'images de marcher. Désormais la cantine de base contient un tableau vide.