### PR TITLE
Optimizations ORM liées au central_kitchen_diagnostics

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -224,7 +224,7 @@ class FullCanteenSerializer(serializers.ModelSerializer):
         # Ideally we would also check the status of the satellite canteen and
         # the central cuisine, for now we omit this check. For now it is the
         # responsibility of the frontend to use this information.
-        if not obj.central_producer_siret:
+        if not obj.central_producer_siret or not obj.production_type == Canteen.ProductionType.ON_SITE_CENTRAL:
             return None
         try:
             central_kitchen = Canteen.objects.get(siret=obj.central_producer_siret)

--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -227,13 +227,14 @@ class FullCanteenSerializer(serializers.ModelSerializer):
         if not obj.central_producer_siret or not obj.production_type == Canteen.ProductionType.ON_SITE_CENTRAL:
             return None
         try:
-            central_kitchen = Canteen.objects.get(siret=obj.central_producer_siret)
-            diagnostics = central_kitchen.diagnostic_set.filter(
+            diagnostics = Diagnostic.objects.filter(
+                canteen__siret=obj.central_producer_siret,
                 central_kitchen_diagnostic_mode__in=[
                     Diagnostic.CentralKitchenDiagnosticMode.ALL,
                     Diagnostic.CentralKitchenDiagnosticMode.APPRO,
-                ]
-            ).only("year", "central_kitchen_diagnostic_mode")
+                ],
+            )
+
             return CentralKitchenDiagnosticSerializer(diagnostics, many=True).data
         except Canteen.DoesNotExist:
             return None


### PR DESCRIPTION
Avant en accédant la page gestion (`gestion/?cantinePage=1`) on avait 1286 req (612 ms)

![image](https://user-images.githubusercontent.com/1225929/226578198-1827ddfe-92a7-41a5-9d56-0ceb892938de.png)

Après cette PR on passe à 39 req (41 ms)

![image](https://user-images.githubusercontent.com/1225929/226578437-31b24d32-c963-4d64-8bef-aa900ca64b81.png)

En utilisant `.only("year", "central_kitchen_diagnostic_mode")` le serializer devait chercher les champs additionnels un par un, provocant beaucoup trop de requêtes supplémentaires.

De plus, en ajoutant la condition `not obj.production_type == Canteen.ProductionType.ON_SITE_CENTRAL` on diminue les cas où ces requêtes doivent s'effectuer.
