### PR TITLE
TD admin : affichage de tous les champs et option de modifier le statut

### DIFF
--- a/data/admin/teledeclaration.py
+++ b/data/admin/teledeclaration.py
@@ -27,6 +27,7 @@ class TeledeclarationAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
     list_display = (
         "canteen_name",
         "year",
+        "applicant",
         "creation_date",
         "status",
     )
@@ -34,6 +35,7 @@ class TeledeclarationAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
     fields = (
         "canteen",
         "year",
+        "applicant",
         "diagnostic",
         "creation_date",
         "status",
@@ -43,11 +45,16 @@ class TeledeclarationAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
     readonly_fields = (
         "canteen",
         "year",
+        "applicant",
         "diagnostic",
         "creation_date",
         "declared_data",
     )
-    search_fields = ("canteen__name",)
+    search_fields = (
+        "canteen__name",
+        "applicant__username",
+        "applicant__email",
+    )
 
     def canteen_name(self, obj):
         return obj.declared_data["canteen"]["name"]

--- a/data/admin/teledeclaration.py
+++ b/data/admin/teledeclaration.py
@@ -34,24 +34,29 @@ class TeledeclarationAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
     list_filter = ("year", "status")
     fields = (
         "canteen",
+        "canteen_siret",
         "year",
         "applicant",
         "diagnostic",
         "creation_date",
         "status",
+        "modification_date",
         "declared_data",
     )
     # want to be able to modify status
     readonly_fields = (
         "canteen",
+        "canteen_siret",
         "year",
         "applicant",
         "diagnostic",
         "creation_date",
+        "modification_date",
         "declared_data",
     )
     search_fields = (
         "canteen__name",
+        "canteen__siret",
         "applicant__username",
         "applicant__email",
     )

--- a/data/admin/teledeclaration.py
+++ b/data/admin/teledeclaration.py
@@ -34,10 +34,24 @@ class TeledeclarationAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
     fields = (
         "canteen",
         "year",
+        "diagnostic",
         "creation_date",
         "status",
         "declared_data",
     )
+    # want to be able to modify status
+    readonly_fields = (
+        "canteen",
+        "year",
+        "diagnostic",
+        "creation_date",
+        "declared_data",
+    )
+    search_fields = ("canteen__name",)
 
     def canteen_name(self, obj):
         return obj.declared_data["canteen"]["name"]
+
+    # overriding mixin
+    def has_change_permission(self, request, obj=None):
+        return True

--- a/data/admin/user.py
+++ b/data/admin/user.py
@@ -35,6 +35,7 @@ class MaCanteenUserAdmin(UserAdmin):
         "first_name",
         "last_name",
         "email",
+        "username",
     )
     readonly_fields = (
         "date_joined",


### PR DESCRIPTION
Bug : un utilisateur a une cantine avec un TD pour 2021 mais sans diagnostic. Je sais pas encore comment c'est arrivé - un possibilité c'est que le diag a été supprimé. Il y a 4 TD avec un vide diagnostic_id, les autre 3 sont des tests. Pour résoudre le pb en court-terme je veux changer le statut de son TD pour qu'elle puisse TD à nouveau.

models/teledeclaration.py line 71 (fn clean()) doesn't check if diagnostic id is null - but rightly so. I think the more proper change would be to either:
- make diagnostic protected if a TD exists for the diag `on_delete=models.PROTECT` (but this will make it difficult/impossible to delete canteens/diags if there is a TD)
- set the TD status to cancelled if the diagnostic is deleted (is the only way to do this with a signal?)