### PR TITLE
Montre le logo entier dans la carte pour le partenaire quand c'est spécifié

### DIFF
--- a/frontend/src/views/PartnersPage/PartnerCard.vue
+++ b/frontend/src/views/PartnersPage/PartnerCard.vue
@@ -8,7 +8,8 @@
     outlined
     :ripple="false"
   >
-    <v-img :src="partner.image || '/static/images/partner-default-image.jpg'" height="120" max-height="120"></v-img>
+    <v-img contain :src="partner.image" height="120" max-height="120" v-if="partner.image"></v-img>
+    <v-img src="/static/images/partner-default-image.jpg" height="120" max-height="120" v-else></v-img>
     <v-card-title class="font-weight-bold">{{ partner.name }}</v-card-title>
     <v-card-subtitle>
       <PartnerIndicators :partner="partner" />


### PR DESCRIPTION
Closes #2966 

![image](https://github.com/betagouv/ma-cantine/assets/1225929/4330d924-5898-4ce1-8568-f95da461bc41)
