### PR TITLE
Bug fix pour le select des cantines lors d'un nouvel achat

### DIFF
--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -72,8 +72,6 @@
                   class="mt-2"
                   auto-select-first
                   no-data-text="Pas de résultats"
-                  :readonly="this.userCanteens.length === 1"
-                  :disabled="this.userCanteens.length === 1"
                 />
               </v-col>
 
@@ -347,6 +345,9 @@ export default {
           else {
             this.purchase = {
               characteristics: [],
+            }
+            if (this.userCanteens.length === 1) {
+              this.purchase.canteen = this.userCanteens[0].id
             }
             this.$refs.form.resetValidation()
             this.fetchOptions() // if the user added a new product or provider, we need to refresh the options

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -366,7 +366,7 @@ export default {
     getProductFamilyDisplayValue(family) {
       if (Object.prototype.hasOwnProperty.call(Constants.ProductFamilies, family))
         return Constants.ProductFamilies[family]
-      return { text: "", color: "" }
+      return { text: "", shortText: "", color: "" }
     },
     getProductCharacteristicsDisplayValue(characteristics) {
       const priorityOrder = Object.keys(Constants.Characteristics)


### PR DESCRIPTION
Closes #2262 

Cette PR adresse trois soucis : 

1- Lors que l'utilisateur clique sur "Valider et ajouter un nouveau" on ne remet pas en place la cantine de l'achat. Ceci était la cause principale du bug car la liste déroulante était en read-only dans le cas ou l'utilisateur avait seulement une cantine

2- En parlant avec @gauthierandre on s'est dit qu'il fallait aussi changer cette propriété read-only lorsque l'utilisateur n'avait qu'une seule cantine - plusieurs pensent que c'est un bug. Il faut garder le pré-remplissage de la cantine, mais laisser le champ modifiable pour qu'iels sachent de quoi il s'agit.

3- Il y avait une exception levée lorsque on ajoutait un achat sans famille : la fonction `capitalise` recevait un undefined car on utilise le `shortText`