### PR TITLE
Permet la modification d'une cantine sans SIRET

### DIFF
--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -449,6 +449,7 @@ export default {
   methods: {
     setSiret(siret) {
       this.siret = siret
+      this.canteen.siret = this.siret
       this.goToStep(1)
     },
     goToStep(index, addHistory = true) {
@@ -491,7 +492,6 @@ export default {
           const cookieValue = readCookie(Constants.TrackingParams[i])
           if (cookieValue) payload[`creation_${Constants.TrackingParams[i]}`] = cookieValue
         }
-        payload.siret = this.siret
       }
 
       this.$store


### PR DESCRIPTION
Closes #2285 

@hfroot J'ai préféré assigner le SIRET de la cantine dans le watcher, ça m'a paru moins mystérieux. 