### PR TITLE
Remplissage automatique des totaux viandes et poissons

### DIFF
--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -47,6 +47,12 @@ class PurchaseSummarySerializer(serializers.Serializer):
     hve = PurchaseField()
     aoc_aop_igp = PurchaseField()
     rouge = PurchaseField()
+    # meat and fish aggregates
+    meat_poultry_total = PurchaseField()
+    meat_poultry_egalim = PurchaseField()
+    meat_poultry_france = PurchaseField()
+    fish_total = PurchaseField()
+    fish_egalim = PurchaseField()
     # complex: by family and label
     viandes_volailles_bio = PurchaseField()
     produits_de_la_mer_bio = PurchaseField()

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -440,7 +440,7 @@ class TestPurchaseApi(APITestCase):
             date="2020-01-01",
             characteristics=[Purchase.Characteristic.BIO, Purchase.Characteristic.LABEL_ROUGE],
             family=Purchase.Family.PRODUITS_DE_LA_MER,
-            price_ht=50,
+            price_ht=55,
         )
 
         # Should be counted on EGALIM
@@ -494,8 +494,8 @@ class TestPurchaseApi(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         body = response.json()
-        self.assertEqual(body["fishTotal"], 155.0)
-        self.assertEqual(body["fishEgalim"], 120.0)
+        self.assertEqual(body["fishTotal"], 160.0)
+        self.assertEqual(body["fishEgalim"], 125.0)
 
     @authenticate
     def test_purchase_not_authorized(self):

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -362,11 +362,15 @@ class TestPurchaseApi(APITestCase):
         canteen = CanteenFactory.create()
         canteen.managers.add(authenticate.user)
 
-        # Should be counted on EGALIM only once
+        # Should be counted both on EGALIM and "Provenance France"
         PurchaseFactory.create(
             canteen=canteen,
             date="2020-01-01",
-            characteristics=[Purchase.Characteristic.BIO, Purchase.Characteristic.LABEL_ROUGE],
+            characteristics=[
+                Purchase.Characteristic.BIO,
+                Purchase.Characteristic.LABEL_ROUGE,
+                Purchase.Characteristic.FRANCE,
+            ],
             family=Purchase.Family.VIANDES_VOLAILLES,
             price_ht=50,
         )
@@ -424,7 +428,7 @@ class TestPurchaseApi(APITestCase):
         body = response.json()
         self.assertEqual(body["meatPoultryTotal"], 155.0)
         self.assertEqual(body["meatPoultryEgalim"], 120.0)
-        self.assertEqual(body["meatPoultryFrance"], 15.0)
+        self.assertEqual(body["meatPoultryFrance"], 65.0)
 
     @authenticate
     def test_purchase_fish_totals(self):

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -281,23 +281,23 @@ class CanteenPurchasesSummaryView(APIView):
         )
         data["meat_poultry_total"] = meat_poultry_purchases.aggregate(total=Sum("price_ht"))["total"]
 
-        meat_poultry_egalim_purchases = purchases.filter(characteristics__overlap=egalim_labels)
-        data["meat_poultry_egalim"] = meat_poultry_egalim_purchases.aggregate(total=Sum("price_ht"))["total"]
+        meat_poultry_egalim = purchases.filter(characteristics__overlap=egalim_labels)
+        data["meat_poultry_egalim"] = meat_poultry_egalim.aggregate(total=Sum("price_ht"))["total"]
 
