### PR TITLE
Structure de la nouvelle page dashboard

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -99,6 +99,7 @@ ENABLE_XP_RESERVATION= Optionnel - `True` pour activer la feature de l'expérime
 ENABLE_XP_VEGE= Optionnel - `True` pour activer la feature de l'expérimentation de l'offre quotidien de repas végétariens.
 ENABLE_PARTNERS= Optionnel - `True` pour afficher nos partenaires sur la page d'accueil.
 ENABLE_TELEDECLARATION= Optionnel - `True` pour permettre les utilisateurs de télédéclarer leur diagnostic.
+ENABLE_DASHBOARD= Optionnel - `True` pour montrer la nouvelle page d'accueil des gestionnaires.
 ```
 
 ### Relances automatiques par email

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -564,6 +564,11 @@ if (window.ENABLE_DASHBOARD) {
     path: "/dashboard",
     name: "DashboardManager",
     component: DashboardManager,
+    meta: {
+        title: "Tableau de bord",
+        authenticationRequired: true,
+    },
+    sitemapGroup: Constants.SitemapGroups.DIAG,
   })
 }
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -53,6 +53,7 @@ import FaqPage from "@/views/FaqPage"
 import SiteMap from "@/views/SiteMap"
 import DeveloperPage from "@/views/DeveloperPage"
 import ImpactMeasuresPage from "@/views/ImpactMeasuresPage"
+import CanteenDashboard from "@/views/CanteenDashboard"
 import Constants from "@/constants"
 
 Vue.use(VueRouter)
@@ -556,12 +557,21 @@ const routes = [
       title: "Mesures de notre impact",
     },
   },
-  {
-    path: "/:catchAll(.*)",
-    component: NotFound,
-    name: "NotFound",
-  },
 ]
+
+if (window.ENABLE_DASHBOARD) {
+  routes.push({
+    path: "/dashboard",
+    name: "CanteenDashboard",
+    component: CanteenDashboard,
+  })
+}
+
+routes.push({
+  path: "/:catchAll(.*)",
+  component: NotFound,
+  name: "NotFound",
+})
 
 const router = new VueRouter({
   mode: "history",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -565,8 +565,8 @@ if (window.ENABLE_DASHBOARD) {
     name: "DashboardManager",
     component: DashboardManager,
     meta: {
-        title: "Tableau de bord",
-        authenticationRequired: true,
+      title: "Tableau de bord",
+      authenticationRequired: true,
     },
     sitemapGroup: Constants.SitemapGroups.DIAG,
   })

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -53,7 +53,7 @@ import FaqPage from "@/views/FaqPage"
 import SiteMap from "@/views/SiteMap"
 import DeveloperPage from "@/views/DeveloperPage"
 import ImpactMeasuresPage from "@/views/ImpactMeasuresPage"
-import CanteenDashboard from "@/views/CanteenDashboard"
+import DashboardManager from "@/views/DashboardManager"
 import Constants from "@/constants"
 
 Vue.use(VueRouter)
@@ -562,8 +562,8 @@ const routes = [
 if (window.ENABLE_DASHBOARD) {
   routes.push({
     path: "/dashboard",
-    name: "CanteenDashboard",
-    component: CanteenDashboard,
+    name: "DashboardManager",
+    component: DashboardManager,
   })
 }
 

--- a/frontend/src/views/CanteenDashboard/index.vue
+++ b/frontend/src/views/CanteenDashboard/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Dashboard
+  </div>
+</template>
+
+<script>
+export default {
+  name: "CanteenDashboard",
+}
+</script>

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -1,0 +1,43 @@
+<template>
+  <v-row>
+    <v-col cols="12" md="4">
+      <v-card outlined>
+        <v-card-title>Qualité des produits</v-card-title>
+      </v-card>
+    </v-col>
+    <v-col cols="12" md="4">
+      <v-row>
+        <v-col cols="12">
+          <v-card outlined>
+            <v-card-title>Lutte contre le gaspillage</v-card-title>
+          </v-card>
+        </v-col>
+        <v-col cols="12">
+          <v-card outlined>
+            <v-card-title>Interdiction du plastique</v-card-title>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-col>
+    <v-col cols="12" md="4">
+      <v-row>
+        <v-col cols="12">
+          <v-card outlined>
+            <v-card-title>Diversification des menus</v-card-title>
+          </v-card>
+        </v-col>
+        <v-col cols="12">
+          <v-card outlined>
+            <v-card-title>Information des convives</v-card-title>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+export default {
+  name: "EgalimProgression",
+}
+</script>

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -2,19 +2,28 @@
   <v-row>
     <v-col cols="12" md="4">
       <v-card outlined>
-        <v-card-title>Qualité des produits</v-card-title>
+        <v-card-title class="text-body-1 font-weight-bold">
+          <v-icon class="mr-2" size="20" color="red">mdi-food-apple</v-icon>
+          Qualité des produits
+        </v-card-title>
       </v-card>
     </v-col>
     <v-col cols="12" md="4">
       <v-row>
         <v-col cols="12">
           <v-card outlined>
-            <v-card-title>Lutte contre le gaspillage</v-card-title>
+            <v-card-title class="text-body-1 font-weight-bold">
+              <v-icon class="mr-2" size="20" color="orange darken-2">mdi-offer</v-icon>
+              Lutte contre le gaspillage
+            </v-card-title>
           </v-card>
         </v-col>
         <v-col cols="12">
           <v-card outlined>
-            <v-card-title>Interdiction du plastique</v-card-title>
+            <v-card-title class="text-body-1 font-weight-bold">
+              <v-icon class="mr-2" size="20" color="blue darken-1">mdi-weather-windy</v-icon>
+              Interdiction du plastique
+            </v-card-title>
           </v-card>
         </v-col>
       </v-row>
@@ -23,12 +32,18 @@
       <v-row>
         <v-col cols="12">
           <v-card outlined>
-            <v-card-title>Diversification des menus</v-card-title>
+            <v-card-title class="text-body-1 font-weight-bold">
+              <v-icon class="mr-2" size="20" color="green darken-2">$leaf-fill</v-icon>
+              Diversification des menus
+            </v-card-title>
           </v-card>
         </v-col>
         <v-col cols="12">
           <v-card outlined>
-            <v-card-title>Information des convives</v-card-title>
+            <v-card-title class="text-body-1 font-weight-bold">
+              <v-icon class="mr-2" size="20" color="amber darken-2">mdi-bullhorn</v-icon>
+              Information des convives
+            </v-card-title>
           </v-card>
         </v-col>
       </v-row>

--- a/frontend/src/views/DashboardManager/EmptyProgression.vue
+++ b/frontend/src/views/DashboardManager/EmptyProgression.vue
@@ -3,10 +3,10 @@
     <v-row>
       <v-col cols="12" sm="6" md="5" class="d-flex flex-column">
         <div v-for="measure in keyMeasures" :key="measure.id" class="d-flex my-3">
-          <div class="text-body-1 font-weight-bold">
+          <p class="text-body-1 font-weight-bold my-0">
             <v-icon class="mr-2" size="20" :color="measure.mdiIconColor">{{ measure.mdiIcon }}</v-icon>
             {{ measure.shortTitle }}
-          </div>
+          </p>
           <v-spacer></v-spacer>
           <v-chip small>À COMPLÈTER</v-chip>
         </div>

--- a/frontend/src/views/DashboardManager/EmptyProgression.vue
+++ b/frontend/src/views/DashboardManager/EmptyProgression.vue
@@ -1,0 +1,11 @@
+<template>
+  <v-card>
+    Pas d'information pour montrer la progression
+  </v-card>
+</template>
+
+<script>
+export default {
+  name: "EmptyProgression",
+}
+</script>

--- a/frontend/src/views/DashboardManager/EmptyProgression.vue
+++ b/frontend/src/views/DashboardManager/EmptyProgression.vue
@@ -1,11 +1,42 @@
 <template>
-  <v-card>
-    Pas d'information pour montrer la progression
+  <v-card outlined class="pa-4">
+    <v-row>
+      <v-col cols="12" sm="6" md="5" class="d-flex flex-column">
+        <div v-for="measure in keyMeasures" :key="measure.id" class="d-flex my-3">
+          <div class="text-body-1 font-weight-bold">
+            <v-icon class="mr-2" size="20" :color="measure.mdiIconColor">{{ measure.mdiIcon }}</v-icon>
+            {{ measure.shortTitle }}
+          </div>
+          <v-spacer></v-spacer>
+          <v-chip small>À COMPLÈTER</v-chip>
+        </div>
+      </v-col>
+      <v-col cols="12" sm="6" md="7" class="text-center">
+        <v-card color="primary lighten-5 fill-height rounded">
+          <v-card-text class="font-weight-bold">Vous êtes prêt.e à vous lancer !</v-card-text>
+          <v-card-text>
+            Réalisez un premier bilan, complet ou intermédiaire, pour mesurer votre avancée par rapport aux objectifs de
+            la loi EGAlim, et parcourez des ressources personnalisées selon votre situation et vos résultats pour vous
+            aider dans votre transition vers une alimentation plus durable.
+          </v-card-text>
+          <div>
+            <v-btn color="primary">Faire le bilan</v-btn>
+          </div>
+        </v-card>
+      </v-col>
+    </v-row>
   </v-card>
 </template>
 
 <script>
+import keyMeasures from "@/data/key-measures.json"
+
 export default {
   name: "EmptyProgression",
+  computed: {
+    keyMeasures() {
+      return keyMeasures
+    },
+  },
 }
 </script>

--- a/frontend/src/views/DashboardManager/EmptyProgression.vue
+++ b/frontend/src/views/DashboardManager/EmptyProgression.vue
@@ -13,7 +13,7 @@
       </v-col>
       <v-col cols="12" sm="6" md="7" class="text-center">
         <v-card color="primary lighten-5 fill-height rounded">
-          <v-card-text class="font-weight-bold">Vous êtes prêt.e à vous lancer !</v-card-text>
+          <v-card-text class="font-weight-bold">Tout est prêt pour se lancer !</v-card-text>
           <v-card-text>
             Réalisez un premier bilan, complet ou intermédiaire, pour mesurer votre avancée par rapport aux objectifs de
             la loi EGAlim, et parcourez des ressources personnalisées selon votre situation et vos résultats pour vous

--- a/frontend/src/views/DashboardManager/index.vue
+++ b/frontend/src/views/DashboardManager/index.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="text-left">
-    <p class="my-4 text-h5 font-weight-bold">Bienvenue {{ loggedUser.firstName }}</p>
+    <h1 class="my-4 text-h5 font-weight-bold">Bienvenue {{ loggedUser.firstName }}</h1>
 
-    <p class="mt-8 mb-2 text-h6 font-weight-bold">
+    <h2 class="mt-8 mb-2 text-h6 font-weight-bold">
       Ma progression
-    </p>
+    </h2>
     <p class="body-2">
       Vous trouverez ci-dessous une vue d'ensemble de votre progression sur les cinq volets de la loi EGAlim.
     </p>
@@ -14,16 +14,16 @@
       <EmptyProgression v-else />
     </div>
 
-    <p class="mt-10 mb-2 text-h6 font-weight-bold">
+    <h2 class="mt-10 mb-2 text-h6 font-weight-bold">
       Mon établissement
-    </p>
+    </h2>
     <p class="body-2">
       Accédez ci-dessous aux différents outils de gestion de votre établissement sur la plateforme « ma cantine ».
     </p>
 
-    <p class="mt-10 mb-2 text-h6 font-weight-bold">
+    <h2 class="mt-10 mb-2 text-h6 font-weight-bold">
       Mes ressources personalisées
-    </p>
+    </h2>
     <p class="body-2">
       Découvrez ci-dessous des articles et des outils pratiques, ainsi que des suggestions de partenaires et des
       cantines inspirantes sur votre territoire qui correspondent à vos enjeux.

--- a/frontend/src/views/DashboardManager/index.vue
+++ b/frontend/src/views/DashboardManager/index.vue
@@ -43,7 +43,7 @@ export default {
       return this.$store.state.loggedUser
     },
     hasProgression() {
-      return true
+      return false
     },
   },
 }

--- a/frontend/src/views/DashboardManager/index.vue
+++ b/frontend/src/views/DashboardManager/index.vue
@@ -1,11 +1,50 @@
 <template>
-  <div>
-    Dashboard
+  <div class="text-left">
+    <p class="my-4 text-h5 font-weight-bold">Bienvenue {{ loggedUser.firstName }}</p>
+
+    <p class="mt-8 mb-2 text-h6 font-weight-bold">
+      Ma progression
+    </p>
+    <p class="body-2">
+      Vous trouverez ci-dessous une vue d'ensemble de votre progression sur les cinq volets de la loi EGAlim.
+    </p>
+
+    <div>
+      <EgalimProgression v-if="hasProgression" />
+      <EmptyProgression v-else />
+    </div>
+
+    <p class="mt-10 mb-2 text-h6 font-weight-bold">
+      Mon établissement
+    </p>
+    <p class="body-2">
+      Accédez ci-dessous aux différents outils de gestion de votre établissement sur la plateforme « ma cantine ».
+    </p>
+
+    <p class="mt-10 mb-2 text-h6 font-weight-bold">
+      Mes ressources personalisées
+    </p>
+    <p class="body-2">
+      Découvrez ci-dessous des articles et des outils pratiques, ainsi que des suggestions de partenaires et des
+      cantines inspirantes sur votre territoire qui correspondent à vos enjeux.
+    </p>
   </div>
 </template>
 
 <script>
+import EmptyProgression from "./EmptyProgression.vue"
+import EgalimProgression from "./EgalimProgression.vue"
+
 export default {
   name: "DashboardManager",
+  components: { EmptyProgression, EgalimProgression },
+  computed: {
+    loggedUser() {
+      return this.$store.state.loggedUser
+    },
+    hasProgression() {
+      return true
+    },
+  },
 }
 </script>

--- a/frontend/src/views/DashboardManager/index.vue
+++ b/frontend/src/views/DashboardManager/index.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: "CanteenDashboard",
+  name: "DashboardManager",
 }
 </script>

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -481,6 +481,7 @@ ENABLE_XP_RESERVATION = os.getenv("ENABLE_XP_RESERVATION") == "True"
 ENABLE_XP_VEGE = os.getenv("ENABLE_XP_VEGE") == "True"
 ENABLE_PARTNERS = os.getenv("ENABLE_PARTNERS") == "True"
 ENABLE_TELEDECLARATION = os.getenv("ENABLE_TELEDECLARATION") == "True"
+ENABLE_DASHBOARD = os.getenv("ENABLE_DASHBOARD") == "True"
 
 # Custom testing
 

--- a/web/templates/vue-app.html
+++ b/web/templates/vue-app.html
@@ -35,6 +35,7 @@
         window.ENVIRONMENT = "{% environment %}"
         window.ENABLE_XP_RESERVATION = "{% enable_xp_reservation %}" === "True"
         window.ENABLE_XP_VEGE = "{% enable_xp_vege %}" === "True"
+        window.ENABLE_DASHBOARD = "{% enable_dashboard %}" === "True"
         window.ENABLE_PARTNERS = "{% enable_partners %}" === "True"
         window.ENABLE_TELEDECLARATION = "{% enable_teledeclaration %}" === "True"
         window.IS_WIDGET = "{{ is_widget }}"

--- a/web/templatetags/featureflags.py
+++ b/web/templatetags/featureflags.py
@@ -22,3 +22,8 @@ def enable_partners():
 @register.simple_tag
 def enable_teledeclaration():
     return getattr(settings, "ENABLE_TELEDECLARATION", "")
+
+
+@register.simple_tag
+def enable_dashboard():
+    return getattr(settings, "ENABLE_DASHBOARD", "")


### PR DESCRIPTION
Cette PR vise à établir les bases des stories liées au nouveau dashboard pour éviter des conflits.

Le dashboard est accessible via `/dashboard` seulement si la feature flag `ENABLE_DASHBOARD` est actvée. Les pages ne sont pas encore fonctionnelles, seulement la structure UI de base est en place.

![image](https://github.com/betagouv/ma-cantine/assets/1225929/50dfb68a-5497-46dd-9834-313a23c6d2b8)

![image](https://github.com/betagouv/ma-cantine/assets/1225929/a85a56a4-6023-4471-af1f-6cd06a2ed7f1)
