### PR TITLE
Améliorer les CTA overlays du EGAlim progression

### DIFF
--- a/frontend/src/scss/dsfr.scss
+++ b/frontend/src/scss/dsfr.scss
@@ -57,6 +57,14 @@
 }
 
 // NB: not all typographies added yet, if the one you need isn't here add it
+.fr-text-lg {
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1.75rem;
+  letter-spacing: normal;
+  text-transform: false;
+}
+
 .fr-text {
   font-size: 1rem;
   font-weight: 400;

--- a/frontend/src/views/DashboardManager/ApproSegment.vue
+++ b/frontend/src/views/DashboardManager/ApproSegment.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="fill-height">
-    <v-card v-if="isCentralDiagnostic" outlined class="fill-height d-flex flex-column">
-      <v-card-title class="font-weight-bold body-1">
-        <v-icon :color="keyMeasure.mdiIconColor" class="mr-2">
+    <v-card v-if="isCentralDiagnostic" outlined class="fill-height d-flex flex-column dsfr pa-6">
+      <v-card-title>
+        <v-icon small :color="keyMeasure.mdiIconColor" class="mx-2">
           {{ keyMeasure.mdiIcon }}
         </v-icon>
-        <h3>{{ keyMeasure.shortTitle }}</h3>
+        <h3 class="font-weight-bold fr-text">{{ keyMeasure.shortTitle }}</h3>
       </v-card-title>
       <v-card-text class="fill-height d-flex flex-column" style="position: relative;">
         <v-spacer />
@@ -43,31 +43,33 @@
         votre outil de gestion habituel si cela est possible pour transférer les données.
       </p>
     </div>
-    <v-card outlined class="fill-height d-flex flex-column" v-else-if="!hasApproData">
-      <v-card-title class="font-weight-bold fr-text">
-        <v-icon small :color="keyMeasure.mdiIconColor" class="mr-2">
+    <v-card outlined class="fill-height d-flex flex-column dsfr pa-6" v-else-if="!hasApproData">
+      <v-card-title>
+        <v-icon small :color="keyMeasure.mdiIconColor" class="mx-2">
           {{ keyMeasure.mdiIcon }}
         </v-icon>
-        <h3>{{ keyMeasure.shortTitle }}</h3>
+        <h3 class="font-weight-bold fr-text">{{ keyMeasure.shortTitle }}</h3>
       </v-card-title>
-      <v-card-text class="fill-height" style="position: relative;">
-        <div class="overlay d-flex flex-column align-center justify-center">
-          <p class="body-2 pa-4 text-center">
+      <v-card-text class="fill-height mt-2">
+        <div class="overlay d-flex flex-column align-center justify-center fill-height pa-6">
+          <p class="fr-text text-center my-10">
             Avec l’outil de suivi d’achats, pilotez en temps réel votre progression EGAlim sur l’année en cours, et
             simplifiez votre prochaine télédéclaration.
           </p>
           <v-btn
+            large
+            class="mb-10"
             color="primary"
             :to="{ name: 'DiagnosticModification', params: { canteenUrlComponent, year: diagnostic.year } }"
           >
-            Commencer
+            <span class="fr-text-lg">Commencer</span>
           </v-btn>
         </div>
       </v-card-text>
     </v-card>
     <v-card :to="link" outlined class="fill-height d-flex flex-column dsfr pa-6" v-else-if="diagnostic">
-      <v-card-title class="mx-1">
-        <v-icon small :color="keyMeasure.mdiIconColor" class="mr-2">
+      <v-card-title>
+        <v-icon small :color="keyMeasure.mdiIconColor" class="mx-2">
           {{ keyMeasure.mdiIcon }}
         </v-icon>
         <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
@@ -172,15 +174,11 @@ export default {
 
 <style scoped>
 .overlay {
-  position: absolute;
-  top: 4%;
-  left: 3%;
-  z-index: 1;
-  background: #bbbbbb50;
-  width: 94%;
-  height: 92%;
+  background: #f5f5fe;
   backdrop-filter: blur(7px);
-  border: dashed #bbb;
+  border: 1.5px dashed #000091;
+  border-radius: 5px;
+  color: #3a3a3a;
 }
 .v-card.dsfr {
   border: solid 1.5px #dddddd;

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -27,6 +27,7 @@
           v-if="!hasPurchases && !otherMeasuresDiagnostic && !hasLastYearDiagnostic"
         >
           <v-btn
+            large
             color="primary"
             :to="{
               name: !otherMeasuresDiagnostic ? 'NewDiagnosticForCanteen' : 'DiagnosticModification',
@@ -34,7 +35,7 @@
               query: { année: year },
             }"
           >
-            Commencer
+            <span class="fr-text-lg">Commencer</span>
           </v-btn>
         </div>
         <v-col cols="12" md="6" class="pt-md-0">
@@ -124,13 +125,15 @@ export default {
 .overlay {
   position: absolute;
   top: 4%;
-  left: 3%;
+  left: 5%;
   z-index: 1;
-  background: #bbbbbb50;
-  width: 94%;
+  background: rgba(245, 245, 254, 0.2);
+  width: 90%;
   height: 92%;
   backdrop-filter: blur(7px);
-  border: dashed #bbb;
+  border: 1.5px dashed #000091;
+  border-radius: 5px;
+  color: #3a3a3a;
 }
 .v-card.dsfr {
   border: solid 1.5px #dddddd;

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -16,7 +16,7 @@
           v-if="!hasPurchases && (!approDiagnostic || !otherMeasuresDiagnostic) && !hasLastYearDiagnostic"
           class="mt-4"
         />
-        <v-divider class="my-6"></v-divider>
+        <hr aria-hidden="true" role="presentation" class="my-6" />
       </div>
       <ApproSegment :purchases="null" :diagnostic="approDiagnostic" :lastYearDiagnostic="null" :canteen="canteen" />
     </v-col>


### PR DESCRIPTION
Re l'utilisation du `hr` et non pas `v-divider` : https://github.com/betagouv/ma-cantine/issues/2820

![Screenshot 2023-10-16 at 18-26-49 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/1f813104-107b-4543-aa16-5ac054eb0ca5)
![Screenshot 2023-10-16 at 18-20-47 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/5114c2e8-72ce-499f-abd1-583836c43375)
