### PR TITLE
Endpoint unique pour `initialData`

### DIFF
--- a/api/tests/test_initial_data.py
+++ b/api/tests/test_initial_data.py
@@ -1,8 +1,10 @@
 import json
+import datetime
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework.test import APITestCase
 from rest_framework import status
-from data.factories import SectorFactory
+from data.factories import SectorFactory, PartnerTypeFactory, CommunityEventFactory, VideoTutorialFactory
 from .utils import authenticate
 
 
@@ -13,6 +15,9 @@ class TestInitialDataApi(APITestCase):
         by other views. If the call isn't authenticated, "loggedUser" should be None
         """
         sector = SectorFactory.create()
+        partner_type = PartnerTypeFactory.create()
+        community_event = CommunityEventFactory.create(end_date=timezone.now() + datetime.timedelta(days=10))
+        video_tutorial = VideoTutorialFactory.create(published=True)
 
         response = self.client.get(reverse("initial_data"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -26,8 +31,16 @@ class TestInitialDataApi(APITestCase):
         self.assertEqual(body["sectors"][0]["name"], sector.name)
 
         self.assertIn("partnerTypes", body)
+        self.assertEqual(len(body["partnerTypes"]), 1)
+        self.assertEqual(body["partnerTypes"][0]["name"], partner_type.name)
+
         self.assertIn("communityEvents", body)
+        self.assertEqual(len(body["communityEvents"]), 1)
+        self.assertEqual(body["communityEvents"][0]["title"], community_event.title)
+
         self.assertIn("videoTutorials", body)
+        self.assertEqual(len(body["videoTutorials"]), 1)
+        self.assertEqual(body["videoTutorials"][0]["title"], video_tutorial.title)
 
     @authenticate
     def test_authenticated_logged_initial_data(self):

--- a/api/tests/test_initial_data.py
+++ b/api/tests/test_initial_data.py
@@ -12,6 +12,10 @@ class TestInitialDataApi(APITestCase):
 
         body = json.loads(response.content.decode())
         self.assertIn("loggedUser", body)
+        self.assertIn("sectors", body)
+        self.assertIn("partnerTypes", body)
+        self.assertIn("communityEvents", body)
+        self.assertIn("videoTutorials", body)
 
     @authenticate
     def test_authenticated_logged_initial_data(self):
@@ -20,3 +24,7 @@ class TestInitialDataApi(APITestCase):
 
         body = json.loads(response.content.decode())
         self.assertIn("loggedUser", body)
+        self.assertIn("sectors", body)
+        self.assertIn("partnerTypes", body)
+        self.assertIn("communityEvents", body)
+        self.assertIn("videoTutorials", body)

--- a/api/tests/test_initial_data.py
+++ b/api/tests/test_initial_data.py
@@ -1,0 +1,22 @@
+import json
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from .utils import authenticate
+
+
+class TestInitialDataApi(APITestCase):
+    def test_unauthenticated_initial_data(self):
+        response = self.client.get(reverse("initial_data"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        body = json.loads(response.content.decode())
+        self.assertIn("loggedUser", body)
+
+    @authenticate
+    def test_authenticated_logged_initial_data(self):
+        response = self.client.get(reverse("initial_data"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        body = json.loads(response.content.decode())
+        self.assertIn("loggedUser", body)

--- a/api/tests/test_initial_data.py
+++ b/api/tests/test_initial_data.py
@@ -2,28 +2,47 @@ import json
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from rest_framework import status
+from data.factories import SectorFactory
 from .utils import authenticate
 
 
 class TestInitialDataApi(APITestCase):
     def test_unauthenticated_initial_data(self):
+        """
+        The initial data request must contain data that is individually managed
+        by other views. If the call isn't authenticated, "loggedUser" should be None
+        """
+        sector = SectorFactory.create()
+
         response = self.client.get(reverse("initial_data"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         body = json.loads(response.content.decode())
         self.assertIn("loggedUser", body)
+        self.assertIsNone(body["loggedUser"])
+
         self.assertIn("sectors", body)
+        self.assertEqual(len(body["sectors"]), 1)
+        self.assertEqual(body["sectors"][0]["name"], sector.name)
+
         self.assertIn("partnerTypes", body)
         self.assertIn("communityEvents", body)
         self.assertIn("videoTutorials", body)
 
     @authenticate
     def test_authenticated_logged_initial_data(self):
+        """
+        Same endpoint, this time with data in the "loggedUser" property. Not needed
+        to thoroughly test the other keys, just making sure they are present.
+        """
         response = self.client.get(reverse("initial_data"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         body = json.loads(response.content.decode())
         self.assertIn("loggedUser", body)
+        self.assertEqual(body["loggedUser"]["id"], authenticate.user.id)
+        self.assertEqual(body["loggedUser"]["email"], authenticate.user.email)
+        self.assertEqual(body["loggedUser"]["username"], authenticate.user.username)
         self.assertIn("sectors", body)
         self.assertIn("partnerTypes", body)
         self.assertIn("communityEvents", body)

--- a/api/urls.py
+++ b/api/urls.py
@@ -31,6 +31,7 @@ from api.views import MessageCreateView, VegetarianExpeView, TeamJoinRequestView
 from api.views import ReviewView, CommunityEventsView, ClaimCanteenView, UndoClaimCanteenView, SatelliteListCreateView
 from api.views import ActionableCanteensListView, ActionableCanteenRetrieveView
 from api.views import CanteenStatusView, VideoTutorialListView, DiagnosticsToTeledeclareListView
+from api.views import InitialDataView
 
 
 urlpatterns = {
@@ -185,6 +186,7 @@ urlpatterns = {
     ),
     path("canteenStatus/siret/<str:siret>", CanteenStatusView.as_view(), name="canteen_status"),
     path("videoTutorials/", VideoTutorialListView.as_view(), name="video_tutorials"),
+    path("initialData/", InitialDataView.as_view(), name="initial_data"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -67,3 +67,4 @@ from .review import ReviewView  # noqa: F401
 from .communityevent import CommunityEventsView  # noqa: F401
 from .partner import PartnersView, PartnerView  # noqa: F401
 from .videotutorial import VideoTutorialListView  # noqa: F401
+from .initial import InitialDataView  # noqa: F401

--- a/api/views/initial.py
+++ b/api/views/initial.py
@@ -1,0 +1,10 @@
+from api.views import LoggedUserView
+from rest_framework.views import APIView
+from django.http import JsonResponse
+from rest_framework import status
+
+
+class InitialDataView(APIView):
+    def get(self, request, *args, **kwargs):
+        json_content = {"loggedUser": LoggedUserView.as_view()(request._request).data}
+        return JsonResponse(json_content, status=status.HTTP_200_OK)

--- a/api/views/initial.py
+++ b/api/views/initial.py
@@ -1,4 +1,4 @@
-from api.views import LoggedUserView
+from api.views import LoggedUserView, SectorListView, PartnerTypeListView, CommunityEventsView, VideoTutorialListView
 from rest_framework.views import APIView
 from django.http import JsonResponse
 from rest_framework import status
@@ -6,5 +6,11 @@ from rest_framework import status
 
 class InitialDataView(APIView):
     def get(self, request, *args, **kwargs):
-        json_content = {"loggedUser": LoggedUserView.as_view()(request._request).data}
+        json_content = {
+            "loggedUser": LoggedUserView.as_view()(request._request).data,
+            "sectors": SectorListView.as_view()(request._request).data,
+            "partnerTypes": PartnerTypeListView.as_view()(request._request).data,
+            "communityEvents": CommunityEventsView.as_view()(request._request).data,
+            "videoTutorials": VideoTutorialListView.as_view()(request._request).data,
+        }
         return JsonResponse(json_content, status=status.HTTP_200_OK)

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -231,13 +231,24 @@ export default new Vuex.Store({
     },
 
     fetchInitialData(context) {
-      return Promise.all([
-        context.dispatch("fetchLoggedUser"),
-        context.dispatch("fetchSectors"),
-        context.dispatch("fetchPartnerTypes"),
-        context.dispatch("fetchUpcomingCommunityEvents"),
-        context.dispatch("fetchVideoTutorials"),
-      ])
+      context.commit("SET_USER_LOADING_STATUS", Constants.LoadingStatus.LOADING)
+      context.commit("SET_CANTEENS_LOADING_STATUS", Constants.LoadingStatus.LOADING)
+      context.commit("SET_COMMUNITY_EVENTS_LOADING_STATUS", Constants.LoadingStatus.LOADING)
+      context.commit("SET_VIDEO_TUTORIALS_LOADING_STATUS", Constants.LoadingStatus.LOADING)
+      return fetch("/api/v1/initialData/")
+        .then(verifyResponse)
+        .then((response) => {
+          context.commit("SET_LOGGED_USER", response.loggedUser)
+          context.commit("SET_SECTORS", response.sectors)
+          context.commit("SET_PARTNER_TYPES", response.partnerTypes)
+          context.commit("SET_UPCOMING_COMMUNITY_EVENTS", response.communityEvents)
+          context.commit("SET_VIDEO_TUTORIALS", response.videoTutorials)
+
+          context.commit("SET_USER_LOADING_STATUS", Constants.LoadingStatus.SUCCESS)
+          context.commit("SET_CANTEENS_LOADING_STATUS", Constants.LoadingStatus.SUCCESS)
+          context.commit("SET_COMMUNITY_EVENTS_LOADING_STATUS", Constants.LoadingStatus.SUCCESS)
+          context.commit("SET_VIDEO_TUTORIALS_LOADING_STATUS", Constants.LoadingStatus.SUCCESS)
+        })
         .then(() => {
           if (context.state.loggedUser) return context.dispatch("fetchUserCanteenPreviews")
         })


### PR DESCRIPTION
Cette PR vise à améliorer la performance de démarrage de l'application en créant un seul endpoint avec les données nécessaires au début de l'application, notamment afin d'éviter ces appels :
```javascript
context.dispatch("fetchLoggedUser"),
context.dispatch("fetchSectors"),
context.dispatch("fetchPartnerTypes"),
context.dispatch("fetchUpcomingCommunityEvents"),
context.dispatch("fetchVideoTutorials"),
```
En test en local, le temps de chargement des données initiales est seulement 4% de celui lors qu'on fait les calls séparément (de 691ms à 27ms). Cette différence sera encore plus important pour les connexions plus lentes.

Après l'appel unique pour les données initiales :
![image](https://github.com/betagouv/ma-cantine/assets/1225929/460a55a3-59fc-4f01-8c5d-b1d92431d4bf)

Avant :
![image](https://github.com/betagouv/ma-cantine/assets/1225929/d50c0789-b9e3-4890-b54b-7e24a19ec0e7)

