### PR TITLE
Avoids mixing appro values from satellite and central cuisines

### DIFF
--- a/frontend/src/components/CanteenPublication.vue
+++ b/frontend/src/components/CanteenPublication.vue
@@ -245,6 +245,7 @@ import {
 import MultiYearSummaryStatistics from "@/components/MultiYearSummaryStatistics"
 import FamiliesGraph from "@/components/FamiliesGraph"
 import ImageGallery from "@/components/ImageGallery"
+import Constants from "@/constants"
 
 export default {
   props: {
@@ -265,10 +266,29 @@ export default {
       // from the central and satellites when necessary to show the whole picture
       return this.canteen.centralKitchenDiagnostics.map((centralDiag) => {
         const satelliteMatchingDiag = this.canteen.diagnostics.find((x) => x.year === centralDiag.year)
-        if (centralDiag.centralKitchenDiagnosticMode === "APPRO" && satelliteMatchingDiag)
-          return Object.assign(satelliteMatchingDiag, centralDiag)
+        if (centralDiag.centralKitchenDiagnosticMode === "APPRO" && satelliteMatchingDiag) {
+          const nonApproSatelliteFields = Object.assign({}, satelliteMatchingDiag)
+          this.approFields.forEach((x) => delete nonApproSatelliteFields[x])
+          return Object.assign(nonApproSatelliteFields, centralDiag)
+        }
         return centralDiag
       })
+    },
+    approFields() {
+      const approSimplifiedFields = [
+        "valueTotalHt",
+        "valueBioHt",
+        "valueSustainableHt",
+        "valueExternalityPerformanceHt",
+        "valueEgalimOthersHt",
+      ]
+      const characteristicGroups = Constants.TeledeclarationCharacteristicGroups
+      const approFields = characteristicGroups.egalim.fields
+        .concat(characteristicGroups.outsideLaw.fields)
+        .concat(characteristicGroups.nonEgalim.fields)
+        .concat(approSimplifiedFields)
+      const percentageApproFields = approFields.map((x) => `percentage${x.charAt(0).toUpperCase() + x.slice(1)}`)
+      return approFields.concat(percentageApproFields)
     },
     diagnostic() {
       if (!this.diagnosticSet) return


### PR DESCRIPTION
Closes #2940
Linked to #2909

Dans la page publication on ne doit pas mélanger les valeurs appro d'une cantine satellite et sa cuisine centrale. 

Dans l'exemple donné en #2940 (Cuisine satellite publiée ayant un diagnostic avec 10% bio, 10% de qualité et durables
Cuisine centrale ayant 100% bio, 0% de qualité et durables), avec le bug on affichait 
![image](https://github.com/betagouv/ma-cantine/assets/1225929/8adf0666-03f5-4990-b49a-1bcc6e6636e7)

Après le fix : 
![image](https://github.com/betagouv/ma-cantine/assets/1225929/9de275f1-ffe8-48cc-bd2c-48c27bc24175)
