### PR TITLE
Feature flag for the XP reservation feature

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -84,6 +84,11 @@ TRELLO_LIST_ID_PUBLICATION= Optionnel - ID de la liste où l'application mettra 
 PIPEDRIVE_API_TOKEN= Optionnel - Token Pipedrive pour créer des cartes contact.
 ```
 
+### Activer les feature flags
+```
+ENABLE_XP_RESERVATION= Optionnel - `True` pour activer la feature de l'expérimentation des systèmes de réservation.
+```
+
 #### Trello
 
 Si vous ne connaissez pas les variables trello, suivez [ce guide](https://developer.atlassian.com/cloud/trello/guides/rest-api/api-introduction/) pour identifier votre clé et token.

--- a/frontend/src/components/KeyMeasureDiagnostic/WasteMeasure.vue
+++ b/frontend/src/components/KeyMeasureDiagnostic/WasteMeasure.vue
@@ -274,7 +274,7 @@ export default {
       return applicableDiagnosticRules(this.canteen)
     },
     showExpeSegment() {
-      return !!this.canteen
+      return !!this.canteen && window.ENABLE_XP_RESERVATION
     },
   },
   methods: {

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -412,3 +412,6 @@ if DEBUG:
 CSP_FRAME_SRC = ("'self'",)
 if DEBUG:
     CSP_FRAME_SRC += CSP_DEBUG_DOMAINS
+
+# Feature flags
+ENABLE_XP_RESERVATION = os.getenv("ENABLE_XP_RESERVATION") == "True"

--- a/web/templates/vue-app.html
+++ b/web/templates/vue-app.html
@@ -1,6 +1,7 @@
 {% load static %}
 {% load analytics %}
 {% load environment %}
+{% load featureflags %}
 {% load render_bundle from webpack_loader %}
 <!DOCTYPE html>
 <html lang="en">
@@ -19,6 +20,7 @@
         window.CSRF_TOKEN = "{{ csrf_token }}";
         window.MATOMO_ID = "{% matomo_id %}";
         window.ENVIRONMENT = "{% environment %}"
+        window.ENABLE_XP_RESERVATION = "{% enable_xp_reservation %}" === "True"
     </script>
     <style>
         @font-face {

--- a/web/templatetags/featureflags.py
+++ b/web/templatetags/featureflags.py
@@ -1,0 +1,9 @@
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+
+@register.simple_tag
+def enable_xp_reservation():
+    return getattr(settings, "ENABLE_XP_RESERVATION", "")


### PR DESCRIPTION
Permet de déployer la fonctionnalité de l'expérimentation dans certaines environnements. Utile pour le rendre visible en staging et non pas en prod ni demo.

Ce commit peut se reverter net une fois que la fonctionnalité soit validée.