### PR TITLE
Bug fix ordre webinaire

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -27,7 +27,7 @@ import AppFooter from "@/components/AppFooter"
 import WebinaireBanner from "@/components/WebinaireBanner"
 import NotificationSnackbar from "@/components/NotificationSnackbar"
 import Constants from "@/constants"
-import { readCookie, sortIdDescending, bannerCookieName, hideCommunityEventsBanner } from "@/utils"
+import { readCookie, largestId, bannerCookieName, hideCommunityEventsBanner } from "@/utils"
 
 export default {
   components: {
@@ -47,7 +47,7 @@ export default {
       }
       const lastHiddenEventId = readCookie(bannerCookieName)
       if (lastHiddenEventId) {
-        const lastEventId = sortIdDescending(upcomingCommunityEvents)[0].id
+        const lastEventId = largestId(upcomingCommunityEvents)
         return lastEventId > parseInt(lastHiddenEventId, 10)
       } else {
         return true

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -360,7 +360,7 @@ export const readCookie = (name) => {
 }
 
 export const largestId = (objects) => {
-  return Math.max(objects.map((x) => x.id))
+  return Math.max(...objects.map((x) => x.id))
 }
 
 export const bannerCookieName = "lastHiddenCommunityEventId"

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -359,8 +359,8 @@ export const readCookie = (name) => {
   return null
 }
 
-export const sortIdDescending = (objects) => {
-  return objects.sort((a, b) => b.id - a.id)
+export const largestId = (objects) => {
+  return Math.max(objects.map((x) => x.id))
 }
 
 export const bannerCookieName = "lastHiddenCommunityEventId"
@@ -369,6 +369,6 @@ export const hideCommunityEventsBanner = (events) => {
   if (events.length === 0) return
   const expirationDate = new Date()
   expirationDate.setFullYear(expirationDate.getFullYear() + 1)
-  const lastEventId = sortIdDescending(events)[0].id
+  const lastEventId = largestId(events)
   document.cookie = `${bannerCookieName}=${lastEventId};max-age=31536000;path=/;expires=${expirationDate.toUTCString()};SameSite=Strict;`
 }


### PR DESCRIPTION
Le problème venait de la fonction `sortIdDescending`, qui était utilisée pour obtenir l'ID le plus grand. `sort` modifie l'ordre d'un tableau sur place, ce qui affectait l'affichage après.

Pour obtenir l'ID le plus grand j'utilise `Math.max`, qui ne change pas l'ordre du tableau.