### PR TITLE
Enlève un espace insécable non-unicode dans la normalisation du SIRET

### DIFF
--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -13,7 +13,7 @@ def camelize(data):
 
 
 def normalise_siret(siret):
-    return siret.replace(" ", "")
+    return siret.replace(" ", "").replace("\xa0", "")
 
 
 class MaCantineOrderingFilter(filters.OrderingFilter):
@@ -37,7 +37,6 @@ class MaCantineOrderingFilter(filters.OrderingFilter):
         return queryset
 
     def get_ordering(self, request, queryset, view):
-
         params = request.query_params.get(self.ordering_param)
         if params:
             fields = [


### PR DESCRIPTION
Ce commit vise à enlever les caractères d'espace insécable non-unicode (`\xa0`) de la normalisation du SIRET.

Normalement on n'aurait pas à gérer ce cas - le fichier doit être Unicode. Par contre, vu que le SIRET est copié-collé souvent des sources diverses, ce caractère peut se trouver dedans notamment dans l'import massif CSV.