### PR TITLE
Evolution du pipeline de génération de données pour open data

### DIFF
--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 from data.factories import DiagnosticFactory, CanteenFactory, UserFactory
+from api.serializers import SectorSerializer
+from api.views.utils import camelize
 from data.models import Teledeclaration
 from macantine.tasks import _extract_dataset_teledeclaration, _extract_dataset_canteen
 import json
@@ -13,11 +15,20 @@ class TestExtractionOpenData(TestCase):
         applicant = UserFactory.create()
         for year_td in [2021, 2022]:
             diagnostic = DiagnosticFactory.create(canteen=canteen, year=year_td, diagnostic_type=None)
-            Teledeclaration.create_from_diagnostic(diagnostic, applicant)
+            td = Teledeclaration.create_from_diagnostic(diagnostic, applicant)
 
         td = _extract_dataset_teledeclaration(year=diagnostic.year)
         assert len(td) == 1, "There should be one teledeclaration for 2021"
         assert len(td.columns) == len(schema_cols), "The columns should match the schema"
+
+        td.status = Teledeclaration.TeledeclarationStatus.CANCELLED
+        td = _extract_dataset_teledeclaration(year=diagnostic.year)
+        self.assertEqual(len(td), 0)
+        
+        canteen.sectors.clear()
+        Teledeclaration.create_from_diagnostic(diagnostic, applicant)
+        td = _extract_dataset_teledeclaration(year=diagnostic.year)
+        self.assertEqual(td.iloc[0]['canteen_sectors'], [''], "The sectors should be an empty list")
 
     def test_extraction_canteen(self):
         schema = json.load(open("data/schemas/schema_cantine.json"))
@@ -41,9 +52,16 @@ class TestExtractionOpenData(TestCase):
         ], "The canteen should not be active because there no manager"
         assert isinstance(canteens["sectors"][0], list), "The sectors should be a list"
         assert len(canteens.columns) == len(schema_cols), "The columns should match the schema."
+        self.assertEqual(canteens[canteens.id == canteen_1.id].iloc[0]['sectors'], [camelize(SectorSerializer(x).data) for x in canteen_1.sectors.all()])
 
         canteen_2.sectors.clear()
         
         canteens = _extract_dataset_canteen()
         assert canteens[canteens.id == canteen_2.id].iloc[0]['sectors'] == [''], "The sectors should be an empty list"
+
+        canteen_1.sectors.clear()
+        try:
+            _extract_dataset_canteen()
+        except Exception:
+            self.fail("The extraction should not fail if one column is completely empty. In this case, there is no sector")
 

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -43,6 +43,7 @@ class TestExtractionOpenData(TestCase):
         assert len(canteens.columns) == len(schema_cols), "The columns should match the schema."
 
         canteen_2.sectors.clear()
+        
         canteens = _extract_dataset_canteen()
-        assert canteens[canteens.id == canteen_2.id].iloc[0]['sectors'] == [], "The sectors should be an empty list"
+        assert canteens[canteens.id == canteen_2.id].iloc[0]['sectors'] == [''], "The sectors should be an empty list"
 

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -46,7 +46,6 @@ class TestExtractionOpenData(TestCase):
         canteen_2.managers.clear()
 
         canteens = _extract_dataset_canteen()
-
         assert len(canteens) == 2, "There should be two canteens"
         assert canteens[canteens.id == canteen_1.id].iloc[0][
             "active_on_ma_cantine"
@@ -56,9 +55,11 @@ class TestExtractionOpenData(TestCase):
         ], "The canteen should not be active because there no manager"
         assert isinstance(canteens["sectors"][0], list), "The sectors should be a list"
         assert len(canteens.columns) == len(schema_cols), "The columns should match the schema."
+
         self.assertEqual(
             canteens[canteens.id == canteen_1.id].iloc[0]["sectors"],
             [camelize(SectorSerializer(x).data) for x in canteen_1.sectors.all()],
+            "The sectors should be a list of sectors",
         )
 
         canteen_2.sectors.clear()

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -41,3 +41,8 @@ class TestExtractionOpenData(TestCase):
         ], "The canteen should not be active because there no manager"
         assert isinstance(canteens["sectors"][0], list), "The sectors should be a list"
         assert len(canteens.columns) == len(schema_cols), "The columns should match the schema."
