### PR TITLE
i18n du texte autocomplete pour manque de résultats

### DIFF
--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -138,6 +138,7 @@
             auto-select-first
             cache-items
             v-model="cityAutocompleteChoice"
+            no-data-text="Pas de résultats. Veuillez renseigner votre ville"
           ></v-autocomplete>
         </v-col>
 

--- a/frontend/src/views/GeneratePosterPage/index.vue
+++ b/frontend/src/views/GeneratePosterPage/index.vue
@@ -37,6 +37,7 @@
               @change="onCanteenAutocompleteChange"
               item-text="name"
               item-value="id"
+              no-data-text="Pas de résultats"
             ></v-autocomplete>
           </v-col>
           <v-col class="my-0 my-sm-4 px-0 px-sm-4 d-flex justify-space-between">
@@ -144,6 +145,7 @@
               :rules="[validators.required]"
               solo
               class="my-4"
+              no-data-text="Pas de résultats"
             ></v-autocomplete>
           </p>
           <p>

--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -22,6 +22,7 @@
                 dense
                 auto-select-first
                 :filter="locationFilter"
+                no-data-text="Pas de résultats"
               ></v-autocomplete>
             </v-col>
             <v-col class="py-2 py-sm-0" cols="12" sm="6" md="4">
@@ -40,6 +41,7 @@
                 dense
                 auto-select-first
                 :filter="locationFilter"
+                no-data-text="Pas de résultats"
               ></v-autocomplete>
             </v-col>
             <v-col class="py-2 py-sm-0" cols="12" sm="6" md="4">

--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -80,6 +80,7 @@
                   id="canteen"
                   class="mt-2"
                   auto-select-first
+                  no-data-text="Pas de résultats"
                 ></v-autocomplete>
               </v-col>
 
@@ -179,6 +180,7 @@
               :rules="showLocalDefinition ? [validators.required] : []"
               id="local-definition"
               class="mt-2"
+              no-data-text="Pas de résultats"
             ></v-autocomplete>
           </v-col>
         </v-expand-transition>


### PR DESCRIPTION
Closes https://github.com/betagouv/ma-cantine/issues/1246

Affiche "Pas de résultats" au lieu de "No data available" dans les `v-autocomplete`.

J'ai décidé de ne pas utiliser `hide-no-data` pour que ça soit clair pour l'utilisateur que l'option n'est pas valide.

![image](https://user-images.githubusercontent.com/1225929/168106467-e9990d3e-3d0a-44ae-b631-5ef6c57a34f1.png)
