### PR TITLE
Correction du lien vers la charte

### DIFF
--- a/frontend/src/views/NewPartner.vue
+++ b/frontend/src/views/NewPartner.vue
@@ -139,7 +139,7 @@
         <template v-slot:label>
           <span class="body-2 grey--text text--darken-3">
             Je déclare avoir lu et et être en accord avec la
-            <a href="/static/documents/charte-referencement-1.pdf" target="_blank" @click.stop>
+            <a href="/static/documents/charte-referencement-acteurs-de-l-ecosysteme.pdf" target="_blank" @click.stop>
               charte de référencement
               <v-icon small color="primary">mdi-open-in-new</v-icon>
             </a>


### PR DESCRIPTION
Le lien vers la charte n'était pas correct dans le formulaire des partenaires