### PR TITLE
Ajustements affiche pour les cuisines centrales et les satellites

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -228,10 +228,7 @@ class FullCanteenSerializer(serializers.ModelSerializer):
                     Diagnostic.CentralKitchenDiagnosticMode.APPRO,
                 ]
             ).only("year", "central_kitchen_diagnostic_mode")
-            return [
-                {"year": diag.year, "central_kitchen_diagnostic_mode": diag.central_kitchen_diagnostic_mode}
-                for diag in diagnostics
-            ]
+            return CentralKitchenDiagnosticSerializer(diagnostics, many=True).data
         except Canteen.DoesNotExist:
             return None
         except Canteen.MultipleObjectsReturned as e:

--- a/frontend/src/views/GeneratePosterPage/CanteenPoster.vue
+++ b/frontend/src/views/GeneratePosterPage/CanteenPoster.vue
@@ -17,9 +17,8 @@
     <div class="spacer"></div>
 
     <p id="introduction">
-      Sur les {{ canteen.dailyMealCount }} repas servis aux convives, pour l’année {{ infoYear }}, voici la répartition,
-      en valeur d’achat, des produits bio, de qualité et durables (liste de labels ci-dessous) utilisés dans la
-      confection des repas
+      {{ introText }}, pour l’année {{ infoYear }}, voici la répartition, en valeur d’achat, des produits bio, de
+      qualité et durables (liste de labels ci-dessous) utilisés dans la confection des repas
     </p>
 
     <p class="pat pat-heading" v-if="patPercentage || patName">Projet Alimentaires Territoriaux</p>
@@ -116,6 +115,17 @@ export default {
     },
     infoYear() {
       return this.diagnostic.year || lastYear()
+    },
+    introText() {
+      if (this.canteen.productionType === "central")
+        return `Sur les ${this.canteen.satelliteCanteensCount || ""} cantines satellites déservies`
+      if (this.canteen.productionType === "central_serving")
+        return `Sur les ${this.canteen.satelliteCanteensCount || ""} cantines satellites déservies et les ${
+          this.canteen.dailyMealCount
+        } repas servis sur place`
+      if (this.canteen.productionType === "site_cooked_elsewhere")
+        return `Sur les repas faits par la cuisine central déservant cette cantine`
+      else return `Sur les ${this.canteen.dailyMealCount || ""} repas servis aux convives`
     },
   },
 }

--- a/frontend/src/views/GeneratePosterPage/index.vue
+++ b/frontend/src/views/GeneratePosterPage/index.vue
@@ -311,11 +311,23 @@ export default {
     isAuthenticated() {
       return !!this.$store.state.loggedUser
     },
+    usesCentralKitchenDiagnostics() {
+      return (
+        this.selectedCanteen?.productionType === "site_cooked_elsewhere" &&
+        this.selectedCanteen?.centralKitchenDiagnostics?.length > 0
+      )
+    },
+    diagnosticSet() {
+      if (!this.selectedCanteen) return null
+      return this.usesCentralKitchenDiagnostics
+        ? this.selectedCanteen.centralKitchenDiagnostics
+        : this.selectedCanteen.diagnostics
+    },
     currentDiagnostic() {
-      return this.selectedCanteen?.diagnostics?.find((x) => x.year === this.publicationYear) || {}
+      return this.diagnosticSet?.find((x) => x.year === this.publicationYear) || {}
     },
     previousDiagnostic() {
-      return this.selectedCanteen?.diagnostics?.find((x) => x.year === this.publicationYear - 1) || {}
+      return this.diagnosticSet?.find((x) => x.year === this.publicationYear - 1) || {}
     },
     hasCanteens() {
       return !!this.$store.state.userCanteenPreviews && this.$store.state.userCanteenPreviews.length > 0


### PR DESCRIPTION
- Pour une cantine satellite on prend désormais en compte les diagnostics de la cuisine centrale
- Le texte est maintenant adapté pour chaque type de cantine :

![image](https://user-images.githubusercontent.com/1225929/221002757-0105c7db-3b78-4aec-a598-7ee8861daaff.png)

![image](https://user-images.githubusercontent.com/1225929/221002798-664c3303-c17b-491e-b59a-e21a612869ba.png)

![image](https://user-images.githubusercontent.com/1225929/221002840-b32938e4-bc29-49ac-be6c-89d41a7a795b.png)

![image](https://user-images.githubusercontent.com/1225929/221002907-9b9eb6b0-ba7c-4eb0-b59a-caef0bfcca80.png)

