### PR TITLE
Enlever la télédéclaration

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -92,6 +92,7 @@ OVERRIDE_TEST_SEED= Optionnel - `seed` utilisé par les tests pour les élément
 ENABLE_XP_RESERVATION= Optionnel - `True` pour activer la feature de l'expérimentation des systèmes de réservation.
 ENABLE_XP_VEGE= Optionnel - `True` pour activer la feature de l'expérimentation de l'offre quotidien de repas végétariens.
 ENABLE_PARTNERS= Optionnel - `True` pour afficher nos partenaires sur la page d'accueil.
+ENABLE_TELEDECLARATION= Optionnel - `True` pour permettre les utilisateurs de télédéclarer leur diagnostic.
 ```
 
 ### Relances automatiques par email

--- a/frontend/src/components/CanteenNavigation.vue
+++ b/frontend/src/components/CanteenNavigation.vue
@@ -96,6 +96,7 @@ export default {
       return diagnostic.teledeclaration && diagnostic.teledeclaration.status === "SUBMITTED"
     },
     shouldTeledeclare(diagnostic) {
+      if (!window.ENABLE_TELEDECLARATION) return false
       return (
         (!diagnostic.teledeclaration || diagnostic.teledeclaration.status == "CANCELLED") &&
         diagnostic.year === lastYear()

--- a/frontend/src/views/DiagnosticEditor/index.vue
+++ b/frontend/src/views/DiagnosticEditor/index.vue
@@ -38,7 +38,7 @@
               </v-btn>
             </v-col>
 
-            <div v-if="isTeledeclarationYear">
+            <div v-if="canTeledeclare">
               <p v-if="!hasActiveTeledeclaration && !canSubmitTeledeclaration" class="text-caption ma-0 pl-4">
                 <v-icon small>mdi-information</v-icon>
                 Vous pourrez télédéclarer ce diagnostic après avoir remplir les données d'approvisionnement
@@ -176,7 +176,7 @@
           </DiagnosticExpansionPanel>
         </v-expansion-panels>
 
-        <div v-if="!hasActiveTeledeclaration && isTeledeclarationYear" class="mt-4" id="teledeclaration">
+        <div v-if="!hasActiveTeledeclaration && canTeledeclare" class="mt-4" id="teledeclaration">
           <h2 class="font-weight-black text-h5 mt-8 mb-4">Télédéclarer mon diagnostic</h2>
           <p>
             Un bilan annuel relatif à la mise en œuvre des dispositions de la loi EGAlim, et notamment des objectifs
@@ -204,7 +204,7 @@
             </v-btn>
             <v-btn
               x-large
-              :outlined="isTeledeclarationYear"
+              :outlined="canTeledeclare"
               color="primary"
               class="ma-3"
               @click="saveDiagnostic"
@@ -218,7 +218,7 @@
               class="ma-3"
               @click="openTeledeclarationPreview"
               :disabled="!canSubmitTeledeclaration"
-              v-if="isTeledeclarationYear"
+              v-if="canTeledeclare"
             >
               <v-icon class="mr-2">$checkbox-circle-fill</v-icon>
               Valider et télédéclarer
@@ -226,7 +226,7 @@
           </div>
           <p
             class="text-caption amber--text text--darken-3 text-md-right mb-0 mx-3 mt-n1"
-            v-if="isTeledeclarationYear && !hasActiveTeledeclaration && !canSubmitTeledeclaration"
+            v-if="canTeledeclare && !hasActiveTeledeclaration && !canSubmitTeledeclaration"
           >
             <v-icon small color="amber darken-3">mdi-alert</v-icon>
             Données d'approvisionnement manquantes.
@@ -357,8 +357,8 @@ export default {
     hasActiveTeledeclaration() {
       return this.diagnostic.teledeclaration && this.diagnostic.teledeclaration.status === "SUBMITTED"
     },
-    isTeledeclarationYear() {
-      return this.diagnostic.year === this.teledeclarationYear
+    canTeledeclare() {
+      return window.ENABLE_TELEDECLARATION && this.diagnostic.year === this.teledeclarationYear
     },
     displayPurchaseHints() {
       return (

--- a/frontend/src/views/DiagnosticEditor/index.vue
+++ b/frontend/src/views/DiagnosticEditor/index.vue
@@ -38,19 +38,25 @@
               </v-btn>
             </v-col>
 
-            <div v-if="canTeledeclare">
-              <p v-if="!hasActiveTeledeclaration && !canSubmitTeledeclaration" class="text-caption ma-0 pl-4">
+            <div>
+              <p
+                v-if="isTeledeclarationPhase && !hasActiveTeledeclaration && !canSubmitTeledeclaration"
+                class="text-caption ma-0 pl-4"
+              >
                 <v-icon small>mdi-information</v-icon>
                 Vous pourrez télédéclarer ce diagnostic après avoir remplir les données d'approvisionnement
               </p>
-              <p v-else-if="!hasActiveTeledeclaration" class="text-body-2 pl-4 mb-0 d-md-flex align-center">
+              <p
+                v-else-if="isTeledeclarationPhase && !hasActiveTeledeclaration"
+                class="text-body-2 pl-4 mb-0 d-md-flex align-center"
+              >
                 <v-icon small color="amber darken-3">mdi-alert</v-icon>
                 &nbsp;Vous n'avez pas encore télédéclaré ce diagnostic -&nbsp;
                 <a color="primary" href="#teledeclaration">
                   télédéclarez-le
                 </a>
               </p>
-              <div v-else class="px-2 mt-2">
+              <div v-else-if="hasActiveTeledeclaration" class="px-2 mt-2">
                 <p class="text-caption mb-2">
                   <v-icon small>$checkbox-fill</v-icon>
                   Ce diagnostic a été télédéclaré {{ timeAgo(diagnostic.teledeclaration.creationDate, true) }}.
@@ -74,9 +80,10 @@
           Cliquez sur les catégories ci-dessous pour remplir votre diagnostic
         </p>
         <div class="caption grey--text text--darken-1" v-if="hasActiveTeledeclaration">
-          <p class="mb-0">Une fois télédéclaré, vous ne pouvez plus modifier votre diagnostic.</p>
+          <p class="mb-2">Une fois télédéclaré, vous ne pouvez plus modifier votre diagnostic.</p>
           <TeledeclarationCancelDialog
             v-model="cancelDialog"
+            v-if="isTeledeclarationPhase"
             @cancel="cancelTeledeclaration"
             :diagnostic="diagnostic"
           />
@@ -176,7 +183,7 @@
           </DiagnosticExpansionPanel>
         </v-expansion-panels>
 
-        <div v-if="!hasActiveTeledeclaration && canTeledeclare" class="mt-4" id="teledeclaration">
+        <div v-if="!hasActiveTeledeclaration && isTeledeclarationPhase" class="mt-4" id="teledeclaration">
           <h2 class="font-weight-black text-h5 mt-8 mb-4">Télédéclarer mon diagnostic</h2>
           <p>
             Un bilan annuel relatif à la mise en œuvre des dispositions de la loi EGAlim, et notamment des objectifs
@@ -204,7 +211,7 @@
             </v-btn>
             <v-btn
               x-large
-              :outlined="canTeledeclare"
+              :outlined="isTeledeclarationPhase"
               color="primary"
               class="ma-3"
               @click="saveDiagnostic"
@@ -218,7 +225,7 @@
               class="ma-3"
               @click="openTeledeclarationPreview"
               :disabled="!canSubmitTeledeclaration"
-              v-if="canTeledeclare"
+              v-if="isTeledeclarationPhase"
             >
               <v-icon class="mr-2">$checkbox-circle-fill</v-icon>
               Valider et télédéclarer
@@ -226,7 +233,7 @@
           </div>
           <p
             class="text-caption amber--text text--darken-3 text-md-right mb-0 mx-3 mt-n1"
-            v-if="canTeledeclare && !hasActiveTeledeclaration && !canSubmitTeledeclaration"
+            v-if="isTeledeclarationPhase && !hasActiveTeledeclaration && !canSubmitTeledeclaration"
           >
             <v-icon small color="amber darken-3">mdi-alert</v-icon>
             Données d'approvisionnement manquantes.
@@ -357,7 +364,7 @@ export default {
     hasActiveTeledeclaration() {
       return this.diagnostic.teledeclaration && this.diagnostic.teledeclaration.status === "SUBMITTED"
     },
-    canTeledeclare() {
+    isTeledeclarationPhase() {
       return window.ENABLE_TELEDECLARATION && this.diagnostic.year === this.teledeclarationYear
     },
     displayPurchaseHints() {

--- a/frontend/src/views/ManagementPage/CanteenCard.vue
+++ b/frontend/src/views/ManagementPage/CanteenCard.vue
@@ -11,7 +11,7 @@
     <v-img :src="canteenImage || '/static/images/canteen-default-image.jpg'" height="160" max-height="160"></v-img>
     <v-card-title class="font-weight-bold">{{ canteen.name }}</v-card-title>
     <v-card-subtitle class="py-1">
-      <v-chip small :color="teledeclarationStatus.color" label class="mr-1">
+      <v-chip v-if="teledeclarationIsActive" small :color="teledeclarationStatus.color" label class="mr-1">
         {{ teledeclarationStatus.text }}
       </v-chip>
       <v-chip small :color="publicationStatus.color" label>
@@ -81,6 +81,9 @@ export default {
     canteenImage() {
       if (!this.canteen.images || this.canteen.images.length === 0) return null
       return this.canteen.images[0].image
+    },
+    teledeclarationIsActive() {
+      return window.ENABLE_TELEDECLARATION
     },
   },
 }

--- a/frontend/src/views/ManagementPage/CentralKitchenCard.vue
+++ b/frontend/src/views/ManagementPage/CentralKitchenCard.vue
@@ -15,7 +15,7 @@
     <v-img :src="canteenImage || '/static/images/canteen-default-image.jpg'" height="160" max-height="160"></v-img>
     <v-card-title class="font-weight-bold">{{ canteen.name }}</v-card-title>
     <v-card-subtitle class="py-1">
-      <v-chip small :color="teledeclarationStatus.color" label class="mr-1">
+      <v-chip v-if="teledeclarationIsActive" small :color="teledeclarationStatus.color" label class="mr-1">
         {{ teledeclarationStatus.text }}
       </v-chip>
       <v-chip small :color="publicationStatus.color" label>
@@ -85,6 +85,9 @@ export default {
     canteenImage() {
       if (!this.canteen.images || this.canteen.images.length === 0) return null
       return this.canteen.images[0].image
+    },
+    teledeclarationIsActive() {
+      return window.ENABLE_TELEDECLARATION
     },
   },
 }

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -469,6 +469,7 @@ if DEBUG:
 ENABLE_XP_RESERVATION = os.getenv("ENABLE_XP_RESERVATION") == "True"
 ENABLE_XP_VEGE = os.getenv("ENABLE_XP_VEGE") == "True"
 ENABLE_PARTNERS = os.getenv("ENABLE_PARTNERS") == "True"
+ENABLE_TELEDECLARATION = os.getenv("ENABLE_TELEDECLARATION") == "True"
 
 # Custom testing
 

--- a/web/templates/vue-app.html
+++ b/web/templates/vue-app.html
@@ -37,6 +37,7 @@
         window.ENABLE_XP_RESERVATION = "{% enable_xp_reservation %}" === "True"
         window.ENABLE_XP_VEGE = "{% enable_xp_vege %}" === "True"
         window.ENABLE_PARTNERS = "{% enable_partners %}" === "True"
+        window.ENABLE_TELEDECLARATION = "{% enable_teledeclaration %}" === "True"
     </script>
 
     <script type="text/javascript">

--- a/web/templatetags/featureflags.py
+++ b/web/templatetags/featureflags.py
@@ -17,3 +17,8 @@ def enable_xp_vege():
 @register.simple_tag
 def enable_partners():
     return getattr(settings, "ENABLE_PARTNERS", "")
+
+
+@register.simple_tag
+def enable_teledeclaration():
+    return getattr(settings, "ENABLE_TELEDECLARATION", "")


### PR DESCRIPTION
En cas d'absence de la feature flag, cette PR enlève les références à la télédéclaration sur trois endroits dans la UI :
- La carte cantine (car ça peut se prêter à confusion d'avoir le "non-télédéclaré" et de ne pas avoir la possibilité de le faire) 
- La navigation sur la page de gestion de la cantine
- Le formulaire du diagnostic

Hors scope :
Les actions ne sont pas gérées par cette PR. Je me suis permis de découper car on n'a pas accès direct à la page des actions depuis qu'on a changé la bannière de la campagne de télédéclaration.

![image](https://user-images.githubusercontent.com/1225929/204824980-c6538b88-7cf7-47be-97b5-abfff8d0912d.png)
![image](https://user-images.githubusercontent.com/1225929/204825042-d6705a82-f4fb-481f-a699-27199e55de81.png)
![image](https://user-images.githubusercontent.com/1225929/204825100-bc34d9a3-4c8b-4218-ba49-71b3896c554b.png)
