### PR TITLE
Uses latest created diagnostic for publication data

### DIFF
--- a/frontend/src/components/CanteenPublication.vue
+++ b/frontend/src/components/CanteenPublication.vue
@@ -108,7 +108,7 @@
 
 <script>
 import labels from "@/data/quality-labels.json"
-import { lastYear, badges, getPercentage, isDiagnosticComplete } from "@/utils"
+import { lastYear, badges, getPercentage, isDiagnosticComplete, latestCreatedDiagnostic } from "@/utils"
 import MultiYearSummaryStatistics from "@/components/MultiYearSummaryStatistics"
 import ImageGallery from "@/components/ImageGallery"
 
@@ -119,13 +119,20 @@ export default {
   data() {
     return {
       labels,
-      publicationYear: lastYear(),
     }
   },
   components: { MultiYearSummaryStatistics, ImageGallery },
   computed: {
     diagnostic() {
-      return this.canteen.diagnostics.find((d) => d.year === this.publicationYear) || {}
+      if (this.canteen) return latestCreatedDiagnostic(this.canteen)
+      return undefined
+    },
+    publicationYear() {
+      if (this.canteen) {
+        const diagnostic = latestCreatedDiagnostic(this.canteen)
+        return diagnostic?.year
+      }
+      return undefined
     },
     bioPercent() {
       return getPercentage(this.diagnostic.valueBioHt, this.diagnostic.valueTotalHt)

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -178,6 +178,17 @@ export const diagnosticsMap = (diagnostics) => {
   }
 }
 
+export const latestCreatedDiagnostic = (canteen) => {
+  const minYear = 2016
+  const maxYear = lastYear()
+  let diagnostic = undefined
+  for (let year = maxYear; year >= minYear; year--) {
+    diagnostic = canteen.diagnostics.find((d) => d.year === year)
+    if (diagnostic) break
+  }
+  return diagnostic
+}
+
 export const getPercentage = (partialValue, totalValue) => {
   if (strictIsNaN(partialValue) || strictIsNaN(totalValue) || totalValue === 0) {
     return null

--- a/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
+++ b/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
@@ -11,9 +11,10 @@
       <CanteenIndicators :canteen="canteen" :singleLine="true" />
     </v-card-subtitle>
     <v-spacer></v-spacer>
-    <v-divider class="pb-2"></v-divider>
-    <div class="grey--text text--darken-2" :style="$vuetify.breakpoint.smAndDown ? '' : 'height: 73px;'">
+    <v-divider class="py-1"></v-divider>
+    <div class="grey--text text--darken-2" :style="$vuetify.breakpoint.smAndDown ? '' : 'height: 95px;'">
       <v-card-text class="py-1 fill-height d-flex flex-column" v-if="diagnostic">
+        <span>En {{ year }} :</span>
         <v-row class="ma-0" v-if="hasPercentages">
           <p class="ma-0 mr-3" v-if="bioPercent">
             <span class="font-weight-black mr-1">{{ bioPercent }} %</span>
@@ -40,7 +41,7 @@
       </v-card-text>
       <div v-else class="d-flex flex-column fill-height">
         <v-spacer></v-spacer>
-        <v-card-text class="py-1">Pas de données renseignées pour {{ publicationYear }}</v-card-text>
+        <v-card-text class="py-1">Pas de données renseignées</v-card-text>
         <v-spacer></v-spacer>
       </div>
     </div>
@@ -49,7 +50,7 @@
 
 <script>
 import CanteenIndicators from "@/components/CanteenIndicators"
-import { lastYear, getPercentage, isDiagnosticComplete, badges } from "@/utils"
+import { getPercentage, isDiagnosticComplete, badges, latestCreatedDiagnostic } from "@/utils"
 
 export default {
   name: "PublishedCanteenCard",
@@ -63,14 +64,13 @@ export default {
     CanteenIndicators,
   },
   data() {
+    const diagnostic = latestCreatedDiagnostic(this.canteen)
     return {
-      publicationYear: lastYear(),
+      diagnostic,
+      year: diagnostic?.year,
     }
   },
   computed: {
-    diagnostic() {
-      return this.canteen.diagnostics.find((d) => d.year === this.publicationYear)
-    },
     canteenBadges() {
       return badges(this.canteen, this.diagnostic, this.$store.state.sectors)
     },


### PR DESCRIPTION
Nous ne prenons pas systématiquement l'année en cours - 1 pour la publication, mais plutôt la dernière année pour laquelle un diagnostic a été créé

![image](https://user-images.githubusercontent.com/1225929/158794502-7ae8d8d3-b40b-408e-abe7-ec8aee4a1aac.png)

![image](https://user-images.githubusercontent.com/1225929/158794640-091581ef-59b6-40c7-81da-051f8c87a79d.png)

![image](https://user-images.githubusercontent.com/1225929/158794713-c8764bc2-5904-483c-9a3e-7d902e05a45e.png)

