### PR TITLE
Améliorer l'accessibilité des lignes qui avec liens/boutons

### DIFF
--- a/frontend/src/components/DsfrAutocomplete.vue
+++ b/frontend/src/components/DsfrAutocomplete.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <label :for="inputId" :class="labelClasses">
+    <label :for="inputId" :class="labelClasses" v-if="$attrs.label">
       {{ $attrs.label }}
     </label>
     <v-autocomplete

--- a/frontend/src/components/DsfrCombobox.vue
+++ b/frontend/src/components/DsfrCombobox.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <label :for="inputId" :class="labelClasses">
+    <label :for="inputId" :class="labelClasses" v-if="$attrs.label">
       {{ $attrs.label }}
     </label>
     <v-combobox

--- a/frontend/src/components/DsfrSelect.vue
+++ b/frontend/src/components/DsfrSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <label :for="inputId" :class="labelClasses">
+    <label :for="inputId" :class="labelClasses" v-if="$attrs.label">
       {{ $attrs.label }}
     </label>
     <v-select

--- a/frontend/src/components/DsfrTextField.vue
+++ b/frontend/src/components/DsfrTextField.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <label :for="inputId" :class="labelClasses">
+    <label :for="inputId" :class="labelClasses" v-if="$attrs.label">
       {{ $attrs.label }}
     </label>
     <v-text-field

--- a/frontend/src/components/DsfrTextarea.vue
+++ b/frontend/src/components/DsfrTextarea.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <label :for="inputId" :class="labelClasses">
+    <label :for="inputId" :class="labelClasses" v-if="$attrs.label">
       {{ $attrs.label }}
     </label>
     <v-textarea

--- a/frontend/src/views/CanteenEditor/SatelliteManagement.vue
+++ b/frontend/src/views/CanteenEditor/SatelliteManagement.vue
@@ -51,6 +51,7 @@
         <template v-slot:[`item.userCanView`]="{ item }">
           <v-btn outlined color="primary" :to="satelliteLink(item)" @click="satelliteAction(item)">
             {{ item.userCanView ? "Mettre à jour" : "Rejoindre l'équipe" }}
+            <span class="d-sr-only">{{ item.userCanView ? "" : "de" }} {{ item.name }}</span>
           </v-btn>
         </template>
         <template v-slot:[`no-data`]>

--- a/frontend/src/views/CanteenEditor/SatelliteManagement.vue
+++ b/frontend/src/views/CanteenEditor/SatelliteManagement.vue
@@ -18,7 +18,6 @@
         :options.sync="options"
         :server-items-length="satelliteCount || 0"
         :items="visibleSatellites"
-        @click:row="onRowClick"
         :headers="headers"
       >
         <template v-slot:top>
@@ -50,7 +49,9 @@
           </v-dialog>
         </template>
         <template v-slot:[`item.userCanView`]="{ item }">
-          <a>{{ item.userCanView ? "Mettre à jour" : "Rejoindre l'équipe" }}</a>
+          <v-btn outlined color="primary" :to="satelliteLink(item)" @click="satelliteAction(item)">
+            {{ item.userCanView ? "Mettre à jour" : "Rejoindre l'équipe" }}
+          </v-btn>
         </template>
         <template v-slot:[`no-data`]>
           Vous n'avez pas renseigné des satellites
@@ -286,13 +287,16 @@ export default {
       this.$watch("options", this.onOptionsChange, { deep: true })
       this.$watch("$route", this.onRouteChange)
     },
-    onRowClick(satellite) {
+    satelliteLink(satellite) {
       if (satellite.userCanView) {
-        this.$router.push({
+        return {
           name: "CanteenModification",
           params: { canteenUrlComponent: this.$store.getters.getCanteenUrlComponent(satellite) },
-        })
-      } else {
+        }
+      }
+    },
+    satelliteAction(satellite) {
+      if (!satellite.userCanView) {
         this.restrictedSatellite = satellite
         this.joinDialog = true
       }
@@ -335,9 +339,6 @@ export default {
 <style scoped>
 .v-data-table {
   border: solid 1px #ddd;
-}
-.v-data-table >>> tr {
-  cursor: pointer;
 }
 
 /* Hides items-per-row */

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -183,6 +183,7 @@
         :items="processedVisiblePurchases"
         @click:row="onRowClick"
       >
+        <!-- TODO: accessible row links -->
         <template v-slot:[`item.family`]="{ item }">
           <v-chip outlined small :color="getProductFamilyDisplayValue(item.family).color" dark class="font-weight-bold">
             {{ getProductFamilyDisplayValue(item.family).text }}

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -183,7 +183,12 @@
         :items="processedVisiblePurchases"
         @click:row="onRowClick"
       >
-        <!-- TODO: accessible row links -->
+        <template v-slot:[`item.description`]="{ item }">
+          <router-link :to="{ name: 'PurchasePage', params: { id: item.id } }">
+            {{ item.description }}
+            <span class="d-sr-only">, {{ item.date }}</span>
+          </router-link>
+        </template>
         <template v-slot:[`item.family`]="{ item }">
           <v-chip outlined small :color="getProductFamilyDisplayValue(item.family).color" dark class="font-weight-bold">
             {{ getProductFamilyDisplayValue(item.family).text }}


### PR DESCRIPTION
Pour satellites et achats. Les liens/boutons devraient être accessible par souris et clavier, trouvable par les lecteurs d'écrans, et ouvrables dans un nouveau onglet

Closes #1893 

![Screenshot from 2022-09-19 17-42-01](https://user-images.githubusercontent.com/9282816/191058983-968d1aa6-3928-4a4b-807f-f1791909dfbb.png)
![Screenshot from 2022-09-21 12-10-54](https://user-images.githubusercontent.com/9282816/191478451-ed91e8f9-d959-4982-87c9-8124b3a1381c.png)
