### PR TITLE
Revendication des cantines

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -53,6 +53,7 @@ class PublicCanteenSerializer(serializers.ModelSerializer):
     diagnostics = PublicDiagnosticSerializer(many=True, read_only=True, source="diagnostic_set")
     logo = Base64ImageField(required=False, allow_null=True)
     images = MediaListSerializer(child=CanteenImageSerializer(), read_only=True)
+    can_be_claimed = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Canteen
@@ -75,7 +76,11 @@ class PublicCanteenSerializer(serializers.ModelSerializer):
             "diversification_comments",
             "plastics_comments",
             "information_comments",
+            "can_be_claimed",
         )
+
+    def get_can_be_claimed(self, obj):
+        return not obj.managers.exists()
 
 
 class FullCanteenSerializer(serializers.ModelSerializer):

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -59,6 +59,3 @@ class PurchaseExportSerializer(serializers.ModelSerializer):
             "price_ht",
         )
         read_only_fields = fields
-
-    def get_category():
-        return

--- a/api/templates/canteen_claim.html
+++ b/api/templates/canteen_claim.html
@@ -1,7 +1,7 @@
 {% extends 'email_base.html' %}
 
 {% block content %}
-    <p>{{ name }} (nom d'utilisateur : {{username}}) veut revendiquer la cantine {{canteen_name}} (ID : {{canteen_id}}).</p>
+    <p>{{ name }} (nom d'utilisateur : {{ username }}) veut revendiquer la cantine {{ canteen_name }} (ID : {{ canteen_id }}).</p>
 
     <p>Si vous êtes d'accord, vous trouverez ici <a href="{{protocol}}://{{domain}}{% url 'admin:data_canteen_change' canteen_id %}">la page admin de la cantine</a> pour ajouter le gestionnare.</p>
 

--- a/api/templates/canteen_claim.html
+++ b/api/templates/canteen_claim.html
@@ -1,0 +1,10 @@
+{% extends 'email_base.html' %}
+
+{% block content %}
+    <p>{{ name }} (nom d'utilisateur : {{username}}) veut revendiquer la cantine {{canteen_name}} (ID : {{canteen_id}}).</p>
+
+    <p>Si vous êtes d'accord, vous trouverez ici <a href="{{protocol}}://{{domain}}{% url 'admin:data_canteen_change' canteen_id %}">la page admin de la cantine</a> pour ajouter le gestionnare.</p>
+
+    <p>Pour contacter {{ name }}, vous pouvez lui écrire à <a href="mailto:{{email}}">{{ email }}</a>.</p>
+
+{% endblock %}

--- a/api/tests/test_published_canteens.py
+++ b/api/tests/test_published_canteens.py
@@ -3,7 +3,9 @@ import datetime
 from datetime import date
 from django.urls import reverse
 from django.utils import timezone
+from django.core import mail
 from django.core.files import File
+from django.test.utils import override_settings
 from rest_framework.test import APITestCase
 from rest_framework import status
 from data.factories import CanteenFactory, SectorFactory
@@ -459,3 +461,34 @@ class TestPublishedCanteenApi(APITestCase):
 
         self.assertEqual(body.get("count"), 1)
         self.assertEqual(len(results[0].get("images")), 3)
+
+    def test_canteen_claim_value(self):
+        canteen = CanteenFactory.create(publication_status=Canteen.PublicationStatus.PUBLISHED.value)
+
+        # The factory creates canteens with managers
+        response = self.client.get(reverse("single_published_canteen", kwargs={"pk": canteen.id}))
+        body = response.json()
+        self.assertFalse(body.get("canBeClaimed"))
+
+        # Now we will remove the manager to change the claim API value
+        canteen.managers.clear()
+        response = self.client.get(reverse("single_published_canteen", kwargs={"pk": canteen.id}))
+        body = response.json()
+        self.assertTrue(body.get("canBeClaimed"))
+
+    @override_settings(DEFAULT_FROM_EMAIL="from@example.com")
+    @override_settings(CONTACT_EMAIL="contact@example.com")
+    @authenticate
+    def test_canteen_claim_request(self):
+        user = authenticate.user
+        canteen = CanteenFactory.create(publication_status=Canteen.PublicationStatus.PUBLISHED.value)
+        canteen.managers.clear()
+
+        response = self.client.post(reverse("claim_canteen", kwargs={"canteen_pk": canteen.id}), None)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertEqual(email.to[0], "contact@example.com")
+        self.assertIn(f"{user.get_full_name()} (nom d'utilisateur : {user.username})", email.body)
+        self.assertIn("veut revendiquer la cantine", email.body)
+        self.assertIn(f"{canteen.name} (ID : {canteen.id}).", email.body)

--- a/api/urls.py
+++ b/api/urls.py
@@ -134,7 +134,7 @@ urlpatterns = {
     path("usernameSuggestion/", UsernameSuggestionView.as_view(), name="username_suggestion"),
     path("reviews/", ReviewView.as_view(), name="create_review"),
     path("communityEvents/", CommunityEventsView.as_view(), name="community_event_list"),
-    path("claimCanteen/", ClaimCanteenView.as_view(), name="claim_canteen"),
+    path("canteens/<int:canteen_pk>/claim/", ClaimCanteenView.as_view(), name="claim_canteen"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/urls.py
+++ b/api/urls.py
@@ -21,8 +21,7 @@ from api.views import PublishCanteenView, UnpublishCanteenView, SendCanteenNotFo
 from api.views import UserCanteenPreviews, CanteenLocationsView
 from api.views import ReservationExpeView, PurchaseListExportView, PurchaseOptionsView, ImportPurchasesView
 from api.views import MessageCreateView, VegetarianExpeView, TeamJoinRequestView
-from api.views import ReviewView
-from api.views import CommunityEventsView
+from api.views import ReviewView, CommunityEventsView, ClaimCanteenView
 
 
 urlpatterns = {
@@ -135,6 +134,7 @@ urlpatterns = {
     path("usernameSuggestion/", UsernameSuggestionView.as_view(), name="username_suggestion"),
     path("reviews/", ReviewView.as_view(), name="create_review"),
     path("communityEvents/", CommunityEventsView.as_view(), name="community_event_list"),
+    path("claimCanteen/", ClaimCanteenView.as_view(), name="claim_canteen"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -13,6 +13,7 @@ from .canteen import (  # noqa: F401
     CanteenStatisticsView,
     CanteenLocationsView,
     TeamJoinRequestView,
+    ClaimCanteenView,
 )
 from .diagnostic import (  # noqa: F401
     DiagnosticCreateView,

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -682,6 +682,12 @@ export default new Vuex.Store({
           throw e
         })
     },
+
+    claimCanteen(context, { payload }) {
+      return fetch("/api/v1/claimCanteen/", { method: "POST", headers, body: JSON.stringify(payload) }).then(
+        verifyResponse
+      )
+    },
   },
 
   getters: {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -683,10 +683,8 @@ export default new Vuex.Store({
         })
     },
 
-    claimCanteen(context, { payload }) {
-      return fetch("/api/v1/claimCanteen/", { method: "POST", headers, body: JSON.stringify(payload) }).then(
-        verifyResponse
-      )
+    claimCanteen(context, { canteenId }) {
+      return fetch(`/api/v1/canteens/${canteenId}/claim/`, { method: "POST", headers }).then(verifyResponse)
     },
   },
 

--- a/frontend/src/views/CanteensPage/CanteenPage.vue
+++ b/frontend/src/views/CanteensPage/CanteenPage.vue
@@ -50,13 +50,13 @@
         <v-alert colored-border color="primary" elevation="2" border="left" type="info" v-else>
           <div>Cet établissement n'a pas de gestionnaire associé. C'est votre établissement ?</div>
           <div v-if="loggedUser" class="mt-2">
-            <v-btn @click="claimCanteen" outlined color="primary">Revendiquer cet établissement</v-btn>
+            <v-btn @click="claimCanteen" outlined color="primary">Rejoindre cet établissement</v-btn>
           </div>
           <div v-else>
             <a :href="`/creer-mon-compte?next=${currentPage}`">Créez votre compte</a>
             ou
             <a :href="`/s-identifier?next=${currentPage}`">connectez-vous</a>
-            pour le revendiquer.
+            pour le rejoindre.
           </div>
         </v-alert>
       </div>

--- a/frontend/src/views/CanteensPage/CanteenPage.vue
+++ b/frontend/src/views/CanteensPage/CanteenPage.vue
@@ -122,15 +122,9 @@ export default {
       if (canteen) document.title = `${this.canteen.name} - ${this.$store.state.pageTitleSuffix}`
     },
     claimCanteen() {
-      const payload = {
-        email: this.loggedUser.email,
-        name: `${this.loggedUser.firstName} ${this.loggedUser.lastName}`,
-        username: this.loggedUser.username,
-        canteen: { name: this.canteen.name, id: this.canteen.id },
-      }
-
+      const canteenId = this.canteen.id
       return this.$store
-        .dispatch("claimCanteen", { payload })
+        .dispatch("claimCanteen", { canteenId })
         .then(() => (this.claimSucceeded = true))
         .catch((e) => this.$store.dispatch("notifyServerError", e))
     },

--- a/web/views.py
+++ b/web/views.py
@@ -47,8 +47,11 @@ class RegisterUserView(FormView):
             self.success_url = reverse_lazy("registration_email_sent_error", kwargs={"username": username})
             return super().form_valid(form)
         else:
-            has_canteens = not self.request.user.is_anonymous and self.request.user.canteens.count() > 0
-            self.success_url = reverse_lazy("app") if has_canteens else "/nouvelle-cantine"
+            if self.request.GET.get("next"):
+                self.success_url = self.request.GET.get("next")
+            else:
+                has_canteens = not self.request.user.is_anonymous and self.request.user.canteens.count() > 0
+                self.success_url = reverse_lazy("app") if has_canteens else "/nouvelle-cantine"
             return super().form_valid(form)
 
 


### PR DESCRIPTION
Lorsqu'on n'est pas identifiés (à noter qu'une redirection vers la page de la cantine est faite après la création de compte ou l'identification) :
![image](https://user-images.githubusercontent.com/1225929/172817456-0481404d-a790-4f25-afd6-c050ab2d1a2c.png)

Lorsqu'on est bien identifiés :
![image](https://user-images.githubusercontent.com/1225929/172817390-11073390-9bd8-4b97-9bcd-31de40afa9dd.png)

Lorsque la requête est bien partie :
![image](https://user-images.githubusercontent.com/1225929/172817574-43139ea6-fe2d-4edf-b708-5b16832e677f.png)

Email reçu par l'équipe (contient des liens vers l'admin de la cantine en question) : 
![image](https://user-images.githubusercontent.com/1225929/172817734-adb3a001-dab7-418b-9ba9-4c1a97225862.png)

Ce qui n'est pas fait mais qui pourra se faire dans un deuxième temps si le besoin est là :
- Un suivi de qui à revendiqué quelle cantine : cela permettrait de ne pas remontrer le bouton _Rejoindre cet établissement_ après un refresh. Ça ne me semble pas très important et ça pourrait empêcher l'utilisateur de relancer une demande.
- La création de compte n'indique pas que l'utilisateur est venu de cette page. Cela dit, on aura une idée de l'utilisation du bouton car on recevra des emails