### PR TITLE
Allows downloading an Excel file with the purchases

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -14,5 +14,5 @@ from .blogpost import BlogPostSerializer  # noqa: F401
 from .password import PasswordSerializer  # noqa: F401
 from .managerinvitation import ManagerInvitationSerializer  # noqa: F401
 from .teledeclaration import ShortTeledeclarationSerializer  # noqa: F401
-from .purchase import PurchaseSerializer, PurchaseSummarySerializer  # noqa: F401
+from .purchase import PurchaseSerializer, PurchaseSummarySerializer, PurchaseExportSerializer  # noqa: F401
 from .reservationexpe import ReservationExpeSerializer  # noqa: F401

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -40,3 +40,23 @@ class PurchaseSummarySerializer(serializers.Serializer):
     hve = serializers.DecimalField(max_digits=20, decimal_places=2, required=False)
     aoc_aop_igp = serializers.DecimalField(max_digits=20, decimal_places=2, required=False)
     rouge = serializers.DecimalField(max_digits=20, decimal_places=2, required=False)
+
+
+class PurchaseExportSerializer(serializers.ModelSerializer):
+    canteen = serializers.SlugRelatedField(read_only=True, slug_field="name")
+
+    class Meta:
+        model = Purchase
+        fields = (
+            "date",
+            "canteen",
+            "description",
+            "provider",
+            "readable_category",
+            "readable_characteristics",
+            "price_ht",
+        )
+        read_only_fields = fields
+
+    def get_category():
+        return

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -370,3 +370,33 @@ class TestPurchaseApi(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.json().get("results", [])
         self.assertEqual(len(results), 0)
+
+    def test_csv_export_unauthenticated(self):
+        response = self.client.get(reverse("purchase_list_export"))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_csv_export(self):
+        canteen = CanteenFactory.create()
+        canteen.managers.add(authenticate.user)
+        PurchaseFactory.create(description="avoine", canteen=canteen)
+        PurchaseFactory.create(description="tomates", canteen=canteen)
+        PurchaseFactory.create(description="pommes", canteen=canteen)
+
+        response = self.client.get(reverse("purchase_list_export"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 3)
+
+    @authenticate
+    def test_csv_export_search(self):
+        canteen = CanteenFactory.create()
+        canteen.managers.add(authenticate.user)
+        PurchaseFactory.create(description="avoine", canteen=canteen)
+        PurchaseFactory.create(description="tomates", canteen=canteen)
+        PurchaseFactory.create(description="pommes", canteen=canteen)
+
+        search_term = "avoine"
+        response = self.client.get(f"{reverse('purchase_list_export')}?search={search_term}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)

--- a/api/urls.py
+++ b/api/urls.py
@@ -19,7 +19,7 @@ from api.views import ImportDiagnosticsView, TeledeclarationCreateView
 from api.views import TeledeclarationCancelView, TeledeclarationPdfView
 from api.views import PublishCanteenView, UnpublishCanteenView, SendCanteenNotFoundEmail
 from api.views import UserCanteenPreviews, CanteenLocationsView
-from api.views import ReservationExpeView
+from api.views import ReservationExpeView, PurchaseListExportView
 
 
 urlpatterns = {
@@ -107,6 +107,11 @@ urlpatterns = {
         "purchases/",
         PurchaseListCreateView.as_view(),
         name="purchase_list_create",
+    ),
+    path(
+        "purchasesExport.xlsx",
+        PurchaseListExportView.as_view(),
+        name="purchase_list_export",
     ),
     path(
         "purchases/<int:pk>",

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -33,5 +33,6 @@ from .purchase import (  # noqa: F401
     PurchaseListCreateView,
     PurchaseRetrieveUpdateDestroyView,
     CanteenPurchasesSummaryView,
+    PurchaseListExportView,
 )
 from .reservationexpe import ReservationExpeView  # noqa: F401

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -1,14 +1,16 @@
 from rest_framework.generics import RetrieveUpdateDestroyAPIView, ListCreateAPIView
 from rest_framework import permissions
-from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.exceptions import NotFound, PermissionDenied, MethodNotAllowed
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from drf_excel.renderers import XLSXRenderer
+from drf_excel.mixins import XLSXFileMixin
 from django.core.exceptions import BadRequest, ObjectDoesNotExist
 from django.db.models import Sum, Q, Func, F
 from django.http import JsonResponse
 from api.permissions import IsLinkedCanteenManager, IsCanteenManager
-from api.serializers import PurchaseSerializer, PurchaseSummarySerializer
+from api.serializers import PurchaseSerializer, PurchaseSummarySerializer, PurchaseExportSerializer
 from data.models import Purchase, Canteen
 from .utils import CamelCaseOrderingFilter, UnaccentSearchFilter
 import logging
@@ -142,3 +144,25 @@ class CanteenPurchasesSummaryView(APIView):
             return canteen
         except Canteen.DoesNotExist as e:
             raise NotFound() from e
+
+
+class PurchaseListExportView(PurchaseListCreateView, XLSXFileMixin):
+    renderer_classes = (XLSXRenderer,)
+    pagination_class = None
+    serializer_class = PurchaseExportSerializer
+
+    column_header = {
+        "titles": [
+            "Date",
+            "Cantine",
+            "Description",
+            "Fournisseur",
+            "Catégorie",
+            "Caractéristiques",
+            "Prix HT",
+        ],
+        "column_width": [18, 25, 25, 20, 25, 25, 10],
+    }
+
+    def post(self, request, *args, **kwargs):
+        raise MethodNotAllowed()

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -70,3 +70,24 @@ class Purchase(models.Model):
         verbose_name="Prix HT",
     )
     invoice_file = models.FileField(null=True, blank=True, upload_to="invoices/%Y/")
+
+    @property
+    def readable_category(self):
+        if not self.category:
+            return None
+        try:
+            return Purchase.Category(self.category).label
+        except Exception:
+            return None
+
+    @property
+    def readable_characteristics(self):
+        if not self.characteristics:
+            return None
+        valid_characteristics = []
+        for characteristic in self.characteristics:
+            try:
+                valid_characteristics.append(Purchase.Characteristic(characteristic).label)
+            except Exception:
+                pass
+        return ", ".join(valid_characteristics) if valid_characteristics else None

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -25,7 +25,7 @@
       ></v-img>
     </div>
     <v-card outlined class="my-4" v-if="visiblePurchases">
-      <div class="d-flex pa-2">
+      <div class="d-flex flex-column flex-sm-row align-center pa-2">
         <v-text-field
           v-model="searchTerm"
           append-icon="mdi-magnify"
@@ -38,10 +38,15 @@
           @click:clear="clearSearch"
           @keyup.enter="search"
         ></v-text-field>
-        <v-btn outlined color="primary" class="mx-4" height="40px" @click="search">
+        <v-btn outlined color="primary" class="mx-4 my-4 my-sm-0" height="40px" @click="search">
           <v-icon>mdi-magnify</v-icon>
           Chercher
         </v-btn>
+        <v-spacer v-if="$vuetify.breakpoint.smAndUp"></v-spacer>
+        <a :href="exportUrl" class="primary--text body-2 mr-sm-4" download>
+          <v-icon class="mr-1" color="primary">mdi-microsoft-excel</v-icon>
+          Télécharger
+        </a>
       </div>
       <v-divider></v-divider>
       <v-data-table
@@ -119,6 +124,13 @@ export default {
         const hasAttachment = !!x.invoiceFile
         return Object.assign(x, { canteen__name: canteen?.name, date, hasAttachment })
       })
+    },
+    exportUrl() {
+      const orderingItems = this.getOrderingItems()
+      let exportUrl = `/api/v1/purchasesExport.xlsx?`
+      if (orderingItems.length > 0) exportUrl += `&ordering=${orderingItems.join(",")}`
+      if (this.searchTerm) exportUrl += `&search=${this.searchTerm}`
+      return exportUrl
     },
   },
   methods: {


### PR DESCRIPTION
L'export du fichier permet de télécharger ce qui est montré dans la table - et prend donc en compte la recherche et le triage. La pagination, par contre, n'est pas considérée dans l'export - çad que s'il y a 5 pages, toutes les 5 pages seront présentes dans le fichier Excel.