### PR TITLE
Améliorer l'affichage du selecteur de logo sur mobile

### DIFF
--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -28,7 +28,7 @@
           ></v-text-field>
         </v-col>
 
-        <v-col cols="12" md="4" height="100%" class="d-flex flex-column">
+        <v-col cols="12" sm="6" md="4" height="100%" class="d-flex flex-column">
           <label class="body-2" for="logo">
             Logo
           </label>
@@ -45,6 +45,7 @@
               color="grey lighten-5"
               class="fill-height"
               style="overflow: hidden;"
+              min-height="170"
             >
               <div v-if="canteen.logo" class="d-flex flex-column fill-height">
                 <v-spacer></v-spacer>


### PR DESCRIPTION
Avant 
![Screenshot 2021-11-09 at 12 59 47](https://user-images.githubusercontent.com/9282816/140920456-fd49328d-226c-4dc6-9b43-dbb6e44538c9.png)

Après
![Screenshot 2021-11-09 at 12 59 27](https://user-images.githubusercontent.com/9282816/140920476-89d5182f-1d2a-40ec-b2d2-ccef9f5d195b.png)

 