### PR TITLE
2615 désactiver bouton validation une fois qu'une requête de td est envoyée

### DIFF
--- a/frontend/src/components/TeledeclarationPreview.vue
+++ b/frontend/src/components/TeledeclarationPreview.vue
@@ -91,12 +91,7 @@
         <v-spacer></v-spacer>
         <v-btn outlined color="primary" class="px-4" @click="closeDialog">Annuler</v-btn>
         <v-btn outlined color="primary" class="ml-4 px-4" @click="goToEditing" v-if="!fromDiagPage">Modifier</v-btn>
-        <v-btn
-          :disabled="clicked.includes(this.diagnostic.id)"
-          color="primary"
-          class="ml-4 px-4"
-          @click="confirmTeledeclaration"
-        >
+        <v-btn :disabled="clicked" color="primary" class="ml-4 px-4" @click="confirmTeledeclaration">
           Télédéclarer ces données
         </v-btn>
       </v-card-actions>
@@ -130,7 +125,7 @@ export default {
       maxCostPerMealExpected: 10,
       minDaysOpenExpected: 50,
       maxDaysOpenExpected: 365,
-      clicked: [],
+      clicked: false,
     }
   },
   computed: {
@@ -793,7 +788,7 @@ export default {
         const teledeclarationFormIsValid = this.$refs["teledeclarationForm"].validate()
         if (!teledeclarationFormIsValid) return
       }
-      this.clicked.push(this.diagnostic.id)
+      this.clicked = true
       this.handlePreviewClose("teledeclare")
       this.$emit("teledeclare")
     },

--- a/frontend/src/components/TeledeclarationPreview.vue
+++ b/frontend/src/components/TeledeclarationPreview.vue
@@ -89,9 +89,18 @@
       </v-form>
       <v-card-actions class="d-flex pr-4 pb-4">
         <v-spacer></v-spacer>
-        <v-btn outlined color="primary" class="px-4" @click="closeDialog">Annuler</v-btn>
-        <v-btn outlined color="primary" class="ml-4 px-4" @click="goToEditing" v-if="!fromDiagPage">Modifier</v-btn>
-        <v-btn :disabled="clicked" color="primary" class="ml-4 px-4" @click="confirmTeledeclaration">
+        <v-btn :disabled="tdLoading" outlined color="primary" class="px-4" @click="closeDialog">Annuler</v-btn>
+        <v-btn
+          :disabled="tdLoading"
+          outlined
+          color="primary"
+          class="ml-4 px-4"
+          @click="goToEditing"
+          v-if="!fromDiagPage"
+        >
+          Modifier
+        </v-btn>
+        <v-btn :disabled="tdLoading" color="primary" class="ml-4 px-4" @click="confirmTeledeclaration">
           Télédéclarer ces données
         </v-btn>
       </v-card-actions>
@@ -125,7 +134,7 @@ export default {
       maxCostPerMealExpected: 10,
       minDaysOpenExpected: 50,
       maxDaysOpenExpected: 365,
-      clicked: false,
+      tdLoading: false,
     }
   },
   computed: {
@@ -788,7 +797,7 @@ export default {
         const teledeclarationFormIsValid = this.$refs["teledeclarationForm"].validate()
         if (!teledeclarationFormIsValid) return
       }
-      this.clicked = true
+      this.tdLoading = true
       this.handlePreviewClose("teledeclare")
       this.$emit("teledeclare")
     },

--- a/frontend/src/components/TeledeclarationPreview.vue
+++ b/frontend/src/components/TeledeclarationPreview.vue
@@ -91,7 +91,14 @@
         <v-spacer></v-spacer>
         <v-btn outlined color="primary" class="px-4" @click="closeDialog">Annuler</v-btn>
         <v-btn outlined color="primary" class="ml-4 px-4" @click="goToEditing" v-if="!fromDiagPage">Modifier</v-btn>
-        <v-btn color="primary" class="ml-4 px-4" @click="confirmTeledeclaration">Télédéclarer ces données</v-btn>
+        <v-btn
+          :disabled="clicked.includes(this.diagnostic.id)"
+          color="primary"
+          class="ml-4 px-4"
+          @click="confirmTeledeclaration"
+        >
+          Télédéclarer ces données
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -123,6 +130,7 @@ export default {
       maxCostPerMealExpected: 10,
       minDaysOpenExpected: 50,
       maxDaysOpenExpected: 365,
+      clicked: [],
     }
   },
   computed: {
@@ -785,6 +793,7 @@ export default {
         const teledeclarationFormIsValid = this.$refs["teledeclarationForm"].validate()
         if (!teledeclarationFormIsValid) return
       }
+      this.clicked.push(this.diagnostic.id)
       this.handlePreviewClose("teledeclare")
       this.$emit("teledeclare")
     },


### PR DESCRIPTION
I have added a value on the front called `clicked`. This value is set to true right when a TD is submitted.

When it is set to true, the button `Télédéclarer ces données` is blocked.

There is a limit to this. If the user reloads the page, the value is reset to its initial value `false`.

Do we find this reasonable as a quick fix ? 

![clicked_false](https://github.com/betagouv/ma-cantine/assets/14170613/90e62c0e-3475-45ed-bcec-26541b1f71de)
![clicked_true](https://github.com/betagouv/ma-cantine/assets/14170613/f2d284d4-4c83-4f24-a4b8-124f2ff63d30)
