### PR TITLE
Enlever les liens d'évitement

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="!!this.$route.name">
-    <div class="fr-skiplinks" ref="skiplinks">
+    <!-- <div class="fr-skiplinks" ref="skiplinks">
       <nav class="fr-container" role="navigation" aria-label="Accès rapide">
         <ul class="fr-skiplinks__list">
           <li><a class="fr-link" href="#contenu">Contenu</a></li>
@@ -8,7 +8,7 @@
           <li><a class="fr-link" href="#pied-de-page">Pied de page</a></li>
         </ul>
       </nav>
-    </div>
+    </div> -->
     <v-app-bar
       app
       clipped-right


### PR DESCRIPTION
closes #2313 

The problems:

- sometimes the header collapses not from scrolling, and I don't know why or how to reproduce it consistently
- the padding around the skip links is too large. I believe setting it to 0 makes it fully hidden once more
- for some reason, when tabbing through the page "Mes cantines" in the header does not get selected
- skip links z index update works in chrome but no more in my version of firefox

Given that we don't have much time and I am not sure they are even being used by anyone, I am removing the banner for now and we can come back to it later