### PR TITLE
Pre-commit black upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
   - id: black
     args: [--line-length=119]
   repo: https://github.com/ambv/black
-  rev: 22.3.0
+  rev: 22.6.0
 - hooks:
   - args:
     - --config=.flake8


### PR DESCRIPTION
Mise à jour de la version de black de pre-commit suite à l'update de dependabot (plus d'info sur [ce commentaire](https://github.com/betagouv/ma-cantine/pull/1562#issuecomment-1175158636))