### PR TITLE
Strips email values for API endpoints

### DIFF
--- a/api/tests/test_subscription.py
+++ b/api/tests/test_subscription.py
@@ -207,3 +207,37 @@ class TestSubscription(APITestCase):
         # SIB API was called correctly
         sib_api_v3_sdk.ContactsApi.assert_called_once()
         fake_sib_api_instance.create_contact.assert_called_with(fake_contact_create)
+
+    @override_settings(NEWSLETTER_SENDINBLUE_LIST_ID="1")
+    @override_settings(ANYMAIL={"SENDINBLUE_API_KEY": "fake-api-key"})
+    def test_email_whitespace(self, _):
+        """
+        When subscribing to the newsletter the email should be stripped
+        """
+
+        class FakeSIBConfiguration:
+            api_key = {}
+
+        class FakeContactCreate:
+            list_ids = None
+            update_enabled = None
+
+        class FakeSIBInstanceAPI:
+            create_contact = MagicMock()
+
+        fake_sib_configuration = FakeSIBConfiguration()
+        fake_contact_create = FakeContactCreate()
+        fake_sib_api_instance = FakeSIBInstanceAPI()
+
+        sib_api_v3_sdk.Configuration = MagicMock(return_value=fake_sib_configuration)
+        sib_api_v3_sdk.ApiClient = MagicMock()
+        sib_api_v3_sdk.ContactsApi = MagicMock(return_value=fake_sib_api_instance)
+        sib_api_v3_sdk.CreateContact = MagicMock(return_value=fake_contact_create)
+
+        response = self.client.post(
+            reverse("subscribe_newsletter"),
+            {"email": "  test@example.com      "},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -393,7 +393,7 @@ class RemoveManagerView(APIView):
 
     def post(self, request, *args, **kwargs):
         try:
-            email = request.data.get("email")
+            email = request.data.get("email", "").strip()
             validate_email(email)
             canteen_id = request.data.get("canteen_id")
             canteen = request.user.canteens.get(id=canteen_id)
@@ -425,7 +425,7 @@ class RemoveManagerView(APIView):
 class SendCanteenNotFoundEmail(APIView):
     def post(self, request):
         try:
-            email = request.data.get("from")
+            email = request.data.get("from", "").strip()
             validate_email(email)
             name = request.data.get("name") or "Un·e utilisateur·rice"
             message = request.data.get("message")
@@ -464,7 +464,7 @@ class TeamJoinRequestView(APIView):
 
     def post(self, request, *args, **kwargs):
         try:
-            email = request.data.get("email")
+            email = request.data.get("email", "").strip()
             validate_email(email)
             name = request.data.get("name")
             message = request.data.get("message")

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -485,7 +485,7 @@ class EmailDiagnosticImportFileView(APIView):
         try:
             file = request.data["file"]
             self._verify_file_size(file)
-            email = request.data.get("email", request.user.email)
+            email = request.data.get("email", request.user.email).strip()
             context = {
                 "from": email,
                 "name": request.data.get("name", request.user.get_full_name()),

--- a/api/views/inquiry.py
+++ b/api/views/inquiry.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class InquiryView(APIView):
     def post(self, request):
         try:
-            email = request.data.get("from")
+            email = request.data.get("from", "").strip()
             name = request.data.get("name")
             message = request.data.get("message")
             inquiry_type = request.data.get("inquiry_type", "autre")

--- a/api/views/subscription.py
+++ b/api/views/subscription.py
@@ -100,7 +100,7 @@ class SubscribeBetaTester(APIView):
 class SubscribeNewsletter(APIView):
     def post(self, request):
         try:
-            email = request.data.get("email")
+            email = request.data.get("email", "").strip()
             validate_email(email)
 
             list_id = settings.NEWSLETTER_SENDINBLUE_LIST_ID

--- a/api/views/user.py
+++ b/api/views/user.py
@@ -105,7 +105,7 @@ class UsernameSuggestionView(APIView):
 
     def post(self, request):
         try:
-            email = request.data.get("email")
+            email = request.data.get("email", "").strip()
             first_name = request.data.get("first_name")
             last_name = request.data.get("last_name")
             if first_name and last_name:


### PR DESCRIPTION
Closes #1716 

Ajout d'un `strip` et une valeur par défaut de `""` aux emails dans l'API.