### PR TITLE
Attaches the header's menu to the tab object to avoid floating pop-ups

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -78,9 +78,9 @@
 
       <template v-slot:extension v-if="$vuetify.breakpoint.mdAndUp">
         <v-divider style="position:absolute; top:0; width:100%;"></v-divider>
-        <v-tabs align-with-title active-class="stealth-active-tab" hide-slider>
+        <v-tabs align-with-title id="header-tabs" active-class="stealth-active-tab" hide-slider>
           <div v-for="(navLink, index) in displayNavLinks" :key="index">
-            <v-menu v-if="navLink.children" rounded="0" offset-y>
+            <v-menu v-if="navLink.children" rounded="0" offset-y attach="#header-tabs" nudge-right="16">
               <template v-slot:activator="{ on, attrs, value }">
                 <v-tab v-bind="attrs" v-on="on" class="mc-tab body-2">
                   {{ navLink.text }}


### PR DESCRIPTION
Closes #1566 

Le bug est reproductible en ouvrant un menu et en scrollant la page lors qu'il est ouvert. 

Plus d'info ici : https://github.com/vuetifyjs/vuetify/issues/795

Bug:
![detached-menu](https://user-images.githubusercontent.com/1225929/177776997-d9c532c6-1369-4905-b8a9-1462c61ab8b0.gif)

Fix:
![detached-menu-fix](https://user-images.githubusercontent.com/1225929/177777201-5b882fdb-ae08-465b-809f-6dfdabb3d5e8.gif)

