### PR TITLE
Fix du bug qui traite tous les 400-BadRequest comme un siret dupliqué

### DIFF
--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -483,8 +483,11 @@ export default {
         .catch((e) => {
           if (e.jsonPromise) {
             e.jsonPromise.then((json) => {
-              this.duplicateSiretCanteen = json
-              this.messageTroubleshooting = `Je veux ajouter une deuxième cantine avec le même SIRET : ${payload.siret}...`
+              const isDuplicateSiret = json.detail === "La resource que vous souhaitez créer existe déjà"
+              if (isDuplicateSiret) {
+                this.duplicateSiretCanteen = json
+                this.messageTroubleshooting = `Je veux ajouter une deuxième cantine avec le même SIRET : ${payload.siret}...`
+              }
             })
             this.$store.dispatch("notifyRequiredFieldsError")
           } else {


### PR DESCRIPTION
Aujourd'hui, tous les 400-BadRequests concernant l'endpoint /canteen/,,, sont interprétés par `CanteenForm.vue` comme un problème de Siret dupliqué. Vu que DRF utilise le 400-BadRequest pour communiquer des problèmes de validation, ça peut être problématique.

Cette PR vise à mieux cibler l'erreur afin d'être sur qu'il s'agit d'un Siret dupliqué avant de montrer l'encart.