### PR TITLE
Fixes the banner not closing

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -41,17 +41,7 @@ export default {
       return this.$store.state.initialDataLoaded
     },
     showWebinaireBanner() {
-      const upcomingCommunityEvents = this.$store.state.upcomingCommunityEvents
-      if (upcomingCommunityEvents.length === 0) {
-        return false
-      }
-      const lastHiddenEventId = readCookie(bannerCookieName)
-      if (lastHiddenEventId) {
-        const lastEventId = largestId(upcomingCommunityEvents)
-        return lastEventId > parseInt(lastHiddenEventId, 10)
-      } else {
-        return true
-      }
+      return this.$store.state.showWebinaireBanner
     },
   },
   mounted() {
@@ -75,6 +65,7 @@ export default {
     initialDataLoaded() {
       if (!this.$store.state.loggedUser) return
       this.$store.dispatch("removeLocalStorageDiagnostics")
+      this.$store.dispatch("setShowWebinaireBanner", this.webinaireCookieIsOutdated())
     },
   },
   beforeMount() {
@@ -83,7 +74,20 @@ export default {
   methods: {
     hideBanner() {
       const upcomingCommunityEvents = this.$store.state.upcomingCommunityEvents
-      hideCommunityEventsBanner(upcomingCommunityEvents)
+      hideCommunityEventsBanner(upcomingCommunityEvents, this.$store)
+    },
+    webinaireCookieIsOutdated() {
+      const upcomingCommunityEvents = this.$store.state.upcomingCommunityEvents
+      if (upcomingCommunityEvents.length === 0) {
+        return false
+      }
+      const lastHiddenEventId = readCookie(bannerCookieName)
+      if (lastHiddenEventId) {
+        const lastEventId = largestId(upcomingCommunityEvents)
+        return lastEventId > parseInt(lastHiddenEventId, 10)
+      } else {
+        return true
+      }
     },
   },
 }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -52,6 +52,8 @@ export default new Vuex.Store({
       status: null,
       title: "",
     },
+
+    showWebinaireBanner: false,
   },
 
   mutations: {
@@ -112,6 +114,9 @@ export default new Vuex.Store({
     },
     SET_UPCOMING_COMMUNITY_EVENTS(state, events) {
       state.upcomingCommunityEvents = events
+    },
+    SET_SHOW_WEBINAIRE_BANNER(state, showWebinaireBanner) {
+      state.showWebinaireBanner = showWebinaireBanner
     },
   },
 
@@ -698,6 +703,10 @@ export default new Vuex.Store({
           return jsonResponse
         })
       })
+    },
+
+    setShowWebinaireBanner(context, showWebinaireBanner) {
+      context.commit("SET_SHOW_WEBINAIRE_BANNER", showWebinaireBanner)
     },
   },
 

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -371,10 +371,11 @@ export const largestId = (objects) => {
 
 export const bannerCookieName = "lastHiddenCommunityEventId"
 
-export const hideCommunityEventsBanner = (events) => {
+export const hideCommunityEventsBanner = (events, store) => {
   if (events.length === 0) return
   const expirationDate = new Date()
   expirationDate.setFullYear(expirationDate.getFullYear() + 1)
   const lastEventId = largestId(events)
   document.cookie = `${bannerCookieName}=${lastEventId};max-age=31536000;path=/;expires=${expirationDate.toUTCString()};SameSite=Strict;`
+  store.dispatch("setShowWebinaireBanner", false)
 }

--- a/frontend/src/views/CommunityPage/index.vue
+++ b/frontend/src/views/CommunityPage/index.vue
@@ -68,7 +68,7 @@ export default {
     },
   },
   mounted() {
-    hideCommunityEventsBanner(this.webinaires)
+    hideCommunityEventsBanner(this.webinaires, this.$store)
   },
 }
 </script>


### PR DESCRIPTION
Les cookies ne sont pas réactives en Vue. Pour pouvoir fermer la bannière depuis outils, une propriété dans le `state` est nécessaire.
Closes #1605 

Bug: 
![banner-bug](https://user-images.githubusercontent.com/1225929/177787115-29d4de37-c02c-4742-ae9e-c26620efd8fd.gif)

Fix: 
![banner-bug-fix](https://user-images.githubusercontent.com/1225929/177787134-334da2a1-2c2c-4504-a2ad-8d4dabd5632e.gif)

