### PR TITLE
Enlevement du « ripple » dans les radio et checkboxes

### DIFF
--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -1,7 +1,7 @@
 import Vue from "vue"
 import Vuetify from "vuetify/lib/framework"
 import theme from "@/theme"
-import { VBtn, VCard } from "vuetify/lib"
+import { VBtn, VCard, VRadio, VCheckbox } from "vuetify/lib"
 import remixJson from "./remix.json"
 
 Vue.use(Vuetify)
@@ -10,6 +10,8 @@ Vue.use(Vuetify)
 VBtn.options.props.ripple.default = false
 VBtn.options.props.elevation.default = 0
 VCard.options.props.ripple.default = false
+VRadio.options.props.ripple.default = false
+VCheckbox.options.props.ripple.default = false
 
 export default new Vuetify({
   theme: theme,

--- a/frontend/src/views/CanteenEditor/CanteenManagers.vue
+++ b/frontend/src/views/CanteenEditor/CanteenManagers.vue
@@ -30,6 +30,7 @@
               v-model="newManagerEmail"
               label="Adresse email"
               :rules="[validators.emailOrEmpty]"
+              class="flex-grow-1"
               validate-on-blur
             />
             <v-btn


### PR DESCRIPTION
J'en profite pour fixer également un petit souci de dimensionnement dans le formulaire d'ajout des gestionnaires additionnels.