### PR TITLE
Updates CKeditor to support Pillow > 10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Deprecated==1.2.14
 dill==0.3.7
 Django==4.2.4
 django-anymail==10.1
-django-ckeditor==6.6.1
+django-ckeditor==6.7.0
 django-csp==3.7
 django-debug-toolbar==4.0.0
 django-filter==23.2


### PR DESCRIPTION
Closes #3002 

Mise à jour de CKEditor pour permettre l'utilisation de Pillow 10

https://django-ckeditor.readthedocs.io/en/latest/#section-1
