### PR TITLE
Amélioration du logging

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -329,20 +329,16 @@ class AddManagerView(APIView):
             AddManagerView.add_manager_to_canteen(email, canteen)
             return _respond_with_team(canteen)
         except ValidationError as e:
-            logger.error(f"Attempt to add manager with invalid email {email}")
-            logger.exception(e)
+            logger.warning(f"Attempt to add manager with invalid email {email}:\n{e}")
             return JsonResponse({"error": "Invalid email"}, status=status.HTTP_400_BAD_REQUEST)
         except Canteen.DoesNotExist as e:
-            logger.error(f"Attempt to add manager to unexistent canteen {canteen_id}")
-            logger.exception(e)
+            logger.warning(f"Attempt to add manager to unexistent canteen {canteen_id}:\n{e}")
             return JsonResponse({"error": "Invalid canteen id"}, status=status.HTTP_404_NOT_FOUND)
         except IntegrityError as e:
-            logger.error(f"Attempt to add existing manager with email {email} to canteen {canteen_id}")
-            logger.exception(e)
+            logger.warning(f"Attempt to add existing manager with email {email} to canteen {canteen_id}:\n{e}")
             return _respond_with_team(canteen)
         except Exception as e:
-            logger.error("Exception occurred while inviting a manager to canteen")
-            logger.exception(e)
+            logger.exception(f"Exception occurred while inviting a manager to canteen:\n{e}")
             return JsonResponse(
                 {"error": "An error has occurred"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -377,14 +373,12 @@ class AddManagerView(APIView):
                 to=[manager_invitation.email],
             )
         except ConnectionRefusedError as e:
-            logger.error(
-                f"The manager invitation email could not be sent to {manager_invitation.email} : Connection Refused. The manager has been added anyway."
+            logger.warning(
+                f"The manager invitation email could not be sent to {manager_invitation.email} : Connection Refused. The manager has been added anyway.\n{e}"
             )
-            logger.exception(e)
             return
         except Exception as e:
-            logger.error(f"The manager invitation email could not be sent to {manager_invitation.email}")
-            logger.exception(e)
+            logger.exception(f"The manager invitation email could not be sent to {manager_invitation.email}\n{e}")
             raise Exception("Error occurred : the mail could not be sent.") from e
 
     @staticmethod
@@ -404,14 +398,12 @@ class AddManagerView(APIView):
                 to=[email],
             )
         except ConnectionRefusedError as e:
-            logger.error(
-                f"The manager add notification email could not be sent to {email} : Connection Refused. The manager has been added anyway."
+            logger.warning(
+                f"The manager add notification email could not be sent to {email} : Connection Refused. The manager has been added anyway.\n{e}"
             )
-            logger.exception(e)
             return
         except Exception as e:
-            logger.error(f"The manager add notification email could not be sent to {email}")
-            logger.exception(e)
+            logger.exception(f"The manager add notification email could not be sent to {email}\n{e}")
             raise Exception("Error occurred : the mail could not be sent.") from e
 
 
@@ -436,16 +428,13 @@ class RemoveManagerView(APIView):
                     pass
             return _respond_with_team(canteen)
         except ValidationError as e:
-            logger.error(f"Attempt to remove manager with invalid email {email}")
-            logger.exception(e)
+            logger.warning(f"Attempt to remove manager with invalid email {email}:\n{e}")
             return JsonResponse({"error": "Invalid email"}, status=status.HTTP_400_BAD_REQUEST)
         except Canteen.DoesNotExist as e:
-            logger.error(f"Attempt to remove manager from unexistent canteen {canteen_id}")
-            logger.exception(e)
+            logger.warning(f"Attempt to remove manager from unexistent canteen {canteen_id}:\n{e}")
             return JsonResponse({"error": "Invalid canteen id"}, status=status.HTTP_404_NOT_FOUND)
         except Exception as e:
-            logger.error("Exception occurred while removing a manager from a canteen")
-            logger.exception(e)
+            logger.exception(f"Exception occurred while removing a manager from a canteen:\n{e}")
             return JsonResponse(
                 {"error": "An error has occurred"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -482,8 +471,7 @@ class SendCanteenNotFoundEmail(APIView):
         except ValidationError:
             return JsonResponse({"error": "Invalid email"}, status=status.HTTP_400_BAD_REQUEST)
         except Exception as e:
-            logger.error("Exception occurred while sending email")
-            logger.exception(e)
+            logger.exception(f"Exception occurred while sending email:\n{e}")
             return JsonResponse(
                 {"error": "An error has occurred"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -536,8 +524,7 @@ class TeamJoinRequestView(APIView):
         except ValidationError:
             return JsonResponse({"error": "Invalid email"}, status=status.HTTP_400_BAD_REQUEST)
         except Exception as e:
-            logger.error("Exception occurred while sending email")
-            logger.exception(e)
+            logger.exception(f"Exception occurred while sending email:\n{e}")
             return JsonResponse(
                 {"error": "An error has occurred"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -729,8 +716,7 @@ class ClaimCanteenView(APIView):
 
             return JsonResponse({}, status=status.HTTP_200_OK)
         except Exception as e:
-            logger.error("Exception occurred while sending email")
-            logger.exception(e)
+            logger.exception(f"Exception occurred while sending email:\n{e}")
             return JsonResponse(
                 {"error": "An error has occurred"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/api/views/inquiry.py
+++ b/api/views/inquiry.py
@@ -38,12 +38,10 @@ class InquiryView(APIView):
 
             return JsonResponse({}, status=status.HTTP_200_OK)
         except ValidationError as e:
-            logger.error("Missing field from inquiry view")
-            logger.exception(e)
+            logger.exception("Missing field from inquiry view:\n{e}")
             raise e
         except Exception as e:
-            logger.error(f"Exception ocurred while handling inquiry. Title: {title}, Body:\n{body}")
-            logger.exception(e)
+            logger.exception(f"Exception ocurred while handling inquiry. Title: {title}, Body:\n{body}:\n{e}")
             return JsonResponse(
                 {"error": "An error has ocurred"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -362,20 +362,19 @@ class ImportPurchasesView(APIView):
             return ImportPurchasesView._get_success_response([], self.purchases_created, errors, start)
 
         except IntegrityError as e:
-            logger.exception(e)
-            logger.error("L'import du fichier CSV a échoué")
+            logger.warning(f"L'import du fichier CSV a échoué:\n{e}")
             return ImportPurchasesView._get_success_response([], 0, errors, start)
 
         except ValidationError as e:
             message = e.message
-            logger.error(message)
+            logger.warning(message)
             message = message
             errors = [{"row": 0, "status": 400, "message": message}]
             return ImportPurchasesView._get_success_response([], 0, errors, start)
 
         except Exception as e:
-            logger.exception(e)
             message = "Échec lors de la lecture du fichier"
+            logger.exception(f"{message}:\n{e}")
             errors = [{"row": 0, "status": 400, "message": message}]
             return ImportPurchasesView._get_success_response([], 0, errors, start)
 
@@ -480,8 +479,7 @@ class ImportPurchasesView(APIView):
 
     @staticmethod
     def _get_error(e, message, error_status, row_number):
-        logger.error(f"Error on row {row_number}")
-        logger.exception(e)
+        logger.warning(f"Error on row {row_number}:\n{e}")
         return {"row": row_number, "status": error_status, "message": message}
 
     def _parse_errors(self, e, row):

--- a/api/views/review.py
+++ b/api/views/review.py
@@ -21,8 +21,8 @@ class ReviewView(CreateAPIView):
             hasDiagnostic = Diagnostic.objects.filter(canteen__managers=user).exists()
             serializer.is_valid(raise_exception=True)
             serializer.save(user=user, hasCanteen=hasCanteen, hasDiagnostic=hasDiagnostic)
-        except IntegrityError:
-            logger.error(
-                f"User with id {user.id} attempted to create second review for page {serializer.validated_data['page']}"
+        except IntegrityError as e:
+            logger.exception(
+                f"User with id {user.id} attempted to create second review for page {serializer.validated_data['page']}:\n{e}"
             )
             raise DuplicateException()

--- a/api/views/subscription.py
+++ b/api/views/subscription.py
@@ -89,13 +89,11 @@ class SubscribeBetaTester(APIView):
             return JsonResponse({}, status=status.HTTP_201_CREATED)
 
         except PipedriveException as e:
-            logger.error(f"Pipedrive API error on request by {name or ''} {email}: {message} ")
-            logger.exception(e)
+            logger.exception(f"Pipedrive API error on request by {name or ''} {email}: {message}:\n{e}")
             return JsonResponse({}, status=status.HTTP_502_BAD_GATEWAY)
 
         except Exception as e:
-            logger.error("Error on beta-tester subscription")
-            logger.exception(e)
+            logger.exception(f"Error on beta-tester subscription:\n{e}")
             return JsonResponse({}, status=status.HTTP_400_BAD_REQUEST)
 
 
@@ -117,21 +115,18 @@ class SubscribeNewsletter(APIView):
         except sib_api_v3_sdk.rest.ApiException as e:
             contact_exists = json.loads(e.body).get("message") == "Contact already exist"
             if contact_exists:
-                logger.error(f"Beta-tester already exists: {email}")
+                logger.warning(f"Beta-tester already exists: {email}")
                 return JsonResponse({}, status=status.HTTP_200_OK)
-            logger.error("SIB API error in beta-tester subsription :")
-            logger.exception(e)
+            logger.exception("SIB API error in beta-tester subsription :\n{e}")
             return JsonResponse(
                 {"error": "Error calling SendInBlue API"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except ValidationError as e:
-            logger.error(f"Invalid email on beta-tester subscription: {email}")
-            logger.exception(e)
+            logger.warning(f"Invalid email on beta-tester subscription: {email}:\n{e}")
             return JsonResponse({"error": "Invalid email"}, status=status.HTTP_400_BAD_REQUEST)
         except Exception as e:
-            logger.error("Error on newsletter subscription")
-            logger.exception(e)
+            logger.exception(f"Error on newsletter subscription:\n{e}")
             return JsonResponse(
                 {"error": "An error has ocurred"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/api/views/user.py
+++ b/api/views/user.py
@@ -118,13 +118,11 @@ class UsernameSuggestionView(APIView):
                 return JsonResponse({"detail": "Missing info"}, status=status.HTTP_400_BAD_REQUEST)
             return JsonResponse({"suggestion": suggested}, status=status.HTTP_200_OK)
         except UsernameSuggestionView.RetryLimitException as e:
-            logger.error(
-                f"Unable to generate a username suggestion for first name: {first_name}, last name: {last_name}, email: {email}. Retry limit exceeded."
+            logger.exception(
+                f"Unable to generate a username suggestion for first name: {first_name}, last name: {last_name}, email: {email}. Retry limit exceeded.\n{e}"
             )
-            logger.exception(e)
         except Exception as e:
-            logger.error("Unable to generate username suggestion. Unexpected error.")
-            logger.exception(e)
+            logger.exception(f"Unable to generate username suggestion. Unexpected error:\n{e}")
 
     @staticmethod
     def _generate_username_with_base(username_suggestion, attempt=0):

--- a/data/models/message.py
+++ b/data/models/message.py
@@ -56,8 +56,7 @@ class Message(models.Model):
             self.sent_date = now()
             self.save()
         except Exception as e:
-            logger.error(f"Error sending message {self.id}")
-            logger.error(e)
+            logger.exception(f"Error sending message {self.id}:\n{e}")
 
     def block(self):
         if self.status == Message.Status.SENT:

--- a/macantine/management/commands/importcsv.py
+++ b/macantine/management/commands/importcsv.py
@@ -45,13 +45,13 @@ class Command(BaseCommand):
 
         try:
             if not row[2]:
-                logger.error(f"CSV row {row} does not contain a SIRET")
+                logger.warning(f"CSV row {row} does not contain a SIRET")
                 return False
 
             siret = row[2].strip()
 
             if siret and Command._siret_exists(siret):
-                logger.error(f"Canteen with SIRET {siret} exists already crating models from CSV row : {row}")
+                logger.warning(f"Canteen with SIRET {siret} exists already crating models from CSV row : {row}")
                 return False
 
             name = row[3].strip()
@@ -62,17 +62,17 @@ class Command(BaseCommand):
 
             try:
                 daily_meal_count = int(row[13]) if row[13] else None
-            except:
+            except Exception:
                 daily_meal_count = None
 
             try:
                 bio_and_sustainable_percentage = int(row[14]) if row[14] else None
-            except:
+            except Exception:
                 bio_and_sustainable_percentage = None
 
             try:
                 bio_percentage = int(row[15]) if row[15] else None
-            except:
+            except Exception:
                 bio_percentage = None
 
             sustainable_percentage = None
@@ -119,13 +119,11 @@ class Command(BaseCommand):
                         logger.info(f"Created diagnostic for 2021 for {canteen.name} (ID: {diagnostic.id})")
                     return canteen
             except IntegrityError as e:
-                logger.error(f"Integrity error when crating models from CSV row : {row}")
-                logger.exception(e)
+                logger.warning(f"Integrity error when crating models from CSV row : {row}\n{e}")
                 return False
 
         except Exception as e:
-            logger.error(f"Unable to create cantine from CSV file : {row}")
-            logger.exception(e)
+            logger.exception(f"Unable to create cantine from CSV file : {row}\n{e}")
             return False
 
     @staticmethod
@@ -167,4 +165,4 @@ class Command(BaseCommand):
                     canteen.department = row[5].split(",")[0]
                     canteen.save()
         except Exception as e:
-            logger.error(f"Error while updating location data : {repr(e)} - {e}")
+            logger.exception(f"Error while updating location data : {repr(e)} - {e}")

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -11,11 +11,13 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 import os
 import sys
+import logging
 from pathlib import Path
 import dotenv  # noqa
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.celery import CeleryIntegration
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -51,11 +53,12 @@ ENVIRONMENT = os.getenv("ENVIRONMENT")
 if not DEBUG:
     sentry_sdk.init(
         dsn="https://db78f7d440094c498a02135e8abefa27@sentry.incubateur.net/2",
-        integrations=[DjangoIntegration()],
+        integrations=[DjangoIntegration(), CeleryIntegration()],
         traces_sample_rate=0,
         send_default_pii=False,
         send_client_reports=False,
     )
+    sentry_sdk.set_level(logging.ERROR)
 
 INTERNAL_IPS = []
 

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -51,11 +51,9 @@ def no_canteen_first_reminder():
             user.email_no_canteen_first_reminder = today
             user.save()
         except ApiException as e:
-            logger.error(f"SIB error when sending first no-cantine email to {user.username}")
-            logger.exception(e)
+            logger.exception(f"SIB error when sending first no-cantine email to {user.username}:\n{e}")
         except Exception as e:
-            logger.error(f"Unable to send first no-cantine reminder email to {user.username}")
-            logger.exception(e)
+            logger.exception(f"Unable to send first no-cantine reminder email to {user.username}:\n{e}")
 
 
 @app.task()
@@ -87,11 +85,9 @@ def no_canteen_second_reminder():
             user.email_no_canteen_second_reminder = today
             user.save()
         except ApiException as e:
-            logger.error(f"SIB error when sending second no-cantine reminder email to {user.username}")
-            logger.exception(e)
+            logger.exception(f"SIB error when sending second no-cantine reminder email to {user.username}:\n{e}")
         except Exception as e:
-            logger.error(f"Unable to send second no-cantine reminder email to {user.username}")
-            logger.exception(e)
+            logger.exception(f"Unable to send second no-cantine reminder email to {user.username}:\n{e}")
 
 
 @app.task()
@@ -130,12 +126,10 @@ def no_diagnostic_first_reminder():
                     canteen.email_no_diagnostic_first_reminder = today
                     canteen.save()
             except ApiException as e:
-                logger.error(
-                    f"SIB error when sending first no-diagnostic email to {manager.username} concerning canteen {canteen.name}"
+                logger.exception(
+                    f"SIB error when sending first no-diagnostic email to {manager.username} concerning canteen {canteen.name}:\n{e}"
                 )
-                logger.exception(e)
             except Exception as e:
-                logger.error(
-                    f"Unable to send first no-diagnostic reminder email to {manager.username} concerning canteen {canteen.name}"
+                logger.exception(
+                    f"Unable to send first no-diagnostic reminder email to {manager.username} concerning canteen {canteen.name}:\n{e}"
                 )
-                logger.exception(e)


### PR DESCRIPTION
Plusieurs améliorations relatives à #1643 

- Les appels successifs à `logger.error` et puis `logger.exception` étaient redondantes car `logger.exception` crée une entrée avec niveau `error` en incluant le stacktrace de l'exception en cours. Depuis la [doc Django](https://docs.djangoproject.com/en/3.2/topics/logging/#making-logging-calls):

> logger.exception(): Creates an ERROR level logging message wrapping the current exception stack frame.

- En générale, les erreurs qui peuvent venir d'une mauvaise donnée rentré par l'utilisateur ou bien par un erreur attendu, sont passés en _warning_ (emails invalides, etc)
- Il y restent quelques `logger.error`, notamment autour du _/views/purchase.py_ et _/views/reservationexpe.py_, je les ai laissés car ils ne sont pas dans le contexte d'une exception et qu'ils dénotent un problème dans notre UI (par ex pouvoir créer un achat dans la cantine de quelqu'un d'autre)

J'ai profité pour ajouter le logging dans Celery et explicitement mettre le niveau minimale de Sentry à _ERROR_ pour ne pas voir les warnings là-dedans. 