### PR TITLE
Permet de revendiquer une cantine non-publiée si elle n'a pas de gestionnaires

### DIFF
--- a/api/tests/test_published_canteens.py
+++ b/api/tests/test_published_canteens.py
@@ -561,17 +561,6 @@ class TestPublishedCanteenApi(APITestCase):
         self.assertFalse(canteen.has_been_claimed)
 
     @authenticate
-    def test_canteen_claim_request_fails_when_not_published(self):
-        canteen = CanteenFactory.create(publication_status=Canteen.PublicationStatus.DRAFT)
-        canteen.managers.clear()
-
-        response = self.client.post(reverse("claim_canteen", kwargs={"canteen_pk": canteen.id}), None)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(canteen.managers.count(), 0)
-        canteen.refresh_from_db()
-        self.assertFalse(canteen.has_been_claimed)
-
-    @authenticate
     def test_undo_claim_canteen(self):
         canteen = CanteenFactory.create(claimed_by=authenticate.user, has_been_claimed=True)
         canteen.managers.add(authenticate.user)

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -1006,7 +1006,7 @@ class ClaimCanteenView(APIView):
         except Canteen.DoesNotExist:
             raise BadRequest()
 
-        if canteen.managers.exists() or canteen.publication_status != Canteen.PublicationStatus.PUBLISHED:
+        if canteen.managers.exists():
             raise BadRequest()
 
         canteen.managers.add(self.request.user)


### PR DESCRIPTION
Closes #2630

@hfroot pas sur pourquoi ce cas avait été ajouté, mais ça n'a pas l'air de correspondre à notre usage. Notamment ça bloque ce type d'actions :

Cette PR vise à permettre la revendication sauf dans le cas où la cantine a déjà un gestionnaire

[Screencast from 15-05-23 17:46:05.webm](https://github.com/betagouv/ma-cantine/assets/1225929/94da1998-2c3e-4772-81af-f73536684d0e)
