### PR TITLE
2684 pipeline de génération de données pour open data

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -341,6 +341,8 @@ class CanteenTeledeclarationSerializer(serializers.ModelSerializer):
             "name",
             "siret",
             "city_insee_code",
+            "department",
+            "region",
             "sectors",
             "line_ministry",
             "daily_meal_count",

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -155,7 +155,8 @@ class Teledeclaration(models.Model):
         """
         from data.factories import TeledeclarationFactory  # Avoids circular import
 
-        version = "9"  # Helps identify which data will be present. Use incremental int values
+        version = "10"  # Helps identify which data will be present. Use incremental int values
+        # Version 10 - Add department and region fields
         # Version 9 - removes legacy fields: value_pat_ht, value_label_hve, value_label_rouge, value_label_aoc_igp and value_pat_ht
 
         status = status or Teledeclaration.TeledeclarationStatus.SUBMITTED

--- a/data/schemas/schema_cantine.json
+++ b/data/schemas/schema_cantine.json
@@ -151,7 +151,7 @@
       "name": "active_on_ma_cantine",
       "type": "boolean",
       "title": "Actif sur Ma Cantine",
-      "description": "Indique si la cantine est active sur l'apllication Ma Cantine ou si elle a été importée via une source de données externe",
+      "description": "A un gestionnaire sur (email) et a fais au moins une action (à définir) - Indique si la cantine est active sur l'apllication Ma Cantine ou si elle a été importée via une source de données externe",
       "example": "true"
     }
   ]

--- a/data/schemas/schema_teledeclaration.json
+++ b/data/schemas/schema_teledeclaration.json
@@ -130,7 +130,7 @@
       "name": "teledeclaration_ratio_bio",
       "type": "integer",
       "title": "Télédéclaration Ratio Bio",
-      "description": "Part du bio dans les achats alimentaires de l'année",
+      "description": "Part du bio dans les achats alimentaires de l'année (ratio basé sur le montant des achats en € HT)",
       "example": "0.1"
     },
     {

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -1,12 +1,11 @@
 from django.test import TestCase
 from data.factories import DiagnosticFactory, CanteenFactory, UserFactory
 from data.models import Teledeclaration
-from macantine.tasks import _extract_dataset_teledeclaration, _extract_dataset_canteen
+from macantine.tasks import _extract_dataset_teledeclaration#, _extract_dataset_canteen
 import json
 
 
 class TestExtractionOpenData(TestCase):
-    # td_columns = ["id", "applicant_id", "teledeclaration_mode", "creation_date", "year", "version", "canteen.id", "canteen.siret", "canteen.name", "canteen.central_producer_siret", "canteen.department", "canteen.region", "canteen.satellite_canteens_count", "canteen.economic_model", "canteen.management_type", "canteen.production_type", "canteen.sectors", "canteen.line_ministry", "teledeclaration.value_bio_ht", "teledeclaration.value_total_ht", "teledeclaration.value_sustainable_ht"]
 
     def test_extraction_teledeclaration(self):
         schema = json.load(open("data/schemas/schema_teledeclaration.json"))

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -1,13 +1,11 @@
 from django.test import TestCase
-from django.core import mail
-from django.test.utils import override_settings
-from django.utils.timezone import now
 from data.factories import DiagnosticFactory, CanteenFactory, UserFactory, TeledeclarationFactory
 from data.models import Teledeclaration
 from macantine.tasks import extract_datasets
 
 
 class TestExtractionOpenData(TestCase):
+    td_columns = ["id", "applicant_id", "teledeclaration_mode", "creation_date", "year", "version", "canteen_id", "canteen_siret", "canteen_name", "cantine_central_kitchen_siret", "canteen_department", "canteen_region", "cantine_satellite_canteens_count", "cantine_economic_model", "cantine_management_type", "cantine_production_type", "canteen_sectors", "canteen_line_ministry", "teledeclaration_ratio_bio", "teledeclaration_ratio_egalim_hors_bio"]
 
     def test_extraction_teledeclaration(self):
         canteen = CanteenFactory.create()
@@ -36,3 +34,4 @@ class TestExtractionOpenData(TestCase):
 
         td = extract_datasets(year=diagnostic.year)
         assert len(td) == 1, "There should be one teledeclaration for 2021"
+        assert td.columns == self.td_columns, "There should be one teledeclaration for 2021"

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+from django.core import mail
+from django.test.utils import override_settings
+from django.utils.timezone import now
+from data.factories import DiagnosticFactory, CanteenFactory, UserFactory, TeledeclarationFactory
+from data.models import Teledeclaration
+
+
+class TestExtractionOpenData(TestCase):
+
+    def test_extraction_teledeclaration(self):
+        canteen = CanteenFactory.create()
+        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2021, diagnostic_type=None)
+        applicant = UserFactory.create()
+        TeledeclarationFactory.create(
+            applicant=applicant,
+            year=diagnostic.year,
+            canteen=canteen,
+            canteen_siret=canteen.siret,
+            status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
+            diagnostic=diagnostic,
+            declared_data={
+                "year": diagnostic.year,
+                "canteen": {
+                    "name": "",
+                },
+                "applicant": {
+                    "name": "",
+                },
+                "teledeclaration": {},
+            },
+            teledeclaration_mode='SITE',
+        )
+        td = extract_dataset_teledeclaration(year=diagnostic.year)
+        assert len(td) == 1, "There should be one teledeclaration for 2021"

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -6,6 +6,7 @@ from data.factories import DiagnosticFactory, CanteenFactory, UserFactory, Teled
 from data.models import Teledeclaration
 from macantine.tasks import extract_datasets
 
+
 class TestExtractionOpenData(TestCase):
 
     def test_extraction_teledeclaration(self):
@@ -31,5 +32,24 @@ class TestExtractionOpenData(TestCase):
             },
             teledeclaration_mode='SITE',
         )
-        td = extract_datasets()
-        assert len(td) == 1, "There should b    e one teledeclaration for 2021"
+        TeledeclarationFactory.create(
+            applicant=applicant,
+            year=diagnostic.year,
+            canteen=canteen,
+            canteen_siret=canteen.siret,
+            status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
+            diagnostic=diagnostic,
+            declared_data={
+                "year": str(int(diagnostic.year) + 1),
+                "canteen": {
+                    "name": "",
+                },
+                "applicant": {
+                    "name": "",
+                },
+                "teledeclaration": {},
+            },
+            teledeclaration_mode='SITE',
+        )
+        td = extract_datasets(year=diagnostic.year)
+        assert len(td) == 1, "There should be one teledeclaration for 2021"

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -13,43 +13,26 @@ class TestExtractionOpenData(TestCase):
         canteen = CanteenFactory.create()
         diagnostic = DiagnosticFactory.create(canteen=canteen, year=2021, diagnostic_type=None)
         applicant = UserFactory.create()
-        TeledeclarationFactory.create(
-            applicant=applicant,
-            year=diagnostic.year,
-            canteen=canteen,
-            canteen_siret=canteen.siret,
-            status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
-            diagnostic=diagnostic,
-            declared_data={
-                "year": diagnostic.year,
-                "canteen": {
-                    "name": "",
+        for year_td in [2021, 2022]:
+            TeledeclarationFactory.create(
+                applicant=applicant,
+                year=year_td,
+                canteen=canteen,
+                canteen_siret=canteen.siret,
+                status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
+                diagnostic=diagnostic,
+                declared_data={
+                    "year": year_td,
+                    "canteen": {
+                        "name": "",
+                    },
+                    "applicant": {
+                        "name": "",
+                    },
+                    "teledeclaration": {},
                 },
-                "applicant": {
-                    "name": "",
-                },
-                "teledeclaration": {},
-            },
-            teledeclaration_mode='SITE',
-        )
-        TeledeclarationFactory.create(
-            applicant=applicant,
-            year=diagnostic.year + 1,
-            canteen=canteen,
-            canteen_siret=canteen.siret,
-            status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
-            diagnostic=diagnostic,
-            declared_data={
-                "year": diagnostic.year + 1,
-                "canteen": {
-                    "name": "",
-                },
-                "applicant": {
-                    "name": "",
-                },
-                "teledeclaration": {},
-            },
-            teledeclaration_mode='SITE',
-        )
+                teledeclaration_mode='SITE',
+            )
+
         td = extract_datasets(year=diagnostic.year)
         assert len(td) == 1, "There should be one teledeclaration for 2021"

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -2,29 +2,31 @@ from django.test import TestCase
 from data.factories import DiagnosticFactory, CanteenFactory, UserFactory
 from data.models import Teledeclaration, Canteen
 from macantine.tasks import _extract_dataset_teledeclaration, _extract_dataset_canteen
+from frictionless import validate
 import json
 import pandas as pd
 
 
 class TestExtractionOpenData(TestCase):
 
-    # def test_extraction_teledeclaration(self):
-    #     schema = json.load(open("data/schemas/schema_teledeclaration.json"))
-    #     schema_cols = [i["name"] for i in schema["fields"]]
-    #     canteen = CanteenFactory.create()
-    #     applicant = UserFactory.create()
-    #     for year_td in [2021, 2022]:
-    #         diagnostic = DiagnosticFactory.create(canteen=canteen, year=year_td, diagnostic_type=None)
-    #         Teledeclaration.create_from_diagnostic(diagnostic, applicant)
+    def test_extraction_teledeclaration(self):
+        schema = json.load(open("data/schemas/schema_teledeclaration.json"))
+        schema_cols = [i["name"] for i in schema["fields"]]
+        canteen = CanteenFactory.create()
+        applicant = UserFactory.create()
+        for year_td in [2021, 2022]:
+            diagnostic = DiagnosticFactory.create(canteen=canteen, year=year_td, diagnostic_type=None)
+            Teledeclaration.create_from_diagnostic(diagnostic, applicant)
 
-    #     td = _extract_dataset_teledeclaration(year=diagnostic.year)
-    #     assert len(td) == 1, "There should be one teledeclaration for 2021"
-    #     assert len(td.columns) == len(schema_cols) + 1, "The columns should match the schema. Adding the index"
+        td = _extract_dataset_teledeclaration(year=diagnostic.year)
+        assert len(td) == 1, "There should be one teledeclaration for 2021"
+        assert len(td.columns) == len(schema_cols), "The columns should match the schema"
 
     def test_extraction_canteen(self):
         schema = json.load(open("data/schemas/schema_cantine.json"))
         schema_cols = [i["name"] for i in schema["fields"]]
 
+        # Adding data in the db
         canteen_1 = CanteenFactory.create()
         canteen_1.managers.add(UserFactory.create())
 
@@ -32,7 +34,9 @@ class TestExtractionOpenData(TestCase):
         canteen_2.managers.clear()
         
         canteens = _extract_dataset_canteen()
+
         assert len(canteens) == 2, "There should be two canteens"
         assert canteens[canteens.id == canteen_1.id].iloc[0]['active_on_ma_cantine'], "The canteen should be active because there is at least one manager"
         assert not canteens[canteens.id == canteen_2.id].iloc[0]['active_on_ma_cantine'], "The canteen should not be active because there no manager"
         assert isinstance(canteens['sectors'][0], list), "The sectors should be a list"
+        assert len(canteens.columns) == len(schema_cols), "The columns should match the schema."

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -22,8 +22,10 @@ class TestExtractionOpenData(TestCase):
 
     def test_extraction_canteen(self):
         schema = json.load(open("data/schemas/schema_cantine.json"))
+        schema_cols = [i["name"] for i in schema["fields"]]
 
         canteen = CanteenFactory.create()
-
+        manager = UserFactory.create()
+        canteen.managers.add(manager)
         canteens = _extract_dataset_canteen()
         assert len(canteens) == 1, "There should be one canteen"

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -34,13 +34,13 @@ class TestExtractionOpenData(TestCase):
         )
         TeledeclarationFactory.create(
             applicant=applicant,
-            year=diagnostic.year,
+            year=diagnostic.year + 1,
             canteen=canteen,
             canteen_siret=canteen.siret,
             status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
             diagnostic=diagnostic,
             declared_data={
-                "year": str(int(diagnostic.year) + 1),
+                "year": diagnostic.year + 1,
                 "canteen": {
                     "name": "",
                 },

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -1,19 +1,22 @@
 from django.test import TestCase
 from data.factories import DiagnosticFactory, CanteenFactory, UserFactory
 from data.models import Teledeclaration
-from macantine.tasks import extract_datasets
+from macantine.tasks import _extract_dataset_teledeclaration, _extract_dataset_canteen
+import json
 
 
 class TestExtractionOpenData(TestCase):
-    td_columns = ["id", "applicant_id", "teledeclaration_mode", "creation_date", "year", "version", "canteen.id", "canteen.siret", "canteen.name", "canteen.central_producer_siret", "canteen.department", "canteen.region", "canteen.satellite_canteens_count", "canteen.economic_model", "canteen.management_type", "canteen.production_type", "canteen.sectors", "canteen.line_ministry", "teledeclaration.value_bio_ht", "teledeclaration.value_total_ht", "teledeclaration.value_sustainable_ht"]
+    # td_columns = ["id", "applicant_id", "teledeclaration_mode", "creation_date", "year", "version", "canteen.id", "canteen.siret", "canteen.name", "canteen.central_producer_siret", "canteen.department", "canteen.region", "canteen.satellite_canteens_count", "canteen.economic_model", "canteen.management_type", "canteen.production_type", "canteen.sectors", "canteen.line_ministry", "teledeclaration.value_bio_ht", "teledeclaration.value_total_ht", "teledeclaration.value_sustainable_ht"]
 
     def test_extraction_teledeclaration(self):
+        schema = json.load(open("data/schemas/schema_teledeclaration.json"))
+        schema_cols = [i["name"] for i in schema["fields"]]
         canteen = CanteenFactory.create()
         applicant = UserFactory.create()
         for year_td in [2021, 2022]:
             diagnostic = DiagnosticFactory.create(canteen=canteen, year=year_td, diagnostic_type=None)
             Teledeclaration.create_from_diagnostic(diagnostic, applicant)
 
-        td = extract_datasets(year=diagnostic.year)
+        td = _extract_dataset_teledeclaration(year=diagnostic.year)
         assert len(td) == 1, "There should be one teledeclaration for 2021"
-        assert len(td.columns) == len(self.td_columns) + 1, "The columns should match the schema. Adding the index"
+        assert len(td.columns) == len(schema_cols) + 1, "The columns should match the schema. Adding the index"

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -25,7 +25,11 @@ class TestExtractionOpenData(TestCase):
         schema_cols = [i["name"] for i in schema["fields"]]
 
         canteen = CanteenFactory.create()
-        manager = UserFactory.create()
-        canteen.managers.add(manager)
+        canteen.managers.add(UserFactory.create())
+
+        CanteenFactory.create()  # Another canteen, but without a manager
+
         canteens = _extract_dataset_canteen()
-        assert len(canteens) == 1, "There should be one canteen"
+        assert len(canteens) == 2, "There should be two canteens"
+        assert canteens.iloc[0]['active_on_ma_cantine'], "The canteen should be active because there is at least one manager"
+        assert not canteens.iloc[1]['active_on_ma_cantine'], "The canteen should not be active because there no manager"

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -1,24 +1,25 @@
 from django.test import TestCase
 from data.factories import DiagnosticFactory, CanteenFactory, UserFactory
-from data.models import Teledeclaration
+from data.models import Teledeclaration, Canteen
 from macantine.tasks import _extract_dataset_teledeclaration, _extract_dataset_canteen
 import json
+import pandas as pd
 
 
 class TestExtractionOpenData(TestCase):
 
-    def test_extraction_teledeclaration(self):
-        schema = json.load(open("data/schemas/schema_teledeclaration.json"))
-        schema_cols = [i["name"] for i in schema["fields"]]
-        canteen = CanteenFactory.create()
-        applicant = UserFactory.create()
-        for year_td in [2021, 2022]:
-            diagnostic = DiagnosticFactory.create(canteen=canteen, year=year_td, diagnostic_type=None)
-            Teledeclaration.create_from_diagnostic(diagnostic, applicant)
+    # def test_extraction_teledeclaration(self):
+    #     schema = json.load(open("data/schemas/schema_teledeclaration.json"))
+    #     schema_cols = [i["name"] for i in schema["fields"]]
+    #     canteen = CanteenFactory.create()
+    #     applicant = UserFactory.create()
+    #     for year_td in [2021, 2022]:
+    #         diagnostic = DiagnosticFactory.create(canteen=canteen, year=year_td, diagnostic_type=None)
+    #         Teledeclaration.create_from_diagnostic(diagnostic, applicant)
 
-        td = _extract_dataset_teledeclaration(year=diagnostic.year)
-        assert len(td) == 1, "There should be one teledeclaration for 2021"
-        assert len(td.columns) == len(schema_cols) + 1, "The columns should match the schema. Adding the index"
+    #     td = _extract_dataset_teledeclaration(year=diagnostic.year)
+    #     assert len(td) == 1, "There should be one teledeclaration for 2021"
+    #     assert len(td.columns) == len(schema_cols) + 1, "The columns should match the schema. Adding the index"
 
     def test_extraction_canteen(self):
         schema = json.load(open("data/schemas/schema_cantine.json"))
@@ -26,13 +27,12 @@ class TestExtractionOpenData(TestCase):
 
         canteen_1 = CanteenFactory.create()
         canteen_1.managers.add(UserFactory.create())
-        print(canteen_1.managers.all())
 
         canteen_2 = CanteenFactory.create()  # Another canteen, but without a manager
         canteen_2.managers.clear()
-        print(canteen_2.managers.all())
         
         canteens = _extract_dataset_canteen()
         assert len(canteens) == 2, "There should be two canteens"
         assert canteens[canteens.id == canteen_1.id].iloc[0]['active_on_ma_cantine'], "The canteen should be active because there is at least one manager"
         assert not canteens[canteens.id == canteen_2.id].iloc[0]['active_on_ma_cantine'], "The canteen should not be active because there no manager"
+        assert isinstance(canteens['sectors'][0], list), "The sectors should be a list"

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -4,7 +4,7 @@ from django.test.utils import override_settings
 from django.utils.timezone import now
 from data.factories import DiagnosticFactory, CanteenFactory, UserFactory, TeledeclarationFactory
 from data.models import Teledeclaration
-
+from macantine.tasks import extract_datasets
 
 class TestExtractionOpenData(TestCase):
 
@@ -31,5 +31,5 @@ class TestExtractionOpenData(TestCase):
             },
             teledeclaration_mode='SITE',
         )
-        td = extract_dataset_teledeclaration(year=diagnostic.year)
-        assert len(td) == 1, "There should be one teledeclaration for 2021"
+        td = extract_datasets()
+        assert len(td) == 1, "There should b    e one teledeclaration for 2021"

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from data.factories import DiagnosticFactory, CanteenFactory, UserFactory
 from data.models import Teledeclaration
-from macantine.tasks import _extract_dataset_teledeclaration#, _extract_dataset_canteen
+from macantine.tasks import _extract_dataset_teledeclaration, _extract_dataset_canteen
 import json
 
 
@@ -19,3 +19,11 @@ class TestExtractionOpenData(TestCase):
         td = _extract_dataset_teledeclaration(year=diagnostic.year)
         assert len(td) == 1, "There should be one teledeclaration for 2021"
         assert len(td.columns) == len(schema_cols) + 1, "The columns should match the schema. Adding the index"
+
+    def test_extraction_canteen(self):
+        schema = json.load(open("data/schemas/schema_cantine.json"))
+
+        canteen = CanteenFactory.create()
+
+        canteens = _extract_dataset_canteen()
+        assert len(canteens) == 1, "There should be one canteen"

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -1,14 +1,11 @@
 from django.test import TestCase
 from data.factories import DiagnosticFactory, CanteenFactory, UserFactory
-from data.models import Teledeclaration, Canteen
+from data.models import Teledeclaration
 from macantine.tasks import _extract_dataset_teledeclaration, _extract_dataset_canteen
-from frictionless import validate
 import json
-import pandas as pd
 
 
 class TestExtractionOpenData(TestCase):
-
     def test_extraction_teledeclaration(self):
         schema = json.load(open("data/schemas/schema_teledeclaration.json"))
         schema_cols = [i["name"] for i in schema["fields"]]
@@ -32,11 +29,15 @@ class TestExtractionOpenData(TestCase):
 
         canteen_2 = CanteenFactory.create()  # Another canteen, but without a manager
         canteen_2.managers.clear()
-        
+
         canteens = _extract_dataset_canteen()
 
         assert len(canteens) == 2, "There should be two canteens"
-        assert canteens[canteens.id == canteen_1.id].iloc[0]['active_on_ma_cantine'], "The canteen should be active because there is at least one manager"
-        assert not canteens[canteens.id == canteen_2.id].iloc[0]['active_on_ma_cantine'], "The canteen should not be active because there no manager"
-        assert isinstance(canteens['sectors'][0], list), "The sectors should be a list"
+        assert canteens[canteens.id == canteen_1.id].iloc[0][
+            "active_on_ma_cantine"
+        ], "The canteen should be active because there is at least one manager"
+        assert not canteens[canteens.id == canteen_2.id].iloc[0][
+            "active_on_ma_cantine"
+        ], "The canteen should not be active because there no manager"
+        assert isinstance(canteens["sectors"][0], list), "The sectors should be a list"
         assert len(canteens.columns) == len(schema_cols), "The columns should match the schema."

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -24,12 +24,15 @@ class TestExtractionOpenData(TestCase):
         schema = json.load(open("data/schemas/schema_cantine.json"))
         schema_cols = [i["name"] for i in schema["fields"]]
 
-        canteen = CanteenFactory.create()
-        canteen.managers.add(UserFactory.create())
+        canteen_1 = CanteenFactory.create()
+        canteen_1.managers.add(UserFactory.create())
+        print(canteen_1.managers.all())
 
-        CanteenFactory.create()  # Another canteen, but without a manager
-
+        canteen_2 = CanteenFactory.create()  # Another canteen, but without a manager
+        canteen_2.managers.clear()
+        print(canteen_2.managers.all())
+        
         canteens = _extract_dataset_canteen()
         assert len(canteens) == 2, "There should be two canteens"
-        assert canteens.iloc[0]['active_on_ma_cantine'], "The canteen should be active because there is at least one manager"
-        assert not canteens.iloc[1]['active_on_ma_cantine'], "The canteen should not be active because there no manager"
+        assert canteens[canteens.id == canteen_1.id].iloc[0]['active_on_ma_cantine'], "The canteen should be active because there is at least one manager"
+        assert not canteens[canteens.id == canteen_2.id].iloc[0]['active_on_ma_cantine'], "The canteen should not be active because there no manager"

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -54,7 +54,7 @@ L'application utilise [python-dotenv](https://pypi.org/project/python-dotenv/), 
 ```
 SECRET= Le secret pour Django (vous pouvez le [générer ici](https://djecrety.ir/))
 DEBUG= `True` pour le développement local ou `False` autrement
-DB_USER= L'utilisateur de la base de données
+DB_USER= L'utilisateur de la base de données. Doit avoir les droits de creation de db pour les tests.
 DB_PASSWORD= Le mot de passe pour accéder à la base de données
 DB_HOST= Le host de la base de données (par ex. '127.0.0.1')
 DB_PORT= Le port de la base de données (par ex. '3306')

--- a/macantine/celery.py
+++ b/macantine/celery.py
@@ -47,6 +47,10 @@ app.conf.beat_schedule = {
         "task": "macantine.tasks.delete_old_historical_records",
         "schedule": nightly,
     },
+    "export_datasets": {
+        "task": "macantine.tasks.export_datasets",
+        "schedule": nightly,
+    }
 }
 
 app.conf.timezone = "Europe/Paris"

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -329,7 +329,7 @@ def _extract_dataset_canteen():
         "sectors",
     ]
     all_canteens = Canteen.objects.all()
-    active_canteens_id = [c.id for c in all_canteens if not c.can_be_claimed]
+    active_canteens_id = Canteen.objects.exclude(managers=None).values_list("id", flat=True)
 
     # Creating a dataframe with all canteens. The canteens can have multiple lines if they have multiple sectors
     canteens = pd.DataFrame(all_canteens.values(*canteens_col))

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -258,3 +258,14 @@ def delete_old_historical_records():
         return
     logger.info(f"History items older than {settings.MAX_DAYS_HISTORICAL_RECORDS} days will be removed.")
     call_command("clean_old_history", days=settings.MAX_DAYS_HISTORICAL_RECORDS, auto=True)
+
+
+def _extract_dataset_teledeclaration():
+    canteens = Canteen.objects.all()
+    return canteens
+
+
+@app.task()
+def extract_datasets():
+    td = _extract_dataset_teledeclaration()
+    return td

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -277,6 +277,7 @@ def _extract_dataset_teledeclaration(year):
     td = _flatten_declared_data(td)
     td['teledeclaration_ratio_bio'] = td['teledeclaration.value_bio_ht'] / td['teledeclaration.value_total_ht']
     td['teledeclaration_ratio_egalim_hors_bio'] = td['teledeclaration.value_sustainable_ht'] / td['teledeclaration.value_total_ht']
+    td = td.loc[:, ~td.columns.duplicated()]
     td = td[td_columns]
     td.columns = td.columns.str.replace('.', '_')
     td = td.reset_index(drop=True)
@@ -322,5 +323,5 @@ def export_datasets(year):
     _export_dataset(td_2021, "campagne_td_2021.csv")
 
     # Registre des cantines
-    # canteens = _extract_dataset_canteen()
-    # _export_dataset(canteens, "registre_cantines.csv")
+    canteens = _extract_dataset_canteen()
+    _export_dataset(canteens, "registre_cantines.csv")

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -289,11 +289,15 @@ def _extract_dataset_teledeclaration(year):
 
 def _extract_dataset_canteen():
     canteens_col = ['id', 'name', 'siret', 'city', 'city_insee_code', 'postal_code', 'department', 'region', 'economic_model', 'management_type', 'production_type', 'satellite_canteens_count', 'central_producer_siret', 'creation_date', 'daily_meal_count', 'yearly_meal_count', 'line_ministry', 'modification_date', 'publication_status', 'logo', 'sectors', 'active_on_ma_cantine']
-    canteens = pd.DataFrame(Canteen.objects.all().values())
-    # canteens_with_manager = Canteen.objects.filter(Q(managers__isnull=False) & Q(manager_field__exists=True)).values_list('id', flat=True)
-    canteens['active_on_ma_cantine'] = True
+    all_canteens = Canteen.objects.all()
+    
+    active_canteens_id = [c.id for c in all_canteens if not c.can_be_claimed]
+
+    canteens = pd.DataFrame(all_canteens.values())
+    canteens['active_on_ma_cantine'] = canteens['id'].apply(lambda x: x in active_canteens_id)
+
     canteens['sectors'] = True
-    # canteens['active_on_ma_cantine'] = canteens['id'].apply(lambda x: x in canteens_with_manager, axis=1)
+    
     canteens = canteens[canteens_col]
     canteens = canteens.reset_index(drop=True)
     return canteens

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -8,8 +8,12 @@ from django.db.models import Q
 from django.core.paginator import Paginator
 from django.db.models import F
 from django.db.models.functions import Length
+<<<<<<< HEAD
 from django.core.management import call_command
 from data.models import User, Canteen
+=======
+from data.models import User, Canteen, Teledeclaration
+>>>>>>> 62be657f... [Pass]
 from .celery import app
 import sib_api_v3_sdk
 from sib_api_v3_sdk.rest import ApiException
@@ -260,12 +264,12 @@ def delete_old_historical_records():
     call_command("clean_old_history", days=settings.MAX_DAYS_HISTORICAL_RECORDS, auto=True)
 
 
-def _extract_dataset_teledeclaration():
-    canteens = Canteen.objects.all()
+def _extract_dataset_teledeclaration(year):
+    canteens = Teledeclaration.objects.filter(year=year)
     return canteens
 
 
 @app.task()
-def extract_datasets():
-    td = _extract_dataset_teledeclaration()
+def extract_datasets(year):
+    td = _extract_dataset_teledeclaration(year)
     return td

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -276,7 +276,6 @@ def _flatten_declared_data(df):
 
 
 def _extract_dataset_teledeclaration(year):
-    # Exact match from the schema : td_columns = ["id", "applicant_id", "teledeclaration_mode", "creation_date", "year", "version", "canteen_id", "canteen_siret", "canteen_name", "cantine_central_kitchen_siret", "canteen_department", "canteen_region", "cantine_satellite_canteens_count", "cantine_economic_model", "cantine_management_type", "cantine_production_type", "canteen_sectors", "canteen_line_ministry", "teledeclaration_ratio_bio", "teledeclaration_ratio_egalim_hors_bio"]
     td_columns = ["id", "applicant_id", "teledeclaration_mode", "creation_date", "year", "version", "canteen.id", "canteen.siret", "canteen.name", "canteen.central_producer_siret", "canteen.department", "canteen.region", "canteen.satellite_canteens_count", "canteen.economic_model", "canteen.management_type", "canteen.production_type", "canteen.sectors", "canteen.line_ministry", "teledeclaration_ratio_bio", "teledeclaration_ratio_egalim_hors_bio"]
     td = pd.DataFrame(Teledeclaration.objects.filter(year=year).values())
     td = _flatten_declared_data(td)
@@ -284,9 +283,20 @@ def _extract_dataset_teledeclaration(year):
     td['teledeclaration_ratio_egalim_hors_bio'] = td['teledeclaration.value_sustainable_ht'] / td['teledeclaration.value_total_ht']
     td = td[td_columns]
     td.columns = td.columns.str.replace('.', '_')
-
     td = td.reset_index(drop=True)
     return td
+
+
+def _extract_dataset_canteen():
+    canteens_col = ['id', 'name', 'siret', 'city', 'city_insee_code', 'postal_code', 'department', 'region', 'economic_model', 'management_type', 'production_type', 'satellite_canteens_count', 'central_producer_siret', 'creation_date', 'daily_meal_count', 'yearly_meal_count', 'line_ministry', 'modification_date', 'publication_status', 'logo', 'sectors', 'active_on_ma_cantine']
+    canteens = pd.DataFrame(Canteen.objects.all().values())
+    # canteens_with_manager = Canteen.objects.filter(Q(managers__isnull=False) & Q(manager_field__exists=True)).values_list('id', flat=True)
+    canteens['active_on_ma_cantine'] = True
+    canteens['sectors'] = True
+    # canteens['active_on_ma_cantine'] = canteens['id'].apply(lambda x: x in canteens_with_manager, axis=1)
+    canteens = canteens[canteens_col]
+    canteens = canteens.reset_index(drop=True)
+    return canteens
 
 
 def _export_dataset(td, file_name):

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -12,8 +12,8 @@ from django.db.models.functions import Length
 from django.core.management import call_command
 from data.models import User, Canteen, Teledeclaration, Sector
 from .celery import app
-import sib_api_v3_sdk
 from django.core.files.storage import default_storage
+import sib_api_v3_sdk
 from sib_api_v3_sdk.rest import ApiException
 
 logger = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,7 @@ oauthlib==3.2.2
 openpyxl==3.1.2
 oscrypto==1.3.0
 packaging==23.1
+pandas==1.5.3
 pathspec==0.11.1
 Pillow==9.5.0
 pipdeptree==2.7.1


### PR DESCRIPTION
Création d'une task d'export des datasets :
* Référentiels des cantines
* Résultats des campagnes de télédéclaration
Les datasets suivent les schémas de modèles publiés dans le dossier `schémas/`