### PR TITLE
Geoloc bot : amélioration des cantines candidates

### DIFF
--- a/macantine/tests/test_geolocation_bot.py
+++ b/macantine/tests/test_geolocation_bot.py
@@ -55,6 +55,8 @@ class TestGeolocationBot(TestCase):
         ]
         _ = [
             CanteenFactory.create(city=None, geolocation_bot_attempts=3, postal_code="69003"),
+            CanteenFactory.create(city=None, geolocation_bot_attempts=0, postal_code="69", city_insee_code=None),
+            CanteenFactory.create(city=None, geolocation_bot_attempts=0, city_insee_code="6009", postal_code=None),
             CanteenFactory.create(department="69", city="Lyon", geolocation_bot_attempts=2),
             CanteenFactory.create(department=None, geolocation_bot_attempts=1, city_insee_code=None, postal_code=None),
         ]


### PR DESCRIPTION
Le bot de géoloc prendra seulement les cantines ayant un code postal de 5 chars ou un code INSEE de 5 chars.