### PR TITLE
Filtrage par cuisine centrale / satellite dans "mes cantines"

### DIFF
--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -511,9 +511,13 @@ class TestCanteenApi(APITestCase):
         user_central_cuisine = CanteenFactory.create(production_type="central")
         user_central_cuisine.managers.add(authenticate.user)
 
-        response = self.client.get(reverse("user_canteens"), {"production_type": "central"})
+        user_central_serving_cuisine = CanteenFactory.create(production_type="central_serving")
+        user_central_serving_cuisine.managers.add(authenticate.user)
+        response = self.client.get(f"{reverse('user_canteens')}?production_type=central,central_serving")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
 
-        self.assertEqual(body["count"], 1)
-        self.assertEqual(body["results"][0]["id"], user_central_cuisine.id)
+        self.assertEqual(body["count"], 2)
+        ids = list(map(lambda x: x["id"], body["results"]))
+        self.assertIn(user_central_cuisine.id, ids)
+        self.assertIn(user_central_serving_cuisine.id, ids)

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -502,3 +502,18 @@ class TestCanteenApi(APITestCase):
         self.assertNotIn("mtm_source_value", body)
         self.assertNotIn("mtm_campaign_value", body)
         self.assertNotIn("mtm_medium_value", body)
+
+    @authenticate
+    def test_get_canteens_filter_production_type(self):
+        user_satellite_canteen = CanteenFactory.create(production_type="site")
+        user_satellite_canteen.managers.add(authenticate.user)
+
+        user_central_cuisine = CanteenFactory.create(production_type="central")
+        user_central_cuisine.managers.add(authenticate.user)
+
+        response = self.client.get(reverse("user_canteens"), {"production_type": "central"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+
+        self.assertEqual(body["count"], 1)
+        self.assertEqual(body["results"][0]["id"], user_central_cuisine.id)

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -188,6 +188,7 @@ class UserCanteensView(ListCreateAPIView):
         UnaccentSearchFilter,
         MaCantineOrderingFilter,
     ]
+    filterset_fields = ("production_type",)
     required_scopes = ["canteen"]
     search_fields = ["name"]
     ordering_fields = ["name", "creation_date", "modification_date", "daily_meal_count"]

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -11,6 +11,7 @@ from django.db import transaction, IntegrityError
 from django.db.models.functions import Cast
 from django.db.models import Sum, FloatField, Avg, Func, F, Q
 from django_filters import rest_framework as django_filters
+from django_filters import BaseInFilter, CharFilter
 from drf_spectacular.utils import extend_schema_view, extend_schema
 from rest_framework.generics import RetrieveAPIView, ListAPIView, ListCreateAPIView
 from rest_framework.generics import RetrieveUpdateDestroyAPIView
@@ -168,6 +169,14 @@ class PublishedCanteenSingleView(RetrieveAPIView):
     queryset = Canteen.objects.filter(publication_status="published")
 
 
+class ProductionTypeInFilter(BaseInFilter, CharFilter):
+    pass
+
+
+class UserCanteensFilterSet(django_filters.FilterSet):
+    production_type = ProductionTypeInFilter(field_name="production_type")
+
+
 @extend_schema_view(
     get=extend_schema(
         summary="Lister avec une pagination des cantines gérées par l'utilisateur. Représentation complète.",
@@ -188,7 +197,7 @@ class UserCanteensView(ListCreateAPIView):
         UnaccentSearchFilter,
         MaCantineOrderingFilter,
     ]
-    filterset_fields = ("production_type",)
+    filterset_class = UserCanteensFilterSet
     required_scopes = ["canteen"]
     search_fields = ["name"]
     ordering_fields = ["name", "creation_date", "modification_date", "daily_meal_count"]

--- a/frontend/src/views/ManagementPage/CanteensPagination.vue
+++ b/frontend/src/views/ManagementPage/CanteensPagination.vue
@@ -98,7 +98,7 @@ export default {
       if (this.page) query.cantinePage = String(this.page)
       if (this.searchTerm) query.recherche = this.searchTerm
       if (this.productionTypeQuery)
-        if (this.productionTypeQuery.indexOf("central") !== -1) query.typeEtablissement = "central"
+        if (this.productionTypeQuery === "central,central_serving") query.typeEtablissement = "central"
         else query.typeEtablissement = "satellite_site"
       return query
     },
@@ -117,9 +117,7 @@ export default {
     fetchCurrentPage() {
       let queryParam = `limit=${this.limit}&offset=${this.offset}`
       if (this.searchTerm) queryParam += `&search=${this.searchTerm}`
-      if (this.productionTypeQuery)
-        for (let i = 0; i < this.productionTypeQuery.length; i++)
-          queryParam += `&production_type=${this.productionTypeQuery[i]}`
+      if (this.productionTypeQuery) queryParam += `&production_type=${this.productionTypeQuery}`
       this.searchTerm = this.$route.query.recherche || null
       this.inProgress = true
 
@@ -157,8 +155,8 @@ export default {
       })
     },
     populateProductionType() {
-      if (this.filterProductionType === "central") this.productionTypeQuery = ["central", "central_serving"]
-      else if (this.filterProductionType === "satellites") this.productionTypeQuery = ["site", "site_cooked_elsewhere"]
+      if (this.filterProductionType === "central") this.productionTypeQuery = "central,central_serving"
+      else if (this.filterProductionType === "satellites") this.productionTypeQuery = "site,site_cooked_elsewhere"
       else this.productionTypeQuery = null
     },
   },

--- a/frontend/src/views/ManagementPage/CanteensPagination.vue
+++ b/frontend/src/views/ManagementPage/CanteensPagination.vue
@@ -17,7 +17,12 @@
           </form>
         </v-col>
         <v-col cols="12" md="4" class="pa-0">
-          <DsfrSelect height="40" v-model="filterProductionType" :items="productionTypeOptions" />
+          <DsfrSelect
+            @change="applyProductionType"
+            height="40"
+            v-model="filterProductionType"
+            :items="productionTypeOptions"
+          />
         </v-col>
       </v-row>
     </v-sheet>
@@ -145,6 +150,12 @@ export default {
       const query = Object.assign(this.query, override)
       this.$router.push({ query }).catch(() => {})
     },
+    applyProductionType() {
+      this.$nextTick(() => {
+        this.page = 1
+        this.$router.push({ query: this.query }).catch(() => {})
+      })
+    },
     populateProductionType() {
       if (this.filterProductionType === "central") this.productionTypeQuery = ["central", "central_serving"]
       else if (this.filterProductionType === "satellites") this.productionTypeQuery = ["site", "site_cooked_elsewhere"]
@@ -161,12 +172,10 @@ export default {
     },
     filterProductionType() {
       this.populateProductionType()
-      this.page = 1
-      this.$router.push({ query: this.query }).catch(() => {})
     },
     $route() {
       this.populateInitialParameters()
-      this.fetchCurrentPage()
+      this.$nextTick(this.fetchCurrentPage)
     },
   },
   mounted() {


### PR DESCRIPTION
J'ai du enlever le dynamic-display des compsants recherche et pagination pour éviter que les éléments sautent partout lors de l'application d'un filtre.

![filter-central-satellite](https://user-images.githubusercontent.com/1225929/198530103-fec12f53-6aaa-4c66-9a9d-79ea786cc038.gif)
