### PR TITLE
Display aléatoire des partenaires

### DIFF
--- a/api/tests/test_partners.py
+++ b/api/tests/test_partners.py
@@ -193,13 +193,14 @@ class TestPartnersApi(APITestCase):
 
     def test_randomized_results(self):
         """
-        Results should be randomized yet consistent with the user
+        Results should be randomized yet consistent with the session
         """
         for i in range(50):
             PartnerFactory.create(published=True)
         user_1 = UserFactory.create()
         user_2 = UserFactory.create()
 
+        # Creates a session
         self.client.force_login(user=user_1)
 
         response = self.client.get(reverse("partners_list"))
@@ -212,6 +213,8 @@ class TestPartnersApi(APITestCase):
         body = response.json()
 
         user_1_results_2 = [x["id"] for x in body.get("results")]
+
+        # Creates a new different session
         self.client.force_login(user=user_2)
 
         response = self.client.get(reverse("partners_list"))

--- a/api/views/partner.py
+++ b/api/views/partner.py
@@ -86,9 +86,6 @@ class PartnersView(ListCreateAPIView):
         return queryset.order_by("?")
 
     def get_seed(self):
-        if self.request.user.is_authenticated:
-            random.seed(self.request.user.id)
-            return random.uniform(-1, 1)
         if not self.request.session.get("seed"):
             self.request.session["seed"] = random.uniform(-1, 1)
         return self.request.session.get("seed")

--- a/api/views/partner.py
+++ b/api/views/partner.py
@@ -85,13 +85,6 @@ class PartnersView(ListCreateAPIView):
         cursor.close()
         return queryset.order_by("?")
 
-    def get_randomized_queryset(self):
-        seed = self.get_seed()
-        cursor = connection.cursor()
-        cursor.execute("SELECT setseed(%s);" % (seed))
-        cursor.close()
-        return Partner.objects.filter(published=True).order_by("?")
-
     def get_seed(self):
         if self.request.user.is_authenticated:
             random.seed(self.request.user.id)


### PR DESCRIPTION
Afin de ne pas donner un avantage à un partenaire en particulier, on randomise les résultats. Pour être sur que la pagination et les filtres fonctionnent, pour une session, l'ordre sera toujours le même

Closes #2763