+
+        canteen_2.sectors.clear()
+        canteens = _extract_dataset_canteen()
+        assert canteens[canteens.id == canteen_2.id].iloc[0]['sectors'] == [], "The sectors should be an empty list"
+

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -2,6 +2,7 @@ import logging
 import datetime
 import requests
 import csv
+import math
 import pandas as pd
 from django.utils import timezone
 from django.conf import settings
@@ -339,7 +340,7 @@ def _extract_dataset_canteen():
     canteens_col.append("active_on_ma_cantine")
 
     # Fetching sectors information and aggreting in list in order to have only one row per canteen
-    canteens["sectors"] = canteens["sectors"].apply(lambda x: Sector.objects.get(id=x))
+    canteens["sectors"] = canteens["sectors"].apply(lambda x: Sector.objects.get(id=x) if not math.isnan(x) else '')
     canteens_sectors = canteens.groupby("id")["sectors"].apply(list)
     del canteens["sectors"]
     canteens = canteens.merge(canteens_sectors, on="id")

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -298,7 +298,7 @@ def _extract_dataset_teledeclaration(year):
         td["teledeclaration.value_sustainable_ht"] / td["teledeclaration.value_total_ht"]
     )
     td = td.loc[:, ~td.columns.duplicated()]
-    td = td[td_columns]
+    td = td.reindex(td_columns, axis="columns")
     td.columns = td.columns.str.replace(".", "_")
     td = td.reset_index(drop=True)
     return td
@@ -359,7 +359,7 @@ def _export_dataset(td, file_name):
 
 
 @app.task()
-def export_datasets(year):
+def export_datasets():
     # Campagnes de télédéclarations
     td_2021 = _extract_dataset_teledeclaration(2021)
     _export_dataset(td_2021, "campagne_td_2021.csv")

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -273,28 +273,9 @@ def _flatten_declared_data(df):
 
 
 def _extract_dataset_teledeclaration(year):
-    td_columns = [
-        "id",
-        "applicant_id",
-        "teledeclaration_mode",
-        "creation_date",
-        "year",
-        "version",
-        "canteen.id",
-        "canteen.siret",
-        "canteen.name",
-        "canteen.central_producer_siret",
-        "canteen.department",
-        "canteen.region",
-        "canteen.satellite_canteens_count",
-        "canteen.economic_model",
-        "canteen.management_type",
-        "canteen.production_type",
-        "canteen.sectors",
-        "canteen.line_ministry",
-        "teledeclaration_ratio_bio",
-        "teledeclaration_ratio_egalim_hors_bio",
-    ]
+    schema = json.load(open("data/schemas/schema_teledeclaration.json"))
+    td_columns = [i["name"].replace("canteen_", "canteen.") for i in schema["fields"]]
+
     td = pd.DataFrame(
         Teledeclaration.objects.filter(year=year, status=Teledeclaration.TeledeclarationStatus.SUBMITTED).values()
     )
@@ -338,11 +319,11 @@ def _extract_dataset_canteen():
     canteens = canteens.merge(canteens_sectors, on="id")
     canteens = canteens.drop_duplicates(subset=["id"])
     canteens = canteens.reset_index(drop=True)
-    
+
     for col_int in schema["fields"]:
         if col_int["type"] == "integer":
             # Force column o Int64 to maintain an integer column despite the NaN values
-            canteens[col_int['name']] = canteens[col_int['name']].astype("Int64")
+            canteens[col_int["name"]] = canteens[col_int["name"]].astype("Int64")
     return canteens
 
 


### PR DESCRIPTION
* Ajout de tests (aucune TD, aucune valeur pour un champ, ...)
* Passage par le serializer des Secteurs pour afficher plus de détails
* Chargement des noms de colonnes directement depuis les schémas
* Ajout de sécurité sur les données manquantes

J'ai ajouté un filtre sur le deletion_date, mais je n'ai pas réussi à le tester car je n'ai pas retrouvé la méthode qui permet de "supprimer" une cantine.