### PR TITLE
Bannière actions

### DIFF
--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -1,6 +1,7 @@
 import os
 import base64
 from django.urls import reverse
+from django.test.utils import override_settings
 from rest_framework.test import APITestCase
 from rest_framework import status
 from data.factories import CanteenFactory, ManagerInvitationFactory
@@ -522,6 +523,7 @@ class TestCanteenApi(APITestCase):
         self.assertIn(user_central_cuisine.id, ids)
         self.assertIn(user_central_serving_cuisine.id, ids)
 
+    @override_settings(ENABLE_TELEDECLARATION=True)
     @authenticate
     def test_get_canteen_actions(self):
         """
@@ -609,6 +611,7 @@ class TestCanteenApi(APITestCase):
             self.assertEqual(returned_canteens[index]["id"], canteen.id)
             self.assertEqual(returned_canteens[index]["action"], action)
 
+    @override_settings(ENABLE_TELEDECLARATION=True)
     @authenticate
     def test_get_diagnostics_to_td(self):
         """

--- a/frontend/src/views/ManagementPage/ActionsBanner.vue
+++ b/frontend/src/views/ManagementPage/ActionsBanner.vue
@@ -1,0 +1,10 @@
+<template>
+  <v-card outlined class="mb-4">
+    <v-card-text class="pb-0 grey--text text--darken-4">
+      Cliquez ci-dessous pour regarder l'état de toutes vos cantines et les actions à faire pour chacune.
+    </v-card-text>
+    <v-card-text class="">
+      <v-btn :to="{ name: 'PendingActions' }" color="primary">Mes actions</v-btn>
+    </v-card-text>
+  </v-card>
+</template>

--- a/frontend/src/views/ManagementPage/index.vue
+++ b/frontend/src/views/ManagementPage/index.vue
@@ -12,7 +12,8 @@
         </v-btn>
       </p>
     </div>
-    <TeledeclarationBanner />
+    <TeledeclarationBanner v-if="showTeledeclarationBanner" />
+    <ActionsBanner v-if="showActionsBanner" />
     <CompleteProfileField :canteenCount="canteenCount" />
     <div class="mt-4">
       <h1 class="my-4 text-h5 font-weight-black">Mes cantines</h1>
@@ -32,14 +33,24 @@ import PageSatisfaction from "@/components/PageSatisfaction.vue"
 import UserTools from "./UserTools"
 import CompleteProfileField from "./CompleteProfileField"
 import TeledeclarationBanner from "./TeledeclarationBanner"
+import ActionsBanner from "./ActionsBanner"
 import validators from "@/validators"
 
 export default {
-  components: { CanteensPagination, UserTools, CompleteProfileField, PageSatisfaction, TeledeclarationBanner },
+  components: {
+    CanteensPagination,
+    UserTools,
+    CompleteProfileField,
+    PageSatisfaction,
+    TeledeclarationBanner,
+    ActionsBanner,
+  },
   data() {
     return {
       validators,
       canteenCount: undefined,
+      showTeledeclarationBanner: false,
+      showActionsBanner: true,
     }
   },
   computed: {


### PR DESCRIPTION
À noter que l'API a été aussi modifiée pour ne pas retourner des actions de télédéclaration si `ENABLE_TELEDECLARATION` est `False`

![image](https://user-images.githubusercontent.com/1225929/212694472-9eec4b59-da81-402d-8e72-9d1faced78c3.png)

