### PR TITLE
Removes confusing chip in canteen cards

### DIFF
--- a/frontend/src/views/ManagementPage/CanteenCard.vue
+++ b/frontend/src/views/ManagementPage/CanteenCard.vue
@@ -11,7 +11,13 @@
     <v-img :src="canteenImage || '/static/images/canteen-default-image.jpg'" height="160" max-height="160"></v-img>
     <v-card-title class="font-weight-bold">{{ canteen.name }}</v-card-title>
     <v-card-subtitle class="py-1">
-      <v-chip v-if="teledeclarationIsActive" small :color="teledeclarationStatus.color" label class="mr-1">
+      <v-chip
+        v-if="teledeclarationIsActive && !usesCentralKitchenDiagnostics"
+        small
+        :color="teledeclarationStatus.color"
+        label
+        class="mr-1"
+      >
         {{ teledeclarationStatus.text }}
       </v-chip>
       <v-chip small :color="publicationStatus.color" label>
@@ -77,6 +83,12 @@ export default {
           text: `Non-télédéclarée (${this.teledeclarationYear})`,
         }
       }
+    },
+    usesCentralKitchenDiagnostics() {
+      return (
+        this.canteen.productionType === "site_cooked_elsewhere" &&
+        this.canteen.centralKitchenDiagnostics?.find((d) => d.year === this.teledeclarationYear)
+      )
     },
     canteenImage() {
       if (!this.canteen.images || this.canteen.images.length === 0) return null


### PR DESCRIPTION
Closes #2578 

Dans un premier temps, comme expliqué dans [ce commentaire](https://github.com/betagouv/ma-cantine/issues/2578#issuecomment-1527515269), on enlève la pastille télédéclaration pour les satellites ayant un diag de leur cusine centrale pour éviter de confondre l'utilisateur.

Avant :
![image](https://user-images.githubusercontent.com/1225929/235152403-cf833eec-e07f-4625-b86b-8572708df45c.png)


Après :
![image](https://user-images.githubusercontent.com/1225929/235152270-72864ec7-333a-477e-ab4f-5803e7311d9f.png)
