### PR TITLE
DSFR : Boutons et cartes

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -109,4 +109,9 @@ export default {
   background-color: #b6d9c8;
   border-radius: 16px;
 }
+
+.theme--light.v-card > .v-card__text,
+.theme--light.v-card > .v-card__subtitle {
+  color: rgba(0, 0, 0, 0.87);
+}
 </style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -114,4 +114,12 @@ export default {
 .theme--light.v-card > .v-card__subtitle {
   color: rgba(0, 0, 0, 0.87);
 }
+
+.v-card.dsfr {
+  border: solid 1px #e0e0e0;
+}
+
+.v-card.dsfr:hover {
+  background-color: #f6f6f6;
+}
 </style>

--- a/frontend/src/components/AppFooter.vue
+++ b/frontend/src/components/AppFooter.vue
@@ -38,7 +38,7 @@
       <v-divider v-if="!showSmallFooter" class="mt-6"></v-divider>
       <ul class="d-flex justify-sm-space-between flex-wrap link-group pl-0">
         <li v-for="(link, index) in bottomLinks" :key="link.text" class="d-flex">
-          <v-btn class="caption px-0" :to="link.to" :ripple="false" text plain>{{ link.text }}</v-btn>
+          <v-btn class="caption px-0" :to="link.to" text plain>{{ link.text }}</v-btn>
           <div class="footer-divider mt-3 mx-4" v-if="index < bottomLinks.length - 1"></div>
         </li>
         <v-spacer></v-spacer>

--- a/frontend/src/components/DiagnosticCard.vue
+++ b/frontend/src/components/DiagnosticCard.vue
@@ -1,6 +1,8 @@
 <template>
   <v-card
-    :class="{ 'd-flex': true, 'flex-column': $vuetify.breakpoint.xsOnly }"
+    outlined
+    :ripple="false"
+    :class="{ 'd-flex': true, 'flex-column': $vuetify.breakpoint.xsOnly, dsfr: true }"
     :to="{ name: 'DiagnosticModification', params: { canteenUrlComponent, year: diagnostic.year } }"
   >
     <v-sheet

--- a/frontend/src/components/DiagnosticCard.vue
+++ b/frontend/src/components/DiagnosticCard.vue
@@ -1,7 +1,6 @@
 <template>
   <v-card
     outlined
-    :ripple="false"
     :class="{ 'd-flex': true, 'flex-column': $vuetify.breakpoint.xsOnly, dsfr: true }"
     :to="{ name: 'DiagnosticModification', params: { canteenUrlComponent, year: diagnostic.year } }"
   >

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -7,6 +7,7 @@ Vue.use(Vuetify)
 
 // Defaults to conform to DSFR
 VBtn.options.props.ripple.default = false
+VBtn.options.props.elevation.default = 0
 VCard.options.props.ripple.default = false
 
 export default new Vuetify({

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -1,8 +1,13 @@
 import Vue from "vue"
 import Vuetify from "vuetify/lib/framework"
 import theme from "@/theme"
+import { VBtn, VCard } from "vuetify/lib"
 
 Vue.use(Vuetify)
+
+// Defaults to conform to DSFR
+VBtn.options.props.ripple.default = false
+VCard.options.props.ripple.default = false
 
 export default new Vuetify({
   theme: theme,

--- a/frontend/src/scss/variables.scss
+++ b/frontend/src/scss/variables.scss
@@ -9,10 +9,12 @@ $title-font: 'Marianne', Arial, sans-serif;
 $btn-text-transform: none;
 $btn-letter-spacing: -0.011em;
 $btn-font-weight: 500;
+$btn-border-radius: 0; // DSFR: https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton/
 
 /* CARD */
 $card-title-word-break: normal !important;
 $card-hover-elevation: 4;
+$card-border-radius: 0; // DSRF: https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/carte/
 
 // /* TEXT FIELD: https://vuetifyjs.com/en/api/v-text-field/#sass-variables */
 // $text-field-solo-dense-control-min-height: 38px !default;

--- a/frontend/src/views/BlogsPage/BlogCard.vue
+++ b/frontend/src/views/BlogsPage/BlogCard.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-card class="fill-height text-left d-flex flex-column" hover :to="{ name: 'BlogPage', params: { id: post.id } }">
+  <v-card
+    class="fill-height text-left d-flex flex-column dsfr"
+    outlined
+    :ripple="false"
+    :to="{ name: 'BlogPage', params: { id: post.id } }"
+  >
     <v-card-title class="text-h6 font-weight-bold">{{ post.title }}</v-card-title>
     <v-card-subtitle class="pt-1">
       {{

--- a/frontend/src/views/BlogsPage/BlogCard.vue
+++ b/frontend/src/views/BlogsPage/BlogCard.vue
@@ -17,6 +17,10 @@
       {{ post.tagline }}
     </v-card-text>
     <v-spacer></v-spacer>
+    <v-card-actions class="px-4 py-4">
+      <v-spacer></v-spacer>
+      <v-icon color="primary">mdi-arrow-right</v-icon>
+    </v-card-actions>
   </v-card>
 </template>
 

--- a/frontend/src/views/BlogsPage/BlogCard.vue
+++ b/frontend/src/views/BlogsPage/BlogCard.vue
@@ -2,7 +2,6 @@
   <v-card
     class="fill-height text-left d-flex flex-column dsfr"
     outlined
-    :ripple="false"
     :to="{ name: 'BlogPage', params: { id: post.id } }"
   >
     <v-card-title class="text-h6 font-weight-bold">{{ post.title }}</v-card-title>

--- a/frontend/src/views/CanteenEditor/PublicationField.vue
+++ b/frontend/src/views/CanteenEditor/PublicationField.vue
@@ -36,7 +36,6 @@
                   small
                   text
                   plain
-                  :ripple="false"
                 >
                   nos cantines
                   <v-icon small color="grey darken-4" class="ml-1">mdi-open-in-new</v-icon>
@@ -49,7 +48,6 @@
                   small
                   text
                   plain
-                  :ripple="false"
                 >
                   Voir un aperçu de la publication
                 </v-btn>

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -289,7 +289,6 @@
             @click="toggleOrderDirection"
             :title="`Resultats affichés en ordre ${orderDescending ? 'décroissant' : 'croissant'}`"
             plain
-            :ripple="false"
           >
             <v-icon v-if="orderDescending">mdi-arrow-down</v-icon>
             <v-icon v-else>

--- a/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
+++ b/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
@@ -2,7 +2,6 @@
   <v-card
     :to="{ name: 'CanteenPage', params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) } }"
     outlined
-    :ripple="false"
     class="pa-4 text-left fill-height d-flex flex-column dsfr"
   >
     <v-card-title class="font-weight-black pt-1">

--- a/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
+++ b/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
@@ -1,8 +1,9 @@
 <template>
   <v-card
     :to="{ name: 'CanteenPage', params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) } }"
-    hover
-    class="pa-4 text-left fill-height d-flex flex-column"
+    outlined
+    :ripple="false"
+    class="pa-4 text-left fill-height d-flex flex-column dsfr"
   >
     <v-card-title class="font-weight-black pt-1">
       {{ canteen.name }}
@@ -45,6 +46,10 @@
         <v-spacer></v-spacer>
       </div>
     </div>
+    <v-card-actions class="px-4 py-0">
+      <v-spacer></v-spacer>
+      <v-icon color="primary">mdi-arrow-right</v-icon>
+    </v-card-actions>
   </v-card>
 </template>
 

--- a/frontend/src/views/CommunityPage/WebinaireCard.vue
+++ b/frontend/src/views/CommunityPage/WebinaireCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="pa-4 dsfr" :href="webinaire.link" outlined :ripple="false">
+  <v-card class="pa-4 dsfr" :href="webinaire.link" outlined>
     <v-row>
       <v-col cols="1" v-if="$vuetify.breakpoint.smAndUp" class="justify-center align-center d-flex">
         <v-avatar color="secondary lighten-1" size="40">

--- a/frontend/src/views/CommunityPage/WebinaireCard.vue
+++ b/frontend/src/views/CommunityPage/WebinaireCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="pa-4" :href="webinaire.link">
+  <v-card class="pa-4 dsfr" :href="webinaire.link" outlined :ripple="false">
     <v-row>
       <v-col cols="1" v-if="$vuetify.breakpoint.smAndUp" class="justify-center align-center d-flex">
         <v-avatar color="secondary lighten-1" size="40">

--- a/frontend/src/views/DiagnosticEditor/TeledeclarationCancelDialog.vue
+++ b/frontend/src/views/DiagnosticEditor/TeledeclarationCancelDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="isOpen" width="500">
     <template v-slot:activator="{ on, attrs }">
-      <v-btn class="text-caption mb-4 px-0" x-small text plain :ripple="false" v-bind="attrs" v-on="on">
+      <v-btn class="text-caption mb-4 px-0" x-small text plain v-bind="attrs" v-on="on">
         <v-icon x-small class="mr-1">mdi-close</v-icon>
         Annuler ma télédéclaration
       </v-btn>

--- a/frontend/src/views/DiagnosticPage.vue
+++ b/frontend/src/views/DiagnosticPage.vue
@@ -27,7 +27,7 @@
           </v-btn>
         </v-card-title>
         <v-card-text class="py-0" v-for="subMeasure in measure.subMeasures" :key="`submeasure: ${subMeasure.id}`">
-          <v-btn class="d-inline mt-n1" text plain :ripple="false" @click="toggleDescriptionDisplay(subMeasure)">
+          <v-btn class="d-inline mt-n1" text plain @click="toggleDescriptionDisplay(subMeasure)">
             <span>{{ subMeasure.title }}.&nbsp;</span>
             <span class="text-decoration-underline">{{ subMeasure.readMore ? "Moins" : "En savoir plus" }}</span>
           </v-btn>

--- a/frontend/src/views/LandingPage/ActionsBlock.vue
+++ b/frontend/src/views/LandingPage/ActionsBlock.vue
@@ -5,7 +5,6 @@
       <v-hover>
         <v-card
           outlined
-          :ripple="false"
           :to="loggedUser ? { name: 'ManagementPage' } : undefined"
           :href="loggedUser ? undefined : '/s-identifier'"
           class="fill-height pa-4 d-flex flex-column hover-transition dsfr"
@@ -37,7 +36,6 @@
       <v-hover>
         <v-card
           outlined
-          :ripple="false"
           :to="{ name: 'PublicCanteenStatisticsPage' }"
           class="fill-height pa-4 d-flex flex-column hover-transition dsfr"
         >
@@ -68,7 +66,6 @@
       <v-hover>
         <v-card
           outlined
-          :ripple="false"
           :to="{ name: 'CanteensHome' }"
           class="fill-height pa-4 d-flex flex-column hover-transition dsfr"
         >

--- a/frontend/src/views/LandingPage/ActionsBlock.vue
+++ b/frontend/src/views/LandingPage/ActionsBlock.vue
@@ -3,97 +3,94 @@
     <v-spacer></v-spacer>
     <v-col cols="12" md="4">
       <v-hover>
-        <template v-slot:default="{ hover }">
-          <v-card
-            :elevation="hover ? 6 : 2"
-            :to="loggedUser ? { name: 'ManagementPage' } : undefined"
-            :href="loggedUser ? undefined : '/s-identifier'"
-            class="fill-height pa-4 d-flex flex-column hover-transition"
-          >
-            <v-img
-              src="/static/images/doodles/secondary/SprintingDoodle.png"
-              v-if="$vuetify.breakpoint.smAndUp"
-              class="mx-auto rounded-0"
-              contain
-              max-height="100"
-            ></v-img>
-            <v-card-title>
-              <h2 class="text-h6 font-weight-bold">
-                Gérer ma cantine pour atteindre mes objectifs
-              </h2>
-            </v-card-title>
-            <v-card-text>
-              Être outillé pour atteindre les objectifs des lois EGAlim et Climat
-            </v-card-text>
+        <v-card
+          outlined
+          :ripple="false"
+          :to="loggedUser ? { name: 'ManagementPage' } : undefined"
+          :href="loggedUser ? undefined : '/s-identifier'"
+          class="fill-height pa-4 d-flex flex-column hover-transition dsfr"
+        >
+          <v-img
+            src="/static/images/doodles/secondary/SprintingDoodle.png"
+            v-if="$vuetify.breakpoint.smAndUp"
+            class="mx-auto rounded-0"
+            contain
+            max-height="100"
+          ></v-img>
+          <v-card-title>
+            <h2 class="text-h6 font-weight-bold">
+              Gérer ma cantine pour atteindre mes objectifs
+            </h2>
+          </v-card-title>
+          <v-card-text>
+            Être outillé pour atteindre les objectifs des lois EGAlim et Climat
+          </v-card-text>
+          <v-spacer></v-spacer>
+          <v-card-actions class="px-4 pt-0">
             <v-spacer></v-spacer>
-            <v-card-actions class="px-4 pt-0">
-              <v-spacer></v-spacer>
-              <v-icon color="primary">mdi-arrow-right</v-icon>
-            </v-card-actions>
-          </v-card>
-        </template>
+            <v-icon color="primary">mdi-arrow-right</v-icon>
+          </v-card-actions>
+        </v-card>
       </v-hover>
     </v-col>
     <v-col cols="12" md="4" :style="{ 'border-right': $vuetify.breakpoint.mdAndUp ? 'dotted 4px #e5fbf0' : 'none' }">
       <v-hover>
-        <template v-slot:default="{ hover }">
-          <v-card
-            :elevation="hover ? 6 : 2"
-            :to="{ name: 'PublicCanteenStatisticsPage' }"
-            class="fill-height pa-4 d-flex flex-column hover-transition"
-          >
-            <v-img
-              src="/static/images/doodles/secondary/SitReadingDoodle.png"
-              v-if="$vuetify.breakpoint.smAndUp"
-              class="mx-auto rounded-0"
-              contain
-              max-height="100"
-            ></v-img>
-            <v-card-title>
-              <h2 class="text-h6 font-weight-bold">
-                Suivre l'évolution de mon territoire
-              </h2>
-            </v-card-title>
-            <v-card-text>
-              Savoir où en sont les établissements de ma région ou mon département
-            </v-card-text>
+        <v-card
+          outlined
+          :ripple="false"
+          :to="{ name: 'PublicCanteenStatisticsPage' }"
+          class="fill-height pa-4 d-flex flex-column hover-transition dsfr"
+        >
+          <v-img
+            src="/static/images/doodles/secondary/SitReadingDoodle.png"
+            v-if="$vuetify.breakpoint.smAndUp"
+            class="mx-auto rounded-0"
+            contain
+            max-height="100"
+          ></v-img>
+          <v-card-title>
+            <h2 class="text-h6 font-weight-bold">
+              Suivre l'évolution de mon territoire
+            </h2>
+          </v-card-title>
+          <v-card-text>
+            Savoir où en sont les établissements de ma région ou mon département
+          </v-card-text>
+          <v-spacer></v-spacer>
+          <v-card-actions class="px-4 pt-0">
             <v-spacer></v-spacer>
-            <v-card-actions class="px-4 pt-0">
-              <v-spacer></v-spacer>
-              <v-icon color="primary">mdi-arrow-right</v-icon>
-            </v-card-actions>
-          </v-card>
-        </template>
+            <v-icon color="primary">mdi-arrow-right</v-icon>
+          </v-card-actions>
+        </v-card>
       </v-hover>
     </v-col>
     <v-col cols="12" md="4">
       <v-hover>
-        <template v-slot:default="{ hover }">
-          <v-card
-            :elevation="hover ? 6 : 2"
-            :to="{ name: 'CanteensHome' }"
-            class="fill-height pa-4 d-flex flex-column hover-transition"
-          >
-            <v-img
-              src="/static/images/doodles/secondary/DogDoodle.png"
-              v-if="$vuetify.breakpoint.smAndUp"
-              class="mx-auto rounded-0"
-              contain
-              max-height="100"
-            ></v-img>
-            <v-card-title class="text-h6 font-weight-bold">
-              <h2 class="text-h6 font-weight-bold">En savoir plus sur la cantine que je fréquente</h2>
-            </v-card-title>
-            <v-card-text>
-              Connaître les initiatives de mon restaurant ou celui de mes enfants
-            </v-card-text>
+        <v-card
+          outlined
+          :ripple="false"
+          :to="{ name: 'CanteensHome' }"
+          class="fill-height pa-4 d-flex flex-column hover-transition dsfr"
+        >
+          <v-img
+            src="/static/images/doodles/secondary/DogDoodle.png"
+            v-if="$vuetify.breakpoint.smAndUp"
+            class="mx-auto rounded-0"
+            contain
+            max-height="100"
+          ></v-img>
+          <v-card-title class="text-h6 font-weight-bold">
+            <h2 class="text-h6 font-weight-bold">En savoir plus sur la cantine que je fréquente</h2>
+          </v-card-title>
+          <v-card-text>
+            Connaître les initiatives de mon restaurant ou celui de mes enfants
+          </v-card-text>
+          <v-spacer></v-spacer>
+          <v-card-actions class="px-4 pt-0">
             <v-spacer></v-spacer>
-            <v-card-actions class="px-4 pt-0">
-              <v-spacer></v-spacer>
-              <v-icon color="primary">mdi-arrow-right</v-icon>
-            </v-card-actions>
-          </v-card>
-        </template>
+            <v-icon color="primary">mdi-arrow-right</v-icon>
+          </v-card-actions>
+        </v-card>
       </v-hover>
     </v-col>
     <v-spacer></v-spacer>

--- a/frontend/src/views/LandingPage/DiscoverMeasuresBlock.vue
+++ b/frontend/src/views/LandingPage/DiscoverMeasuresBlock.vue
@@ -26,9 +26,9 @@
             {{ measure.title }}
           </v-card-title>
           <v-spacer></v-spacer>
-          <v-card-actions class="px-4 mr-4">
+          <v-card-actions class="px-4 py-4">
             <v-spacer></v-spacer>
-            <p class="text-decoration-underline text-body-2 font-weight-medium primary--text">En savoir plus</p>
+            <v-icon color="primary">mdi-arrow-right</v-icon>
           </v-card-actions>
         </v-card>
       </v-col>

--- a/frontend/src/views/LandingPage/DiscoverMeasuresBlock.vue
+++ b/frontend/src/views/LandingPage/DiscoverMeasuresBlock.vue
@@ -16,7 +16,6 @@
       <v-col cols="12" sm="4" v-for="measure in keyMeasures" :key="measure.id">
         <v-card
           outlined
-          :ripple="false"
           :to="{ name: 'KeyMeasurePage', params: { id: measure.id } }"
           class="fill-height d-flex flex-column px-3 dsfr"
         >

--- a/frontend/src/views/LandingPage/DiscoverMeasuresBlock.vue
+++ b/frontend/src/views/LandingPage/DiscoverMeasuresBlock.vue
@@ -15,9 +15,10 @@
     <v-row class="justify-center mt-8 mx-0 mx-md-n4 cta-group pa-4">
       <v-col cols="12" sm="4" v-for="measure in keyMeasures" :key="measure.id">
         <v-card
-          hover
+          outlined
+          :ripple="false"
           :to="{ name: 'KeyMeasurePage', params: { id: measure.id } }"
-          class="fill-height d-flex flex-column px-3"
+          class="fill-height d-flex flex-column px-3 dsfr"
         >
           <v-card-text class="pb-1 pt-6">
             <v-icon>{{ measure.mdiIcon }}</v-icon>

--- a/frontend/src/views/ManagementPage/CanteenCard.vue
+++ b/frontend/src/views/ManagementPage/CanteenCard.vue
@@ -4,7 +4,9 @@
       name: 'CanteenModification',
       params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
     }"
-    hover
+    class="dsfr"
+    outlined
+    :ripple="false"
   >
     <v-img :src="canteenImage || '/static/images/canteen-default-image.jpg'" height="160"></v-img>
     <v-card-title class="font-weight-bold">{{ canteen.name }}</v-card-title>

--- a/frontend/src/views/ManagementPage/CanteenCard.vue
+++ b/frontend/src/views/ManagementPage/CanteenCard.vue
@@ -13,9 +13,13 @@
         {{ publicationStatus.text }}
       </v-chip>
     </v-card-subtitle>
-    <v-card-subtitle v-if="canteen.dailyMealCount || canteen.city || canteen.sectors" class="mt-0">
+    <v-card-subtitle v-if="canteen.dailyMealCount || canteen.city || canteen.sectors" class="mt-0 pb-0">
       <CanteenIndicators :canteen="canteen" />
     </v-card-subtitle>
+    <v-card-actions class="px-4 py-4">
+      <v-spacer></v-spacer>
+      <v-icon color="primary">mdi-arrow-right</v-icon>
+    </v-card-actions>
   </v-card>
 </template>
 

--- a/frontend/src/views/ManagementPage/CanteensPagination.vue
+++ b/frontend/src/views/ManagementPage/CanteensPagination.vue
@@ -41,7 +41,6 @@
         <v-card
           class="d-flex flex-column align-center justify-center dsfr"
           outlined
-          :ripple="false"
           min-height="220"
           height="80%"
           :to="{ name: 'NewCanteen' }"

--- a/frontend/src/views/ManagementPage/CanteensPagination.vue
+++ b/frontend/src/views/ManagementPage/CanteensPagination.vue
@@ -39,8 +39,9 @@
       </v-col>
       <v-col cols="12" sm="6" md="4" height="100%" class="d-flex flex-column">
         <v-card
-          class="d-flex flex-column align-center justify-center"
-          hover
+          class="d-flex flex-column align-center justify-center dsfr"
+          outlined
+          :ripple="false"
           min-height="220"
           height="80%"
           :to="{ name: 'NewCanteen' }"

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -222,7 +222,6 @@
         <v-card
           class="dsfr d-flex flex-column align-center justify-center"
           outlined
-          :ripple="false"
           min-height="220"
           height="80%"
           :to="{ name: 'NewCanteen' }"

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -220,8 +220,9 @@
     <v-row v-else-if="visiblePurchases" class="mt-4">
       <v-col cols="12" sm="6" md="4" height="100%" class="d-flex flex-column">
         <v-card
-          class="d-flex flex-column align-center justify-center"
-          hover
+          class="dsfr d-flex flex-column align-center justify-center"
+          outlined
+          :ripple="false"
           min-height="220"
           height="80%"
           :to="{ name: 'NewCanteen' }"


### PR DESCRIPTION
### Cartes

Suivant [les cartes DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/carte/), nos cartes ont maintenant un radius de zéro, et une flèche en bas pour indiquer le lien. La couleur de police a aussi changé.

L'effet ripple a été enlevé et une nouvelle class `dsfr` est disponible pour la couleur de la bordure et le hover. J'ai décidé de ne pas le mettre dans toutes les cartes car il y a des cas légitimes de _v-card_ ou l'on voudrait ne pas avoir la UI d'une carte DSFR. 

![image](https://user-images.githubusercontent.com/1225929/183417662-b358abea-ab17-4cab-85bc-8c42d38957ec.png)
![image](https://user-images.githubusercontent.com/1225929/183052769-ce311342-8556-44a3-953c-b88458e1d17b.png)

### Boutons

Suivant [les boutons DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton/), nos boutons ont maintenant un radius de zéro. L'effet ripple a été enlevé aussi. Auparavant, les boutons principaux, avait un peu d'élévation, ceci n'est plus le cas.

![image](https://user-images.githubusercontent.com/1225929/183052678-b3613296-6e9c-431c-9d16-5d7c54da7c0a.png)
![image](https://user-images.githubusercontent.com/1225929/183423177-ea9390f0-a4cb-453d-87eb-0fc5695b78a3.png)
