### PR TITLE
Adds CORS use for image fetching on html2pdf library

### DIFF
--- a/frontend/src/views/GeneratePosterPage/index.vue
+++ b/frontend/src/views/GeneratePosterPage/index.vue
@@ -375,7 +375,7 @@ export default {
       const pdfOptions = {
         filename: `Affiche_convives_${canteenName.replaceAll(" ", "_")}_${this.form.diagnostic.year}.pdf`,
         image: { type: "jpeg", quality: 1 },
-        html2canvas: { scale: 2, dpi: 300, letterRendering: true },
+        html2canvas: { scale: 2, dpi: 300, letterRendering: true, useCORS: true },
         jsPDF: { unit: "in", format: "a4", orientation: "portrait" },
       }
       return html2pdf()


### PR DESCRIPTION
Le souci venait du fait que les logos sont hébérgés dans un serveur à part (Cellar). En ajoutant CORS dans les options de la lib on arrive a bien les obtenir.

Plus d'info : https://github.com/eKoopmans/html2pdf.js/issues/105

Closes #1212 