### PR TITLE
Remplissage automatique du nom d'utilistaeur

### DIFF
--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -46,6 +46,13 @@ class TestLoggedUserApi(APITestCase):
         self.assertIn("suggestion", body)
         self.assertEqual(body["suggestion"], "omar-khe_ting")
 
+    def test_username_generation_with_accents(self):
+        response = self.client.post(reverse("username_suggestion"), {"first_name": "Oscar", "last_name": "Abé"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = json.loads(response.content.decode())
+        self.assertIn("suggestion", body)
+        self.assertEqual(body["suggestion"], "oscar_abe")
+
     def test_with_email(self):
         response = self.client.post(reverse("username_suggestion"), {"email": "tester_12@example.com"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/web/templates/auth/register.html
+++ b/web/templates/auth/register.html
@@ -87,6 +87,44 @@
                 document.getElementById("id_creation_mtm_medium").setAttribute("value", readCookie("mtm_medium"))
         </script>
 
+        <script>
+            const firstNameField = document.getElementById("id_first_name")
+            const lastNameField = document.getElementById("id_last_name")
+            const usernameField = document.getElementById("id_username")
+            const emailField = document.getElementById("id_email")
+
+            function populateUsername() {
+                firstName = firstNameField.value
+                lastName = lastNameField.value
+                email = emailField.value
+
+                if (!(firstName && lastName) && !email)
+                    return
+                httpRequest = new XMLHttpRequest()
+                httpRequest.open('POST', '/api/v1/usernameSuggestion/', true)
+                httpRequest.setRequestHeader('Content-Type', 'application/json')
+                httpRequest.setRequestHeader('X-CSRFToken', '{{ csrf_token }}')
+                httpRequest.onreadystatechange = function() {
+                    if (this.readyState === XMLHttpRequest.DONE && this.status === 200) {
+                        const response = JSON.parse(httpRequest.responseText)
+                        usernameField.value = usernameField.value || response.suggestion
+                    }
+                }
+                httpRequest.send(JSON.stringify({
+                    firstName: firstName,
+                    lastName: lastName,
+                    email: email,
+                }))
+            }
+
+            if (firstNameField && lastNameField && emailField && usernameField) {
+                firstNameField.addEventListener("blur", populateUsername)
+                lastNameField.addEventListener("blur", populateUsername)
+                emailField.addEventListener("blur", populateUsername)
+            }
+
+        </script>
+
     </form>
     <a href="{% url 'login' %}"><button>J'ai déjà un compte</button></a>
 {% endblock %}

--- a/web/templates/auth/register.html
+++ b/web/templates/auth/register.html
@@ -94,6 +94,9 @@
             const emailField = document.getElementById("id_email")
 
             function populateUsername() {
+                if (!!usernameField.value)
+                    return
+
                 firstName = firstNameField.value
                 lastName = lastNameField.value
                 email = emailField.value


### PR DESCRIPTION
Le _username_ sera rempli seulement si le champ est vide. En cas d'erreur, on fail silencieusement. 

J'ai profité pour normaliser et traiter les accents dans les suggestions.

![username_generation](https://user-images.githubusercontent.com/1225929/167383904-7038f9f8-8d52-4392-9e65-634ef8fc37e9.gif)
