### PR TITLE
Rendre la page pour publier la cantine plus clair

### DIFF
--- a/frontend/src/components/AddPublishedCanteenWidget.vue
+++ b/frontend/src/components/AddPublishedCanteenWidget.vue
@@ -1,0 +1,66 @@
+<template>
+  <DsfrCallout icon=" ">
+    <div class="ml-n4">
+      <p class="text-body-1 font-weight-bold">
+        Ajoutez un aperçu sur votre site
+      </p>
+      <div class="text-body-2" style="font-family: monospace;">
+        <DsfrTextField class="widget-text-field" :value="iframeCodeSnippet" readonly hide-details />
+        <div class="d-flex mt-6 mb-2">
+          <v-btn small color="primary" outlined @click="onWidgetCopy">
+            <v-icon small class="mr-2">$clipboard-fill</v-icon>
+            Copier
+          </v-btn>
+          <div class="green--text text--darken-3 ml-4 mt-1" v-if="showCopySuccessMessage">
+            <v-icon small color="success">$checkbox-circle-fill</v-icon>
+            Copié
+          </div>
+        </div>
+      </div>
+    </div>
+  </DsfrCallout>
+</template>
+
+<script>
+import DsfrCallout from "@/components/DsfrCallout"
+import DsfrTextField from "@/components/DsfrTextField"
+
+export default {
+  name: "AddPublishedCanteenWidget",
+  props: {
+    canteen: {
+      type: Object,
+      required: true,
+    },
+  },
+  components: { DsfrCallout, DsfrTextField },
+  data() {
+    return {
+      showCopySuccessMessage: false,
+    }
+  },
+  computed: {
+    iframeCodeSnippet() {
+      const pathname = this.$router.resolve({
+        name: "CanteenPage",
+        params: { canteenUrlComponent: this.$store.getters.getCanteenUrlComponent(this.canteen) },
+      }).href
+      const url = `${window.location.origin}/widgets${pathname}`
+      return `<iframe src='${url}' style='width: 480px; height: 420px;' scrolling='no'></iframe>`
+    },
+  },
+  methods: {
+    onWidgetCopy() {
+      navigator.clipboard.writeText(this.iframeCodeSnippet)
+      this.showCopySuccessMessage = true
+      setTimeout(() => (this.showCopySuccessMessage = false), 3000)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.widget-text-field >>> .v-input .v-input__slot {
+  background: white !important;
+}
+</style>

--- a/frontend/src/components/CanteenNavigation.vue
+++ b/frontend/src/components/CanteenNavigation.vue
@@ -48,6 +48,9 @@
             <v-icon small class="mr-2">mdi-bullhorn</v-icon>
             <v-list-item-title class="text-body-2 font-weight-bold">
               Publication
+              <v-icon v-if="isPublished" color="grey" small>
+                $checkbox-circle-fill
+              </v-icon>
             </v-list-item-title>
             <v-badge dot inline v-if="readyToPublish"></v-badge>
           </v-list-item>
@@ -89,6 +92,9 @@ export default {
     },
     showSatellitePage() {
       return this.canteen.productionType === "central" || this.canteen.productionType === "central_serving"
+    },
+    isPublished() {
+      return this.canteen.publicationStatus === "published"
     },
   },
   methods: {

--- a/frontend/src/components/CanteenNavigation.vue
+++ b/frontend/src/components/CanteenNavigation.vue
@@ -28,7 +28,7 @@
               :to="{ name: 'DiagnosticModification', params: { canteenUrlComponent, year: diagnostic.year } }"
               class="mb-0"
             >
-              <v-list-item-title class="text-body-2 pl-6 d-flex align-center">
+              <v-list-item-title class="text-body-2 font-weight-bold pl-6 d-flex align-center">
                 {{ diagnostic.year }}&nbsp;
                 <v-icon v-if="hasActiveTeledeclaration(diagnostic)" color="grey" small>
                   $checkbox-circle-fill
@@ -56,8 +56,8 @@
               <v-badge dot inline v-if="readyToPublish"></v-badge>
             </v-list-item>
             <v-list-item v-if="isCentralCuisine" :ripple="false" :to="{ name: 'PublishSatellites' }" class="mt-n2">
-              <v-list-item-title class="text-body-2 pl-6">
-                Satellites
+              <v-list-item-title class="text-body-2 font-weight-bold pl-6">
+                Publier mes satellites
               </v-list-item-title>
             </v-list-item>
           </div>

--- a/frontend/src/components/CanteenNavigation.vue
+++ b/frontend/src/components/CanteenNavigation.vue
@@ -13,7 +13,7 @@
             <v-icon small class="mr-2">$restaurant-fill</v-icon>
             <v-list-item-title class="text-body-2 font-weight-bold">{{ canteen.name }}</v-list-item-title>
           </v-list-item>
-          <v-list-item :ripple="false" :to="{ name: 'SatelliteManagement' }" v-if="showSatellitePage">
+          <v-list-item :ripple="false" :to="{ name: 'SatelliteManagement' }" v-if="isCentralCuisine">
             <v-icon small class="mr-2">$community-fill</v-icon>
             <v-list-item-title class="text-body-2 font-weight-bold">Satellites</v-list-item-title>
           </v-list-item>
@@ -21,14 +21,14 @@
             <v-icon small class="mr-2">$draft-fill</v-icon>
             <v-list-item-title class="text-body-2 font-weight-bold">Diagnostics</v-list-item-title>
           </v-list-item>
-          <div v-if="$vuetify.breakpoint.smAndUp">
+          <div v-if="$vuetify.breakpoint.smAndUp" class="mt-n2">
             <v-list-item
               v-for="diagnostic in orderedDiagnostics"
               :key="`diagnostic-${diagnostic.id}`"
               :to="{ name: 'DiagnosticModification', params: { canteenUrlComponent, year: diagnostic.year } }"
               class="mb-0"
             >
-              <v-list-item-title class="text-body-2 font-weight-bold pl-6 d-flex align-center">
+              <v-list-item-title class="text-body-2 pl-6 d-flex align-center">
                 {{ diagnostic.year }}&nbsp;
                 <v-icon v-if="hasActiveTeledeclaration(diagnostic)" color="grey" small>
                   $checkbox-circle-fill
@@ -44,15 +44,28 @@
               Améliorer ma cantine
             </v-list-item-title>
           </v-list-item>
-          <v-list-item :ripple="false" :to="{ name: 'PublicationForm' }">
+          <div v-if="isPublished || hasSite">
+            <v-list-item :ripple="false" :to="{ name: 'PublicationForm' }">
+              <v-icon small class="mr-2">mdi-bullhorn</v-icon>
+              <v-list-item-title class="text-body-2 font-weight-bold">
+                Publication
+                <v-icon v-if="isPublished" color="grey" small>
+                  $checkbox-circle-fill
+                </v-icon>
+              </v-list-item-title>
+              <v-badge dot inline v-if="readyToPublish"></v-badge>
+            </v-list-item>
+            <v-list-item v-if="isCentralCuisine" :ripple="false" :to="{ name: 'PublishSatellites' }" class="mt-n2">
+              <v-list-item-title class="text-body-2 pl-6">
+                Satellites
+              </v-list-item-title>
+            </v-list-item>
+          </div>
+          <v-list-item v-else :ripple="false" :to="{ name: 'PublishSatellites' }" class="mt-n2">
             <v-icon small class="mr-2">mdi-bullhorn</v-icon>
             <v-list-item-title class="text-body-2 font-weight-bold">
-              Publication
-              <v-icon v-if="isPublished" color="grey" small>
-                $checkbox-circle-fill
-              </v-icon>
+              Publier mes satellites
             </v-list-item-title>
-            <v-badge dot inline v-if="readyToPublish"></v-badge>
           </v-list-item>
           <v-list-item :ripple="false" :to="{ name: 'CanteenManagers' }">
             <v-icon small class="mr-2">$team-fill</v-icon>
@@ -90,11 +103,14 @@ export default {
         hasDiagnosticApproData(diagnostic)
       )
     },
-    showSatellitePage() {
+    isCentralCuisine() {
       return this.canteen.productionType === "central" || this.canteen.productionType === "central_serving"
     },
     isPublished() {
       return this.canteen.publicationStatus === "published"
+    },
+    hasSite() {
+      return ["site", "site_cooked_elsewhere", "central_serving"].includes(this.canteen.productionType)
     },
   },
   methods: {

--- a/frontend/src/components/SatelliteTable.vue
+++ b/frontend/src/components/SatelliteTable.vue
@@ -51,7 +51,7 @@
         <v-btn
           v-else-if="satelliteAction && satelliteAction(item)"
           outlined
-          color="primary"
+          :color="satelliteAction(item).color || 'primary'"
           @click="satelliteAction(item).action()"
         >
           {{ satelliteAction(item).text }}

--- a/frontend/src/components/SatelliteTable.vue
+++ b/frontend/src/components/SatelliteTable.vue
@@ -45,6 +45,7 @@
       </template>
       <template v-slot:[`item.userCanView`]="{ item }">
         <v-btn v-if="!item.userCanView" outlined color="primary" @click="requestAccess(item)">
+          <v-icon small class="mr-2">mdi-key</v-icon>
           Rejoindre l'équipe
           <span class="d-sr-only">de {{ item.name }}</span>
         </v-btn>
@@ -54,6 +55,7 @@
           :color="satelliteAction(item).color || 'primary'"
           @click="satelliteAction(item).action()"
         >
+          <v-icon v-if="satelliteAction(item).icon" small class="mr-2">{{ satelliteAction(item).icon }}</v-icon>
           {{ satelliteAction(item).text }}
           <span class="d-sr-only">{{ item.name }}</span>
         </v-btn>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -35,6 +35,7 @@ import DiagnosticList from "@/views/CanteenEditor/DiagnosticList"
 import CanteenManagers from "@/views/CanteenEditor/CanteenManagers"
 import CanteenDeletion from "@/views/CanteenEditor/CanteenDeletion"
 import PublicationForm from "@/views/CanteenEditor/PublicationForm"
+import PublishSatellites from "@/views/CanteenEditor/PublishSatellites"
 import DashboardPage from "@/views/CanteenEditor/DashboardPage"
 import DiagnosticEditor from "@/views/DiagnosticEditor"
 import DiagnosticsImporter from "@/views/DiagnosticsImporter"
@@ -359,6 +360,14 @@ const routes = [
         path: "publier",
         name: "PublicationForm",
         component: PublicationForm,
+        meta: {
+          authenticationRequired: true,
+        },
+      },
+      {
+        path: "publier-satellites",
+        name: "PublishSatellites",
+        component: PublishSatellites,
         meta: {
           authenticationRequired: true,
         },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -365,7 +365,7 @@ const routes = [
         },
       },
       {
-        path: "publier-satellites",
+        path: "publier-mes-satellites",
         name: "PublishSatellites",
         component: PublishSatellites,
         meta: {

--- a/frontend/src/views/CanteenEditor/PublicationField.vue
+++ b/frontend/src/views/CanteenEditor/PublicationField.vue
@@ -1,22 +1,21 @@
 <template>
   <div>
-    <PublicationPreviewDialog
-      v-if="!isNewCanteen"
-      :canteen="canteen"
-      :value="showPreview"
-      @close="showPreview = false"
-    />
-    <v-row v-if="!isNewCanteen">
+    <PublicationPreviewDialog :canteen="canteen" :value="showPreview" @close="showPreview = false" />
+    <v-row>
       <v-col cols="12">
-        <v-checkbox hide-details="auto" class="mt-0" color="primary" :input-value="value" @change="updateValue">
+        <v-checkbox
+          hide-details="auto"
+          class="mt-0"
+          color="primary"
+          :input-value="value"
+          @change="updateValue"
+          :rules="[validators.checked]"
+          validate-on-blur
+        >
           <template v-slot:label>
             <p class="text-body-2 grey--text text--darken-4 pb-0 my-0 ml-2" :class="{ 'pt-1': isDraft }">
               J'accepte que les données relatives aux mesures EGAlim de ma cantine soient visibles sur
-              <router-link
-                :to="{
-                  name: 'CanteensHome',
-                }"
-              >
+              <router-link :to="{ name: 'CanteensHome' }">
                 nos cantines
               </router-link>
               <br />
@@ -41,6 +40,7 @@
 
 <script>
 import PublicationPreviewDialog from "@/views/ManagementPage/PublicationPreviewDialog"
+import validators from "@/validators"
 
 export default {
   name: "PublicationField",
@@ -58,12 +58,10 @@ export default {
   data() {
     return {
       showPreview: false,
+      validators,
     }
   },
   computed: {
-    isNewCanteen() {
-      return !this.canteen.id
-    },
     isDraft() {
       return this.canteen.publicationStatus === "draft"
     },

--- a/frontend/src/views/CanteenEditor/PublicationField.vue
+++ b/frontend/src/views/CanteenEditor/PublicationField.vue
@@ -10,7 +10,10 @@
       <v-col cols="12">
         <v-checkbox hide-details="auto" class="mt-0" color="primary" :input-value="value" @change="updateValue">
           <template v-slot:label>
-            <p class="text-body-2 grey--text text--darken-4 pt-1 pb-0 my-0 ml-2">
+            <p
+              class="text-body-2 grey--text text--darken-4 pb-0 my-0 ml-2"
+              :class="{ 'pt-1': !originalCanteenIsPublished }"
+            >
               J'accepte que les données relatives aux mesures EGAlim de ma cantine soient visibles sur
               <router-link
                 :to="{

--- a/frontend/src/views/CanteenEditor/PublicationField.vue
+++ b/frontend/src/views/CanteenEditor/PublicationField.vue
@@ -10,10 +10,7 @@
       <v-col cols="12">
         <v-checkbox hide-details="auto" class="mt-0" color="primary" :input-value="value" @change="updateValue">
           <template v-slot:label>
-            <p
-              class="text-body-2 grey--text text--darken-4 pb-0 my-0 ml-2"
-              :class="{ 'pt-1': !originalCanteenIsPublished }"
-            >
+            <p class="text-body-2 grey--text text--darken-4 pb-0 my-0 ml-2" :class="{ 'pt-1': isDraft }">
               J'accepte que les données relatives aux mesures EGAlim de ma cantine soient visibles sur
               <router-link
                 :to="{
@@ -23,28 +20,7 @@
                 nos cantines
               </router-link>
               <br />
-              <span v-if="originalCanteenIsPublished">
-                Cette cantine est actuellement publiée sur
-                <v-btn
-                  @click.stop
-                  :href="
-                    $router.resolve({
-                      name: 'CanteenPage',
-                      params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
-                    }).href
-                  "
-                  class="text-body-2 pl-0 text-decoration-underline"
-                  id="canteen-page-link"
-                  target="_blank"
-                  small
-                  text
-                  plain
-                >
-                  nos cantines
-                  <v-icon small color="grey darken-4" class="ml-1">mdi-open-in-new</v-icon>
-                </v-btn>
-              </span>
-              <span v-else>
+              <span v-if="isDraft">
                 <v-btn
                   @click.stop="showPreview = true"
                   class="text-body-2 px-0 text-decoration-underline grey--text text--darken-4"
@@ -88,8 +64,8 @@ export default {
     isNewCanteen() {
       return !this.canteen.id
     },
-    originalCanteenIsPublished() {
-      return this.canteen.publicationStatus === "published"
+    isDraft() {
+      return this.canteen.publicationStatus === "draft"
     },
   },
   methods: {
@@ -103,8 +79,5 @@ export default {
 <style scoped>
 .v-btn--plain:not(.v-btn--active):not(.v-btn--loading):not(:focus):not(:hover) >>> .v-btn__content {
   opacity: 1;
-}
-#canteen-page-link {
-  vertical-align: inherit;
 }
 </style>

--- a/frontend/src/views/CanteenEditor/PublicationForm/CentralKitchen.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/CentralKitchen.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <h1 class="font-weight-black text-h4 my-4">Publier mes satellites</h1>
     <div v-if="!receivesGuests">
       <p>
         « {{ originalCanteen.name }} » est une cuisine centrale sans lieu de consommation. La publication concerne
@@ -37,12 +36,14 @@
         </v-btn>
       </p>
       <p v-else>
+        <!-- TODO: do not show this if have no satellites -->
         <v-icon size="30" color="green">
           $checkbox-circle-fill
         </v-icon>
         Tous vos satellites sont publiés.
       </p>
     </div>
+    <!-- TODO: if have no satellites, encourage adding them -->
     <SatelliteTable
       ref="satelliteTable"
       :headers="satelliteTableHeaders"
@@ -53,6 +54,7 @@
       @mountedAndFetched="mountedAndFetched"
       @paramsChanged="updateRoute"
       @satellitesLoaded="updateSatellitesCounts"
+      class="mb-4"
     />
     <p v-if="published && !receivesGuests" class="mt-8">
       Précédemment vous aviez choisi de publier cette cantine. En tant que cuisine centrale, vous pouvez désormais

--- a/frontend/src/views/CanteenEditor/PublicationForm/CentralKitchen.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/CentralKitchen.vue
@@ -35,8 +35,7 @@
           <span v-else>Publier la cantine satellite</span>
         </v-btn>
       </p>
-      <p v-else>
-        <!-- TODO: do not show this if have no satellites -->
+      <p v-else-if="satelliteCount">
         <v-icon size="30" color="green">
           $checkbox-circle-fill
         </v-icon>

--- a/frontend/src/views/CanteenEditor/PublicationForm/CentralKitchen.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/CentralKitchen.vue
@@ -88,6 +88,7 @@ export default {
         { text: "Publiée ?", value: "publicationStatus" },
         { text: "", value: "userCanView", sortable: false },
       ],
+      satelliteCount: 0,
       unpublishedCount: undefined,
       satellitesToPublish: [],
       pubLoading: false,
@@ -151,6 +152,7 @@ export default {
       const that = this
       return {
         text: isDraft ? "Publier" : "Retirer la publication",
+        color: isDraft ? "green darken-3" : "red darken-3",
         action() {
           store
             .dispatch(isDraft ? "publishCanteen" : "unpublishCanteen", {

--- a/frontend/src/views/CanteenEditor/PublicationForm/CentralKitchen.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/CentralKitchen.vue
@@ -153,6 +153,7 @@ export default {
       return {
         text: isDraft ? "Publier" : "Retirer la publication",
         color: isDraft ? "green darken-3" : "red darken-3",
+        icon: isDraft ? "mdi-bullhorn" : "mdi-cancel",
         action() {
           store
             .dispatch(isDraft ? "publishCanteen" : "unpublishCanteen", {

--- a/frontend/src/views/CanteenEditor/PublicationForm/index.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/index.vue
@@ -180,9 +180,9 @@ export default {
   computed: {
     pageTitle() {
       if (this.isPublished) {
-        return "La publication"
+        return "Votre publication"
       } else {
-        return "Publier le lieu de service"
+        return "Publier votre lieu de service"
       }
     },
     hasChanged() {

--- a/frontend/src/views/CanteenEditor/PublicationForm/index.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/index.vue
@@ -2,7 +2,9 @@
   <div class="text-left">
     <h1 class="font-weight-black text-h4 my-4">{{ pageTitle }}</h1>
     <PublicationStateNotice v-if="receivesGuests" :canteen="originalCanteen" class="my-4" />
+    <CentralKitchen v-if="isCentralCuisine" :originalCanteen="originalCanteen" />
     <div v-if="!isDraft">
+      <h2 class="mt-8 mb-2" v-if="isCentralCuisine">Gérer le lieu de service</h2>
       <p>
         <v-icon color="green">$checkbox-circle-fill</v-icon>
         Cette cantine est actuellement publiée sur
@@ -18,9 +20,7 @@
         </router-link>
       </p>
       <AddPublishedCanteenWidget :canteen="originalCanteen" />
-      <h2 class="mt-8 mb-2">Modifier la publication</h2>
     </div>
-    <CentralKitchen v-if="isCentralCuisine" :originalCanteen="originalCanteen" />
     <div v-if="isDraft && !hasDiagnostics && receivesGuests">
       <p>
         Vous n'avez pas encore rempli des diagnostics pour « {{ originalCanteen.name }} ». Les diagnostics sont un
@@ -39,6 +39,8 @@
       </v-btn>
     </div>
     <div v-else-if="receivesGuests">
+      <h2 class="mt-8 mb-2" v-if="!isDraft">Modifier la publication</h2>
+      <h2 class="mt-8 mb-2" v-else-if="isCentralCuisine">Publier le lieu de service</h2>
       <v-form ref="form" @submit.prevent>
         <label for="general">
           Décrivez si vous le souhaitez le fonctionnement, l'organisation, l'historique de votre établissement...
@@ -170,8 +172,9 @@ export default {
   computed: {
     pageTitle() {
       if (this.isCentralCuisine) {
-        return "Publier mes satellites"
-      } else if (this.isDraft) {
+        return "Gérer mes satellites"
+      }
+      if (this.isDraft) {
         return "Publier ma cantine"
       } else {
         return "La publication"

--- a/frontend/src/views/CanteenEditor/PublicationForm/index.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/index.vue
@@ -22,7 +22,7 @@
     </div>
     <div v-else-if="receivesGuests">
       <v-form ref="form" v-model="formIsValid">
-        <label class="body-2" for="general">
+        <label for="general">
           Décrivez si vous le souhaitez le fonctionnement, l'organisation, l'historique de votre établissement...
         </label>
         <DsfrTextarea

--- a/frontend/src/views/CanteenEditor/PublicationForm/index.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/index.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="text-left">
+    <h1 class="font-weight-black text-h4 my-4">{{ pageTitle }}</h1>
+    <PublicationStateNotice v-if="receivesGuests" :canteen="originalCanteen" class="my-4" />
     <CentralKitchen v-if="isCentralCuisine" :originalCanteen="originalCanteen" />
     <div v-if="isDraft && !hasDiagnostics && receivesGuests">
-      <h1 class="font-weight-black text-h4 my-4">Publier ma cantine</h1>
       <p>
         Vous n'avez pas encore rempli des diagnostics pour « {{ originalCanteen.name }} ». Les diagnostics sont un
         prérequis pour la publication
@@ -20,9 +21,7 @@
       </v-btn>
     </div>
     <div v-else-if="receivesGuests">
-      <h1 class="font-weight-black text-h4 my-4">Publier ma cantine</h1>
       <v-form ref="form" v-model="formIsValid">
-        <PublicationStateNotice :canteen="originalCanteen" class="my-4" />
         <label class="body-2" for="general">
           Décrivez si vous le souhaitez le fonctionnement, l'organisation, l'historique de votre établissement...
         </label>
@@ -142,6 +141,15 @@ export default {
     window.confirm(LEAVE_WARNING) ? next() : next(false)
   },
   computed: {
+    pageTitle() {
+      if (this.isCentralCuisine) {
+        return "Publier mes satellites"
+      } else if (this.isDraft) {
+        return "Publier ma cantine"
+      } else {
+        return "Modifier ma publication"
+      }
+    },
     hasChanged() {
       const publicationRequested =
         this.publicationRequested &&

--- a/frontend/src/views/CanteenEditor/PublicationForm/index.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/index.vue
@@ -2,9 +2,7 @@
   <div class="text-left">
     <h1 class="font-weight-black text-h4 my-4">{{ pageTitle }}</h1>
     <PublicationStateNotice v-if="receivesGuests" :canteen="originalCanteen" class="my-4" />
-    <CentralKitchen v-if="isCentralCuisine" :originalCanteen="originalCanteen" />
-    <div v-if="!isDraft">
-      <h2 class="mt-8 mb-2" v-if="isCentralCuisine">Gérer le lieu de service</h2>
+    <div v-if="isPublished">
       <p>
         <v-icon color="green">$checkbox-circle-fill</v-icon>
         Cette cantine est actuellement publiée sur
@@ -20,8 +18,20 @@
         </router-link>
       </p>
       <AddPublishedCanteenWidget :canteen="originalCanteen" />
+      <div v-if="!receivesGuests">
+        <p class="mt-8">
+          Précédemment vous aviez choisi de publier cette cantine. En tant que cuisine centrale, vous pouvez désormais
+          retirer cette publication.
+        </p>
+        <v-sheet rounded color="grey lighten-4 pa-3 my-6" class="d-flex">
+          <v-spacer></v-spacer>
+          <v-btn x-large color="primary" @click="removeCanteenPublication">
+            Retirer la publication
+          </v-btn>
+        </v-sheet>
+      </div>
     </div>
-    <div v-if="isDraft && !hasDiagnostics && receivesGuests">
+    <div v-else-if="!hasDiagnostics && receivesGuests">
       <p>
         Vous n'avez pas encore rempli des diagnostics pour « {{ originalCanteen.name }} ». Les diagnostics sont un
         prérequis pour la publication
@@ -38,9 +48,8 @@
         Ajouter un diagnostic
       </v-btn>
     </div>
-    <div v-else-if="receivesGuests">
-      <h2 class="mt-8 mb-2" v-if="!isDraft">Modifier la publication</h2>
-      <h2 class="mt-8 mb-2" v-else-if="isCentralCuisine">Publier le lieu de service</h2>
+    <div v-if="receivesGuests">
+      <h2 class="mt-8 mb-2" v-if="isPublished">Modifier la publication</h2>
       <v-form ref="form" @submit.prevent>
         <label for="general">
           Décrivez si vous le souhaitez le fonctionnement, l'organisation, l'historique de votre établissement...
@@ -59,13 +68,13 @@
         <v-btn x-large outlined color="primary" class="mr-4 align-self-center" :to="{ name: 'ManagementPage' }">
           Annuler
         </v-btn>
-        <v-btn v-if="isDraft" x-large color="primary" @click="publishCanteen">
+        <v-btn v-if="!isPublished" x-large color="primary" @click="publishCanteen">
           Publier
         </v-btn>
         <v-btn v-else x-large color="red darken-3" class="mr-4" outlined @click="removeCanteenPublication">
           Retirer la publication
         </v-btn>
-        <v-btn v-if="!isDraft" x-large color="primary" @click="saveCanteen">
+        <v-btn v-if="isPublished" x-large color="primary" @click="saveCanteen">
           Mettre à jour
         </v-btn>
       </v-sheet>
@@ -79,7 +88,6 @@ import { getObjectDiff, isDiagnosticComplete, lastYear } from "@/utils"
 import PublicationStateNotice from "../PublicationStateNotice"
 import DsfrTextarea from "@/components/DsfrTextarea"
 import AddPublishedCanteenWidget from "@/components/AddPublishedCanteenWidget"
-import CentralKitchen from "./CentralKitchen"
 
 const LEAVE_WARNING = "Voulez-vous vraiment quitter cette page ? Vos changements n'ont pas été sauvegardés."
 
@@ -90,7 +98,7 @@ export default {
       type: Object,
     },
   },
-  components: { PublicationField, PublicationStateNotice, DsfrTextarea, AddPublishedCanteenWidget, CentralKitchen },
+  components: { PublicationField, PublicationStateNotice, DsfrTextarea, AddPublishedCanteenWidget },
   data() {
     return {
       acceptPublication: false,
@@ -171,13 +179,10 @@ export default {
   },
   computed: {
     pageTitle() {
-      if (this.isCentralCuisine) {
-        return "Gérer mes satellites"
-      }
-      if (this.isDraft) {
-        return "Publier ma cantine"
-      } else {
+      if (this.isPublished) {
         return "La publication"
+      } else {
+        return "Publier le lieu de service"
       }
     },
     hasChanged() {
@@ -202,8 +207,8 @@ export default {
     hasDiagnostics() {
       return this.originalCanteen.diagnostics && this.originalCanteen.diagnostics.length > 0
     },
-    isDraft() {
-      return this.canteen.publicationStatus === "draft"
+    isPublished() {
+      return this.canteen.publicationStatus === "published"
     },
   },
 }

--- a/frontend/src/views/CanteenEditor/PublicationForm/index.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/index.vue
@@ -5,7 +5,7 @@
     <div v-if="isPublished">
       <p>
         <v-icon color="green">$checkbox-circle-fill</v-icon>
-        Cette cantine est actuellement publiée sur
+        Votre lieu de service est actuellement publié sur
         <router-link
           :to="{
             name: 'CanteenPage',
@@ -48,17 +48,14 @@
         Ajouter un diagnostic
       </v-btn>
     </div>
+    <p v-if="isCentralCuisine">
+      <router-link :to="{ name: 'PublishSatellites' }">Gérer la publication de mes satellites</router-link>
+    </p>
     <div v-if="receivesGuests">
       <h2 class="mt-8 mb-2" v-if="isPublished">Modifier la publication</h2>
       <v-form ref="form" @submit.prevent>
         <label for="general">
           Décrivez si vous le souhaitez le fonctionnement, l'organisation, l'historique de votre établissement...
-          <br />
-          <span class="caption grey--text text--darken-1">
-            Vous pouvez par exemple raconter l'histoire du lieu, du bâtiment, de l'association ou de l'entreprise ou des
-            personnes qui gérent cet établissement, ses spécificités, ses caractéristiques techniques, logistiques...
-            Cela peut aussi être une anecdote dont vous êtes fiers, une certification, un label...
-          </span>
         </label>
         <DsfrTextarea id="general" class="my-2" rows="5" counter="500" v-model="canteen.publicationComments" />
         <PublicationField class="mb-4" :canteen="canteen" v-model="acceptPublication" />

--- a/frontend/src/views/CanteenEditor/PublicationForm/index.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/index.vue
@@ -2,6 +2,24 @@
   <div class="text-left">
     <h1 class="font-weight-black text-h4 my-4">{{ pageTitle }}</h1>
     <PublicationStateNotice v-if="receivesGuests" :canteen="originalCanteen" class="my-4" />
+    <div v-if="!isDraft">
+      <p>
+        <v-icon color="green">$checkbox-circle-fill</v-icon>
+        Cette cantine est actuellement publiée sur
+        <router-link
+          :to="{
+            name: 'CanteenPage',
+            params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
+          }"
+          target="_blank"
+        >
+          nos cantines
+          <v-icon small class="ml-1" color="primary">mdi-open-in-new</v-icon>
+        </router-link>
+      </p>
+      <AddPublishedCanteenWidget :canteen="originalCanteen" />
+      <h2 class="mt-8 mb-2">Modifier la publication</h2>
+    </div>
     <CentralKitchen v-if="isCentralCuisine" :originalCanteen="originalCanteen" />
     <div v-if="isDraft && !hasDiagnostics && receivesGuests">
       <p>
@@ -58,6 +76,7 @@ import PublicationField from "../PublicationField"
 import { getObjectDiff, isDiagnosticComplete, lastYear } from "@/utils"
 import PublicationStateNotice from "../PublicationStateNotice"
 import DsfrTextarea from "@/components/DsfrTextarea"
+import AddPublishedCanteenWidget from "@/components/AddPublishedCanteenWidget"
 import CentralKitchen from "./CentralKitchen"
 
 const LEAVE_WARNING = "Voulez-vous vraiment quitter cette page ? Vos changements n'ont pas été sauvegardés."
@@ -69,7 +88,7 @@ export default {
       type: Object,
     },
   },
-  components: { PublicationField, PublicationStateNotice, DsfrTextarea, CentralKitchen },
+  components: { PublicationField, PublicationStateNotice, DsfrTextarea, AddPublishedCanteenWidget, CentralKitchen },
   data() {
     return {
       acceptPublication: false,
@@ -155,7 +174,7 @@ export default {
       } else if (this.isDraft) {
         return "Publier ma cantine"
       } else {
-        return "Modifier ma publication"
+        return "La publication"
       }
     },
     hasChanged() {

--- a/frontend/src/views/CanteenEditor/PublicationStateNotice.vue
+++ b/frontend/src/views/CanteenEditor/PublicationStateNotice.vue
@@ -1,19 +1,6 @@
 <template>
   <div>
-    <DsfrCallout v-if="isPublished" icon="$checkbox-circle-fill" color="green">
-      Cette cantine est actuellement publiée sur
-      <router-link
-        :to="{
-          name: 'CanteenPage',
-          params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
-        }"
-        target="_blank"
-      >
-        nos cantines
-        <v-icon small class="ml-1" color="primary">mdi-open-in-new</v-icon>
-      </router-link>
-    </DsfrCallout>
-    <DsfrCallout v-else-if="readyToPublish" class="mb-1">
+    <DsfrCallout v-if="isDraft && readyToPublish" class="mb-1">
       <span class="grey--text text--darken-2">
         Vos données d'approvisionnement pour l'année {{ publicationYear }} sont completées, alors nous vous encourageons
         de publier votre cantine.
@@ -23,7 +10,7 @@
       </span>
     </DsfrCallout>
     <!-- includeLink currently only used by CanteenPage, where we don't want this to show. Bit hacky -->
-    <DsfrCallout color="#C08C65" class="mb-1" v-else-if="!includeLink">
+    <DsfrCallout color="#C08C65" class="mb-1" v-else-if="isDraft && !includeLink">
       <span class="grey--text text--darken-2">
         Nous vous conseillons de remplir des
         <router-link :to="{ name: 'DiagnosticList', params: { canteenUrlComponent } }">
@@ -57,10 +44,10 @@ export default {
     },
     readyToPublish() {
       const diagnostic = this.canteen.diagnostics.find((x) => x.year === this.publicationYear)
-      return this.canteen.publicationStatus === "draft" && !!diagnostic && hasDiagnosticApproData(diagnostic)
+      return this.isDraft && !!diagnostic && hasDiagnosticApproData(diagnostic)
     },
-    isPublished() {
-      return this.canteen.publicationStatus === "published"
+    isDraft() {
+      return this.canteen.publicationStatus === "draft"
     },
   },
 }

--- a/frontend/src/views/CanteenEditor/PublicationStateNotice.vue
+++ b/frontend/src/views/CanteenEditor/PublicationStateNotice.vue
@@ -1,26 +1,37 @@
 <template>
   <div>
-    <div v-if="!isPublished">
-      <DsfrCallout v-if="readyToPublish" class="mb-1">
-        <span class="grey--text text--darken-2">
-          Vos données d'approvisionnement pour l'année {{ publicationYear }} sont completées, alors nous vous
-          encourageons de publier votre cantine.
-          <router-link v-if="includeLink" :to="{ name: 'PublicationForm', params: { canteenUrlComponent } }">
-            Publier cette cantine.
-          </router-link>
-        </span>
-      </DsfrCallout>
-      <!-- includeLink currently only used by CanteenPage, where we don't want this to show. Bit hacky -->
-      <DsfrCallout color="#C08C65" class="mb-1" v-else-if="!includeLink">
-        <span class="grey--text text--darken-2">
-          Nous vous conseillons de remplir des
-          <router-link :to="{ name: 'DiagnosticList', params: { canteenUrlComponent } }">
-            données d'approvisionnement pour l'année {{ this.publicationYear }}
-          </router-link>
-          avant que vous publiiez vos données.
-        </span>
-      </DsfrCallout>
-    </div>
+    <DsfrCallout v-if="isPublished" icon="$checkbox-circle-fill" color="green">
+      Cette cantine est actuellement publiée sur
+      <router-link
+        :to="{
+          name: 'CanteenPage',
+          params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
+        }"
+        target="_blank"
+      >
+        nos cantines
+        <v-icon small class="ml-1" color="primary">mdi-open-in-new</v-icon>
+      </router-link>
+    </DsfrCallout>
+    <DsfrCallout v-else-if="readyToPublish" class="mb-1">
+      <span class="grey--text text--darken-2">
+        Vos données d'approvisionnement pour l'année {{ publicationYear }} sont completées, alors nous vous encourageons
+        de publier votre cantine.
+        <router-link v-if="includeLink" :to="{ name: 'PublicationForm', params: { canteenUrlComponent } }">
+          Publier cette cantine.
+        </router-link>
+      </span>
+    </DsfrCallout>
+    <!-- includeLink currently only used by CanteenPage, where we don't want this to show. Bit hacky -->
+    <DsfrCallout color="#C08C65" class="mb-1" v-else-if="!includeLink">
+      <span class="grey--text text--darken-2">
+        Nous vous conseillons de remplir des
+        <router-link :to="{ name: 'DiagnosticList', params: { canteenUrlComponent } }">
+          données d'approvisionnement pour l'année {{ this.publicationYear }}
+        </router-link>
+        avant que vous publiiez vos données.
+      </span>
+    </DsfrCallout>
   </div>
 </template>
 

--- a/frontend/src/views/CanteenEditor/PublicationStateNotice.vue
+++ b/frontend/src/views/CanteenEditor/PublicationStateNotice.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="!isPublished">
-      <DsfrCallout v-if="readyToPublish" class="mb-1 body-2">
+      <DsfrCallout v-if="readyToPublish" class="mb-1">
         <span class="grey--text text--darken-2">
           Vos données d'approvisionnement pour l'année {{ publicationYear }} sont completées, alors nous vous
           encourageons de publier votre cantine.
@@ -11,7 +11,7 @@
         </span>
       </DsfrCallout>
       <!-- includeLink currently only used by CanteenPage, where we don't want this to show. Bit hacky -->
-      <DsfrCallout color="#C08C65" class="mb-1 body-2" v-else-if="!includeLink">
+      <DsfrCallout color="#C08C65" class="mb-1" v-else-if="!includeLink">
         <span class="grey--text text--darken-2">
           Nous vous conseillons de remplir des
           <router-link :to="{ name: 'DiagnosticList', params: { canteenUrlComponent } }">

--- a/frontend/src/views/CanteenEditor/PublishSatellites.vue
+++ b/frontend/src/views/CanteenEditor/PublishSatellites.vue
@@ -1,24 +1,6 @@
 <template>
-  <div>
-    <div v-if="!receivesGuests">
-      <p>
-        « {{ originalCanteen.name }} » est une cuisine centrale sans lieu de consommation. La publication concerne
-        <b>uniquement les lieux de restauration recevant des convives.</b>
-      </p>
-      <p>
-        Vous pouvez
-        <router-link :to="{ name: 'NewCanteen' }">ajouter une cantine satellite</router-link>
-        ou indiquer que
-        <router-link
-          :to="{
-            name: 'CanteenModification',
-            params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(originalCanteen) },
-          }"
-        >
-          votre cuisine centrale reçoit aussi des convives sur place.
-        </router-link>
-      </p>
-    </div>
+  <div class="text-left">
+    <h1 class="font-weight-black text-h4 my-4">Publier mes satellites</h1>
     <div>
       <v-row v-if="pubLoading" class="green--text">
         <v-col cols="1" justify-self="center">
@@ -55,16 +37,25 @@
       @satellitesLoaded="updateSatellitesCounts"
       class="mb-4"
     />
-    <p v-if="published && !receivesGuests" class="mt-8">
-      Précédemment vous aviez choisi de publier cette cantine. En tant que cuisine centrale, vous pouvez désormais
-      retirer cette publication.
-    </p>
-    <v-sheet v-if="published && !receivesGuests" rounded color="grey lighten-4 pa-3 my-6" class="d-flex">
-      <v-spacer></v-spacer>
-      <v-btn x-large color="primary" @click="removeCanteenPublication">
-        Retirer la publication
-      </v-btn>
-    </v-sheet>
+    <div v-if="!receivesGuests">
+      <p>
+        « {{ originalCanteen.name }} » est une cuisine centrale sans lieu de consommation. La publication concerne
+        <b>uniquement les lieux de restauration recevant des convives.</b>
+      </p>
+      <p>
+        Vous pouvez
+        <router-link :to="{ name: 'NewCanteen' }">ajouter une cantine satellite</router-link>
+        ou indiquer que
+        <router-link
+          :to="{
+            name: 'CanteenModification',
+            params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(originalCanteen) },
+          }"
+        >
+          votre cuisine centrale reçoit aussi des convives sur place.
+        </router-link>
+      </p>
+    </div>
   </div>
 </template>
 
@@ -72,7 +63,7 @@
 import SatelliteTable from "@/components/SatelliteTable"
 
 export default {
-  name: "CentralKitchenPublication",
+  name: "PublishSatellites",
   components: { SatelliteTable },
   props: {
     originalCanteen: {
@@ -81,7 +72,6 @@ export default {
   },
   data() {
     return {
-      published: this.originalCanteen.publicationStatus !== "draft",
       satelliteTableHeaders: [
         { text: "Nom", value: "name" },
         { text: "SIRET", value: "siret" },
@@ -196,6 +186,9 @@ export default {
           this.pubLoading = false
         })
     },
+  },
+  created() {
+    document.title = `Publier satellites - ${this.originalCanteen.name} - ${this.$store.state.pageTitleSuffix}`
   },
 }
 </script>

--- a/frontend/src/views/CanteenEditor/PublishSatellites.vue
+++ b/frontend/src/views/CanteenEditor/PublishSatellites.vue
@@ -12,7 +12,8 @@
       </v-row>
       <p v-else-if="unpublishedCount">
         {{ publishActionPreamble }}
-        <v-btn class="primary ml-2" @click="massPublication" v-if="satellitesToPublish.length">
+        <br />
+        <v-btn class="primary mt-3" @click="massPublication" v-if="satellitesToPublish.length">
           <span v-if="satellitesToPublish.length > 1">Publier {{ satellitesToPublish.length }} satellites</span>
           <span v-else>Publier la cantine satellite</span>
         </v-btn>

--- a/frontend/src/views/CanteensPage/CanteenPage.vue
+++ b/frontend/src/views/CanteensPage/CanteenPage.vue
@@ -40,26 +40,7 @@
             </v-card-subtitle>
           </v-col>
           <v-col v-if="isCanteenManager">
-            <DsfrCallout icon=" ">
-              <div class="ml-n4">
-                <p class="text-body-1 font-weight-bold">
-                  Ajoutez un aperçu sur votre site
-                </p>
-                <div class="text-body-2" style="font-family: monospace;">
-                  <DsfrTextField class="widget-text-field" :value="iframeCodeSnippet" readonly hide-details />
-                  <div class="d-flex mt-6 mb-2">
-                    <v-btn small color="primary" outlined @click="onWidgetCopy">
-                      <v-icon small class="mr-2">$clipboard-fill</v-icon>
-                      Copier
-                    </v-btn>
-                    <div class="green--text text--darken-3 ml-4 mt-1" v-if="showCopySuccessMessage">
-                      <v-icon small color="success">$checkbox-circle-fill</v-icon>
-                      Copié
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </DsfrCallout>
+            <AddPublishedCanteenWidget :canteen="canteen" />
           </v-col>
         </v-row>
       </v-card>
@@ -100,7 +81,7 @@ import CanteenIndicators from "@/components/CanteenIndicators"
 import BreadcrumbsNav from "@/components/BreadcrumbsNav"
 import labels from "@/data/quality-labels.json"
 import DsfrCallout from "@/components/DsfrCallout"
-import DsfrTextField from "@/components/DsfrTextField.vue"
+import AddPublishedCanteenWidget from "@/components/AddPublishedCanteenWidget"
 
 export default {
   data() {
@@ -118,7 +99,7 @@ export default {
     CanteenIndicators,
     BreadcrumbsNav,
     DsfrCallout,
-    DsfrTextField,
+    AddPublishedCanteenWidget,
   },
   props: {
     canteenUrlComponent: {
@@ -139,10 +120,6 @@ export default {
     isCanteenManager() {
       return this.canteen.isManagedByUser
     },
-    iframeCodeSnippet() {
-      const url = `${window.location.origin}/widgets${window.location.pathname}`
-      return `<iframe src='${url}' style='width: 480px; height: 420px;' scrolling='no'></iframe>`
-    },
   },
   methods: {
     setCanteen(canteen) {
@@ -155,11 +132,6 @@ export default {
         .dispatch("claimCanteen", { canteenId })
         .then(() => (this.claimSucceeded = true))
         .catch((e) => this.$store.dispatch("notifyServerError", e))
-    },
-    onWidgetCopy() {
-      navigator.clipboard.writeText(this.iframeCodeSnippet)
-      this.showCopySuccessMessage = true
-      setTimeout(() => (this.showCopySuccessMessage = false), 3000)
     },
   },
   beforeMount() {
@@ -188,9 +160,3 @@ export default {
   },
 }
 </script>
-
-<style scoped>
-.widget-text-field >>> .v-input .v-input__slot {
-  background: white !important;
-}
-</style>

--- a/frontend/src/views/ManagementPage/CentralKitchenCard.vue
+++ b/frontend/src/views/ManagementPage/CentralKitchenCard.vue
@@ -18,7 +18,12 @@
       <v-chip v-if="teledeclarationIsActive" small :color="teledeclarationStatus.color" label class="mr-1">
         {{ teledeclarationStatus.text }}
       </v-chip>
-      <v-chip small :color="publicationStatus.color" label>
+      <v-chip
+        small
+        :color="publicationStatus.color"
+        label
+        v-if="this.canteen.publicationStatus === 'published' || this.canteen.productionType === 'central_serving'"
+      >
         {{ publicationStatus.text }}
       </v-chip>
     </v-card-subtitle>


### PR DESCRIPTION
Changements faits :

Tous:
- Ajouter coche dans le nav à côté du mot "Publication"
- MAJ titre de la page en fonction d'état
- utiliser text-body-1 pas -2
- ajouter callout quand publiée (NB aussi visible sur la page modification de la cantine, je peux pas decider si j'aime ça ou non)
- deplacer le hint (long et trop petit en hint) comme caption du label suivant [Champ avec texte d’aide](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/champ-de-saisie)
- Rendre les actions de publier, retirer, et mettre à jour plus claires
- Ajouter option embed

Cuisines Centrales:
- enlever "Tous satellites publiés" si 0 satellites
- icones et couleurs pour les boutons satellites

Cuisines Centrales avec site:
- deplacer le PublicationStateNotice au debut de la page

## Une cuisine site

![Screenshot from 2023-03-20 16-53-34](https://user-images.githubusercontent.com/9282816/226395993-5cfec4cb-7dd6-4d19-bbbd-5189d5cf2ffb.png)


## Cuisine centrale avec un lieu de service

![Screenshot from 2023-03-20 16-54-53](https://user-images.githubusercontent.com/9282816/226396539-abe0e543-a469-4542-9254-ed1d38977de8.png)
![Screenshot from 2023-03-20 16-54-47](https://user-images.githubusercontent.com/9282816/226396545-1ba3a735-3be0-4b4b-aecf-a25e7637dcea.png)

## CC sans site publiée

![Screenshot from 2023-03-20 16-55-43](https://user-images.githubusercontent.com/9282816/226396881-62a68fca-ae6d-4045-805c-b0cf222f1bcd.png)

et non publiée

![Screenshot from 2023-03-20 16-56-16](https://user-images.githubusercontent.com/9282816/226397044-830de057-f89b-41de-97f2-f7be8763eff3.png)

