### PR TITLE
Enlever garde-fou sur jours de service pour les cuisines centrales

### DIFF
--- a/frontend/src/components/TeledeclarationPreview.vue
+++ b/frontend/src/components/TeledeclarationPreview.vue
@@ -668,6 +668,8 @@ export default {
     },
     daysOpenPerYear() {
       if (!this.canteen.dailyMealCount || !this.canteen.yearlyMealCount) return
+      // can't easily estimate days open for even central_serving without taking into account all satellites
+      if (this.canteen.isCentralCuisine) return
       return Number(this.canteen.yearlyMealCount / this.canteen.dailyMealCount).toFixed(0)
     },
     approSummary() {


### PR DESCRIPTION
Closes #2420

Je sais pas s'il vaut le coup dans un deuxième PR de :
- vérifier que le nombre de repas par jour par chaque satellite n'est pas > total repas livrés par an de la CC
- ajouter une estimation de jours de service d'une central_serving en faisant : (total repas livrés par an par la CC - SUM(repas par an satellites))/repas par jour central_serving