### PR TITLE
Mise du lien pour le premier bilan Egalim (campagne de télédéclaration 2022)

### DIFF
--- a/frontend/src/views/ManagementPage/TeledeclarationBanner.vue
+++ b/frontend/src/views/ManagementPage/TeledeclarationBanner.vue
@@ -21,6 +21,16 @@
           Le guide de télédéclaration
           <v-icon small class="ml-2">mdi-open-in-new</v-icon>
         </v-btn>
+        <v-btn
+          text
+          href="https://1648047458-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2F-MSCF7Mdc8yfeIjMxMZr%2Fuploads%2FlNPOtFoTKyfj5UnjZKJj%2FEGAlim%20Bilan%20statistique%202023%20d%C3%A9finitif.pdf?alt=media"
+          target="_blank"
+          rel="noopener"
+          class="text-decoration-underline"
+        >
+          Bilan EGAlim pour la campagne de 2022
+          <v-icon small class="ml-2">mdi-open-in-new</v-icon>
+        </v-btn>
       </v-card-actions>
     </div>
   </v-card>

--- a/frontend/src/views/ManagementPage/index.vue
+++ b/frontend/src/views/ManagementPage/index.vue
@@ -24,7 +24,8 @@
         href="https://1648047458-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2F-MSCF7Mdc8yfeIjMxMZr%2Fuploads%2FlNPOtFoTKyfj5UnjZKJj%2FEGAlim%20Bilan%20statistique%202023%20d%C3%A9finitif.pdf?alt=media"
         target="_blank"
         rel="noopener"
-        class="text-decoration-underline px-0 mt-n1"
+        class="text-decoration-underline px-0"
+        style="margin-top: -5px"
       >
         bilan EGAlim pour la campagne de 2022
         <v-icon small class="ml-2">mdi-open-in-new</v-icon>

--- a/frontend/src/views/ManagementPage/index.vue
+++ b/frontend/src/views/ManagementPage/index.vue
@@ -17,6 +17,19 @@
         v-model="showCanteenCreationPrompt"
       />
     </div>
+    <div v-if="canteenCount === 0" class="body-2 font-weight-medium">
+      Prenez connaissance du
+      <v-btn
+        text
+        href="https://1648047458-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2F-MSCF7Mdc8yfeIjMxMZr%2Fuploads%2FlNPOtFoTKyfj5UnjZKJj%2FEGAlim%20Bilan%20statistique%202023%20d%C3%A9finitif.pdf?alt=media"
+        target="_blank"
+        rel="noopener"
+        class="text-decoration-underline px-0 mt-n1"
+      >
+        bilan EGAlim pour la campagne de 2022
+        <v-icon small class="ml-2">mdi-open-in-new</v-icon>
+      </v-btn>
+    </div>
     <TeledeclarationBanner v-if="showPendingTeledeclarationBanner" />
     <ActionsBanner v-else-if="showActionsBanner" />
     <SuccessBanner v-else-if="showSuccessBanner" />


### PR DESCRIPTION
Suite à une discussion avec @valeriemerle, cette PR vise à inclure pour la dernière semaine de la TD un lien vers le premier bilan Egalim (campagne de télédéclaration 2022) afin de dédramatiser et donner un peu de contexte aux utilisateurs avant leur télédéclaration.

Nous avons identifié - pour l'instant - deux endroits où le mettre :

![image](https://github.com/betagouv/ma-cantine/assets/1225929/9c801ab0-daac-44e6-92c8-eeb3f258924f)

![image](https://github.com/betagouv/ma-cantine/assets/1225929/bc9a9dcd-40e3-4422-9f4c-bcacb8025b8e)
