### PR TITLE
Fix de la charte des achats

### DIFF
--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -328,7 +328,7 @@ def complete_diag_data(purchases, data):
             other_labels_characteristics.append(characteristic)
         # Non-EGAlim totals: contains no labels or only one or more of other_labels
         non_egalim_purchases = purchase_family.filter(
-            Q(characteristics__contained_by=other_labels_characteristics) | Q(characteristics__len=0)
+            Q(characteristics__contained_by=(other_labels_characteristics + [""])) | Q(characteristics__len=0)
         ).distinct()
         key = "value_" + family.lower() + "_non_egalim"
         data[key] = non_egalim_purchases.aggregate(total=Sum("price_ht"))["total"] or 0


### PR DESCRIPTION
Closes #2987 

Ceci es un quick fix à un bug remonté par un utilisateur : la charte montre trop de bio pour ses achats (voir issue lié à cette PR).

La raison étant que l'import des achats assigne un string vide dans le tableau des caractéristiques lors que le fichier n'en spécifie aucune pour une ligne. Ceci doit être aussi réparé dans une autre PR, potentiellement faisant un fix avec une migration.

Entre-temps, cette PR considère un string vide `""` un caractéristique non-EGAlim afin de fixer le problème rapidement.

Mes achats:
![image](https://github.com/betagouv/ma-cantine/assets/1225929/1df38352-e3b3-4dcf-af73-f1272cd28974)

Sans le fix (100% bio affiché par erreur):
![image](https://github.com/betagouv/ma-cantine/assets/1225929/ab26bcba-295d-4c2d-8a3c-7a32abeecf16)

Avec le fix:
![image](https://github.com/betagouv/ma-cantine/assets/1225929/86e4e6dc-28e5-4173-9508-f8e0c4b94e65)
