### PR TITLE
Refactor de la function pour les department items

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,5 +1,6 @@
 import Constants from "@/constants"
 import jsonBadges from "@/badges"
+import jsonDepartments from "@/departments.json"
 
 export const timeAgo = (date, displayPrefix = false) => {
   if (typeof date === "string") {
@@ -517,6 +518,11 @@ export const approSummary = (diagnostic) => {
   }
   return "Incomplet"
 }
+
+export const departmentItems = jsonDepartments.map((x) => ({
+  text: `${x.departmentCode} - ${x.departmentName}`,
+  value: x.departmentCode,
+}))
 
 function hasValue(val) {
   if (typeof val === "string") {

--- a/frontend/src/views/NewPartner.vue
+++ b/frontend/src/views/NewPartner.vue
@@ -170,8 +170,7 @@ import DsfrTextField from "@/components/DsfrTextField"
 import DsfrTextarea from "@/components/DsfrTextarea"
 import DsfrSelect from "@/components/DsfrSelect"
 import DsfrRadio from "@/components/DsfrRadio"
-import jsonDepartments from "@/departments.json"
-import { sectorsSelectList, toBase64 } from "@/utils"
+import { sectorsSelectList, toBase64, departmentItems } from "@/utils"
 
 export default {
   name: "NewPartner",
@@ -244,10 +243,7 @@ export default {
           text: "Diversifier mes sources de protéines",
         },
       ],
-      departmentItems: jsonDepartments.map((x) => ({
-        text: `${x.departmentCode} - ${x.departmentName}`,
-        value: x.departmentCode,
-      })),
+      departmentItems,
     }
   },
   computed: {

--- a/frontend/src/views/PartnersPage/PartnersHome.vue
+++ b/frontend/src/views/PartnersPage/PartnersHome.vue
@@ -229,7 +229,6 @@ import NewPartnerCard from "@/views/PartnersPage/NewPartnerCard"
 import GeneralContactForm from "@/components/GeneralContactForm"
 import ReferencingInfo from "./ReferencingInfo"
 import { getObjectDiff, sectorsSelectList, departmentItems } from "@/utils"
-import jsonDepartments from "@/departments.json"
 
 export default {
   name: "PartnersHome",
@@ -432,30 +431,19 @@ export default {
         this.filters[key].value = f.default
       })
     },
-    setLocations(enabledLocationIds, jsonLocations, locationKeyWord, locationsWord) {
-      const enabledLocations = jsonLocations
-        .filter((x) => enabledLocationIds.indexOf(x[`${locationKeyWord}Code`]) > -1)
-        .map((x) => ({
-          text: `${x[`${locationKeyWord}Code`]} - ${x[`${locationKeyWord}Name`]}`,
-          value: x[`${locationKeyWord}Code`],
-        }))
-      const headerText = `Nous n'avons pas encore d'établissements dans ces ${locationsWord} :`
-      const header = { header: headerText }
-
+    setLocations(enabledLocationIds) {
+      const enabledLocations = departmentItems.filter((x) => enabledLocationIds.indexOf(x.value) > -1)
+      const header = { header: `Nous n'avons pas encore d'établissements dans ces departements :` }
       const divider = { divider: true }
 
-      const disabledLocations = jsonLocations
-        .filter((x) => enabledLocationIds.indexOf(x[`${locationKeyWord}Code`]) === -1)
-        .map((x) => ({
-          text: `${x[`${locationKeyWord}Code`]} - ${x[`${locationKeyWord}Name`]}`,
-          value: x[`${locationKeyWord}Code`],
-          disabled: true,
-        }))
+      const disabledLocations = departmentItems
+        .filter((x) => enabledLocationIds.indexOf(x.value) === -1)
+        .map((x) => Object.assign(x, { disabled: true }))
 
       return [...enabledLocations, divider, header, ...disabledLocations]
     },
     setDepartments(enabledDepartmentIds) {
-      this.departmentItems = this.setLocations(enabledDepartmentIds, jsonDepartments, "department", "départements")
+      this.departmentItems = this.setLocations(enabledDepartmentIds)
     },
     setSectors(enabledSectorIds) {
       // so few partners and so many sectors that I decided to filter the sectors

--- a/frontend/src/views/PartnersPage/PartnersHome.vue
+++ b/frontend/src/views/PartnersPage/PartnersHome.vue
@@ -228,7 +228,7 @@ import PartnerCard from "@/views/PartnersPage/PartnerCard"
 import NewPartnerCard from "@/views/PartnersPage/NewPartnerCard"
 import GeneralContactForm from "@/components/GeneralContactForm"
 import ReferencingInfo from "./ReferencingInfo"
-import { getObjectDiff, sectorsSelectList } from "@/utils"
+import { getObjectDiff, sectorsSelectList, departmentItems } from "@/utils"
 import jsonDepartments from "@/departments.json"
 
 export default {
@@ -329,10 +329,7 @@ export default {
           icon: "$money-euro-box-fill",
         },
       ],
-      departmentItems: jsonDepartments.map((x) => ({
-        text: `${x.departmentCode} - ${x.departmentName}`,
-        value: x.departmentCode,
-      })),
+      departmentItems,
       sectors: [],
       typeItems: [],
       gratuityOptions: [


### PR DESCRIPTION
Extraction d'une fonction de mappage utilisée à plusieurs endroits de l'appli pour rendre une liste de departements compatible avec une liste déroulante.

J'ai décidé de laisser `CanteensHome` inchangé car la fonction a été généralisée pour traiter les régions (et potentiellement d'autres divisions territoriales).