### PR TITLE
Améliorer UI de cartes de la page d'accueil

### DIFF
--- a/frontend/src/views/LandingPage/ActionsBlock.vue
+++ b/frontend/src/views/LandingPage/ActionsBlock.vue
@@ -6,7 +6,7 @@
         <v-hover>
           <template v-slot:default="{ hover }">
             <v-card
-              :elevation="hover ? 10 : 2"
+              :elevation="hover ? 6 : 2"
               :to="loggedUser ? { name: 'ManagementPage' } : undefined"
               :href="!loggedUser ? '/s-identifier' : undefined"
               class="fill-height pa-4 d-flex flex-column hover-transition"
@@ -39,7 +39,7 @@
         <v-hover>
           <template v-slot:default="{ hover }">
             <v-card
-              :elevation="hover ? 10 : 2"
+              :elevation="hover ? 6 : 2"
               :to="{ name: 'CanteensHome' }"
               class="fill-height pa-4 d-flex flex-column hover-transition"
             >
@@ -69,7 +69,7 @@
         <v-hover>
           <template v-slot:default="{ hover }">
             <v-card
-              :elevation="hover ? 10 : 2"
+              :elevation="hover ? 6 : 2"
               :to="{ name: 'PublicCanteenStatisticsPage' }"
               class="fill-height pa-4 d-flex flex-column hover-transition"
             >


### PR DESCRIPTION
Having replaced the elevation UI logic for the landing page cards to make the hover more obvious, I lost the nice transition for the shadow present by default on v-cards. I copied the styling from a v-card in the CSS here. Figured I'd create a PR to highlight this hackiness...