### PR TITLE
Redirection lors que la page nécessite d'être identifié

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -551,7 +551,7 @@ function chooseAuthorisedRoute(to, from, next) {
     else if (to.meta.home && store.state.loggedUser && store.state.loggedUser.isDev) next({ name: "DeveloperPage" })
     else if (to.meta.home) next({ name: "LandingPage" })
     else if (!to.meta.authenticationRequired || store.state.loggedUser) next()
-    else next({ name: "NotFound" })
+    else window.location.href = `/s-identifier?next=${to.path}`
   }
 }
 


### PR DESCRIPTION
Cette PR fait une double redirection : 
1- Si un utilisateur essaie d'accéder une page protégée (par ex _modifier-ma-cantine/1--Cantine/modifier/_) et qu'iel n'est pas identifié, on fait une redirection vers la page de login (_s-identifier_) avec un paramètre `next`.
2- Après l'authentification, l'utilisateur sera redirigé automatiquement vers la page qu'iel essayait d'accéder au début (_modifier-ma-cantine/1--Cantine/modifier/_).

Closes #2128