### PR TITLE
Ajustement des emails automatiques

### DIFF
--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -158,8 +158,7 @@ def _covered_by_central_kitchen(canteen):
             covered_by_central_kitchen = central_kitchen.diagnostic_set.filter(
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
             ).exists()
-            if covered_by_central_kitchen:
-                return True
+            return covered_by_central_kitchen
         except Canteen.DoesNotExist:
             pass
         except Canteen.MultipleObjectsReturned as e:


### PR DESCRIPTION
Les gestionnaires d'une cuisine satellite ne recevront plus de rappel concernant le diagnostic si leur cuisine centrale a fait un diagnostic complet pour eux