### PR TITLE
Fix link for ONBOARDING file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Accompagner au mieux les acteurs de la restauration collective dans leur offre a
 
 ## Aspects techniques
 
-Si vous voulez installer l'environnement en local : [ONBOARDING.md](./ONBOARDING.md)
+Si vous voulez installer l'environnement en local : [ONBOARDING.md](./docs/ONBOARDING.md)
 
 ### Architecture
 


### PR DESCRIPTION
The current link referencing the ONBOARDING file is broken as it lacks the `docs/` prefix.

The PR fixes this link.