### PR TITLE
Bug : chiffre avec des éspaces pour les champs repas

### DIFF
--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -207,6 +207,7 @@
           </label>
           <DsfrTextField
             id="daily-meals"
+            type="number"
             hide-details="auto"
             :rules="showDailyMealCount ? [validators.greaterThanZero] : []"
             :disabled="!showDailyMealCount"
@@ -231,6 +232,7 @@
           </label>
           <DsfrTextField
             id="yearly-meals"
+            type="number"
             hide-details="auto"
             :rules="[validators.greaterThanZero, greaterThanDailyMealCount]"
             validate-on-blur
@@ -242,6 +244,7 @@
         <v-col cols="12" md="4" :class="showSatelliteCanteensCount ? '' : 'grey--text text--darken-1'">
           <DsfrTextField
             label="Nombre de cantines/lieux de service à qui je fournis des repas"
+            type="number"
             hide-details="auto"
             :rules="showSatelliteCanteensCount ? [validators.greaterThanZero] : []"
             :disabled="!showSatelliteCanteensCount"


### PR DESCRIPTION
Closes #2031 

A minimum fix to ensure the error message is displayed. I think a proper fix with a format check would be better, but more time consuming. 

Maybe adding a hint for the number format, or improving the error message would help in this case. We would still have a bigger problem for non-required number fields though.

MDN input type="number" results in the input passed to any validation functions being undefined when the input is not a strict number (ie nothing but numbers and . or , allowed). There are a few different possible solutions, but to get it consistent across the site would be a chunk of work. Related to #1894 .

![Screenshot 2022-10-25 at 12 20 37](https://user-images.githubusercontent.com/9282816/197748926-2eca0435-dfb6-4395-81b9-90b5a19474e3.png)
