### PR TITLE
Validation de taille maximale pour import de CSV

### DIFF
--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -106,7 +106,6 @@ class ImportDiagnosticsView(APIView):
         diagnostics_created = 0
         canteens = {}
         errors = []
-        # TODO: make sure won't overflow memory with a big file
 
         filestring = file.read().decode("utf-8-sig")
         dialect = csv.Sniffer().sniff(filestring[:1024])

--- a/frontend/src/views/DiagnosticsImporter/FileDrop.vue
+++ b/frontend/src/views/DiagnosticsImporter/FileDrop.vue
@@ -66,6 +66,9 @@ export default {
       required: true,
       type: String,
     },
+    maxSize: {
+      required: false,
+    },
     value: {
       type: File,
     },
@@ -89,12 +92,14 @@ export default {
       if (this.disabled) return
       const file = e.dataTransfer?.files[0]
       this.isDragging = false
-      this.$emit("input", file)
+      if (this.sizeIsValid(file)) this.$emit("input", file)
+      else this.clearFile()
     },
     onFileInputChange(e) {
       if (this.disabled) return
       const file = e.target.files[0]
-      this.$emit("input", file)
+      if (this.sizeIsValid(file)) this.$emit("input", file)
+      else this.clearFile()
     },
     clearFile() {
       if (this.disabled) return
@@ -107,6 +112,12 @@ export default {
     openFileChooser() {
       if (this.disabled) return
       if (!this.hasFile) this.$refs["csv-file-upload"].click()
+    },
+    sizeIsValid(file) {
+      if (!this.maxSize) return true
+      const sizeIsValid = parseInt(file.size) < this.maxSize
+      if (!sizeIsValid) window.alert("Ce fichier est trop grand, merci d'utiliser un fichier de moins de 10Mo")
+      return sizeIsValid
     },
   },
 }

--- a/frontend/src/views/DiagnosticsImporter/index.vue
+++ b/frontend/src/views/DiagnosticsImporter/index.vue
@@ -25,6 +25,7 @@
       v-model="file"
       subtitle="Format CSV encodé en UTF-8 attendu"
       :acceptTypes="['.csv', 'text/csv', '.tsv', 'text/tsv']"
+      maxSize="10485760"
       @upload="upload"
       :disabled="importInProgress"
     />

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -315,3 +315,6 @@ if DEBUG_PERFORMANCE:
     INTERNAL_IPS.append("127.0.0.1")
     INSTALLED_APPS.append("debug_toolbar")
     MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+
+# Maximum CSV import file size: 10Mo
+CSV_IMPORT_MAX_SIZE = 10485760


### PR DESCRIPTION
Pour commencer la taille maximale serait de 10Mo (~100k lignes). Cela devrait suffire largement et ne met pas en péril le serveur de prod.

L’intérêt de le mettre en `settings.py` c'est de pouvoir créer des tests en faisant un `override_settings`.