### PR TITLE
Ajouter pourcentages de viandes et poissons à la page cantine publiée

### DIFF
--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -179,7 +179,36 @@ FIELDS = META_FIELDS + SIMPLE_APPRO_FIELDS + COMPLETE_APPRO_FIELDS + NON_APPRO_F
 
 
 def appro_to_percentages(representation, instance):
-    appro_field = SIMPLE_APPRO_FIELDS + COMPLETE_APPRO_FIELDS
+    # first do the percentages relative to meat and fish totals
+    # not removing these totals so that can then calculate the percent of those compared to global total
+    meat_total = representation.get("value_meat_poultry_ht")
+    if meat_total:
+        field = "value_meat_poultry_egalim_ht"
+        value = representation.get(field)
+        if value:
+            representation[f"percentage_{field}"] = value / meat_total
+        representation.pop(field, None)
+        field = "value_meat_poultry_france_ht"
+        value = representation.get(field)
+        if value:
+            representation[f"percentage_{field}"] = value / meat_total
+        representation.pop(field, None)
+
+    fish_total = representation.get("value_fish_ht")
+    if fish_total:
+        field = "value_fish_egalim_ht"
+        value = representation.get(field)
+        if value:
+            representation[f"percentage_{field}"] = value / fish_total
+        representation.pop(field, None)
+
+    appro_field = (
+        "value_total_ht",
+        "value_bio_ht",
+        "value_sustainable_ht",
+        "value_externality_performance_ht",
+        "value_egalim_others_ht",
+    ) + COMPLETE_APPRO_FIELDS  # meat and fish totals included in COMPLETE
     total = instance.value_total_ht
 
     for field in appro_field:

--- a/api/tests/test_published_canteens.py
+++ b/api/tests/test_published_canteens.py
@@ -722,6 +722,8 @@ class TestPublishedCanteenApi(APITestCase):
             value_total_ht=1200,
             value_bio_ht=600,
             value_sustainable_ht=300,
+            value_meat_poultry_ht=200,
+            value_meat_poultry_egalim_ht=100,
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
         )
 
@@ -735,3 +737,5 @@ class TestPublishedCanteenApi(APITestCase):
         self.assertEqual(serialized_diag["percentageValueTotalHt"], 1)
         self.assertEqual(serialized_diag["percentageValueBioHt"], 0.5)
         self.assertEqual(serialized_diag["percentageValueSustainableHt"], 0.25)
+        # the following is a percentage of the meat total, not global total
+        self.assertEqual(serialized_diag["percentageValueMeatPoultryEgalimHt"], 0.5)

--- a/frontend/src/components/CanteenPublication.vue
+++ b/frontend/src/components/CanteenPublication.vue
@@ -20,17 +20,16 @@
         </v-card-text>
       </v-card>
 
-      <h3
-        class="font-weight-black text-body-1 grey--text text--darken-4 my-4"
-        v-if="diagnostic.diagnosticType === 'COMPLETE'"
-      >
+      <h3 class="font-weight-black text-body-1 grey--text text--darken-4 my-4">
         Total
       </h3>
       <v-row>
-        <v-col cols="12" sm="6" md="4" v-if="diagnostic.percentageValueBioHt">
+        <v-col cols="12" sm="6" md="4" v-if="toPercentage(diagnostic.percentageValueBioHt)">
           <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
             <p class="ma-0">
-              <span class="grey--text text-h5 font-weight-black text--darken-2 mr-1">{{ bioPercent }} %</span>
+              <span class="grey--text text-h5 font-weight-black text--darken-2 mr-1">
+                {{ toPercentage(diagnostic.percentageValueBioHt) }} %
+              </span>
               <span class="caption grey--text text--darken-2">
                 bio
               </span>
@@ -46,10 +45,12 @@
             </div>
           </v-card>
         </v-col>
-        <v-col cols="12" sm="6" md="4" v-if="diagnostic.percentageValueSustainableHt">
+        <v-col cols="12" sm="6" md="4" v-if="toPercentage(sustainableTotal)">
           <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
             <p class="ma-0">
-              <span class="grey--text text-h5 font-weight-black text--darken-2 mr-1">{{ sustainablePercent }} %</span>
+              <span class="grey--text text-h5 font-weight-black text--darken-2 mr-1">
+                {{ toPercentage(sustainableTotal) }} %
+              </span>
               <span class="caption grey--text text--darken-2">
                 durables et de qualité (hors bio)
               </span>
@@ -70,17 +71,85 @@
           </v-card>
         </v-col>
       </v-row>
