### PR TITLE
Ne pas permettre la publication aux cantines sans diagnostic

### DIFF
--- a/frontend/src/components/DiagnosticIntroduction.vue
+++ b/frontend/src/components/DiagnosticIntroduction.vue
@@ -1,5 +1,5 @@
 <template>
-  <p>
+  <p class="body-1">
     Créez un diagnostic pour découvrir où vous en êtes des mesures EGAlim. Si vous le souhaitez, la création d'un
     diagnostic vous permettra également de mettre en avant votre cantine en la publiant sur
     <router-link :to="{ name: 'CanteensHome' }" class="text-decoration-underline primary--text">

--- a/frontend/src/views/CanteenEditor/CanteenDeletion.vue
+++ b/frontend/src/views/CanteenEditor/CanteenDeletion.vue
@@ -3,7 +3,7 @@
     <h1 class="font-weight-black text-h4 my-4">
       Supprimer ma cantine
     </h1>
-    <p class="body-2 mb-10">
+    <p class="body-1 mb-10">
       La suppression d'une cantine entraîne aussi celle des diagnostics associés. Aucun gestionnaire ne sera en mesure
       d'accéder aux données après la suppression.
     </p>

--- a/frontend/src/views/CanteenEditor/CanteenManagers.vue
+++ b/frontend/src/views/CanteenEditor/CanteenManagers.vue
@@ -3,7 +3,7 @@
     <h1 class="font-weight-black text-h4 my-4">
       Gestionnaires
     </h1>
-    <p class="body-2">
+    <p class="body-1">
       Tous les gestionnaires peuvent modifier et supprimer une cantine, ainsi qu'ajouter et enlever autres
       gestionnaires.
     </p>

--- a/frontend/src/views/CanteenEditor/PublicationForm.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="text-left">
     <h1 class="font-weight-black text-h4 my-4">Publier ma cantine</h1>
-    <div v-if="!canPublish">
+    <div v-if="isCentralCuisine">
       <p>
         « {{ originalCanteen.name }} » est une cuisine centrale sans lieu de consommation. La publication concerne
         <b>uniquement les lieux de restauration recevant des convives.</b>
@@ -29,6 +29,23 @@
           Retirer la publication
         </v-btn>
       </v-sheet>
+    </div>
+    <div v-else-if="isDraft && !hasDiagnostics">
+      <p>
+        Vous n'avez pas encore rempli des diagnostics pour « {{ originalCanteen.name }} ». Les diagnostics sont un
+        prérequis pour la publication
+      </p>
+      <v-btn
+        x-large
+        color="primary"
+        class="mt-4"
+        :to="{
+          name: 'NewDiagnosticForCanteen',
+          params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(originalCanteen) },
+        }"
+      >
+        Ajouter un diagnostic
+      </v-btn>
     </div>
     <div v-else>
       <v-alert color="amber darken-3" class="mb-1 body-2" v-if="!currentDiagnosticComplete" outlined>
@@ -180,8 +197,14 @@ export default {
     canteenUrlComponent() {
       return this.$store.getters.getCanteenUrlComponent(this.canteen)
     },
-    canPublish() {
-      return this.originalCanteen.productionType !== "central"
+    isCentralCuisine() {
+      return this.originalCanteen.productionType === "central"
+    },
+    hasDiagnostics() {
+      return this.originalCanteen.diagnostics && this.originalCanteen.diagnostics.length > 0
+    },
+    isDraft() {
+      return this.canteen.publicationStatus === "draft"
     },
   },
 }


### PR DESCRIPTION
Cette validation est faite uniquement dans la UI coté utilisateurs. Publier une cantine sans diagnostics reste possible depuis l'admin.

Les cantines sans diagnostics déjà puliées restent ainsi.

J'ai profité pour uniformiser la police des sous-titres de ces pages à `body-1`

![image](https://user-images.githubusercontent.com/1225929/158837850-8af6bb5a-45a7-4791-933d-fd9ba7e32f03.png)
