### PR TITLE
Show appro summary in TD preview

### DIFF
--- a/frontend/src/components/TeledeclarationPreview.vue
+++ b/frontend/src/components/TeledeclarationPreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="isOpen" max-width="750">
+  <v-dialog v-model="isOpen" max-width="900">
     <v-card ref="content">
       <v-card-title class="font-weight-bold">
         {{ canteen ? "Télédéclaration : " + canteen.name : "Votre télédéclaration" }}
@@ -13,7 +13,7 @@
             <thead>
               <tr>
                 <th style="height: 0;" class="text-left"></th>
-                <th style="height: 0; min-width: 150px;" class="text-left"></th>
+                <th style="height: 0;" class="text-left"></th>
               </tr>
             </thead>
             <tbody>
@@ -27,9 +27,12 @@
                 <td :class="item.isNumber ? 'text-right' : 'text-left'">{{ item.value }}</td>
               </tr>
               <tr>
-                <td class="text-left font-weight-bold" v-if="showApproItems" colspan="2">
+                <td class="text-left font-weight-bold" v-if="showApproItems">
                   Saisie de données d'approvisionnement :
                   {{ diagnostic.diagnosticType === "COMPLETE" ? "Complète" : "Simple" }}
+                </td>
+                <td class="text-left grey--text text--darken-2" colspan="2" v-if="showApproItems">
+                  {{ approSummary }}
                 </td>
                 <td class="text-left font-weight-bold" v-else colspan="2">
                   Données d'approvisonnement renseignées par la cuisine centrale
@@ -74,7 +77,7 @@
 <script>
 import Constants from "@/constants"
 import validators from "@/validators"
