### PR TITLE
Purchase filtering

### DIFF
--- a/frontend/src/components/CanteenIndicators.vue
+++ b/frontend/src/components/CanteenIndicators.vue
@@ -25,6 +25,8 @@
 </template>
 
 <script>
+import { capitalise } from "@/utils"
+
 export default {
   name: "CanteenIndicators",
   props: {
@@ -44,7 +46,7 @@ export default {
       const sectorDisplay = this.canteen.sectors
         .map((sectorId) => sectors.find((x) => x.id === sectorId).name.toLowerCase())
         .join(", ")
-      return sectorDisplay.charAt(0).toUpperCase() + sectorDisplay.slice(1)
+      return capitalise(sectorDisplay)
     },
     hasSatelliteCanteens() {
       return (

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -90,6 +90,7 @@ export default Object.freeze({
     },
   },
   Characteristics: {
+    // NB: the order of these keys reflects the priority of the label in EGAlim sum calculations
     // NB: the order of these can affect the aesthetics of the display on PurchasePage, esp for long texts
     BIO: { text: "Bio" },
     LABEL_ROUGE: { text: "Label rouge" },

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -427,3 +427,7 @@ export const hideCommunityEventsBanner = (events, store) => {
   document.cookie = `${bannerCookieName}=${lastEventId};max-age=31536000;path=/;expires=${expirationDate.toUTCString()};SameSite=Strict;`
   store.dispatch("setShowWebinaireBanner", false)
 }
+
+export const capitalise = (str) => {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}

--- a/frontend/src/views/DiagnosticEditor/index.vue
+++ b/frontend/src/views/DiagnosticEditor/index.vue
@@ -289,7 +289,16 @@ import SimplifiedQualityValues from "./SimplifiedQualityValues"
 import ExtendedQualityValues from "./ExtendedQualityValues"
 import TeledeclarationPreview from "@/components/TeledeclarationPreview"
 import Constants from "@/constants"
-import { getObjectDiff, timeAgo, strictIsNaN, lastYear, diagnosticYears, getPercentage, readCookie } from "@/utils"
+import {
+  getObjectDiff,
+  timeAgo,
+  strictIsNaN,
+  lastYear,
+  diagnosticYears,
+  getPercentage,
+  readCookie,
+  capitalise,
+} from "@/utils"
 import DsfrSelect from "@/components/DsfrSelect"
 
 const LEAVE_WARNING = "Voulez-vous vraiment quitter cette page ? Le diagnostic n'a pas été sauvegardé."
@@ -582,7 +591,7 @@ export default {
       if (this.diagnostic.plasticTablewareSubstituted) summary.push("ustensils")
       if (summary.length === 0) return "Pas de mesures de substitution"
       summary = summary.join(", ") + " substitués"
-      return summary.charAt(0).toUpperCase() + summary.slice(1)
+      return capitalise(summary)
     },
     saveDiagnostic() {
       const diagnosticFormsAreValid = this.validateForms()

--- a/frontend/src/views/ManagementPage/CanteensPagination.vue
+++ b/frontend/src/views/ManagementPage/CanteensPagination.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-sheet class="px-3 mt-6 mb-6" elevation="0">
+    <v-sheet class="px-3 mt-6 mb-6" elevation="0" v-if="showFilters">
       <v-row>
         <v-col cols="12" md="7" class="pa-0 pr-md-8">
           <form role="search" class="d-block d-sm-flex align-end" onsubmit="return false">
@@ -26,7 +26,7 @@
         </v-col>
       </v-row>
     </v-sheet>
-    <DsfrPagination class="mb-6" v-model="page" :length="Math.ceil(canteenCount / limit)" />
+    <DsfrPagination class="mb-6" v-model="page" :length="Math.ceil(canteenCount / limit)" v-if="showPagination" />
     <v-sheet fluid height="200" v-if="inProgress">
       <v-progress-circular indeterminate style="left: 50%; top: 50%"></v-progress-circular>
     </v-sheet>
@@ -101,6 +101,12 @@ export default {
       if (this.searchTerm) query.recherche = this.searchTerm
       if (this.filterProductionType !== "all") query.typeEtablissement = this.filterProductionType
       return query
+    },
+    showFilters() {
+      return this.canteenCount > this.limit || this.searchTerm || this.filterProductionType
+    },
+    showPagination() {
+      return this.canteenCount > this.limit
     },
   },
   methods: {

--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -237,7 +237,7 @@ import keyMeasures from "@/data/key-measures.json"
 import jsonDepartments from "@/departments.json"
 import jsonRegions from "@/regions.json"
 import jsonEpcis from "@/epcis.json"
-import { lastYear, normaliseText, sectorsSelectList } from "@/utils"
+import { lastYear, normaliseText, sectorsSelectList, capitalise } from "@/utils"
 import BreadcrumbsNav from "@/components/BreadcrumbsNav"
 import DsfrAutocomplete from "@/components/DsfrAutocomplete"
 import DsfrSelect from "@/components/DsfrSelect"
@@ -288,6 +288,7 @@ export default {
     this.populateInitialParameters()
     this.loadLocations()
     this.updateStatistics()
+    this.updateDocumentTitle()
   },
   computed: {
     departments() {
@@ -560,17 +561,16 @@ export default {
       if (!Array.isArray(this.chosenRegions)) this.chosenRegions = [this.chosenRegions]
       this.chosenDepartments = this.$route.query.department || []
       if (!Array.isArray(this.chosenDepartments)) this.chosenDepartments = [this.chosenDepartments]
+      this.chosenEpcis = this.$route.query.epcis || []
+      if (!Array.isArray(this.chosenEpcis)) this.chosenEpcis = [this.chosenEpcis]
       this.chosenSectors = this.$route.query.sectors?.split(",").map((s) => parseInt(s, 10)) || []
-      let queryEpcis = this.$route.query.epcis
-      queryEpcis = queryEpcis || []
-      this.chosenEpcis = Array.isArray(queryEpcis) ? queryEpcis : [queryEpcis]
     },
     updateDocumentTitle() {
       let title = `Les cantines dans ma collectivité - ${this.$store.state.pageTitleSuffix}`
-      if (this.chosenRegions.length || this.chosenDepartments.length) {
+      if (this.chosenRegions.length || this.chosenDepartments.length || this.chosenEpcis.length) {
         let locationText = this.createLocationText()
         if (locationText.startsWith("les")) {
-          locationText = locationText.charAt(0).toUpperCase() + locationText.slice(1)
+          locationText = capitalise(locationText)
         }
         title = `${locationText} - ${title}`
       }

--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -72,6 +72,8 @@
                   class="mt-2"
                   auto-select-first
                   no-data-text="Pas de résultats"
+                  :readonly="this.userCanteens.length === 1"
+                  :disabled="this.userCanteens.length === 1"
                 />
               </v-col>
 
@@ -401,6 +403,9 @@ export default {
     if (this.isNewPurchase) {
       this.purchase = {
         characteristics: [],
+      }
+      if (this.userCanteens.length === 1) {
+        this.purchase.canteen = this.userCanteens[0].id
       }
       return
     }

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -369,7 +369,7 @@ export default {
       const remaining = characteristics.length - displayCount
       characteristics.splice(displayCount, Infinity)
       let str = characteristics.map((c) => this.getCharacteristicDisplayValue(c).text).join(", ")
-      if (remaining > 0) str += ` et ${remaining} autres`
+      if (remaining > 0) str += ` et ${remaining} autre${remaining > 1 ? "s" : ""}`
       return str
     },
     getCharacteristicDisplayValue(characteristic) {

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -73,8 +73,29 @@
       </div>
       <v-expand-transition>
         <div v-show="showFilters" class="px-4 pb-6 pt-0">
-          <v-row>
-            <v-col cols="12" sm="6" md="4">
+          <v-row v-if="userCanteens.length > 1">
+            <v-col cols="12" sm="8">
+              <label
+                for="filter-canteen"
+                :class="{ 'text-body-2': true, 'active-filter-label': appliedFilters.canteen > 0 }"
+              >
+                Établissement
+              </label>
+              <DsfrAutocomplete
+                id="filter-canteen"
+                v-model="appliedFilters.canteen"
+                :items="userCanteens"
+                item-text="name"
+                item-value="id"
+                auto-select-first
+                hide-details
+                clearable
+                class="mt-2"
+              />
+            </v-col>
+          </v-row>
+          <v-row class="mt-0">
+            <v-col cols="12" sm="6" md="5">
               <label
                 for="filter-family"
                 :class="{ 'text-body-2': true, 'active-filter-label': !!appliedFilters.family }"
@@ -90,7 +111,7 @@
                 class="mt-2"
               />
             </v-col>
-            <v-col cols="12" sm="6">
+            <v-col cols="12" sm="5">
               <label
                 for="filter-characteristics"
                 :class="{ 'text-body-2': true, 'active-filter-label': appliedFilters.characteristics.length > 0 }"
@@ -241,16 +262,17 @@
 </template>
 
 <script>
-import { formatDate, getObjectDiff } from "@/utils"
+import { formatDate, getObjectDiff, normaliseText } from "@/utils"
 import Constants from "@/constants"
 import DsfrTextField from "@/components/DsfrTextField"
 import BreadcrumbsNav from "@/components/BreadcrumbsNav"
 import DsfrSelect from "@/components/DsfrSelect"
 import DsfrSearchField from "@/components/DsfrSearchField"
+import DsfrAutocomplete from "@/components/DsfrAutocomplete"
 
 export default {
   name: "PurchasesHome",
-  components: { DsfrTextField, BreadcrumbsNav, DsfrSelect, DsfrSearchField },
+  components: { DsfrTextField, BreadcrumbsNav, DsfrSelect, DsfrSearchField, DsfrAutocomplete },
   data() {
     return {
       searchTerm: null,
@@ -284,6 +306,7 @@ export default {
       endDateMenu: false,
       appliedFilters: {
         family: null,
+        canteen: null,
         characteristics: [],
         startDate: null,
         endDate: null,
@@ -311,13 +334,20 @@ export default {
         this.appliedFilters.family !== null ||
         this.appliedFilters.characteristics.length !== 0 ||
         this.appliedFilters.startDate !== null ||
-        this.appliedFilters.endDate !== null
+        this.appliedFilters.endDate !== null ||
+        this.appliedFilters.canteen !== null
       )
     },
     hasCanteens() {
       return !!this.$store.state.userCanteenPreviews && this.$store.state.userCanteenPreviews.length > 0
     },
     // TODO: format choice lists to have explanation of inactive choices
+    userCanteens() {
+      const canteens = this.$store.state.userCanteenPreviews
+      return canteens.sort((a, b) => {
+        return normaliseText(a.name) > normaliseText(b.name) ? 1 : 0
+      })
+    },
   },
   methods: {
     getProductFamilyDisplayValue(family) {
@@ -377,6 +407,7 @@ export default {
       if (this.appliedFilters.family) apiQueryParams += `&family=${this.appliedFilters.family}`
       if (this.appliedFilters.startDate) apiQueryParams += `&date_after=${this.appliedFilters.startDate}`
       if (this.appliedFilters.endDate) apiQueryParams += `&date_before=${this.appliedFilters.endDate}`
+      if (this.appliedFilters.canteen) apiQueryParams += `&canteen__id=${this.appliedFilters.canteen}`
       if (this.appliedFilters.characteristics.length > 0)
         apiQueryParams += `&characteristics=${this.appliedFilters.characteristics.join("&characteristics=")}`
       return apiQueryParams
@@ -390,6 +421,7 @@ export default {
         urlQueryParams["famille"] = this.getProductFamilyDisplayValue(this.appliedFilters.family).text
       if (this.appliedFilters.startDate) urlQueryParams["après"] = this.appliedFilters.startDate
       if (this.appliedFilters.endDate) urlQueryParams["avant"] = this.appliedFilters.endDate
+      if (this.appliedFilters.canteen) urlQueryParams["cantine"] = this.appliedFilters.canteen
       if (this.appliedFilters.characteristics.length > 0)
         urlQueryParams["caracteristiques"] = this.appliedFilters.characteristics
           .map((c) => this.getCharacteristicDisplayValue(c).text)
@@ -432,9 +464,10 @@ export default {
         endDate: this.$route.query.avant || null,
         characteristics,
         family: this.getChoiceValueFromText(Constants.ProductFamilies, this.$route.query.famille),
+        canteen: Number(this.$route.query.cantine) || null,
       }
       const filterChanges = this.appliedFilters ? getObjectDiff(this.appliedFilters, filters) : filters
-      if (Object.keys(filterChanges).length > 0) this.$set(this, "appliedFilters", filterChanges)
+      if (Object.keys(filterChanges).length > 0) this.$set(this, "appliedFilters", filters)
     },
     clearSearch() {
       this.searchTerm = ""
@@ -450,6 +483,7 @@ export default {
         endDate: null,
         characteristics: [],
         family: null,
+        canteen: null,
       })
     },
     onAppliedFiltersChange() {

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -212,8 +212,11 @@
         </template>
         <template v-slot:[`item.family`]="{ item }">
           <v-chip outlined small :color="getProductFamilyDisplayValue(item.family).color" dark class="font-weight-bold">
-            {{ getProductFamilyDisplayValue(item.family).text }}
+            {{ capitalise(getProductFamilyDisplayValue(item.family).shortText) }}
           </v-chip>
+        </template>
+        <template v-slot:[`item.characteristics`]="{ item }">
+          {{ getProductCharacteristicsDisplayValue(item.characteristics) }}
         </template>
         <template v-slot:[`item.priceHt`]="{ item }">
           {{ item.priceHt.toLocaleString("fr-FR", { style: "currency", currency: "EUR" }) }}
@@ -262,7 +265,7 @@
 </template>
 
 <script>
-import { formatDate, getObjectDiff, normaliseText } from "@/utils"
+import { formatDate, getObjectDiff, normaliseText, capitalise } from "@/utils"
 import Constants from "@/constants"
 import DsfrTextField from "@/components/DsfrTextField"
 import BreadcrumbsNav from "@/components/BreadcrumbsNav"
@@ -295,6 +298,7 @@ export default {
         },
         { text: "Produit", value: "description", sortable: true },
         { text: "Famille", value: "family", sortable: false },
+        { text: "Caratéristiques", value: "characteristics", sortable: false },
         { text: "Cantine", value: "canteen__name", sortable: true },
         { text: "Prix HT", value: "priceHt", sortable: true, align: "end" },
         { text: "", value: "hasAttachment", sortable: false },
@@ -354,6 +358,19 @@ export default {
       if (Object.prototype.hasOwnProperty.call(Constants.ProductFamilies, family))
         return Constants.ProductFamilies[family]
       return { text: "", color: "" }
+    },
+    getProductCharacteristicsDisplayValue(characteristics) {
+      const priorityOrder = Object.keys(Constants.Characteristics)
+      characteristics = characteristics.filter((c) => priorityOrder.indexOf(c) > -1)
+      characteristics.sort((a, b) => {
+        return priorityOrder.indexOf(a) - priorityOrder.indexOf(b)
+      })
+      const displayCount = 3
+      const remaining = characteristics.length - displayCount
+      characteristics.splice(displayCount, Infinity)
+      let str = characteristics.map((c) => this.getCharacteristicDisplayValue(c).text).join(", ")
+      if (remaining > 0) str += ` et ${remaining} autres`
+      return str
     },
     getCharacteristicDisplayValue(characteristic) {
       if (Object.prototype.hasOwnProperty.call(Constants.Characteristics, characteristic))
@@ -504,6 +521,9 @@ export default {
       this.$watch("appliedFilters", this.onAppliedFiltersChange, { deep: true })
       this.$watch("options", this.onOptionsChange, { deep: true })
       this.$watch("$route", this.onRouteChange)
+    },
+    capitalise(str) {
+      return capitalise(str)
     },
   },
   beforeMount() {


### PR DESCRIPTION
Closes #2193 and #2191

New things :
- For users with more than one canteen, show canteen filter on purchase page
- For users with just one canteen, prefill and disable canteen field on purchase page for UX improvement
- On canteen mgmt page, don't show filters and pagination if have fewer than 6 canteens
- On canteen mgmt page, hide pagination if a filter results in fewer than 6 canteens
- On purchases page, add characteristics column
- On purchases page, use short text for family to give more space to other columns
- Add capitalise method and refactor
- Fix doc title bug with stats page where the title (as seen in tab name) was not set properly if the link with location parameters was loaded directly (as opposed to when filtering from the page, which works)


## Canteen purchase filter
![Screenshot from 2023-01-06 11-57-59](https://user-images.githubusercontent.com/9282816/211001861-1dbd23f6-ddd8-4ca1-ab47-7a56da864a61.png)
### Hidden if only one canteen
![Screenshot from 2023-01-06 11-57-47](https://user-images.githubusercontent.com/9282816/211001863-2744bff7-3eca-44ae-b7b5-88907552101b.png)

## Prefill purchase canteen
![Screenshot from 2023-01-06 11-57-38](https://user-images.githubusercontent.com/9282816/211001867-a32a1c8b-592f-4ef6-8e9b-63cf66395be8.png)

## Filter and pagination hide
![Screenshot from 2023-01-06 12-07-56](https://user-images.githubusercontent.com/9282816/211001849-aadc58c9-d006-4d8e-8c36-084c88e2536e.png)

## Pagination display from result count
![Screenshot from 2023-01-06 12-11-29](https://user-images.githubusercontent.com/9282816/211001834-5d9b4df8-1a8c-4715-898c-bee52b3d1f2b.png)
![Screenshot from 2023-01-06 12-11-21](https://user-images.githubusercontent.com/9282816/211001844-fa67e5ed-4a40-4367-943f-282e62f01f5d.png)
![Screenshot from 2023-01-06 12-11-18](https://user-images.githubusercontent.com/9282816/211001847-eddb2bbb-c95e-4ee0-a5c8-3bb922bdb5e5.png)

## Characteristics column + family shortening
![Screenshot from 2023-01-06 13-24-15](https://user-images.githubusercontent.com/9282816/211012169-6ab4c5d3-d4d7-40a3-9a3f-d6337c7f043c.png)

