### PR TITLE
Page chiffres : coherent UI pour les chiffres badges reussits

### DIFF
--- a/frontend/src/views/PublicCanteenStatisticsPage/BadgeCard.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/BadgeCard.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-card class="fill-height text-center pt-4 pb-2 px-2 d-flex flex-column" outlined>
+  <v-card
+    class="fill-height text-center pt-4 pb-2 px-2 d-flex flex-column"
+    outlined
+    style="max-height: 10rem; max-width: 20rem;"
+  >
     <v-img max-width="30" contain :src="`/static/images/badges/${measure.badgeId}.svg`" class="mx-auto" alt=""></v-img>
     <v-card-text class="mx-auto px-1">
       <span class="grey--text text-h5 font-weight-black text--darken-2" style="line-height: inherit;">

--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -211,14 +211,10 @@
       <p class="mb-8">
         Parmi les mêmes {{ statistics.diagnosticsCount }} cantines qui ont commencé un diagnostic&nbsp;:
       </p>
-      <v-row class="justify-space-between mt-8 mb-8 px-2">
-        <BadgeCard
-          v-for="measure in otherMeasures"
-          :key="measure.id"
-          :measure="measure"
-          :percentageAchieved="statistics[measure.badgeId + 'Percent']"
-          class="mb-4"
-        />
+      <v-row class="my-8">
+        <v-col cols="12" sm="6" md="5" v-for="measure in otherMeasures" :key="measure.id" class="mb-4">
+          <BadgeCard :measure="measure" :percentageAchieved="statistics[measure.badgeId + 'Percent']" />
+        </v-col>
       </v-row>
       <BadgesExplanation />
     </div>


### PR DESCRIPTION
![Screenshot from 2023-01-18 18-29-25](https://user-images.githubusercontent.com/9282816/213252556-41a8caef-d42c-4a60-9d29-2390986291a5.png)
![Screenshot from 2023-01-18 18-29-16](https://user-images.githubusercontent.com/9282816/213252567-fc06840e-823e-4f43-ab33-f0a765778ead.png)
![Screenshot from 2023-01-18 18-29-08](https://user-images.githubusercontent.com/9282816/213252575-e4992bd7-d152-47ab-8c7b-a987f71870bc.png)

closes #2127 
