### PR TITLE
Vérification de daily_meal_count and yearly_meal_count au début de l'import

### DIFF
--- a/api/tests/test_import_diagnostics.py
+++ b/api/tests/test_import_diagnostics.py
@@ -373,7 +373,7 @@ class TestImportDiagnosticsAPI(APITestCase):
         )
         self.assertEqual(
             errors.pop(0)["message"],
-            "Champ 'repas par jour' : La valeur «\xa0not a number\xa0» doit être un nombre entier.",
+            "Champ 'repas par jour' : Ce champ doit être un numéro entier.",
         )
         self.assertEqual(
             errors.pop(0)["message"],

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -262,8 +262,12 @@ class ImportDiagnosticsView(ABC, APIView):
     def _validate_canteen(row):
         if not row[5]:
             raise ValidationError({"daily_meal_count": "Ce champ ne peut pas être vide."})
+        if not row[5].strip().isdigit():
+            raise ValidationError({"daily_meal_count": "Ce champ doit être un numéro entier."})
         if not row[6]:
             raise ValidationError({"yearly_meal_count": "Ce champ ne peut pas être vide."})
+        if not row[6].strip().isdigit():
+            raise ValidationError({"yearly_meal_count": "Ce champ doit être un numéro entier."})
         elif not row[2] and not row[3]:
             raise ValidationError(
                 {"postal_code": "Ce champ ne peut pas être vide si le code INSEE de la ville est vide."}


### PR DESCRIPTION
Suite au souci remonté par Pauline dans lequel le message d'erreur pour la colonne manquante du `yearly_meal_count` concernait plutôt l'email, cette PR essaie de mieux cerner l'erreur.

Vu qu'on a un numéro flou de colonnes (les dernières n'étant pas olbigatoires), il est difficile de savoir quel colonne manque. Par contre, en vérifiant que `daily_meal_count` et `yearly_meal_count` soient des numéros entiers très tôt dans le procès on peut déjà mieux cerner la raison de l'échec.