-        meat_poultry_egalim_france = purchases.filter(
+        meat_poultry_france = purchases.filter(
             characteristics__contains=[
                 "FRANCE",
             ]
         )
-        data["meat_poultry_france"] = meat_poultry_egalim_france.aggregate(total=Sum("price_ht"))["total"]
+        data["meat_poultry_france"] = meat_poultry_france.aggregate(total=Sum("price_ht"))["total"]
 
         fish_purchases = purchases.filter(
             family=Purchase.Family.PRODUITS_DE_LA_MER,
         )
         data["fish_total"] = fish_purchases.aggregate(total=Sum("price_ht"))["total"]
 
-        fish_egalim_purchases = fish_purchases.filter(characteristics__overlap=egalim_labels)
-        data["fish_egalim"] = fish_egalim_purchases.aggregate(total=Sum("price_ht"))["total"]
+        fish_egalim = fish_purchases.filter(characteristics__overlap=egalim_labels)
+        data["fish_egalim"] = fish_egalim.aggregate(total=Sum("price_ht"))["total"]
 
         return Response(PurchaseSummarySerializer(data).data)
 

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -229,6 +229,9 @@ class CanteenPurchasesSummaryView(APIView):
             "BIO",
             "LABEL_ROUGE",
             "AOCAOP_IGP_STG",
+            "AOCAOP",
+            "IGP",
+            "STG",
             "HVE",
             "PECHE_DURABLE",
             "RUP",
@@ -236,6 +239,7 @@ class CanteenPurchasesSummaryView(APIView):
             "FERMIER",
             "EXTERNALITES",
             "PERFORMANCE",
+            "EQUIVALENTS",
         ]
         other_labels = ["FRANCE", "SHORT_DISTRIBUTION", "LOCAL"]
         # reset filter to 0 exclusions
@@ -292,7 +296,7 @@ class CanteenPurchasesSummaryView(APIView):
         )
         data["fish_total"] = fish_purchases.aggregate(total=Sum("price_ht"))["total"]
 
-        fish_egalim_purchases = purchases.filter(characteristics__overlap=egalim_labels)
+        fish_egalim_purchases = fish_purchases.filter(characteristics__overlap=egalim_labels)
         data["fish_egalim"] = fish_egalim_purchases.aggregate(total=Sum("price_ht"))["total"]
 
         return Response(PurchaseSummarySerializer(data).data)

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -272,6 +272,29 @@ class CanteenPurchasesSummaryView(APIView):
                 key = family.lower() + "_" + label.lower()
                 data[key] = fam_label.aggregate(total=Sum("price_ht"))["total"]
 
+        meat_poultry_purchases = purchases.filter(
+            family=Purchase.Family.VIANDES_VOLAILLES,
+        )
+        data["meat_poultry_total"] = meat_poultry_purchases.aggregate(total=Sum("price_ht"))["total"]
+
+        meat_poultry_egalim_purchases = purchases.filter(characteristics__overlap=egalim_labels)
+        data["meat_poultry_egalim"] = meat_poultry_egalim_purchases.aggregate(total=Sum("price_ht"))["total"]
+
+        meat_poultry_egalim_france = purchases.filter(
+            characteristics__contains=[
+                "FRANCE",
+            ]
+        )
+        data["meat_poultry_france"] = meat_poultry_egalim_france.aggregate(total=Sum("price_ht"))["total"]
+
+        fish_purchases = purchases.filter(
+            family=Purchase.Family.PRODUITS_DE_LA_MER,
+        )
+        data["fish_total"] = fish_purchases.aggregate(total=Sum("price_ht"))["total"]
+
+        fish_egalim_purchases = purchases.filter(characteristics__overlap=egalim_labels)
+        data["fish_egalim"] = fish_egalim_purchases.aggregate(total=Sum("price_ht"))["total"]
+
         return Response(PurchaseSummarySerializer(data).data)
 
     def _get_canteen(self, canteen_id, request):

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -281,10 +281,10 @@ class CanteenPurchasesSummaryView(APIView):
         )
         data["meat_poultry_total"] = meat_poultry_purchases.aggregate(total=Sum("price_ht"))["total"]
 
-        meat_poultry_egalim = purchases.filter(characteristics__overlap=egalim_labels)
+        meat_poultry_egalim = meat_poultry_purchases.filter(characteristics__overlap=egalim_labels)
         data["meat_poultry_egalim"] = meat_poultry_egalim.aggregate(total=Sum("price_ht"))["total"]
 
