### PR TITLE
Filtre par commune dans les cantines publiées

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -182,6 +182,7 @@ class PublishedCanteenFilterSet(django_filters.FilterSet):
             "department",
             "region",
             "sectors",
+            "city_insee_code",
             "min_daily_meal_count",
             "max_daily_meal_count",
             "management_type",

--- a/frontend/src/views/CanteenEditor/CityField.vue
+++ b/frontend/src/views/CanteenEditor/CityField.vue
@@ -5,6 +5,8 @@
     :items="communes"
     :search-input.sync="search"
     auto-select-first
+    cache-items
+    @click:clear="$emit('update:inseeCode', null)"
     v-model="cityAutocompleteChoice"
     :no-data-text="noDataText"
     v-bind="$attrs"
@@ -52,7 +54,6 @@ export default {
       return fetch(queryUrl)
         .then((response) => response.json())
         .then((response) => {
-          this.clearCache()
           const communes = response.features
           this.communes = communes.map((commune) => {
             return { text: `${commune.properties.label} (${commune.properties.context})`, value: commune.properties }

--- a/frontend/src/views/CanteenEditor/CityField.vue
+++ b/frontend/src/views/CanteenEditor/CityField.vue
@@ -19,7 +19,14 @@ import DsfrAutocomplete from "@/components/DsfrAutocomplete"
 export default {
   name: "CityField",
   components: { DsfrAutocomplete },
-  props: ["location"],
+  props: {
+    location: {
+      default: () => ({}),
+    },
+    value: {
+      required: false,
+    },
+  },
   data() {
     return {
       cityAutocompleteChoice: null,
@@ -72,12 +79,15 @@ export default {
     },
     cityAutocompleteChoice(val) {
       if (val?.label) {
-        this.$emit("locationUpdate", {
+        const jsonRepresentation = {
           city: val.label,
           cityInseeCode: val.citycode,
           postalCode: val.postcode,
           department: val.context.split(",")[0],
-        })
+        }
+        const inseeCode = val.citycode
+        this.$emit("locationUpdate", jsonRepresentation)
+        this.$emit("input", inseeCode)
       }
 
       this.search = this.location.city

--- a/frontend/src/views/CanteenEditor/CityField.vue
+++ b/frontend/src/views/CanteenEditor/CityField.vue
@@ -7,9 +7,7 @@
     auto-select-first
     cache-items
     v-model="cityAutocompleteChoice"
-    :no-data-text="
-      this.loadingCommunes ? 'Chargement en cours...' : 'Pas de résultats. Veuillez renseigner votre ville'
-    "
+    :no-data-text="noDataText"
     v-bind="$attrs"
     v-on="$listeners"
   />
@@ -36,6 +34,14 @@ export default {
       loadingCommunes: false,
       search: null,
     }
+  },
+  computed: {
+    noDataText() {
+      if (!this.search || this.search.length < 3) {
+        return "Veuillez rentrer au moins trois caractères"
+      }
+      return this.loadingCommunes ? "Chargement en cours..." : "Pas de résultats"
+    },
   },
   methods: {
     queryCommunes(val) {

--- a/frontend/src/views/CanteenEditor/CityField.vue
+++ b/frontend/src/views/CanteenEditor/CityField.vue
@@ -57,7 +57,7 @@ export default {
     },
     populateCityAutocomplete() {
       if (this.location.city && this.location.cityInseeCode && this.location.postalCode && this.location.department) {
-        let initialCityAutocomplete = {
+        const initialCityAutocomplete = {
           text: this.location.city,
           value: {
             label: this.location.city,

--- a/frontend/src/views/CanteenEditor/CityField.vue
+++ b/frontend/src/views/CanteenEditor/CityField.vue
@@ -37,6 +37,7 @@ export default {
   },
   methods: {
     queryCommunes(val) {
+      if (val?.length < 3) return
       this.loadingCommunes = true
       const queryUrl = "https://api-adresse.data.gouv.fr/search/?q=" + val + "&type=municipality&autocomplete=1"
       return fetch(queryUrl)
@@ -53,8 +54,9 @@ export default {
         })
     },
     populateCityAutocomplete() {
+      let initialCityAutocomplete = {}
       if (this.location.city && this.location.cityInseeCode && this.location.postalCode && this.location.department) {
-        const initialCityAutocomplete = {
+        initialCityAutocomplete = {
           text: this.location.city,
           value: {
             label: this.location.city,
@@ -63,13 +65,23 @@ export default {
             context: this.location.department,
           },
         }
-        this.communes.push(initialCityAutocomplete)
-        this.cityAutocompleteChoice = initialCityAutocomplete.value
+      } else if (this.value && !this.cityAutocompleteChoice) {
+        initialCityAutocomplete = {
+          text: `Code INSEE : ${this.value}`,
+          value: {
+            label: `Code INSEE : ${this.value}`,
+            citycode: this.value,
+            postcode: null,
+            context: null,
+          },
+        }
       }
+      this.communes.push(initialCityAutocomplete)
+      this.cityAutocompleteChoice = initialCityAutocomplete.value
     },
   },
   beforeMount() {
-    if (this.location.city) {
+    if (this.location.city || this.value) {
       this.populateCityAutocomplete()
     }
   },
@@ -78,7 +90,7 @@ export default {
       return val && val !== this.location.city && this.queryCommunes(val)
     },
     cityAutocompleteChoice(val) {
-      if (val?.label) {
+      if (val?.label && val?.context) {
         const jsonRepresentation = {
           city: val.label,
           cityInseeCode: val.citycode,
@@ -91,6 +103,9 @@ export default {
       }
 
       this.search = this.location.city
+    },
+    value() {
+      if (!this.location || !this.location.city) this.populateCityAutocomplete()
     },
   },
 }

--- a/frontend/src/views/CanteenEditor/CityField.vue
+++ b/frontend/src/views/CanteenEditor/CityField.vue
@@ -54,7 +54,7 @@ export default {
         })
     },
     populateCityAutocomplete() {
-      let initialCityAutocomplete = {}
+      let initialCityAutocomplete = { text: "" }
       if (this.location.city && this.location.cityInseeCode && this.location.postalCode && this.location.department) {
         initialCityAutocomplete = {
           text: this.location.city,

--- a/frontend/src/views/CanteenEditor/CityField.vue
+++ b/frontend/src/views/CanteenEditor/CityField.vue
@@ -5,7 +5,6 @@
     :items="communes"
     :search-input.sync="search"
     auto-select-first
-    cache-items
     v-model="cityAutocompleteChoice"
     :no-data-text="noDataText"
     v-bind="$attrs"

--- a/frontend/src/views/CanteenEditor/CityField.vue
+++ b/frontend/src/views/CanteenEditor/CityField.vue
@@ -5,7 +5,6 @@
     :items="communes"
     :search-input.sync="search"
     auto-select-first
-    cache-items
     v-model="cityAutocompleteChoice"
     :no-data-text="noDataText"
     v-bind="$attrs"
@@ -112,9 +111,6 @@ export default {
           this.disableSearchWatcher = false
           this.loadingCommunes = false
         })
-    },
-    clearCache() {
-      if (this.$refs?.autocomplete?.$refs?.autocomplete) this.$refs.autocomplete.$refs.autocomplete.cachedItems = []
     },
   },
   beforeMount() {

--- a/frontend/src/views/CanteenEditor/CityField.vue
+++ b/frontend/src/views/CanteenEditor/CityField.vue
@@ -74,7 +74,7 @@ export default {
     },
     fillFromInseeCode(inseeCode) {
       this.loadingCommunes = true
-      const queryUrl = "https://api-adresse.data.gouv.fr/search/?q=" + inseeCode + "&type=municipality&autocomplete=1"
+      const queryUrl = `https://api-adresse.data.gouv.fr/search/?q=${inseeCode}&type=municipality&citycode=${inseeCode}`
       return fetch(queryUrl)
         .then((response) => response.json())
         .then((response) => {

--- a/frontend/src/views/CanteenEditor/CityField.vue
+++ b/frontend/src/views/CanteenEditor/CityField.vue
@@ -56,9 +56,8 @@ export default {
         })
     },
     populateCityAutocomplete() {
-      let initialCityAutocomplete = { text: "" }
       if (this.location.city && this.location.cityInseeCode && this.location.postalCode && this.location.department) {
-        initialCityAutocomplete = {
+        let initialCityAutocomplete = {
           text: this.location.city,
           value: {
             label: this.location.city,

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -121,6 +121,27 @@
           </v-col>
           <v-col cols="12" sm="6" md="4">
             <label
+              for="select-department"
+              :class="{
+                'text-body-2': true,
+                'active-filter-label': !!filters.department.value,
+              }"
+            >
+              Commune
+            </label>
+            <CityField
+              v-model="filters.city_insee_code.value"
+              clearable
+              hide-details
+              id="select-commune"
+              placeholder="Toutes les communes"
+              class="mt-1"
+            />
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="12" sm="6" md="4">
+            <label
               for="select-sector"
               :class="{
                 'text-body-2': true,
@@ -138,6 +159,40 @@
               id="select-sector"
               placeholder="Tous les secteurs"
               class="mt-1"
+            />
+          </v-col>
+          <v-col cols="12" sm="4" md="3">
+            <label
+              for="select-management-type"
+              :class="{ 'text-body-2': true, 'active-filter-label': !!filters.management_type.value }"
+            >
+              Mode de gestion
+            </label>
+            <DsfrSelect
+              v-model="filters.management_type.value"
+              :items="managementTypes"
+              clearable
+              hide-details
+              id="select-management-type"
+              class="mt-1"
+              placeholder="Tous les modes"
+            />
+          </v-col>
+          <v-col cols="12" sm="6" md="5">
+            <label
+              for="select-production-type"
+              :class="{ 'text-body-2': true, 'active-filter-label': !!filters.production_type.value }"
+            >
+              Type d'établissement
+            </label>
+            <DsfrSelect
+              v-model="filters.production_type.value"
+              :items="productionTypes"
+              clearable
+              hide-details
+              id="select-production-type"
+              class="mt-1"
+              placeholder="Tous les cantines"
             />
           </v-col>
         </v-row>
@@ -236,40 +291,6 @@
                 />
               </div>
             </div>
-          </v-col>
-          <v-col cols="12" sm="4" md="3">
-            <label
-              for="select-management-type"
-              :class="{ 'text-body-2': true, 'active-filter-label': !!filters.management_type.value }"
-            >
-              Mode de gestion
-            </label>
-            <DsfrSelect
-              v-model="filters.management_type.value"
-              :items="managementTypes"
-              clearable
-              hide-details
-              id="select-management-type"
-              class="mt-1"
-              placeholder="Tous les modes"
-            />
-          </v-col>
-          <v-col cols="12" sm="6" md="5">
-            <label
-              for="select-production-type"
-              :class="{ 'text-body-2': true, 'active-filter-label': !!filters.production_type.value }"
-            >
-              Type d'établissement
-            </label>
-            <DsfrSelect
-              v-model="filters.production_type.value"
-              :items="productionTypes"
-              clearable
-              hide-details
-              id="select-production-type"
-              class="mt-1"
-              placeholder="Tous les cantines"
-            />
           </v-col>
           <v-col cols="12" sm="6" md="5">
             <label for="select-badge" :class="{ 'text-body-2': true, 'active-filter-label': !!filters.badge.value }">
@@ -392,6 +413,7 @@ import DsfrSelect from "@/components/DsfrSelect"
 import DsfrTextarea from "@/components/DsfrTextarea"
 import DsfrPagination from "@/components/DsfrPagination"
 import DsfrSearchField from "@/components/DsfrSearchField"
+import CityField from "@/views/CanteenEditor/CityField"
 
 const DEFAULT_ORDER = "creation"
 
@@ -405,6 +427,7 @@ export default {
     DsfrTextarea,
     DsfrPagination,
     DsfrSearchField,
+    CityField,
   },
   data() {
     const user = this.$store.state.loggedUser
@@ -425,6 +448,11 @@ export default {
         },
         region: {
           param: "region",
+          value: null,
+          default: null,
+        },
+        city_insee_code: {
+          param: "commune",
           value: null,
           default: null,
         },

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -138,8 +138,6 @@
               class="mt-1"
             />
           </v-col>
-        </v-row>
-        <v-row>
           <v-col cols="12" sm="6" md="4">
             <label
               for="select-sector"

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -121,7 +121,7 @@
           </v-col>
           <v-col cols="12" sm="6" md="4">
             <label
-              for="select-department"
+              for="select-commune"
               :class="{
                 'text-body-2': true,
                 'active-filter-label': !!filters.department.value,

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -130,7 +130,7 @@
               Commune
             </label>
             <CityField
-              v-model="filters.city_insee_code.value"
+              :inseeCode.sync="filters.city_insee_code.value"
               clearable
               hide-details
               id="select-commune"


### PR DESCRIPTION
Version minimale d'un filtre par commune : 

![image](https://github.com/betagouv/ma-cantine/assets/1225929/5686b8d4-30dc-4e3b-b5d7-092e3c6ac3a5)

À savoir :
- Le filtre - contrairement aux autres - ne grise pas les options non disponibles
- Lors qu'on load la page avec un filtre commune déjà présent, on essaie d'obtenir le nom de la ville avec une recherche par code INSEE. Si jamais cette recherche ne donne rien, on affiche le code INSEE.

Par ex :

Lors qu'on sélectionne une commune
![image](https://github.com/betagouv/ma-cantine/assets/1225929/968ee8b1-da4b-40c4-9c92-884ae96e0d7a)

Lors qu'on reload la page et qu'on ne trouve pas le code INSEE 
![image](https://github.com/betagouv/ma-cantine/assets/1225929/2f740994-1cd5-4032-b7a9-6fa2332fb3ea)


