### PR TITLE
Enlève le nom des routes parentes

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -175,7 +175,6 @@ const routes = [
   },
   {
     path: "/nos-cantines",
-    name: "CanteensPage",
     component: CanteensPage,
     children: [
       {
@@ -212,7 +211,6 @@ const routes = [
   },
   {
     path: "/blog",
-    name: "BlogsPage",
     component: BlogsPage,
     children: [
       {
@@ -238,7 +236,6 @@ const routes = [
   },
   {
     path: "/acteurs-de-l-eco-systeme",
-    name: "PartnersPage",
     component: PartnersPage,
     children: [
       {


### PR DESCRIPTION
Lors qu'on donne un nom à un route parente sur vue-router, on a ces warnings dans le navigateur :

```
[vue-router] Named Route 'CanteensPage' has a default child route. When navigating to this named route (:to="{name: 'CanteensPage'}"), the default child route will not be rendered. Remove the name from this route and use the name of the default child route for named links instead.

[vue-router] Named Route 'BlogsPage' has a default child route. When navigating to this named route (:to="{name: 'BlogsPage'}"), the default child route will not be rendered. Remove the name from this route and use the name of the default child route for named links instead.

[vue-router] Named Route 'PartnersPage' has a default child route. When navigating to this named route (:to="{name: 'PartnersPage'}"), the default child route will not be rendered. Remove the name from this route and use the name of the default child route for named links instead.
```

Cette PR enlève ces noms du index 