### PR TITLE
Enlève les champs legacy du serializer pour le diagnostic

### DIFF
--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -7,10 +7,6 @@ SIMPLE_APPRO_FIELDS = (
     "value_total_ht",
     "value_bio_ht",
     "value_sustainable_ht",
-    "value_pat_ht",
-    "value_label_rouge",
-    "value_label_aoc_igp",
-    "value_label_hve",
     "value_externality_performance_ht",
     "value_egalim_others_ht",
     "value_meat_poultry_ht",
@@ -194,7 +190,6 @@ class CentralKitchenDiagnosticSerializer(serializers.ModelSerializer):
     value_egalim_others_ht = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
-
         fields = (
             META_FIELDS
             + (
@@ -279,7 +274,6 @@ class PublicDiagnosticSerializer(serializers.ModelSerializer):
 
 
 class FullDiagnosticSerializer(serializers.ModelSerializer):
-
     teledeclaration = ShortTeledeclarationSerializer(source="latest_submitted_teledeclaration")
 
     class Meta:

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -49,11 +49,7 @@ class TestDiagnosticsApi(APITestCase):
             "year": 2020,
             "value_bio_ht": 1000,
             "value_sustainable_ht": 3000,
-            "value_pat_ht": 200,
             "value_total_ht": 10000,
-            "value_label_rouge": 10,
-            "value_label_aoc_igp": 20,
-            "value_label_hve": 30,
             "has_waste_diagnostic": True,
             "has_waste_plan": False,
             "waste_actions": ["INSCRIPTION", "AWARENESS"],
@@ -217,10 +213,6 @@ class TestDiagnosticsApi(APITestCase):
         self.assertEqual(diagnostic.donation_quantity, decimal.Decimal("60.6"))
         self.assertEqual(diagnostic.communication_frequency, "YEARLY")
         self.assertTrue(diagnostic.communicates_on_food_quality)
-        self.assertEqual(diagnostic.value_pat_ht, 200)
-        self.assertEqual(diagnostic.value_label_rouge, 10)
-        self.assertEqual(diagnostic.value_label_aoc_igp, 20)
-        self.assertEqual(diagnostic.value_label_hve, 30)
         self.assertEqual(diagnostic.creation_mtm_source, "mtm_source_value")
         self.assertEqual(diagnostic.creation_mtm_campaign, "mtm_campaign_value")
         self.assertEqual(diagnostic.creation_mtm_medium, "mtm_medium_value")

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -150,8 +150,8 @@ class Teledeclaration(models.Model):
         """
         from data.factories import TeledeclarationFactory  # Avoids circular import
 
-        version = "8"  # Helps identify which data will be present. Use incremental int values
-        # Version 8 - contains additional canteen and satellite fields in JSON serialized object
+        version = "9"  # Helps identify which data will be present. Use incremental int values
+        # Version 9 - removes legacy fields: value_pat_ht, value_label_hve, value_label_rouge, value_label_aoc_igp and value_pat_ht
 
         status = status or Teledeclaration.TeledeclarationStatus.SUBMITTED
 

--- a/frontend/tests/unit/PublishedCanteenCard.spec.js
+++ b/frontend/tests/unit/PublishedCanteenCard.spec.js
@@ -15,7 +15,6 @@ describe("PublishedCanteenCard.vue", () => {
       year: 2021,
       valueBioHt: 5000,
       valueSustainableHt: 2000,
-      valuePatHt: 1000,
       valueTotalHt: 10000,
       cookingPlasticSubstituted: true,
       servingPlasticSubstituted: true,


### PR DESCRIPTION
Ne sont plus utilisés :
- value_pat_ht
- value_label_hve
- value_label_rouge
- value_label_aoc_igp

Pour l'instant on les maintient dans la base de données pour ne pas perdre l'info des diagnostics précedents 