### PR TITLE
Adds Celery to the project for the management of asynchronous tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ celerybeat-schedule.db
 .clever.json
 
 .vscode/*.code-snippets
+
+# Celery
+celerybeat-schedule
+celerybeat-schedule.db

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -82,6 +82,7 @@ TRELLO_API_TOKEN= Optionnel - Permet la création de cartes Trello suite à une 
 TRELLO_LIST_ID_CONTACT= Optionnel - ID de la liste où l'application mettra des cartes suite à une demande de contact de la part de l'utilistauer. Conseils en-dessous pour l'obtenir.
 TRELLO_LIST_ID_PUBLICATION= Optionnel - ID de la liste où l'application mettra des cartes suite à une demande de publication de la part de l'utilistauer. Conseils en-dessous pour l'obtenir.
 PIPEDRIVE_API_TOKEN= Optionnel - Token Pipedrive pour créer des cartes contact.
+REDIS_URL= Optionnel - L'instance redis à utiliser pour les tâches asynchrones. Cette fonctionnalité n'est pas encore utilisée. Par exemple : 'redis://localhost:6379/0'
 ```
 
 ### Activer les feature flags
@@ -185,3 +186,9 @@ Il faut néanmoins tenir en compte que la mise en page ne sera pas visible et qu
 ### 2- Utiliser Maildev
 
 [Maildev](https://maildev.github.io/maildev/) est un outil ouvert qui exécute un serveur SMTP en local et qui permet de visualiser tous les emails traités. En l'installant de façon globale on peut mettre 'django.core.mail.backends.smtp.EmailBackend' comme variable d'environnement `EMAIL_BACKEND` pour l'utiliser.
+
+### Celery
+
+Celery est un gestionnaire de tâches asynchrone. À l'heure actuelle il n'est pas utilisé, mais le roadmap prévoit la mise en place de tâches récurrentes. Pour l'utiliser, un serveur redis est nécessaire.
+
+Pour staging/demo/prod, le chemin du fichier d'instantiation de Celery doit être spéficié dans la console CleverCloud sous la variable `CC_PYTHON_CELERY_MODULE=macantine.celery`. La fonctionnalité Celery Beat doit aussi être activée : `CC_PYTHON_CELERY_USE_BEAT=true`, ainsi que le timezone souhaité : `CELERY_TIMEZONE:'Europe/Paris'`

--- a/macantine/celery.py
+++ b/macantine/celery.py
@@ -1,0 +1,19 @@
+import os
+import dotenv
+from celery import Celery
+
+# from celery.schedules import crontab
+
+dotenv.load_dotenv()
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "macantine.settings")
+
+app = Celery("macantine", broker=os.getenv("REDIS_URL"), backend=os.getenv("REDIS_URL"), include=["macantine.tasks"])
+
+# Exemple task configuration
+# app.conf.beat_schedule = {"hello_world": {"task": "macantine.tasks.hello_world", "schedule": crontab(minute="*/1")}}
+
+app.conf.beat_schedule = {}
+app.conf.timezone = "Europe/Paris"
+
+if __name__ == "__main__":
+    app.start()

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -1,0 +1,11 @@
+##############################################
+# Insert Celery tasks here using @app.task()
+# Example below
+##############################################
+
+# from .celery import app
+
+
+# @app.task()
+# def hello_world():
+#     print("Hello ma cantine!")


### PR DESCRIPTION
Ajout de Celery pour les tâches asynchrones.

Pour l'instant seule l’échafaudage est en place. Pour implémenter une première fonctionnalité dessus il faudrait :
- Ajouter un add-on redis (peut être commun à staging/prod, mais en vrai pas sur que ça soit une fonctionnalité qu'on ait envie d'avoir ailleurs qu'en prod)
- Ajouter les variables d'environnement précisées dans ONBOARDING.md dans l'instance souhaitée
