### PR TITLE
Ajout des données des satellites dans la télédéclaration

### DIFF
--- a/api/templates/teledeclaration_pdf.html
+++ b/api/templates/teledeclaration_pdf.html
@@ -83,6 +83,15 @@
             Vous avez choisi de déclarer les données d'approvisionnement au nom de toutes vos cantines satellites.
         </p>
         {% endif %}
+        {% if teledeclaration_mode == "CENTRAL_ALL" or teledeclaration_mode == "CENTRAL_APPRO" %}
+            {% if satellites %}
+                Cette télédéclaration concerne les cuisines satallites :
+                <br />
+                {% for satellite in satellites %}
+                · {{ satellite.name }} (Siret : {{satellite.siret}})<br />
+                {% endfor %}
+            {% endif %}
+        {% endif %}
         <p>
             Pour l'année {{ year }}, les données suivantes ont été télédéclarées le
             {{ date|date:"l j F Y" }} via la plateforme numérique ma cantine :

--- a/api/templates/teledeclaration_pdf.html
+++ b/api/templates/teledeclaration_pdf.html
@@ -85,7 +85,7 @@
         {% endif %}
         {% if teledeclaration_mode == "CENTRAL_ALL" or teledeclaration_mode == "CENTRAL_APPRO" %}
             {% if satellites %}
-                Cette télédéclaration concerne les cuisines satallites :
+                Cette télédéclaration concerne les cuisines satellites :
                 <br />
                 {% for satellite in satellites %}
                 · {{ satellite.name }} (Siret : {{satellite.siret}})<br />

--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -172,6 +172,7 @@ class TeledeclarationPdfView(APIView):
                     "teledeclaration_mode": teledeclaration.teledeclaration_mode,
                     "central_kitchen_siret": central_kitchen_siret,
                     "central_kitchen_name": central_kitchen_name,
+                    "satellites": declared_data.get("satellites", []),
                 },
             }
             html = template.render(context)

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -336,6 +336,12 @@ class Teledeclaration(models.Model):
             "central_kitchen_siret": diagnostic.canteen.central_producer_siret,
             "teledeclaration": {**json_appro_teledeclaration, **json_other_teledeclaration},
         }
+
+        if is_central_cuisine:
+            json_fields["satellites"] = [
+                {"id": x.id, "siret": x.siret, "name": x.name} for x in diagnostic.canteen.satellites
+            ]
+            json_fields["satellite_canteens_count"] = diagnostic.canteen.satellite_canteens_count
         return TeledeclarationFactory.create(
             applicant=applicant,
             year=diagnostic.year,


### PR DESCRIPTION
Ceci permet de mitiger le cas des changements dans les cantines satellites après la télédéclaration. 

L'information est aussi présente dans le PDF de la télédéclaration.

![image](https://user-images.githubusercontent.com/1225929/206427733-0029c38c-cc50-45cb-8305-75eb66e99fb4.png)
