### PR TITLE
Fix echec aléatoire du test automatique

### DIFF
--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -37,7 +37,7 @@ class TestCanteenStatsApi(APITestCase):
             sectors=[school],
         )
         # this canteen will be included in the canteen count, but not the diagnostic count
-        #   which is used to calculate the measure success percentages
+        # which is used to calculate the measure success percentages
         out_of_date = CanteenFactory.create(
             region=region,
             publication_status=Canteen.PublicationStatus.PUBLISHED.value,
@@ -70,6 +70,7 @@ class TestCanteenStatsApi(APITestCase):
             value_egalim_others_ht=0,
             has_waste_diagnostic=True,
             waste_actions=["action1", "action2"],
+            has_donation_agreement=True,
             vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.LOW,
             cooking_plastic_substituted=True,
             serving_plastic_substituted=True,

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -755,8 +755,7 @@ class CanteenStatisticsView(APIView):
         data["sustainable_percent"] = int((agg["sustainable_share__avg"] or 0) * 100)
 
         # --- badges ---
-        total_diag = diagnostics
-        total_diag = total_diag.count()
+        total_diag = diagnostics.count()
         data["diagnostics_count"] = total_diag
         data["approPercent"] = 0
         data["wastePercent"] = 0


### PR DESCRIPTION
Le badge waste se donne de cette façon : 
```python
waste_badge_query = waste_badge_query.filter(waste_actions_len__gt=0)
waste_badge_query = waste_badge_query.filter(
    Q(canteen__daily_meal_count__lt=3000) | Q(has_donation_agreement=True)
)
```

Ça veut dire que si le `DiagnosticFactory` produit un diagnostic avec `has_donation_agreement = False` et que la catine a plus de 3000 daily_meal_count le test fail.

Le fix le plus simple est d'aussi spécifier le `has_donation_agreement` à `True` pour s'assurer que le badge est toujours obtenu.