-import { capitalise, sectorsSelectList } from "@/utils"
+import { capitalise, sectorsSelectList, approSummary } from "@/utils"
 
 export default {
   props: {
@@ -599,6 +602,9 @@ export default {
     costPerMeal() {
       // assuming yearlyMealCount required by TD form
       return Number(this.diagnostic.valueTotalHt / this.canteen.yearlyMealCount).toFixed(2)
+    },
+    approSummary() {
+      return approSummary(this.diagnostic)
     },
   },
   methods: {

--- a/frontend/src/views/DiagnosticEditor/index.vue
+++ b/frontend/src/views/DiagnosticEditor/index.vue
@@ -121,7 +121,7 @@
             iconColour="red"
             icon="mdi-food-apple"
             heading="Plus de produits de qualité et durables dans nos assiettes"
-            :summary="approSummary() || 'Incomplet'"
+            :summary="approSummary"
             :formIsValid="formIsValid.quality"
             :disabled="!showApproPanel"
           >
@@ -338,12 +338,12 @@ import Constants from "@/constants"
 import {
   getObjectDiff,
   timeAgo,
-  strictIsNaN,
   lastYear,
   diagnosticYears,
-  getPercentage,
   readCookie,
   capitalise,
+  approTotals,
+  approSummary,
 } from "@/utils"
 import DsfrSelect from "@/components/DsfrSelect"
 import SatelliteManagement from "@/views/CanteenEditor/SatelliteManagement"
@@ -529,6 +529,9 @@ export default {
     hasSatelliteCountInconsistency() {
       return this.isCentralCanteen && this.canteen.satelliteCanteensCount !== this.satelliteDbCount
     },
+    approSummary() {
+      return approSummary(this.diagnostic, this.extendedDiagnostic)
+    },
   },
   beforeMount() {
     this.refreshDiagnostic()
@@ -547,43 +550,7 @@ export default {
       if (this.originalCanteen) this.$set(this, "canteen", JSON.parse(JSON.stringify(this.originalCanteen)))
     },
     approTotals() {
-      let bioTotal = this.diagnostic.valueBioHt
-      let siqoTotal = this.diagnostic.valueSustainableHt
-      let perfExtTotal = this.diagnostic.valueExternalityPerformanceHt
-      let egalimOthersTotal = this.diagnostic.valueEgalimOthersHt
-      if (this.extendedDiagnostic) {
-        bioTotal = 0
-        siqoTotal = 0
-        perfExtTotal = 0
-        egalimOthersTotal = 0
-        const egalimFields = Constants.TeledeclarationCharacteristicGroups.egalim.fields
-        egalimFields.forEach((field) => {
-          const value = parseFloat(this.diagnostic[field])
-          if (value) {
-            if (field.endsWith("Bio")) {
-              bioTotal += value
-            } else if (!field.startsWith("valueLabel") && !field.endsWith("Ht")) {
-              if (field.endsWith("LabelRouge") || field.endsWith("AocaopIgpStg")) {
-                siqoTotal += value
-              } else if (field.endsWith("Performance") || field.endsWith("Externalites")) {
-                perfExtTotal += value
-              } else {
-                egalimOthersTotal += value
-              }
-            }
-          }
-        })
-        bioTotal = +bioTotal.toFixed(2)
-        siqoTotal = +siqoTotal.toFixed(2)
-        perfExtTotal = +perfExtTotal.toFixed(2)
-        egalimOthersTotal = +egalimOthersTotal.toFixed(2)
-      }
-      return {
-        bioTotal,
-        siqoTotal,
-        perfExtTotal,
-        egalimOthersTotal,
-      }
+      return approTotals(this.diagnostic)
     },
     meatPoultryTotals() {
       let meatPoultryEgalim = this.diagnostic.valueSustainableHt
@@ -628,20 +595,6 @@ export default {
         fishEgalim = +fishEgalim.toFixed(2)
       }
       return { fishEgalim }
-    },
-    approSummary() {
-      if (this.diagnostic.valueTotalHt > 0) {
-        const { bioTotal, siqoTotal, perfExtTotal, egalimOthersTotal } = this.approTotals()
-        const qualityTotal = (siqoTotal || 0) + (perfExtTotal || 0) + (egalimOthersTotal || 0)
-        let summary = []
-        if (hasValue(bioTotal)) {
-          summary.push(`${getPercentage(bioTotal, this.diagnostic.valueTotalHt)} % bio`)
-        }
-        if (hasValue(qualityTotal)) {
-          summary.push(`${getPercentage(qualityTotal, this.diagnostic.valueTotalHt)} % de qualité et durable`)
-        }
-        return summary.join(", ")
-      }
     },
     plasticSummary() {
       let summary = []
@@ -885,13 +838,5 @@ export default {
       this.fetchPurchasesSummary()
     },
   },
-}
-
-function hasValue(val) {
-  if (typeof val === "string") {
-    return !!val
-  } else {
-    return !strictIsNaN(val)
-  }
 }
 </script>


### PR DESCRIPTION
Review this first https://github.com/betagouv/ma-cantine/pull/2349

Desktop
![Screenshot 2023-02-14 at 13 00 37](https://user-images.githubusercontent.com/9282816/218733709-e220c5cb-3889-4b40-a1d3-01bbf7157ac6.png)

iPad
![Screenshot 2023-02-14 at 13 00 30](https://user-images.githubusercontent.com/9282816/218733713-3a5a7fee-5e20-435f-b0ab-7726b302e3e9.png)

Phone
![Screenshot 2023-02-14 at 13 00 15](https://user-images.githubusercontent.com/9282816/218733665-9a1e3cb2-3bb2-45b7-93ec-749f56591b1b.png)

## NB: modified appro summary
The copy of approSummary to utils involved modifying it (lines 489-492) so that it doesn't show 0 % de qualité et durable when none of the fields are filled in (because at this point it is je ne sais pas, not 0)

Both
![Screenshot 2023-02-14 at 13 03 08](https://user-images.githubusercontent.com/9282816/218733677-d48d1bf7-fcd3-4534-8459-6dfaa5a881fd.png)

Just quality
![Screenshot 2023-02-14 at 13 03 02](https://user-images.githubusercontent.com/9282816/218733688-55512bab-e95a-43c4-9dbd-a22445faf72f.png)

Just bio
![Screenshot 2023-02-14 at 13 02 54](https://user-images.githubusercontent.com/9282816/218733693-5829f6cb-868c-452b-a428-1a65b22f1ba2.png)

Has total, but doesn't have anything else
![Screenshot 2023-02-14 at 13 02 48](https://user-images.githubusercontent.com/9282816/218733698-f3850018-72e8-4fac-9f96-27409a7ddc16.png)

Doesn't have total
![Screenshot 2023-02-14 at 13 02 41](https://user-images.githubusercontent.com/9282816/218733703-2b96eb3f-298e-41c1-a5d5-888f4f98eeee.png)
