### PR TITLE
Fix de la condition d'affichage du callout pour le centralProducerSiret

### DIFF
--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -212,7 +212,7 @@
               de la cuisine centrale.
             </p>
             <v-expand-transition>
-              <DsfrCallout v-if="centralKitchen">
+              <DsfrCallout v-if="centralKitchen && centralKitchen.id && centralKitchen.name">
                 <p v-if="centralKitchen.isManagedByUser" class="mb-0">
                   Ce SIRET correspond à l'établissement que vous gérez
                   <router-link


### PR DESCRIPTION
Closes #2689

Depuis qu'on enrichi l'endpoint `canteenStatus` avec les données de l'API SIRET, on retourne toujours un objet avec au moins le SIRET. Donc la condition n'était plus la bonne. Pour que le lien et l'affichage fonctionnent, nous devons avoir au minimum l'id et le nom de la cantine.