### PR TITLE
Cache la barre de recherche lorsqu'il y a moins de 6 cantines

### DIFF
--- a/frontend/src/views/ManagementPage/CanteensPagination.vue
+++ b/frontend/src/views/ManagementPage/CanteensPagination.vue
@@ -2,7 +2,7 @@
   <div>
     <v-sheet class="px-3 mt-6 mb-6" elevation="0">
       <v-row>
-        <v-col cols="12" md="7" class="pa-0">
+        <v-col cols="12" md="7" class="pa-0" v-if="showPagination">
           <form role="search" class="d-block d-sm-flex" onsubmit="return false">
             <v-text-field
               hide-details="auto"


### PR DESCRIPTION
Même logique que pour les éléments de pagination.

Plus de six cantines : 

![image](https://user-images.githubusercontent.com/1225929/168607922-75597443-2a0b-4364-baac-cdc6baebdc2d.png)

Moins de six cantines : 

![image](https://user-images.githubusercontent.com/1225929/168607994-9c0bc428-75b3-4f58-98d6-78961200de84.png)
