### PR TITLE
Encourager le remplissage du diagnostic de l'année precedente

### DIFF
--- a/frontend/src/views/DiagnosticEditor/index.vue
+++ b/frontend/src/views/DiagnosticEditor/index.vue
@@ -618,6 +618,10 @@ export default {
       } else this.$router.replace({ name: "NotFound" })
       const defaultDiagnosticType = this.showExtendedDiagnostic() ? "COMPLETE" : "SIMPLE"
       this.$set(this.diagnostic, "diagnosticType", this.diagnostic.diagnosticType || defaultDiagnosticType)
+      if (!this.diagnostic.year) {
+        const hasLastYearDiag = this.originalCanteen.diagnostics.some((d) => d.year === this.teledeclarationYear)
+        if (!hasLastYearDiag) this.$set(this.diagnostic, "year", this.teledeclarationYear)
+      }
     },
     refreshCanteen() {
       if (this.originalCanteen) this.$set(this, "canteen", JSON.parse(JSON.stringify(this.originalCanteen)))

--- a/frontend/src/views/ManagementPage/CanteenCard.vue
+++ b/frontend/src/views/ManagementPage/CanteenCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card
     :to="{
-      name: 'CanteenModification',
+      name: 'DiagnosticList',
       params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
     }"
     class="dsfr d-flex flex-column"


### PR DESCRIPTION
En remplacant les liens vers le formulaire cantine avec les liens vers la page diagnostics