### PR TITLE
Données economiques masquées dans les endpoints publics

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -11,6 +11,7 @@ from .canteen import (  # noqa: F401
     SatelliteTeledeclarationSerializer,
 )
 from .diagnostic import (  # noqa: F401
+    ManagerDiagnosticSerializer,
     PublicDiagnosticSerializer,
     FullDiagnosticSerializer,
     CentralKitchenDiagnosticSerializer,

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -183,10 +183,14 @@ def appro_to_percentages(representation, instance):
     total = instance.value_total_ht
 
     for field in appro_field:
+        new_field_name = f"percentage_{field}"
         if representation.get(field):
-            representation[field] = representation[field] / total if total else None
+            representation[new_field_name] = representation[field] / total if total else None
+        representation.pop(field, None)
 
-    representation["value_total_ht"] = 1
+    representation["percentage_value_total_ht"] = 1
+    representation.pop("value_total_ht", None)
+
     return representation
 
 

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -178,6 +178,18 @@ META_FIELDS = (
 FIELDS = META_FIELDS + SIMPLE_APPRO_FIELDS + COMPLETE_APPRO_FIELDS + NON_APPRO_FIELDS
 
 
+def appro_to_percentages(representation, instance):
+    appro_field = SIMPLE_APPRO_FIELDS + COMPLETE_APPRO_FIELDS
+    total = instance.value_total_ht
+
+    for field in appro_field:
+        if representation.get(field):
+            representation[field] = representation[field] / total if total else None
+
+    representation["value_total_ht"] = 1
+    return representation
+
+
 class CentralKitchenDiagnosticSerializer(serializers.ModelSerializer):
     """
     This serializer masks financial data and gives the basic information on appro as percentages
@@ -199,21 +211,21 @@ class CentralKitchenDiagnosticSerializer(serializers.ModelSerializer):
             [representation.pop(field, "") for field in NON_APPRO_FIELDS]
         if instance.diagnostic_type == Diagnostic.DiagnosticType.SIMPLE:
             [representation.pop(field, "") for field in COMPLETE_APPRO_FIELDS]
-        return CentralKitchenDiagnosticSerializer.to_percentages(representation, instance)
-
-    def to_percentages(representation, instance):
-        appro_field = SIMPLE_APPRO_FIELDS + COMPLETE_APPRO_FIELDS
-        total = instance.value_total_ht
-
-        for field in appro_field:
-            if representation.get(field):
-                representation[field] = representation[field] / total if total else None
-
-        representation["value_total_ht"] = 1
-        return representation
+        return appro_to_percentages(representation, instance)
 
 
 class PublicDiagnosticSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Diagnostic
+        fields = FIELDS
+        read_ony_fields = FIELDS
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        return appro_to_percentages(representation, instance)
+
+
+class ManagerDiagnosticSerializer(serializers.ModelSerializer):
     class Meta:
         model = Diagnostic
         read_only_fields = ("id",)

--- a/api/tests/test_published_canteens.py
+++ b/api/tests/test_published_canteens.py
@@ -597,8 +597,8 @@ class TestPublishedCanteenApi(APITestCase):
 
         serialized_diagnostic = body.get("centralKitchenDiagnostics")[0]
         self.assertEqual(serialized_diagnostic["id"], diagnostic.id)
-        self.assertEqual(serialized_diagnostic["valueTotalHt"], 1)
-        self.assertEqual(serialized_diagnostic["valueBioHt"], 0.5)
+        self.assertEqual(serialized_diagnostic["percentageValueTotalHt"], 1)
+        self.assertEqual(serialized_diagnostic["percentageValueBioHt"], 0.5)
 
     def test_satellite_published_without_bio(self):
         central_siret = "22730656663081"
@@ -627,8 +627,8 @@ class TestPublishedCanteenApi(APITestCase):
 
         serialized_diagnostic = body.get("centralKitchenDiagnostics")[0]
         self.assertEqual(serialized_diagnostic["id"], diagnostic.id)
-        self.assertEqual(serialized_diagnostic["valueTotalHt"], 1)
-        self.assertEqual(serialized_diagnostic["valueBioHt"], None)
+        self.assertEqual(serialized_diagnostic["percentageValueTotalHt"], 1)
+        self.assertNotIn("percentageValueBioHt", serialized_diagnostic)
 
     def test_satellite_published_no_type(self):
         """
@@ -699,10 +699,10 @@ class TestPublishedCanteenApi(APITestCase):
         serialized_diag_2020 = next(filter(lambda x: x["year"] == 2020, serialized_diagnostics))
         serialized_diag_2021 = next(filter(lambda x: x["year"] == 2021, serialized_diagnostics))
 
-        self.assertIn("valueTotalHt", serialized_diag_2020)
+        self.assertIn("percentageValueTotalHt", serialized_diag_2020)
         self.assertNotIn("hasWasteDiagnostic", serialized_diag_2020)
 
-        self.assertIn("valueTotalHt", serialized_diag_2021)
+        self.assertIn("percentageValueTotalHt", serialized_diag_2021)
         self.assertIn("hasWasteDiagnostic", serialized_diag_2021)
 
     def test_percentage_values(self):
@@ -732,6 +732,6 @@ class TestPublishedCanteenApi(APITestCase):
         self.assertEqual(len(body.get("diagnostics")), 1)
         serialized_diag = body.get("diagnostics")[0]
 
-        self.assertEqual(serialized_diag["valueTotalHt"], 1)
-        self.assertEqual(serialized_diag["valueBioHt"], 0.5)
-        self.assertEqual(serialized_diag["valueSustainableHt"], 0.25)
+        self.assertEqual(serialized_diag["percentageValueTotalHt"], 1)
+        self.assertEqual(serialized_diag["percentageValueBioHt"], 0.5)
+        self.assertEqual(serialized_diag["percentageValueSustainableHt"], 0.25)

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -9,7 +9,7 @@ from drf_spectacular.utils import extend_schema_view, extend_schema
 from rest_framework.generics import UpdateAPIView, CreateAPIView
 from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.views import APIView
-from api.serializers import PublicDiagnosticSerializer
+from api.serializers import ManagerDiagnosticSerializer
 from data.models import Canteen
 from api.permissions import (
     IsCanteenManager,
@@ -32,12 +32,12 @@ class DiagnosticCreateView(CreateAPIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope]
     required_scopes = ["canteen"]
     model = Diagnostic
-    serializer_class = PublicDiagnosticSerializer
+    serializer_class = ManagerDiagnosticSerializer
 
     def get_serializer(self, *args, **kwargs):
         kwargs.setdefault("context", self.get_serializer_context())
         kwargs.setdefault("action", "create")
-        return PublicDiagnosticSerializer(*args, **kwargs)
+        return ManagerDiagnosticSerializer(*args, **kwargs)
 
     def perform_create(self, serializer):
         try:
@@ -71,7 +71,7 @@ class DiagnosticUpdateView(UpdateAPIView):
     ]
     required_scopes = ["canteen"]
     model = Diagnostic
-    serializer_class = PublicDiagnosticSerializer
+    serializer_class = ManagerDiagnosticSerializer
     queryset = Diagnostic.objects.all()
 
     def put(self, request, *args, **kwargs):

--- a/frontend/src/components/CanteenPublication.vue
+++ b/frontend/src/components/CanteenPublication.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="text-left">
-    <div v-if="diagnostic && diagnostic.valueTotalHt && (diagnostic.valueBioHt || diagnostic.valueSustainableHt)">
+    <div
+      v-if="
+        diagnostic &&
+          diagnostic.percentageValueTotalHt &&
+          (diagnostic.percentageValueBioHt || diagnostic.percentageValueSustainableHt)
+      "
+    >
       <h2 class="font-weight-black text-h6 grey--text text--darken-4 my-4">
         Que mange-t-on dans les assiettes en {{ publicationYear }} ?
       </h2>
@@ -21,7 +27,7 @@
         Total
       </h3>
       <v-row>
-        <v-col cols="12" sm="6" md="4" v-if="diagnostic.valueBioHt">
+        <v-col cols="12" sm="6" md="4" v-if="diagnostic.percentageValueBioHt">
           <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
             <p class="ma-0">
               <span class="grey--text text-h5 font-weight-black text--darken-2 mr-1">{{ bioPercent }} %</span>
@@ -40,7 +46,7 @@
             </div>
           </v-card>
         </v-col>
-        <v-col cols="12" sm="6" md="4" v-if="diagnostic.valueSustainableHt">
+        <v-col cols="12" sm="6" md="4" v-if="diagnostic.percentageValueSustainableHt">
           <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
             <p class="ma-0">
               <span class="grey--text text-h5 font-weight-black text--darken-2 mr-1">{{ sustainablePercent }} %</span>
@@ -207,7 +213,7 @@ export default {
       return this.diagnostic?.year
     },
     bioPercent() {
-      return Math.round(this.diagnostic.valueBioHt * 100)
+      return Math.round(this.diagnostic.percentageValueBioHt * 100)
     },
     sustainablePercent() {
       return Math.round(getSustainableTotal(this.diagnostic) * 100)

--- a/frontend/src/components/CanteenPublication.vue
+++ b/frontend/src/components/CanteenPublication.vue
@@ -161,7 +161,6 @@ import labels from "@/data/quality-labels.json"
 import {
   lastYear,
   badges,
-  getPercentage,
   hasDiagnosticApproData,
   latestCreatedDiagnostic,
   applicableDiagnosticRules,
@@ -208,10 +207,10 @@ export default {
       return this.diagnostic?.year
     },
     bioPercent() {
-      return getPercentage(this.diagnostic.valueBioHt, this.diagnostic.valueTotalHt)
+      return Math.round(this.diagnostic.valueBioHt * 100)
     },
     sustainablePercent() {
-      return getPercentage(getSustainableTotal(this.diagnostic), this.diagnostic.valueTotalHt)
+      return Math.round(getSustainableTotal(this.diagnostic) * 100)
     },
     earnedBadges() {
       const canteenBadges = badges(this.canteen, this.diagnostic, this.$store.state.sectors)

--- a/frontend/src/components/FamiliesGraph.vue
+++ b/frontend/src/components/FamiliesGraph.vue
@@ -149,7 +149,7 @@ export default {
       return colors[baseColor][modifier]
     },
     getValuesForCharacteristic(characteristicId) {
-      const usesPercentages = "percentageValueHt" in this.diagnostic
+      const usesPercentages = "percentageValueTotalHt" in this.diagnostic
       const baseFields = {
         VIANDES_VOLAILLES: usesPercentages ? "percentageValueViandesVolailles" : "valueViandesVolailles",
         CHARCUTERIE: usesPercentages ? "percentageValueCharcuterie" : "valueCharcuterie",
@@ -177,7 +177,7 @@ export default {
       return this.families.map((family) => {
         const baseField = baseFields[family.id]
         const field = `${baseField}${modifier}`
-        return diag[field]
+        return diag[field] || 0
       })
     },
   },

--- a/frontend/src/components/FamiliesGraph.vue
+++ b/frontend/src/components/FamiliesGraph.vue
@@ -149,15 +149,16 @@ export default {
       return colors[baseColor][modifier]
     },
     getValuesForCharacteristic(characteristicId) {
+      const usesPercentages = "percentageValueHt" in this.diagnostic
       const baseFields = {
-        VIANDES_VOLAILLES: "valueViandesVolailles",
-        CHARCUTERIE: "valueCharcuterie",
-        PRODUITS_DE_LA_MER: "valueProduitsDeLaMer",
-        FRUITS_ET_LEGUMES: "valueFruitsEtLegumes",
-        PRODUITS_LAITIERS: "valueProduitsLaitiers",
-        BOULANGERIE: "valueBoulangerie",
-        BOISSONS: "valueBoissons",
-        AUTRES: "valueAutres",
+        VIANDES_VOLAILLES: usesPercentages ? "percentageValueViandesVolailles" : "valueViandesVolailles",
+        CHARCUTERIE: usesPercentages ? "percentageValueCharcuterie" : "valueCharcuterie",
+        PRODUITS_DE_LA_MER: usesPercentages ? "percentageValueProduitsDeLaMer" : "valueProduitsDeLaMer",
+        FRUITS_ET_LEGUMES: usesPercentages ? "percentageValueFruitsEtLegumes" : "valueFruitsEtLegumes",
+        PRODUITS_LAITIERS: usesPercentages ? "percentageValueProduitsLaitiers" : "valueProduitsLaitiers",
+        BOULANGERIE: usesPercentages ? "percentageValueBoulangerie" : "valueBoulangerie",
+        BOISSONS: usesPercentages ? "percentageValueBoissons" : "valueBoissons",
+        AUTRES: usesPercentages ? "percentageValueAutres" : "valueAutres",
       }
       const baseModifiers = {
         BIO: "Bio",

--- a/frontend/src/components/MultiYearSummaryStatistics.vue
+++ b/frontend/src/components/MultiYearSummaryStatistics.vue
@@ -56,11 +56,9 @@ export default {
   computed: {
     seriesData() {
       return {
-        bio: this.completedDiagnostics.map((d) => getPercentage(d.valueBioHt, d.valueTotalHt)),
-        sustainable: this.completedDiagnostics.map((d) => getPercentage(getSustainableTotal(d), d.valueTotalHt)),
-        other: this.completedDiagnostics.map((d) => {
-          return 100 - getPercentage(d.valueBioHt, d.valueTotalHt) - getPercentage(d.valueSustainableHt, d.valueTotalHt)
-        }),
+        bio: this.completedDiagnostics.map(this.bioPercentage),
+        sustainable: this.completedDiagnostics.map(this.sustainablePercentage),
+        other: this.completedDiagnostics.map(this.otherPercentage),
       }
     },
     series() {
@@ -147,6 +145,21 @@ export default {
           enabled: false,
         },
       }
+    },
+  },
+  methods: {
+    bioPercentage(diag) {
+      return "percentageValueBioHt" in diag
+        ? Math.round(diag.percentageValueBioHt * 100)
+        : getPercentage(diag.valueBioHt, diag.valueTotalHt)
+    },
+    sustainablePercentage(diag) {
+      return "percentageValueTotalHt" in diag
+        ? Math.round(getSustainableTotal(diag) * 100)
+        : getPercentage(getSustainableTotal(diag), diag.valueTotalHt)
+    },
+    otherPercentage(diag) {
+      return 100 - this.bioPercentage(diag) - this.sustainablePercentage(diag)
     },
   },
 }

--- a/frontend/src/views/CanteensPage/CanteenWidget.vue
+++ b/frontend/src/views/CanteensPage/CanteenWidget.vue
@@ -63,7 +63,7 @@
 <script>
 import CanteenIndicators from "@/components/CanteenIndicators"
 import labels from "@/data/quality-labels.json"
-import { badges, getPercentage, latestCreatedDiagnostic, applicableDiagnosticRules, getSustainableTotal } from "@/utils"
+import { badges, latestCreatedDiagnostic, applicableDiagnosticRules, getSustainableTotal } from "@/utils"
 
 export default {
   data() {
@@ -110,10 +110,10 @@ export default {
       return this.diagnostic?.year
     },
     bioPercent() {
-      return getPercentage(this.diagnostic.valueBioHt, this.diagnostic.valueTotalHt)
+      return Math.round(this.diagnostic.valueBioHt * 100)
     },
     sustainablePercent() {
-      return getPercentage(getSustainableTotal(this.diagnostic), this.diagnostic.valueTotalHt)
+      return Math.round(getSustainableTotal(this.diagnostic) * 100)
     },
     canteenBadges() {
       return badges(this.canteen, this.diagnostic, this.$store.state.sectors)

--- a/frontend/src/views/CanteensPage/CanteenWidget.vue
+++ b/frontend/src/views/CanteensPage/CanteenWidget.vue
@@ -110,7 +110,7 @@ export default {
       return this.diagnostic?.year
     },
     bioPercent() {
-      return Math.round(this.diagnostic.valueBioHt * 100)
+      return Math.round(this.diagnostic.percentageValueBioHt * 100)
     },
     sustainablePercent() {
       return Math.round(getSustainableTotal(this.diagnostic) * 100)

--- a/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
+++ b/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
@@ -96,7 +96,8 @@ export default {
         })
     },
     bioPercent() {
-      return this.diagValuePercent("valueBioHt")
+      if (!this.diagnostic || !hasDiagnosticApproData(this.diagnostic)) return null
+      return Math.round(this.diagnostic["percentageValueBioHt"] * 100)
     },
     sustainablePercent() {
       if (this.diagnostic && hasDiagnosticApproData(this.diagnostic))
@@ -111,10 +112,6 @@ export default {
     },
   },
   methods: {
-    diagValuePercent(valueKey) {
-      if (!this.diagnostic || !hasDiagnosticApproData(this.diagnostic)) return null
-      return Math.round(this.diagnostic[valueKey] * 100)
-    },
     badgeTitle(badge) {
       return `${badge.title}${badge.earned ? "" : " (à faire)"}`
     },

--- a/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
+++ b/frontend/src/views/CanteensPage/PublishedCanteenCard.vue
@@ -58,7 +58,7 @@
 
 <script>
 import CanteenIndicators from "@/components/CanteenIndicators"
-import { getPercentage, getSustainableTotal, hasDiagnosticApproData, badges, latestCreatedDiagnostic } from "@/utils"
+import { getSustainableTotal, hasDiagnosticApproData, badges, latestCreatedDiagnostic } from "@/utils"
 
 export default {
   name: "PublishedCanteenCard",
@@ -100,7 +100,7 @@ export default {
     },
     sustainablePercent() {
       if (this.diagnostic && hasDiagnosticApproData(this.diagnostic))
-        return getPercentage(getSustainableTotal(this.diagnostic), this.diagnostic.valueTotalHt)
+        return Math.round(getSustainableTotal(this.diagnostic) * 100)
       return null
     },
     hasPercentages() {
@@ -113,7 +113,7 @@ export default {
   methods: {
     diagValuePercent(valueKey) {
       if (!this.diagnostic || !hasDiagnosticApproData(this.diagnostic)) return null
-      return getPercentage(this.diagnostic[valueKey], this.diagnostic.valueTotalHt)
+      return Math.round(this.diagnostic[valueKey] * 100)
     },
     badgeTitle(badge) {
       return `${badge.title}${badge.earned ? "" : " (à faire)"}`


### PR DESCRIPTION
Les données économiques de l'appro sont désormais présentées en pourcentages dans les endpoints API. 