### PR TITLE
Validation de l'email dans la page « mon compte »

### DIFF
--- a/frontend/src/views/AccountSummaryPage/AccountEditor.vue
+++ b/frontend/src/views/AccountSummaryPage/AccountEditor.vue
@@ -94,6 +94,7 @@
               v-model="userCopy.email"
               :rules="[validators.email]"
               validate-on-blur
+              :error-messages="emailErrorMessages"
             />
           </v-col>
           <v-col cols="12" md="9">
@@ -166,6 +167,7 @@ export default {
       bypassLeaveWarning: false,
       jobOptions: Constants.Jobs,
       sourceOptions: Constants.UserSources,
+      emailErrorMessages: [],
     }
   },
   computed: {
@@ -213,7 +215,17 @@ export default {
           this.$router.push(nextRoute)
         })
         .catch((e) => {
-          this.$store.dispatch("notifyServerError", e)
+          if (e.jsonPromise) {
+            e.jsonPromise.then((json) => {
+              if (json.email) {
+                this.emailErrorMessages = json.email
+                return
+              }
+              this.$store.dispatch("notifyServerError", e)
+            })
+          } else {
+            this.$store.dispatch("notifyServerError", e)
+          }
         })
     },
     onProfilePhotoUploadClick() {

--- a/frontend/src/views/AccountSummaryPage/AccountEditor.vue
+++ b/frontend/src/views/AccountSummaryPage/AccountEditor.vue
@@ -94,6 +94,7 @@
               v-model="userCopy.email"
               :rules="[validators.email]"
               validate-on-blur
+              @change="emailErrorMessages = []"
               :error-messages="emailErrorMessages"
             />
           </v-col>


### PR DESCRIPTION
La validation qu'on a dans le frontend pour l'email n'est aussi sophistiqué que celle de Django dans le backend.

Un exemple c'est les TLDs. En mettant un faux TLD la validation frontend passe alors que celle coté backend ne passe pas. On a déjà eu ce souci avec des clients - qui reçoivent un erreur générique "Oops" alors que simplement l'email a un typo.

Cette PR prend aussi le retour du backend concernant l'email et met une validation dans le champ si nécessaire. Seul bémol : le message n'est pas exactement le même qu'avec la validation frontend, mais ça reste clair.

Closes #2103 
![email-validation](https://user-images.githubusercontent.com/1225929/204535122-7de166b3-e2f8-4f38-9fd4-94aeaac6ad1c.gif)

