### PR TITLE
Enlève un `only` pas à jour

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -1110,7 +1110,7 @@ class SatelliteListCreateView(ListCreateAPIView):
         return Canteen.objects.only("siret").get(pk=canteen_pk).satellites
 
     def post(self, request, canteen_pk):
-        canteen = Canteen.objects.only("siret", "central_producer_siret").get(pk=canteen_pk)
+        canteen = Canteen.objects.get(pk=canteen_pk)
         siret_satellite = request.data.get("siret")
         created = False
 


### PR DESCRIPTION
Closes #2662 

Dans la méthode on utilise (indirectement) autres paramètres qui nécessitent une requête additionnel par la suite. Le `only` à mon avis est un peu overkill.