### PR TITLE
Links label to input element in DSFR fields

### DIFF
--- a/frontend/src/components/DsfrAutocomplete.vue
+++ b/frontend/src/components/DsfrAutocomplete.vue
@@ -35,21 +35,21 @@ export default {
   data() {
     return {
       searchInput: null,
+      inputId: null,
     }
-  },
-  computed: {
-    inputId() {
-      return this.$refs?.["autocomplete"]?.$refs?.["input"].id
-    },
   },
   methods: {
     removeInnerLabel() {
       const labels = this.$refs["autocomplete"].$el.getElementsByTagName("label")
       if (labels && labels.length > 0) for (const label of labels) label.parentNode.removeChild(label)
     },
+    assignInputId() {
+      this.inputId = this.$refs?.["autocomplete"]?.$refs?.["input"].id
+    },
   },
   mounted() {
     this.removeInnerLabel()
+    this.assignInputId()
   },
 }
 </script>

--- a/frontend/src/components/DsfrCombobox.vue
+++ b/frontend/src/components/DsfrCombobox.vue
@@ -36,10 +36,10 @@ export default {
       default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
     },
   },
+  data() {
+    return { inputId: null }
+  },
   computed: {
-    inputId() {
-      return this.$refs?.["combobox"]?.$refs?.["input"].id
-    },
     value() {
       return this.$refs["combobox"].value
     },
@@ -52,9 +52,13 @@ export default {
     validate() {
       return this.$refs["combobox"].validate()
     },
+    assignInputId() {
+      this.inputId = this.$refs?.["combobox"]?.$refs?.["input"].id
+    },
   },
   mounted() {
     this.removeInnerLabel()
+    this.assignInputId()
   },
 }
 </script>

--- a/frontend/src/components/DsfrSelect.vue
+++ b/frontend/src/components/DsfrSelect.vue
@@ -29,10 +29,10 @@ export default {
       default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
     },
   },
+  data() {
+    return { inputId: null }
+  },
   computed: {
-    inputId() {
-      return this.$refs?.["select"]?.$refs?.["input"].id
-    },
     value() {
       return this.$refs["select"].value
     },
@@ -45,9 +45,13 @@ export default {
     validate() {
       return this.$refs["select"].validate()
     },
+    assignInputId() {
+      this.inputId = this.$refs?.["select"]?.$refs?.["input"].id
+    },
   },
   mounted() {
     this.removeInnerLabel()
+    this.assignInputId()
   },
 }
 </script>

--- a/frontend/src/components/DsfrTextField.vue
+++ b/frontend/src/components/DsfrTextField.vue
@@ -33,10 +33,10 @@ export default {
       default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
     },
   },
+  data() {
+    return { inputId: null }
+  },
   computed: {
-    inputId() {
-      return this.$refs?.["text-field"]?.$refs?.["input"].id
-    },
     lazyValue() {
       return this.$refs["text-field"].lazyValue
     },
@@ -52,9 +52,13 @@ export default {
     validate() {
       return this.$refs["text-field"].validate()
     },
+    assignInputId() {
+      this.inputId = this.$refs?.["text-field"]?.$refs?.["input"].id
+    },
   },
   mounted() {
     this.removeInnerLabel()
+    this.assignInputId()
   },
 }
 </script>

--- a/frontend/src/components/DsfrTextarea.vue
+++ b/frontend/src/components/DsfrTextarea.vue
@@ -28,10 +28,10 @@ export default {
       default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
     },
   },
+  data() {
+    return { inputId: null }
+  },
   computed: {
-    inputId() {
-      return this.$refs?.["textarea"]?.$refs?.["input"].id
-    },
     value() {
       return this.$refs["textarea"].value
     },
@@ -44,9 +44,13 @@ export default {
     validate() {
       return this.$refs["textarea"].validate()
     },
+    assignInputId() {
+      this.inputId = this.$refs?.["textarea"]?.$refs?.["input"].id
+    },
   },
   mounted() {
     this.removeInnerLabel()
+    this.assignInputId()
   },
 }
 </script>


### PR DESCRIPTION
Précédemment, la propriété `inputId` était évaluée avant que les $refs soient initialisés. La propriété n'était pas réactive du fait qu'elle faisait référence à un composant imbriqué. Il vaut mieux mettre la valeur de l'inputId après `mounted`.

Closes #2245 

![image](https://user-images.githubusercontent.com/1225929/220395957-c2c296cd-0555-48b7-9167-1a6face90ac2.png)
