### PR TITLE
Fixes regional stats to include new simple diag fields

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -526,7 +526,13 @@ def badges_for_queryset(diagnostic_year_queryset):
         )
         appro_share_query = appro_share_query.annotate(
             combined_share=Cast(
-                (Sum("value_bio_ht") + Sum("value_sustainable_ht")) / Sum("value_total_ht"),
+                (
+                    Sum("value_bio_ht")
+                    + Sum("value_sustainable_ht")
+                    + Sum("value_externality_performance_ht")
+                    + Sum("value_egalim_others_ht")
+                )
+                / Sum("value_total_ht"),
                 FloatField(),
             )
         )

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -616,7 +616,11 @@ class CanteenStatisticsView(APIView):
             bio_share=Cast(Sum("value_bio_ht") / Sum("value_total_ht"), FloatField())
         )
         appro_share_query = appro_share_query.annotate(
-            sustainable_share=Cast(Sum("value_sustainable_ht") / Sum("value_total_ht"), FloatField())
+            sustainable_share=Cast(
+                (Sum("value_sustainable_ht") + Sum("value_externality_performance_ht") + Sum("value_egalim_others_ht"))
+                / Sum("value_total_ht"),
+                FloatField(),
+            )
         )
         agg = appro_share_query.aggregate(Avg("bio_share"), Avg("sustainable_share"))
         # no need for particularly fancy rounding


### PR DESCRIPTION
Les stats régionales ne prenaient pas en compte les champs _value_externality_performance_ht_ et _value_egalim_others_ht_. Avec cette mise à jour ils sont dedans.