### PR TITLE
Adds w3.org for xmlns attributes in svgs

### DIFF
--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -374,6 +374,7 @@ CSP_IMG_SRC = (
     "voxusagers.numerique.gouv.fr",
     "'unsafe-inline'",
     "stats.data.gouv.fr",
+    "www.w3.org",
 )
 if DEBUG:
     CSP_IMG_SRC += CSP_DEBUG_DOMAINS


### PR DESCRIPTION
Petite addition à la liste des domaines pour les images : "www.w3.org"

La raison : le paramètre `xmlns` dans nos fichiers SVGs : https://stackoverflow.com/questions/18467982/are-svg-parameters-such-as-xmlns-and-version-needed