### PR TITLE
Tooltip contient le pourcentage et non pas la valeur totale

### DIFF
--- a/frontend/src/components/FamiliesGraph.vue
+++ b/frontend/src/components/FamiliesGraph.vue
@@ -105,7 +105,14 @@ export default {
           },
         },
         tooltip: {
-          y: { formatter: percentageFormatter },
+          y: {
+            formatter: function(value, { series, seriesIndex }) {
+              const row = series[seriesIndex]
+              const sum = row.reduce((a, b) => a + b, 0)
+              const percentage = (value / sum) * 100
+              return `${percentage.toFixed(2)} %`
+            },
+          },
         },
       }
     },


### PR DESCRIPTION
Aujourd'hui le tooltip pour les familles contient la valeur totale et non pas le pourcentage (comme avant).

![image](https://user-images.githubusercontent.com/1225929/224356933-e1b99cc3-9a5b-4168-b4cc-caca548ed8b4.png)
