### PR TITLE
Remarques UX des statistiques régionales

### DIFF
--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -71,7 +71,8 @@
                   : "s ont publié leurs données (répertoriées dans"
               }}
               <!-- eslint-disable-next-line prettier/prettier-->
-              <router-link :to="{ name: 'CanteensHome' }">nos cantines</router-link>).
+              <router-link :to="{ name: 'CanteensHome' }">nos cantines</router-link>
+              ).
             </p>
           </div>
           <VueApexCharts
@@ -314,6 +315,11 @@ export default {
     statsLevelDisplay() {
       return { department: "ce département", region: "cette région", site: "ce site" }[this.statsLevel]
     },
+    chosenRegionName() {
+      return this.chosenRegion
+        ? jsonRegions.find((region) => region.regionCode === this.chosenRegion).regionName || this.chosenRegion
+        : null
+    },
   },
   methods: {
     loadLocations() {
@@ -341,10 +347,8 @@ export default {
           value: x[`${locationKeyWord}Code`],
         }))
 
-      const includeDisabledDepartments = !this.chosenRegion || locationKeyWord === "region"
-      if (!includeDisabledDepartments) return enabledLocations
-
-      const headerText = `Nous n'avons pas encore d'établissements dans ces ${locationsWord} :`
+      let headerText = this.chosenRegion ? `Pour la région « ${this.chosenRegionName} », nous ` : "Nous "
+      headerText += `n'avons pas encore d'établissements dans ces ${locationsWord} :`
       const header = { header: headerText }
       const divider = { divider: true }
 