-      <h3
-        class="font-weight-black text-body-1 grey--text text--darken-4 mt-4"
-        v-if="diagnostic.diagnosticType === 'COMPLETE'"
-      >
-        Catégories EGAlim par famille de produit
-      </h3>
-      <FamiliesGraph
-        v-if="diagnostic.diagnosticType === 'COMPLETE'"
-        :diagnostic="diagnostic"
-        :height="$vuetify.breakpoint.xs ? '440px' : '380px'"
-      />
+      <div v-if="diagnostic.diagnosticType === 'COMPLETE'">
+        <h3 class="font-weight-black text-body-1 grey--text text--darken-4 mt-4">
+          Catégories EGAlim par famille de produit
+        </h3>
+        <FamiliesGraph :diagnostic="diagnostic" :height="$vuetify.breakpoint.xs ? '440px' : '380px'" />
+      </div>
+      <div v-else>
+        <h3 class="font-weight-black text-body-1 grey--text text--darken-4 my-4">
+          Par famille de produit
+        </h3>
+        <v-row>
+          <v-col cols="12" sm="4" md="4" v-if="toPercentage(diagnostic.percentageValueMeatPoultryEgalimHt)">
+            <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
+              <p class="ma-0">
+                <span class="grey--text text-h5 font-weight-black text--darken-2 mr-1">
+                  {{ toPercentage(diagnostic.percentageValueMeatPoultryEgalimHt) }} %
+                </span>
+                <span class="caption grey--text text--darken-2">
+                  viandes et volailles EGAlim
+                </span>
+              </p>
+              <div class="mt-2">
+                <v-icon size="30" color="brown">
+                  mdi-food-steak
+                </v-icon>
+                <v-icon size="30" color="brown">
+                  mdi-food-drumstick
+                </v-icon>
+                <v-icon size="30" color="green">
+                  $checkbox-circle-fill
+                </v-icon>
+              </div>
+            </v-card>
+          </v-col>
+          <v-col cols="12" sm="4" md="4" v-if="toPercentage(diagnostic.percentageValueMeatPoultryFranceHt)">
+            <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
+              <p class="ma-0">
+                <span class="grey--text text-h5 font-weight-black text--darken-2 mr-1">
+                  {{ toPercentage(diagnostic.percentageValueMeatPoultryFranceHt) }} %
+                </span>
+                <span class="caption grey--text text--darken-2">
+                  viandes et volailles provenance France
+                </span>
+              </p>
+              <div class="mt-2">
+                <v-icon size="30" color="brown">
+                  mdi-food-steak
+                </v-icon>
+                <v-icon size="30" color="brown">
+                  mdi-food-drumstick
+                </v-icon>
+                <v-icon size="30" color="indigo">
+                  $france-line
+                </v-icon>
+              </div>
+            </v-card>
+          </v-col>
+          <v-col cols="12" sm="4" md="4" v-if="toPercentage(diagnostic.percentageValueFishEgalimHt)">
+            <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
+              <p class="ma-0">
+                <span class="grey--text text-h5 font-weight-black text--darken-2 mr-1">
+                  {{ toPercentage(diagnostic.percentageValueFishEgalimHt) }} %
+                </span>
+                <span class="caption grey--text text--darken-2">
+                  produits aquatiques EGAlim
+                </span>
+              </p>
+              <div class="mt-2">
+                <v-icon size="30" color="blue">
+                  mdi-fish
+                </v-icon>
+                <v-icon size="30" color="green">
+                  $checkbox-circle-fill
+                </v-icon>
+              </div>
+            </v-card>
+          </v-col>
+        </v-row>
+      </div>
     </div>
 
     <h2 class="font-weight-black text-h6 grey--text text--darken-4 mt-8 mb-n4" v-if="Object.keys(earnedBadges).length">
@@ -212,11 +281,8 @@ export default {
     publicationYear() {
       return this.diagnostic?.year
     },
-    bioPercent() {
-      return Math.round(this.diagnostic.percentageValueBioHt * 100)
-    },
-    sustainablePercent() {
-      return Math.round(getSustainableTotal(this.diagnostic) * 100)
+    sustainableTotal() {
+      return getSustainableTotal(this.diagnostic)
     },
     earnedBadges() {
       const canteenBadges = badges(this.canteen, this.diagnostic, this.$store.state.sectors)
@@ -244,6 +310,11 @@ export default {
     },
     applicableRules() {
       return applicableDiagnosticRules(this.canteen)
+    },
+  },
+  methods: {
+    toPercentage(value) {
+      return Math.round(value * 100)
     },
   },
 }

--- a/frontend/src/components/CanteenPublication.vue
+++ b/frontend/src/components/CanteenPublication.vue
@@ -78,7 +78,7 @@
         <FamiliesGraph :diagnostic="diagnostic" :height="$vuetify.breakpoint.xs ? '440px' : '380px'" />
       </div>
       <div v-else>
-        <h3 class="font-weight-black text-body-1 grey--text text--darken-4 my-4">
+        <h3 class="font-weight-black text-body-1 grey--text text--darken-4 mb-4 mt-8">
           Par famille de produit
         </h3>
         <v-row>


### PR DESCRIPTION
Also
- fixes edge case where a percentage of 0 < x < 1 in a category will show as 0 % when I assume the logic we want is not that
- fixes calculation of meat and fish percentages to be against their total not global purchases totals
- fixes publication preview since don't have percentage calculation in unpublished canteen diag

![Screenshot from 2023-04-11 12-54-06](https://user-images.githubusercontent.com/9282816/231139965-13477bf4-bf52-4f72-8df9-e856dcd4e51c.png)
![Screenshot from 2023-04-11 12-54-31](https://user-images.githubusercontent.com/9282816/231139953-574352bd-2eb8-4173-8c59-df392f1c7ebd.png)
![Screenshot from 2023-04-11 12-54-22](https://user-images.githubusercontent.com/9282816/231139958-62b1c5ac-d9e0-47b0-a3b7-9d2550893dc8.png)
