### PR TITLE
Valeurs non-pertinents mises à null dans la TD

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -328,6 +328,7 @@ class CanteenTeledeclarationSerializer(serializers.ModelSerializer):
     central_producer_siret = serializers.SerializerMethodField(read_only=True)
     satellite_canteens_count = serializers.SerializerMethodField(read_only=True)
     line_ministry = serializers.SerializerMethodField(read_only=True)
+    daily_meal_count = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Canteen
@@ -363,6 +364,11 @@ class CanteenTeledeclarationSerializer(serializers.ModelSerializer):
     def get_line_ministry(self, obj):
         concerned_sectors = obj.sectors.filter(has_line_ministry=True)
         return obj.line_ministry if len(concerned_sectors) > 0 else None
+
+    def get_daily_meal_count(self, obj):
+        if obj.production_type == Canteen.ProductionType.CENTRAL:
+            return None
+        return obj.daily_meal_count
 
 
 # remember to update TD version if you update this

--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -325,6 +325,8 @@ class CanteenStatusSerializer(serializers.ModelSerializer):
 # remember to update TD version if you update this
 class CanteenTeledeclarationSerializer(serializers.ModelSerializer):
     sectors = SectorSerializer(many=True, read_only=True)
+    central_producer_siret = serializers.SerializerMethodField(read_only=True)
+    satellite_canteens_count = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Canteen
@@ -343,6 +345,19 @@ class CanteenTeledeclarationSerializer(serializers.ModelSerializer):
             "satellite_canteens_count",
             "central_producer_siret",
         )
+
+    def get_central_producer_siret(self, obj):
+        if not obj.production_type == Canteen.ProductionType.ON_SITE_CENTRAL:
+            return None
+        return obj.central_producer_siret
+
+    def get_satellite_canteens_count(self, obj):
+        if (
+            not obj.production_type == Canteen.ProductionType.CENTRAL
+            and not obj.production_type == Canteen.ProductionType.CENTRAL_SERVING
+        ):
+            return None
+        return obj.satellite_canteens_count
 
 
 # remember to update TD version if you update this

--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -327,6 +327,7 @@ class CanteenTeledeclarationSerializer(serializers.ModelSerializer):
     sectors = SectorSerializer(many=True, read_only=True)
     central_producer_siret = serializers.SerializerMethodField(read_only=True)
     satellite_canteens_count = serializers.SerializerMethodField(read_only=True)
+    line_ministry = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Canteen
@@ -358,6 +359,10 @@ class CanteenTeledeclarationSerializer(serializers.ModelSerializer):
         ):
             return None
         return obj.satellite_canteens_count
+
+    def get_line_ministry(self, obj):
+        concerned_sectors = obj.sectors.filter(has_line_ministry=True)
+        return obj.line_ministry if len(concerned_sectors) > 0 else None
 
 
 # remember to update TD version if you update this

--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -582,6 +582,7 @@ class TestTeledeclarationApi(APITestCase):
             siret="79300704800044",
             satellite_canteens_count=3,
             central_producer_siret="18704793618411",
+            daily_meal_count=10,
         )
         canteen.managers.add(authenticate.user)
         diagnostic = DiagnosticFactory.create(
@@ -598,6 +599,7 @@ class TestTeledeclarationApi(APITestCase):
         canteen_json = teledeclaration.declared_data.get("canteen")
         self.assertIsNone(canteen_json["satellite_canteens_count"])
         self.assertIsNone(canteen_json["central_producer_siret"])
+        self.assertEqual(canteen_json["daily_meal_count"], 10)
 
         # If we change its type to cuisine centrale we should get the satellite count
         teledeclaration = Teledeclaration.objects.get(diagnostic=diagnostic).delete()
@@ -612,6 +614,7 @@ class TestTeledeclarationApi(APITestCase):
         canteen_json = teledeclaration.declared_data.get("canteen")
         self.assertEqual(canteen_json["satellite_canteens_count"], 3)
         self.assertIsNone(canteen_json["central_producer_siret"])
+        self.assertIsNone(canteen_json["daily_meal_count"])
 
         # If we change its type to satellite we should get the central_producer_siret
         teledeclaration = Teledeclaration.objects.get(diagnostic=diagnostic).delete()
@@ -626,6 +629,7 @@ class TestTeledeclarationApi(APITestCase):
         canteen_json = teledeclaration.declared_data.get("canteen")
         self.assertIsNone(canteen_json["satellite_canteens_count"])
         self.assertEqual(canteen_json["central_producer_siret"], "18704793618411")
+        self.assertEqual(canteen_json["daily_meal_count"], 10)
 
     @authenticate
     def test_dynamically_include_line_ministry(self):


### PR DESCRIPTION
- [x] central_kitchen_siret
- [x] satellite_canteens_count
- [x] satellites?
- [x] line_ministry

Note : Satellites are already added dynamically only if the canteen is a central cuisine

```python
if is_central_cuisine:
            serialized_satellites = [SatelliteTeledeclarationSerializer(x).data for x in canteen.satellites]
            json_fields["satellites"] = serialized_satellites
            json_fields["satellite_canteens_count"] = canteen.satellite_canteens_count
```