### PR TITLE
Allows specifying a random seed for tests

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -83,6 +83,7 @@ TRELLO_LIST_ID_CONTACT= Optionnel - ID de la liste où l'application mettra des 
 TRELLO_LIST_ID_PUBLICATION= Optionnel - ID de la liste où l'application mettra des cartes suite à une demande de publication de la part de l'utilistauer. Conseils en-dessous pour l'obtenir.
 PIPEDRIVE_API_TOKEN= Optionnel - Token Pipedrive pour créer des cartes contact.
 REDIS_URL= Optionnel - L'instance redis à utiliser pour les tâches asynchrones. Cette fonctionnalité n'est pas encore utilisée. Par exemple : 'redis://localhost:6379/0'
+OVERRIDE_TEST_SEED= Optionnel - `seed` utilisé par les tests pour les éléments aléatoires. Utile lors qu'un test échoue et qu'on veut reproduire exactement ce qu'il s'est passé.
 ```
 
 ### Activer les feature flags

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -419,3 +419,8 @@ if DEBUG:
 # Feature flags
 ENABLE_XP_RESERVATION = os.getenv("ENABLE_XP_RESERVATION") == "True"
 ENABLE_PARTNERS = os.getenv("ENABLE_PARTNERS") == "True"
+
+# Custom testing
+
+TEST_RUNNER = "macantine.testrunner.MaCantineTestRunner"
+OVERRIDE_TEST_SEED = os.getenv("OVERRIDE_TEST_SEED", None)

--- a/macantine/testrunner.py
+++ b/macantine/testrunner.py
@@ -1,0 +1,13 @@
+import factory.random
+from random import randint
+from django.conf import settings
+from django.test.runner import DiscoverRunner
+
+
+class MaCantineTestRunner(DiscoverRunner):
+    def setup_test_environment(self, **kwargs):
+        override_seed = settings.OVERRIDE_TEST_SEED
+        seed = int(override_seed) if override_seed else randint(0, 65535)
+        factory.random.reseed_random(seed)
+        print("Using seed: {}".format(seed))
+        super().setup_test_environment(**kwargs)


### PR DESCRIPTION
Désormais, lorsqu'on lance les tests on verra le `seed` utilisé pour les éléments aléatoires de FacotryBoy

```bash
> python manage.py test
Using seed: 46026
Found xxx test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
```

Si nos tests échouent, on peut les reproduire exactement en indiquant le `seed` dans la variable d'environnement `OVERRIDE_TEST_SEED`, par ex : 

```bash
# .env
...
OVERRIDE_TEST_SEED="46026"
...
```