### PR TITLE
Permet la modification du SIRET pour une cantine existante

### DIFF
--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -184,6 +184,35 @@ class TestCanteenApi(APITestCase):
         self.assertEqual(created_canteen.reservation_expe_participant, True)
 
     @authenticate
+    def test_modify_central_kitchen_siret(self):
+        """
+        A change in the SIRET of a central cuisine must update the "central_producer_siret" of
+        its satellites
+        """
+        central_kitchen = CanteenFactory.create(siret="03201976246133", production_type=Canteen.ProductionType.CENTRAL)
+        central_kitchen.managers.add(authenticate.user)
+
+        satellites = [
+            CanteenFactory.create(
+                production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret="03201976246133"
+            ),
+            CanteenFactory.create(
+                production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret="03201976246133"
+            ),
+            CanteenFactory.create(
+                production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret="03201976246133"
+            ),
+        ]
+
+        payload = {"siret": "35662897196149"}
+        response = self.client.patch(reverse("single_canteen", kwargs={"pk": central_kitchen.id}), payload)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for satellite in satellites:
+            satellite.refresh_from_db()
+            self.assertEqual(satellite.central_producer_siret, "35662897196149")
+
+    @authenticate
     def test_soft_delete(self):
         canteen = CanteenFactory.create()
         canteen.managers.add(authenticate.user)

--- a/data/signals.py
+++ b/data/signals.py
@@ -1,6 +1,6 @@
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
-from .models import User, ManagerInvitation
+from .models import User, ManagerInvitation, Canteen
 
 
 @receiver(post_save, sender=User)
@@ -10,3 +10,16 @@ def update_canteen_managers(sender, instance, created, **kwargs):
         for link in canteen_links:
             link.canteen.managers.add(instance)
             link.delete()
+
+
+@receiver(pre_save, sender=Canteen)
+def update_satellites_siret(sender, instance, raw, using, update_fields, **kwargs):
+    if raw or not instance.is_central_cuisine:
+        return
+    try:
+        obj = sender.objects.get(pk=instance.pk)
+        siret_has_changed = obj.siret != instance.siret
+        if siret_has_changed:
+            Canteen.objects.filter(central_producer_siret=obj.siret).update(central_producer_siret=instance.siret)
+    except sender.DoesNotExist:
+        pass  # Object is new

--- a/data/signals.py
+++ b/data/signals.py
@@ -1,6 +1,9 @@
+import logging
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from .models import User, ManagerInvitation, Canteen
+
+logger = logging.getLogger(__name__)
 
 
 @receiver(post_save, sender=User)
