### PR TITLE
Assure que les valeurs calculés pour le diag simplifié soient valides

### DIFF
--- a/frontend/src/views/DiagnosticEditor/index.vue
+++ b/frontend/src/views/DiagnosticEditor/index.vue
@@ -411,6 +411,10 @@ export default {
             }
           }
         })
+        bioTotal = +bioTotal.toFixed(2)
+        siqoTotal = +siqoTotal.toFixed(2)
+        perfExtTotal = +perfExtTotal.toFixed(2)
+        egalimOthersTotal = +egalimOthersTotal.toFixed(2)
       }
       return {
         bioTotal,
@@ -440,6 +444,8 @@ export default {
           if (isEgalim) meatPoultryEgalim += value
           if (isFrance) meatPoultryFrance += value
         })
+        meatPoultryEgalim = +meatPoultryEgalim.toFixed(2)
+        meatPoultryFrance = +meatPoultryFrance.toFixed(2)
       }
       return { meatPoultryEgalim, meatPoultryFrance }
     },
@@ -457,6 +463,7 @@ export default {
           if (!isFish || !value) return
           fishEgalim += value
         })
+        fishEgalim = +fishEgalim.toFixed(2)
       }
       return { fishEgalim }
     },


### PR DESCRIPTION
La somme des valeurs pour remplir le diag simplifié peut contenir des erreurs d'approximation, par exemple : 
![image](https://user-images.githubusercontent.com/1225929/201672734-4a0de34a-0117-49ab-8319-51a7bba0bf21.png)

En s'assurant que les chiffres calculées aient toujous deux chiffres après la virgule on règle ce problème. C'est seulement nécessaire lors qu'on rempli le diagnostic complèt.

J'ai utilisé le [unary plus](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus) avec un `toFixed` pour éviter des erreurs de rounding.