### PR TITLE
Màj du type de production d'une cantine satellite

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -1129,6 +1129,7 @@ class SatelliteListCreateView(ListCreateAPIView):
                     raise PermissionDenied("Cette cantine est déjà fourni par une autre cuisine centrale")
 
                 satellite.central_producer_siret = canteen.siret
+                satellite.production_type = Canteen.ProductionType.ON_SITE_CENTRAL
                 satellite.save()
             else:
                 new_satellite = FullCanteenSerializer(data=request.data)


### PR DESCRIPTION
Cette PR met à jour le production_type d'une cantine après avoir été désignée par une cuisine centrale comme satellite.

Closes #2612 