@@ -20,6 +23,15 @@ def update_satellites_siret(sender, instance, raw, using, update_fields, **kwarg
         obj = sender.objects.get(pk=instance.pk)
         siret_has_changed = obj.siret != instance.siret
         if siret_has_changed:
-            Canteen.objects.filter(central_producer_siret=obj.siret).update(central_producer_siret=instance.siret)
+            logger.info(
+                f"SIRET change. Central kitchen {instance.id} ({instance.name}) changed its SIRET from {obj.siret} to {instance.siret}"
+            )
+            satellites = Canteen.objects.filter(central_producer_siret=obj.siret).only("id")
+            for satellite in satellites:
+                logger.info(
+                    f"SIRET change. Satellite cantine {satellite.id} changed its central_producer_siret from {obj.siret} to {instance.siret}"
+                )
+            satellites.update(central_producer_siret=instance.siret)
+
     except sender.DoesNotExist:
         pass  # Object is new

--- a/data/signals.py
+++ b/data/signals.py
@@ -29,7 +29,7 @@ def update_satellites_siret(sender, instance, raw, using, update_fields, **kwarg
             satellites = Canteen.objects.filter(central_producer_siret=obj.siret).only("id")
             for satellite in satellites:
                 logger.info(
-                    f"SIRET change. Satellite cantine {satellite.id} changed its central_producer_siret from {obj.siret} to {instance.siret}"
+                    f"SIRET change. Satellite cantine {satellite.id} had its central_producer_siret changed automatically from {obj.siret} to {instance.siret}"
                 )
             satellites.update(central_producer_siret=instance.siret)
 

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -32,7 +32,7 @@
         pour les cantines scolaires.
       </p>
 
-      <SiretCheck @siretIsValid="setSiret" class="mt-10" />
+      <SiretCheck @siretIsValid="setSiret" :existingCanteenSiret="canteen ? canteen.siret : null" class="mt-10" />
 
       <p class="caption mb-n8">
         Pour toute question ou difficulté veuillez consulter notre
@@ -49,7 +49,7 @@
           <p>SIRET</p>
           <p class="grey--text text--darken-2">
             {{ siret || canteen.siret }}
-            <v-btn v-if="!canteen.siret" small @click="goToStep(0)">Modifier</v-btn>
+            <v-btn small @click="goToStep(0)">Modifier</v-btn>
           </p>
           <DsfrTextField
             hide-details="auto"

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -32,12 +32,7 @@
         pour les cantines scolaires.
       </p>
 
-      <SiretCheck
-        @siretIsValid="setSiret"
-        :existingCanteenSiret="canteen ? canteen.siret : null"
-        :existingCanteenId="canteen ? canteen.id : null"
-        class="mt-10"
-      />
+      <SiretCheck @siretIsValid="setSiret" :canteen="canteen" class="mt-10" />
 
       <p class="caption mb-n8">
         Pour toute question ou difficulté veuillez consulter notre

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -32,7 +32,12 @@
         pour les cantines scolaires.
       </p>
 
-      <SiretCheck @siretIsValid="setSiret" :canteen="canteen" class="mt-10" />
+      <SiretCheck
+        @siretIsValid="setSiret"
+        :canteen="canteen"
+        @updateCanteen="(x) => $emit('updateCanteen', x)"
+        class="mt-10"
+      />
 
       <p class="caption mb-n8">
         Pour toute question ou difficulté veuillez consulter notre

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -32,7 +32,12 @@
         pour les cantines scolaires.
       </p>
 
-      <SiretCheck @siretIsValid="setSiret" :existingCanteenSiret="canteen ? canteen.siret : null" class="mt-10" />
+      <SiretCheck
+        @siretIsValid="setSiret"
+        :existingCanteenSiret="canteen ? canteen.siret : null"
+        :existingCanteenId="canteen ? canteen.id : null"
+        class="mt-10"
+      />
 
       <p class="caption mb-n8">
         Pour toute question ou difficulté veuillez consulter notre

--- a/frontend/src/views/CanteenEditor/SiretCheck.vue
+++ b/frontend/src/views/CanteenEditor/SiretCheck.vue
@@ -95,7 +95,7 @@
         large
         outlined
         color="primary"
-        v-if="!existingCanteenSiret"
+        v-if="!canteen || !canteen.siret"
         class="ml-4 align-self-center"
         :to="{ name: 'ManagementPage' }"
       >
@@ -113,11 +113,11 @@ import DsfrTextarea from "@/components/DsfrTextarea"
 export default {
   name: "SiretCheck",
   components: { DsfrTextField, DsfrTextarea },
-  props: ["existingCanteenSiret", "existingCanteenId"],
+  props: ["canteen"],
   data() {
     const user = this.$store.state.loggedUser
     return {
-      siret: this.existingCanteenSiret,
+      siret: this.canteen?.siret,
       duplicateSiretCanteen: undefined,
       user,
       fromName: `${user.firstName} ${user.lastName}`,
@@ -138,7 +138,7 @@ export default {
         return
       }
 
-      if (this.existingCanteenSiret && this.siret === this.existingCanteenSiret) {
+      if (this.canteen?.siret && this.siret === this.canteen?.siret) {
         this.$emit("siretIsValid", this.siret)
         return
       }
@@ -183,9 +183,9 @@ export default {
         .catch((e) => this.$store.dispatch("notifyServerError", e))
     },
     saveSiretIfNeeded() {
-      if (!this.existingCanteenId) return Promise.resolve()
+      if (!this.canteen?.id) return Promise.resolve()
       const payload = { siret: this.siret }
-      return this.$store.dispatch("updateCanteen", { id: this.existingCanteenId, payload }).then(() => {
+      return this.$store.dispatch("updateCanteen", { id: this.canteen?.id, payload }).then(() => {
         this.$store.dispatch("notify", {
           status: "success",
           message: "Votre SIRET a bien été mis à jour",

--- a/frontend/src/views/CanteenEditor/SiretCheck.vue
+++ b/frontend/src/views/CanteenEditor/SiretCheck.vue
@@ -91,7 +91,14 @@
       >
         Valider
       </v-btn>
-      <v-btn large outlined color="primary" class="ml-4 align-self-center" :to="{ name: 'ManagementPage' }">
+      <v-btn
+        large
+        outlined
+        color="primary"
+        v-if="!existingCanteenSiret"
+        class="ml-4 align-self-center"
+        :to="{ name: 'ManagementPage' }"
+      >
         Annuler
       </v-btn>
     </v-row>
@@ -106,10 +113,11 @@ import DsfrTextarea from "@/components/DsfrTextarea"
 export default {
   name: "SiretCheck",
   components: { DsfrTextField, DsfrTextarea },
+  props: ["existingCanteenSiret"],
   data() {
     const user = this.$store.state.loggedUser
     return {
-      siret: undefined,
+      siret: this.existingCanteenSiret,
       duplicateSiretCanteen: undefined,
       user,
       fromName: `${user.firstName} ${user.lastName}`,
@@ -129,6 +137,9 @@ export default {
         window.scrollTo(0, 0)
         return
       }
+
+      if (this.existingCanteenSiret && this.siret === this.existingCanteenSiret) this.$emit("siretIsValid", this.siret)
+
       return fetch("/api/v1/canteenStatus/siret/" + this.siret)
         .then((response) => response.json())
         .then((response) => {

--- a/frontend/src/views/CanteenEditor/SiretCheck.vue
+++ b/frontend/src/views/CanteenEditor/SiretCheck.vue
@@ -185,11 +185,12 @@ export default {
     saveSiretIfNeeded() {
       if (!this.canteen?.id) return Promise.resolve()
       const payload = { siret: this.siret }
-      return this.$store.dispatch("updateCanteen", { id: this.canteen?.id, payload }).then(() => {
+      return this.$store.dispatch("updateCanteen", { id: this.canteen?.id, payload }).then((canteen) => {
         this.$store.dispatch("notify", {
           status: "success",
           message: "Votre SIRET a bien été mis à jour",
         })
+        this.$emit("updateCanteen", canteen)
       })
     },
   },


### PR DESCRIPTION
Au passage, la modification du SIRET d'une cuisine centrale met à jour le champ "central_producer_siret" automatiquement