-        meat_poultry_france = purchases.filter(
+        meat_poultry_france = meat_poultry_purchases.filter(
             characteristics__contains=[
                 "FRANCE",
             ]

--- a/frontend/src/views/DiagnosticEditor/ExtendedQualityValues.vue
+++ b/frontend/src/views/DiagnosticEditor/ExtendedQualityValues.vue
@@ -59,6 +59,14 @@
       class="mt-2"
       :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
     />
+    <PurchaseHint
+      v-if="displayPurchaseHints"
+      v-model="diagnostic.valueMeatPoultryHt"
+      @autofill="checkTotal"
+      purchaseType="totaux viandes et volailles"
+      :amount="purchasesSummary.meatPoultryTotal"
+      :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
+    />
 
     <label :for="'fish-' + diagnostic.year" class="body-2 mt-4 d-block">
       <div class="d-inline-flex mr-2">
@@ -84,6 +92,14 @@
       :messages="fishError ? [errorMessage] : undefined"
       @blur="checkTotal"
       class="mt-2"
+      :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
+    />
+    <PurchaseHint
+      v-if="displayPurchaseHints"
+      v-model="diagnostic.valueFishHt"
+      @autofill="checkTotal"
+      purchaseType="totaux de poissons, produits de la mer et aquaculture"
+      :amount="purchasesSummary.fishTotal"
       :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
     />
 

--- a/frontend/src/views/DiagnosticEditor/SimplifiedQualityValues.vue
+++ b/frontend/src/views/DiagnosticEditor/SimplifiedQualityValues.vue
@@ -215,6 +215,14 @@
       class="mt-2"
       :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
     />
+    <PurchaseHint
+      v-if="displayPurchaseHints"
+      v-model="diagnostic.valueMeatPoultryHt"
+      @autofill="checkTotal"
+      purchaseType="totaux viandes et volailles"
+      :amount="purchasesSummary.meatPoultryTotal"
+      :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
+    />
 
     <!-- Viande et volailles EGALIM -->
     <div class="d-block d-sm-flex align-center mt-8">
@@ -247,6 +255,14 @@
       :error="meatPoultryError"
       @blur="checkTotal"
       class="mt-2"
+      :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
+    />
+    <PurchaseHint
+      v-if="displayPurchaseHints"
+      v-model="diagnostic.valueMeatPoultryEgalimHt"
+      @autofill="checkTotal"
+      purchaseType="viandes et volailles EGAlim"
+      :amount="purchasesSummary.meatPoultryEgalim"
       :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
     />
 
@@ -283,6 +299,14 @@
       class="mt-2"
       :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
     />
+    <PurchaseHint
+      v-if="displayPurchaseHints"
+      v-model="diagnostic.valueMeatPoultryFranceHt"
+      @autofill="checkTotal"
+      purchaseType="viandes et volailles provenance France"
+      :amount="purchasesSummary.meatPoultryFrance"
+      :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
+    />
 
     <!-- Poissons -->
     <v-divider class="mb-4 mt-8"></v-divider>
@@ -317,6 +341,14 @@
       class="mt-2"
       :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
     />
+    <PurchaseHint
+      v-if="displayPurchaseHints"
+      v-model="diagnostic.valueFishHt"
+      @autofill="checkTotal"
+      purchaseType="totaux de poissons, produits de la mer et aquaculture"
+      :amount="purchasesSummary.fishTotal"
+      :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
+    />
 
     <!-- Poissons EGALIM -->
     <div class="d-block d-sm-flex align-center mt-8">
@@ -346,6 +378,14 @@
       :error="fishError"
       @blur="checkTotal"
       class="mt-2"
+      :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
+    />
+    <PurchaseHint
+      v-if="displayPurchaseHints"
+      v-model="diagnostic.valueFishEgalimHt"
+      @autofill="checkTotal"
+      purchaseType="poissons, produits de la mer et aquaculture EGAlim"
+      :amount="purchasesSummary.fishEgalim"
       :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
     />
   </div>


### PR DESCRIPTION
Closes #1924 

Ajout des totaux pour les familles « viandes et volailles » et « poissons, produits de la mer et aquaculture »

![image](https://user-images.githubusercontent.com/1225929/193609739-d34a0230-75ee-45a7-abe9-36d7a7173741.png)

![image](https://user-images.githubusercontent.com/1225929/193609813-34d8cba8-b2b5-4160-8bdf-b3fa8bcfe62b.png)
