### PR TITLE
Ne permet plus la modification des diagnostics depuis admin cantine

### DIFF
--- a/data/admin/diagnostic.py
+++ b/data/admin/diagnostic.py
@@ -23,6 +23,13 @@ class DiagnosticInline(admin.TabularInline):
     fields = ("year", "creation_date")
     readonly_fields = fields
     extra = 0
+    can_delete = False
+
+    def has_add_permission(self, request, obj):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
 
 
 @admin.register(Diagnostic)


### PR DESCRIPTION
L'ajout et suppression du diagnostic avec notre validation custom ne permettent pas de gérer correctement les erreurs lorsque cette validation ne passe pas. 

Comme fix temporaire : seulement permettre la modification d'un diagnostic en admin depuis la page dediée. 