@@ -373,7 +377,7 @@ export default {
           jsonDepartments.find((department) => department.departmentCode === this.chosenDepartment).departmentName
         } »`
       } else if (this.chosenRegion) {
-        locationText = `« ${jsonRegions.find((region) => region.regionCode === this.chosenRegion).regionName} »`
+        locationText = `« ${this.chosenRegionName} »`
       } else {
         locationText = this.defaultLocationText
       }
@@ -410,7 +414,9 @@ export default {
     },
     populateInitialParameters() {
       this.chosenDepartment = this.$route.query.department
-      this.chosenRegion = this.$route.query.region
+      this.chosenRegion = this.chosenDepartment
+        ? jsonDepartments.find((department) => department.departmentCode === this.chosenDepartment).regionCode
+        : this.$route.query.region
     },
     updateDocumentTitle() {
       let title = "Les statistiques dans ma collectivité - ma-cantine.beta.gouv.fr"

--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -405,7 +405,8 @@ export default {
       let query = {}
       if (this.chosenDepartment) {
         query.department = this.chosenDepartment
-      } else if (this.chosenRegion) {
+      }
+      if (this.chosenRegion) {
         query.region = this.chosenRegion
       }
       // The empty catch is the suggested error management here : https://github.com/vuejs/vue-router/issues/2872#issuecomment-519073998
@@ -416,9 +417,7 @@ export default {
     },
     populateInitialParameters() {
       this.chosenDepartment = this.$route.query.department
-      this.chosenRegion = this.chosenDepartment
-        ? jsonDepartments.find((department) => department.departmentCode === this.chosenDepartment).regionCode
-        : this.$route.query.region
+      this.chosenRegion = this.$route.query.region
     },
     updateDocumentTitle() {
       let title = "Les statistiques dans ma collectivité - ma-cantine.beta.gouv.fr"

--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -346,7 +346,10 @@ export default {
           value: x[`${locationKeyWord}Code`],
         }))
 
-      let headerText = this.chosenRegion ? `Pour la région « ${this.chosenRegionName} », nous ` : "Nous "
+      let headerText =
+        this.chosenRegion && locationKeyWord == "department"
+          ? `Pour la région « ${this.chosenRegionName} », nous `
+          : "Nous "
       headerText += `n'avons pas encore d'établissements dans ces ${locationsWord} :`
       const header = { header: headerText }
       const divider = { divider: true }

--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -71,8 +71,7 @@
                   : "s ont publié leurs données (répertoriées dans"
               }}
               <!-- eslint-disable-next-line prettier/prettier-->
-              <router-link :to="{ name: 'CanteensHome' }">nos cantines</router-link>
-              ).
+              <router-link :to="{ name: 'CanteensHome' }">nos cantines</router-link>).
             </p>
           </div>
           <VueApexCharts

--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -1,54 +1,60 @@
 <template>
   <div class="text-left grey--text text--darken-4">
     <h1 class="text-h4 font-weight-black black--text mt-3 mb-6">Découvrir les démarches chez vous</h1>
-    <!-- Add some introductory text? -->
-    <v-form class="my-4 pb-8">
-      <v-row>
-        <v-col cols="12" sm="6" md="4">
-          <label for="select-region" class="text-body-2">
-            Région
-          </label>
-          <v-autocomplete
-            v-model="chosenRegion"
-            :items="regions"
-            clearable
-            hide-details
-            id="select-region"
-            placeholder="Toutes les régions"
-            class="mt-1"
-            outlined
-            dense
-            auto-select-first
-            :filter="locationFilter"
-          ></v-autocomplete>
-        </v-col>
-        <v-col cols="12" sm="6" md="4">
-          <label for="select-department" class="text-body-2">
-            Département
-          </label>
-          <v-autocomplete
-            v-model="chosenDepartment"
-            :items="departments"
-            clearable
-            hide-details
-            id="select-department"
-            placeholder="Tous les départements"
-            class="mt-1"
-            outlined
-            dense
-            auto-select-first
-            :filter="locationFilter"
-          ></v-autocomplete>
-        </v-col>
-        <v-col cols="12" sm="6" md="4" class="d-flex align-end">
-          <v-btn x-large color="primary" @click="updateRoute">
-            Afficher les statistiques
-          </v-btn>
-        </v-col>
-      </v-row>
-    </v-form>
+
+    <v-card outlined>
+      <v-card-text>
+        <v-form class="my-4">
+          <v-row>
+            <v-col class="py-0" cols="12" sm="6" md="4">
+              <label for="select-region" class="text-body-2">
+                Région
+              </label>
+              <v-autocomplete
+                v-model="chosenRegion"
+                :items="regions"
+                clearable
+                hide-details
+                id="select-region"
+                placeholder="Toutes les régions"
+                class="mt-1"
+                outlined
+                dense
+                auto-select-first
+                :filter="locationFilter"
+              ></v-autocomplete>
+            </v-col>
+            <v-col class="py-2 py-sm-0" cols="12" sm="6" md="4">
+              <label for="select-department" class="text-body-2">
+                Département
+              </label>
+              <v-autocomplete
+                v-model="chosenDepartment"
+                :items="departments"
+                clearable
+                hide-details
+                id="select-department"
+                placeholder="Tous les départements"
+                class="mt-1"
+                outlined
+                dense
+                auto-select-first
+                :filter="locationFilter"
+              ></v-autocomplete>
+            </v-col>
+          </v-row>
+          <v-row class="mt-8">
+            <v-col cols="12" sm="6" md="4">
+              <v-btn x-large color="primary" @click="updateRoute">
+                Afficher les statistiques
+              </v-btn>
+            </v-col>
+          </v-row>
+        </v-form>
+      </v-card-text>
+    </v-card>
     <div v-if="locationText" class="py-8">
-      <h2 class="text-h5 font-weight-bold mb-8">Les statistiques pour « {{ locationText }} »</h2>
+      <h2 class="text-h5 font-weight-bold mb-8">Les statistiques pour {{ locationText }}</h2>
       <v-row :class="{ 'flex-column': $vuetify.breakpoint.smAndDown }">
         <v-col cols="12" md="6" class="pr-0">
           <div id="published-canteen-text" class="mb-5">
@@ -216,7 +222,7 @@ export default {
       loadedDepartmentIds: [],
       loadedRegionIds: [],
       sectorChartTitle: "Nombre de cantines par secteur",
-      defaultLocationText: "ma cantine",
+      defaultLocationText: "l'ensemble de la plateforme",
       statsLevel: "site",
     }
   },
@@ -334,9 +340,12 @@ export default {
           text: `${x[`${locationKeyWord}Code`]} - ${x[`${locationKeyWord}Name`]}`,
           value: x[`${locationKeyWord}Code`],
         }))
+
+      const includeDisabledDepartments = !this.chosenRegion || locationKeyWord === "region"
+      if (!includeDisabledDepartments) return enabledLocations
+
       const headerText = `Nous n'avons pas encore d'établissements dans ces ${locationsWord} :`
       const header = { header: headerText }
-
       const divider = { divider: true }
 
       const disabledLocations = jsonLocations
@@ -360,10 +369,11 @@ export default {
     createLocationText() {
       let locationText
       if (this.chosenDepartment) {
-        locationText = jsonDepartments.find((department) => department.departmentCode === this.chosenDepartment)
-          .departmentName
+        locationText = `« ${
+          jsonDepartments.find((department) => department.departmentCode === this.chosenDepartment).departmentName
+        } »`
       } else if (this.chosenRegion) {
-        locationText = jsonRegions.find((region) => region.regionCode === this.chosenRegion).regionName
+        locationText = `« ${jsonRegions.find((region) => region.regionCode === this.chosenRegion).regionName} »`
       } else {
         locationText = this.defaultLocationText
       }


### PR DESCRIPTION
1- Délimitation visuelle du formulaire et repositionnement du bouton  : 
![image](https://user-images.githubusercontent.com/1225929/152372698-d49d598a-31e8-4dfa-95ed-648799273bda.png)

2- Formulation "Les statistiques pour l'ensemble de la plateforme" lorsqu'aucun territoire n'est sélectionné :
![image](https://user-images.githubusercontent.com/1225929/152372848-07744759-ccd6-4fed-bfb9-ef81d439dcc1.png)

3- Enlève la formulation "_Nous n'avons pas encore d'établissements dans ces départements_"  lorsqu’une région est choisie : 
![image](https://user-images.githubusercontent.com/1225929/152373069-6f589037-14bd-4029-82cb-888a94c0f2e0.png)

![image](https://user-images.githubusercontent.com/1225929/152373112-494754bc-51dd-4422-b323-b97e04ce0308.png)
