### PR TITLE
Améliorer la navigation des cantines publiées

### DIFF
--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -536,7 +536,7 @@ export default {
       this.$router.push({ query }).catch(() => {})
     },
     updateOrder() {
-      const override = this.order ? { page: 1, trier: this.order.display } : { page: 1 }
+      const override = this.order ? { page: this.page, trier: this.order.display } : { page: this.page }
       const query = Object.assign(this.query, override)
       this.$router.push({ query }).catch(() => {})
     },
@@ -584,10 +584,10 @@ export default {
       if (this.$refs[ref].validate()) this.appliedFilters[ref] = parseInt(this.$refs[ref].lazyValue) || null
     },
     updateRouter(query) {
-      if (!this.$route.query.page) {
-        this.$router.replace({ query }).catch(() => {})
-      } else {
+      if (this.$route.query.page) {
         this.$router.push({ query }).catch(() => {})
+      } else {
+        this.$router.replace({ query }).catch(() => {})
       }
     },
     sendEmail() {
@@ -678,6 +678,7 @@ export default {
     },
     toggleOrderDirection() {
       this.orderDescending = !this.orderDescending
+      this.page = 1 // reset page to 1 when changing order direction
     },
   },
   watch: {

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -579,6 +579,7 @@ export default {
         minCombined: parseInt(this.$route.query.minQualite) || null,
       }
       this.orderBy = this.$route.query.trier?.slice(0, -3) || DEFAULT_ORDER
+      this.orderDescending = this.$route.query.trier?.slice(-3) === "Dec"
     },
     onChangeIntegerFilter(ref) {
       if (this.$refs[ref].validate()) this.appliedFilters[ref] = parseInt(this.$refs[ref].lazyValue) || null

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -268,7 +268,7 @@
           <v-pagination
             v-model="page"
             :length="Math.ceil(publishedCanteenCount / limit)"
-            :total-visible="5"
+            :total-visible="7"
           ></v-pagination>
         </v-col>
         <v-spacer></v-spacer>
@@ -297,7 +297,7 @@
         class="my-6"
         v-model="page"
         :length="Math.ceil(publishedCanteenCount / limit)"
-        :total-visible="5"
+        :total-visible="7"
       ></v-pagination>
     </div>
     <div v-else class="d-flex flex-column align-center py-10">


### PR DESCRIPTION
To recreate bugs:

- navigate to page x in /nos-cantines, click on a canteen then click back. You get redirected to page 1 instead of x
- change order of results to ascending with arrow next to selection, navigate to canteen and click back. You get results descending.

Changed page options so that can always see 'neighbouring' pages:
![Screenshot 2021-11-15 at 15 33 00](https://user-images.githubusercontent.com/9282816/141806405-8c66e554-3479-4a8b-bd37-54e4fcf8b95a.png)

![Screenshot 2021-11-15 at 15 33 06](https://user-images.githubusercontent.com/9282816/141806415-d257d636-73ca-4a51-9118-b31e412cf51e.png)
