### PR TITLE
Fix du crash de l'admin avec l'historique des achats

### DIFF
--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from django.utils import timezone
 from data.models import Canteen, Teledeclaration
 from .diagnostic import DiagnosticInline
-from .softdeletionadmin import SoftDeletionAdmin, SoftDeletionStatusFilter
+from .softdeletionadmin import SoftDeletionHistoryAdmin, SoftDeletionStatusFilter
 
 
 class CanteenForm(forms.ModelForm):
@@ -39,7 +39,7 @@ def unpublish(modeladmin, request, queryset):
 
 
 @admin.register(Canteen)
-class CanteenAdmin(SoftDeletionAdmin):
+class CanteenAdmin(SoftDeletionHistoryAdmin):
     form = CanteenForm
     inlines = (DiagnosticInline,)
     fields = (

--- a/data/admin/softdeletionadmin.py
+++ b/data/admin/softdeletionadmin.py
@@ -7,7 +7,7 @@ def restore_objects(modeladmin, request, queryset):
     queryset.update(deletion_date=None)
 
 
-class SoftDeletionAdmin(SimpleHistoryAdmin):
+class SoftDeletionAdmin(admin.ModelAdmin):
     actions = [restore_objects]
 
     def get_queryset(self, request):
@@ -22,6 +22,10 @@ class SoftDeletionAdmin(SimpleHistoryAdmin):
 
     def delete_queryset(self, request, queryset):
         return queryset.hard_delete()
+
+
+class SoftDeletionHistoryAdmin(SoftDeletionAdmin, SimpleHistoryAdmin):
+    pass
 
 
 class SoftDeletionStatusFilter(admin.SimpleListFilter):


### PR DESCRIPTION
Closes #2958

Dans l'admin, quand on cliquait sur l'historique d'un élément "achat" ça provoquait un crash.

La raison étant qu'on avait lié la base de l'admin pour des objets "soft delete" avec l'historique. Pourtant, pas tous les objets soft-delete ont l'historique activé.