### PR TITLE
Stats régionnales : dédupliquer les cantines et diagnostics

### DIFF
--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -143,7 +143,7 @@ class TestCanteenStatsApi(APITestCase):
         social = SectorFactory.create(name="Social")
         CanteenFactory.create(sectors=[school])
         CanteenFactory.create(sectors=[enterprise])
-        CanteenFactory.create(sectors=[enterprise, social])
+        CanteenFactory.create(sectors=[enterprise, social, school])
         CanteenFactory.create(sectors=[social])
 
         response = self.client.get(
@@ -153,6 +153,11 @@ class TestCanteenStatsApi(APITestCase):
 
         body = response.json()
         self.assertEqual(body["canteenCount"], 3)
+        expected_sectors = {}
+        expected_sectors[str(school.id)] = 2
+        expected_sectors[str(enterprise.id)] = 2
+        expected_sectors[str(social.id)] = 1
+        self.assertEqual(body["sectors"], expected_sectors)
 
     def test_canteen_stats_missing_data(self):
         response = self.client.get(reverse("canteen_statistics"), {"region": "01"})

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -773,7 +773,7 @@ class CanteenStatisticsView(APIView):
         if sectors:
             sectors = [s for s in sectors if s.isdigit()]
             canteens = canteens.filter(sectors__in=sectors)
-        return canteens
+        return canteens.distinct()
 
     def _filter_diagnostics(year, regions, departments, postal_codes, sectors):
         diagnostics = Diagnostic.objects.filter(year=year)
@@ -785,7 +785,7 @@ class CanteenStatisticsView(APIView):
             diagnostics = diagnostics.filter(canteen__region__in=regions)
         if sectors:
             diagnostics = diagnostics.filter(canteen__sectors__in=sectors)
-        return diagnostics
+        return diagnostics.distinct()
 
 
 class CanteenLocationsView(APIView):


### PR DESCRIPTION
Closes #2072 

pour tester chez toi - filtre par un secteur. Après, trouver un autre secteur qui a des resultats dans le premier. Filtre par les deux secteurs et on voit que les cantines avec les deux secteurs sont comptabilisées deux fois

# localhost, staging
![localhost-staging](https://user-images.githubusercontent.com/9282816/200918033-a7db2e6c-e47d-421d-a849-91d29a656e1f.png)

# localhost, branche
![localhost-branch](https://user-images.githubusercontent.com/9282816/200918058-1dfd9752-8441-4d50-a7a5-e5cbf7ad4db1.png)
