### PR TITLE
Enlève le "/>" au début de l'affichage

### DIFF
--- a/web/templates/vue-app.html
+++ b/web/templates/vue-app.html
@@ -15,7 +15,7 @@
     <meta property="og:title" content="ma cantine" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="{% hostname %}{{ request.get_full_path }}" />
-    <meta property="og:description" content=" Pour une alimentation saine, de qualité et plus durable dans nos assiettes grâce à EGAlim"> />
+    <meta property="og:description" content=" Pour une alimentation saine, de qualité et plus durable dans nos assiettes grâce à EGAlim" />
     <meta property="og:image" content="{% hostname %}{% static 'images/card-social-media.png' %}" />
 
     <!-- Twitter meta tags -->


### PR DESCRIPTION
Aujourd'hui il y a un "/>" en haut à droite de l'écran les premiers instants de l'application. Cette mini PR l'enlève.