### PR TITLE
Permet l'usage de la virgule comme separateur decimal

### DIFF
--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -7,6 +7,7 @@ class PurchaseSerializer(serializers.ModelSerializer):
 
     canteen = serializers.PrimaryKeyRelatedField(read_only=True)
     invoice_file = Base64FileField(required=False, allow_null=True)
+    price_ht = serializers.DecimalField(localize=True, max_digits=20, decimal_places=2)
 
     class Meta:
         model = Purchase


### PR DESCRIPTION
Plutôt que faire le changement coté front, l'API peut gérer la localisation de décimales présentés sous forme de string

![comma-separated-decimal](https://user-images.githubusercontent.com/1225929/157267374-a9197778-e3b6-4276-99b5-5b6b7989cd78.gif)
