### PR TITLE
Bug fix quand les fichiers d'import ne sont pas en UTF-8

### DIFF
--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -64,8 +64,8 @@ class ImportDiagnosticsView(ABC, APIView):
             logger.warning(f"{message}")
             self.errors = [{"row": 0, "status": 400, "message": message}]
         except UnicodeDecodeError as e:
-            message = e.message
-            logger.warning(f"{message}")
+            message = e.reason
+            logger.warning(f"UnicodeDecodeError: {message}")
             self.errors = [{"row": 0, "status": 400, "message": "Le fichier doit être sauvegardé en Unicode (utf-8)"}]
         except Exception as e:
             logger.exception(f"Échec lors de la lecture du fichier:\n{e}")

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -42,8 +42,8 @@ class ImportPurchasesView(APIView):
             return ImportPurchasesView._get_success_response([], 0, errors, start)
 
         except UnicodeDecodeError as e:
-            message = e.message
-            logger.warning(f"{message}")
+            message = e.reason
+            logger.warning(f"UnicodeDecodeError: {message}")
             self.errors = [{"row": 0, "status": 400, "message": "Le fichier doit être sauvegardé en Unicode (utf-8)"}]
             return ImportPurchasesView._get_success_response([], 0, errors, start)
 


### PR DESCRIPTION
J'ai eu du mal d'écrire un test pour ça, je crois c'est parce que la requête en Jest n'est pas exactement comme la requête en réel. Je pense que ça vaut pas trop le coup de passer du temps en debuggant le test quand c'est facile à tester à la main.

J'utilise ce fichier :

[iso-8859-1_encoding.csv](https://github.com/betagouv/ma-cantine/files/11956455/iso-8859-1_encoding.csv)

![Screenshot 2023-07-05 at 11-51-19 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/b92ca215-ad08-4eb4-a864-35cfc2244691)

Le test que j'ai essayé :

```
    @authenticate
    def test_bad_file_encoding(self, _):
        """
        If the file is not encoded in UTF-8, throw error
        """
        with open("./api/tests/files/iso-8859-1_encoding.csv", encoding="iso-8859-1") as diag_file:
            response = self.client.post(reverse("import_diagnostics"), {"file": diag_file})
        self.assertEqual(response.status_code, status.HTTP_200_OK)
        body = response.json()
        self.assertEqual(body["count"], 0)
        self.assertEqual(len(body["errors"]), 1)
        self.assertEqual(body["errors"][0]["message"], "Le fichier doit être sauvegardé en Unicode (utf-8)")
```