### PR TITLE
Fix du bug lors de l'ajout de gestionnaire du aux espaces

### DIFF
--- a/api/tests/test_manager_invitations.py
+++ b/api/tests/test_manager_invitations.py
@@ -78,7 +78,7 @@ class TestManagerInvitationApi(APITestCase):
         """
         canteen = CanteenFactory.create()
         canteen.managers.add(authenticate.user)
-        payload = {"canteenId": canteen.id, "email": "test@example.com"}
+        payload = {"canteenId": canteen.id, "email": "  test@example.com"}
         response = self.client.post(reverse("add_manager"), payload)
         body = response.json()
 

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -301,7 +301,7 @@ class AddManagerView(APIView):
 
     def post(self, request, *args, **kwargs):
         try:
-            email = request.data.get("email")
+            email = request.data.get("email").strip() if request.data.get("email") else None
             validate_email(email)
             canteen_id = request.data.get("canteen_id")
             canteen = request.user.canteens.get(id=canteen_id)

--- a/frontend/src/views/CanteenEditor/CanteenManagers.vue
+++ b/frontend/src/views/CanteenEditor/CanteenManagers.vue
@@ -98,7 +98,7 @@ export default {
       this.$store
         .dispatch("addManager", {
           canteenId: this.originalCanteen.id,
-          email: this.newManagerEmail,
+          email: this.newManagerEmail.trim(),
         })
         .then((managementTeam) => {
           this.$store.dispatch("notify", {
@@ -119,7 +119,7 @@ export default {
       this.$store
         .dispatch("removeManager", {
           canteenId: this.originalCanteen.id,
-          email: manager.email,
+          email: manager.email.trim(),
         })
         .then((managementTeam) => {
           this.$store.dispatch("notify", {


### PR DESCRIPTION
Aujourd'hui si un utilisateur essaie d'ajouter un gestionnaire et par erreur met un espace dans le formulaire (e.g., "   test@example.com"), un erreur se produit.