### PR TITLE
Ajout du waste-summary pour la page « ma progression »

### DIFF
--- a/frontend/src/views/MyProgress/ProgressTab.vue
+++ b/frontend/src/views/MyProgress/ProgressTab.vue
@@ -71,6 +71,7 @@
         </v-row>
         <component
           :is="`${keyMeasure.baseComponent}Summary`"
+          :canteen="canteen"
           :diagnostic="diagnostic"
           :centralDiagnostic="centralDiagnostic"
         />

--- a/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
@@ -28,6 +28,10 @@
           </li>
         </ul>
       </li>
+      <li v-else>
+        <v-icon color="primary" class="mr-2">$close-line</v-icon>
+        Je n’ai pas encore mis en place des actions concrètes contre le gaspillage
+      </li>
 
       <li v-if="displayDiagnostic.hasWasteMeasures">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>

--- a/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
@@ -63,10 +63,7 @@ import wasteActions from "@/data/waste-actions.json"
 export default {
   name: "WasteMeasureSummary",
   props: {
-    diagnostic: {
-      type: Object,
-      required: true,
-    },
+    diagnostic: {},
     centralDiagnostic: {},
     canteen: {
       type: Object,

--- a/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fr-text">
-    <ul>
+    <ul role="list">
       <li v-if="displayDiagnostic.hasWasteDiagnostic">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>
@@ -31,7 +31,7 @@
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>
           J’ai mis en place les actions suivantes :
-          <ul class="mt-2">
+          <ul role="list" class="mt-2">
             <li class="fr-text-xs mb-1" v-for="(action, index) in appliedWasteActions" :key="`${action}-${index}`">
               {{ action }}
             </li>
@@ -49,7 +49,7 @@
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>
           J’ai réalisé des mesures de mon gaspillage alimentaire :
-          <ul class="mt-2">
+          <ul role="list" class="mt-2">
             <li class="fr-text-xs mb-1" v-for="measure in wasteMeasures" :key="measure.label">
               {{ measure.label }} :
               <span class="font-weight-bold">{{ measure.value }}</span>
@@ -69,7 +69,7 @@
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>
           Je propose une ou des conventions de dons à des associations habilitées d’aide alimentaire
-          <ul class="mt-2">
+          <ul role="list" class="mt-2">
             <li class="fr-text-xs mb-1" v-for="measure in donationMeasures" :key="measure.label">
               {{ measure.label }} :
               <span class="font-weight-bold">{{ measure.value }}</span>

--- a/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
@@ -3,59 +3,79 @@
     <ul>
       <li v-if="displayDiagnostic.hasWasteDiagnostic">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
-        J’ai réalisé un diagnostic sur les causes probables de gaspillage alimentaire
+        <div>
+          J’ai réalisé un diagnostic sur les causes probables de gaspillage alimentaire
+        </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
-        Je n’ai pas encore réalisé un diagnostic sur les causes probables de gaspillage alimentaire
+        <div>
+          Je n’ai pas encore réalisé un diagnostic sur les causes probables de gaspillage alimentaire
+        </div>
       </li>
 
       <li v-if="displayDiagnostic.hasWastePlan">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
-        J’ai mis en place un plan d’action adapté au diagnostic réalisé
+        <div>
+          J’ai mis en place un plan d’action adapté au diagnostic réalisé
+        </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
-        Je n’ai pas encore mis en place un plan d’action adapté au diagnostic réalisé
+        <div>
+          Je n’ai pas encore mis en place un plan d’action adapté au diagnostic réalisé
+        </div>
       </li>
 
       <li v-if="appliedWasteActions">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
-        J’ai mis en place les actions suivantes :
-        <ul class="mt-2">
-          <li class="fr-text-xs ml-9 mb-1" v-for="(action, index) in appliedWasteActions" :key="`${action}-${index}`">
-            {{ action }}
-          </li>
-        </ul>
+        <div>
+          J’ai mis en place les actions suivantes :
+          <ul class="mt-2">
+            <li class="fr-text-xs mb-1" v-for="(action, index) in appliedWasteActions" :key="`${action}-${index}`">
+              {{ action }}
+            </li>
+          </ul>
+        </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
-        Je n’ai pas encore mis en place des actions concrètes contre le gaspillage
+        <div>
+          Je n’ai pas encore mis en place des actions concrètes contre le gaspillage
+        </div>
       </li>
 
       <li v-if="displayDiagnostic.hasWasteMeasures">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
-        J’ai réalisé des mesures de mon gaspillage alimentaire :
-        <ul class="mt-2">
-          <li class="fr-text-xs ml-9 mb-1" v-for="measure in wasteMeasures" :key="measure.label">
-            {{ measure.label }} :
-            <span class="font-weight-bold">{{ measure.value }}</span>
-          </li>
-        </ul>
+        <div>
+          J’ai réalisé des mesures de mon gaspillage alimentaire :
+          <ul class="mt-2">
+            <li class="fr-text-xs mb-1" v-for="measure in wasteMeasures" :key="measure.label">
+              {{ measure.label }} :
+              <span class="font-weight-bold">{{ measure.value }}</span>
+            </li>
+          </ul>
+        </div>
       </li>
 
       <li v-else>
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
-        Je n’ai pas encore réalisé des mesures de mon gaspillage alimentaire
+        <div>
+          Je n’ai pas encore réalisé des mesures de mon gaspillage alimentaire
+        </div>
       </li>
 
       <li v-if="canteen.reservationExpeParticipant">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
-        Je suis volontaire pour l’expérimentation autour de la réservation de repas
+        <div>
+          Je suis volontaire pour l’expérimentation autour de la réservation de repas
+        </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
-        Je ne suis pas volontaire pour l’expérimentation autour de la réservation de repas
+        <div>
+          Je ne suis pas volontaire pour l’expérimentation autour de la réservation de repas
+        </div>
       </li>
     </ul>
   </div>
@@ -108,5 +128,9 @@ ul {
 }
 li {
   margin-bottom: 14px;
+  display: flex;
+}
+li .v-icon {
+  align-items: baseline;
 }
 </style>

--- a/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
@@ -65,6 +65,26 @@
         </div>
       </li>
 
+      <li v-if="displayDonationAgreementSegment && displayDiagnostic.hasDonationAgreement">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        <div>
+          Je propose une ou des conventions de dons à des associations habilitées d’aide alimentaire
+          <ul class="mt-2">
+            <li class="fr-text-xs mb-1" v-for="measure in donationMeasures" :key="measure.label">
+              {{ measure.label }} :
+              <span class="font-weight-bold">{{ measure.value }}</span>
+            </li>
+          </ul>
+        </div>
+      </li>
+
+      <li v-else-if="displayDonationAgreementSegment">
+        <v-icon color="primary" class="mr-2">$close-line</v-icon>
+        <div>
+          Je ne propose pas de convention de dons à des associations habilitées d’aide alimentaire
+        </div>
+      </li>
+
       <li v-if="canteen.reservationExpeParticipant">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>
@@ -83,6 +103,7 @@
 
 <script>
 import wasteActions from "@/data/waste-actions.json"
+import { applicableDiagnosticRules } from "@/utils"
 
 export default {
   name: "WasteMeasureSummary",
@@ -116,6 +137,17 @@ export default {
     },
     displayDiagnostic() {
       return this.usesCentralDiagnostic ? this.centralDiagnostic : this.diagnostic
+    },
+    displayDonationAgreementSegment() {
+      return applicableDiagnosticRules(this.canteen).hasDonationAgreement
+    },
+    donationMeasures() {
+      const d = this.displayDiagnostic
+      return [
+        { label: "Fréquence de dons", value: d.donationFrequency ? `${d.donationFrequency} dons/an` : "—" },
+        { label: "Quantité des denrées données", value: d.donationQuantity ? `${d.donationQuantity} kg/an` : "—" },
+        { label: "Type de denrées données", value: d.donationFoodType ? `${d.donationFoodType}` : "—" },
+      ]
     },
   },
 }

--- a/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
@@ -6,7 +6,7 @@
         J’ai réalisé un diagnostic sur les causes probables de gaspillage alimentaire
       </li>
       <li v-else>
-        <v-icon color="grey darken-1" class="mr-2">$information-line</v-icon>
+        <v-icon color="primary" class="mr-2">$close-line</v-icon>
         Je n’ai pas encore réalisé un diagnostic sur les causes probables de gaspillage alimentaire
       </li>
 
@@ -15,7 +15,7 @@
         J’ai mis en place un plan d’action adapté au diagnostic réalisé
       </li>
       <li v-else>
-        <v-icon color="grey darken-1" class="mr-2">$information-line</v-icon>
+        <v-icon color="primary" class="mr-2">$close-line</v-icon>
         Je n’ai pas encore mis en place un plan d’action adapté au diagnostic réalisé
       </li>
 
@@ -41,7 +41,7 @@
       </li>
 
       <li v-else>
-        <v-icon color="grey darken-1" class="mr-2">$information-line</v-icon>
+        <v-icon color="primary" class="mr-2">$close-line</v-icon>
         Je n’ai pas encore réalisé des mesures de mon gaspillage alimentaire
       </li>
 
@@ -50,7 +50,7 @@
         Je suis volontaire pour l’expérimentation autour de la réservation de repas
       </li>
       <li v-else>
-        <v-icon color="grey darken-1" class="mr-2">$information-line</v-icon>
+        <v-icon color="primary" class="mr-2">$close-line</v-icon>
         Je ne suis pas volontaire pour l’expérimentation autour de la réservation de repas
       </li>
     </ul>

--- a/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
@@ -52,7 +52,7 @@
           <ul role="list" class="mt-2">
             <li class="fr-text-xs mb-1" v-for="measure in wasteMeasures" :key="measure.label">
               {{ measure.label }} :
-              <span class="font-weight-bold">{{ measure.value }}</span>
+              <span class="font-weight-bold ml-1">{{ measure.value }}</span>
             </li>
           </ul>
         </div>
@@ -72,7 +72,7 @@
           <ul role="list" class="mt-2">
             <li class="fr-text-xs mb-1" v-for="measure in donationMeasures" :key="measure.label">
               {{ measure.label }} :
-              <span class="font-weight-bold">{{ measure.value }}</span>
+              <span class="font-weight-bold ml-1">{{ measure.value }}</span>
             </li>
           </ul>
         </div>

--- a/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fr-text">
     <ul>
-      <li v-if="diagnostic.hasWasteDiagnostic">
+      <li v-if="displayDiagnostic.hasWasteDiagnostic">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         J’ai réalisé un diagnostic sur les causes probables de gaspillage alimentaire
       </li>
@@ -10,7 +10,7 @@
         Je n’ai pas encore réalisé un diagnostic sur les causes probables de gaspillage alimentaire
       </li>
 
-      <li v-if="diagnostic.hasWastePlan">
+      <li v-if="displayDiagnostic.hasWastePlan">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         J’ai mis en place un plan d’action adapté au diagnostic réalisé
       </li>
@@ -29,7 +29,7 @@
         </ul>
       </li>
 
-      <li v-if="diagnostic.hasWasteMeasures">
+      <li v-if="displayDiagnostic.hasWasteMeasures">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         J’ai réalisé des mesures de mon gaspillage alimentaire :
         <ul class="mt-2">
@@ -67,6 +67,7 @@ export default {
       type: Object,
       required: true,
     },
+    centralDiagnostic: {},
     canteen: {
       type: Object,
       required: true,
@@ -74,20 +75,26 @@ export default {
   },
   computed: {
     appliedWasteActions() {
-      if (!this.diagnostic.wasteActions?.length) return null
+      if (!this.displayDiagnostic.wasteActions?.length) return null
       return [
-        ...this.diagnostic.wasteActions.map((x) => wasteActions[x]),
-        ...[this.diagnostic.otherWasteAction],
+        ...this.displayDiagnostic.wasteActions.map((x) => wasteActions[x]),
+        ...[this.displayDiagnostic.otherWasteAction],
       ].filter((x) => !!x)
     },
     wasteMeasures() {
-      const diag = this.diagnostic
+      const diag = this.displayDiagnostic
       return [
         { label: "Reste de pain", value: diag.breadLeftovers ? `${diag.breadLeftovers} kg/an` : "—" },
         { label: "Reste plateau", value: diag.servedLeftovers ? `${diag.servedLeftovers} kg/an` : "—" },
         { label: "Reste en production", value: diag.unservedLeftovers ? `${diag.unservedLeftovers} kg/an` : "—" },
         { label: "Reste de composantes", value: diag.sideLeftovers ? `${diag.sideLeftovers} kg/an` : "—" },
       ]
+    },
+    usesCentralDiagnostic() {
+      return this.centralDiagnostic?.centralKitchenDiagnosticMode === "ALL"
+    },
+    displayDiagnostic() {
+      return this.usesCentralDiagnostic ? this.centralDiagnostic : this.diagnostic
     },
   },
 }

--- a/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
@@ -6,7 +6,7 @@
         J’ai réalisé un diagnostic sur les causes probables de gaspillage alimentaire
       </li>
       <li v-else>
-        <v-icon color="primary" class="mr-2">$information-line</v-icon>
+        <v-icon color="grey darken-1" class="mr-2">$information-line</v-icon>
         Je n’ai pas encore réalisé un diagnostic sur les causes probables de gaspillage alimentaire
       </li>
 
@@ -15,7 +15,7 @@
         J’ai mis en place un plan d’action adapté au diagnostic réalisé
       </li>
       <li v-else>
-        <v-icon color="primary" class="mr-2">$information-line</v-icon>
+        <v-icon color="grey darken-1" class="mr-2">$information-line</v-icon>
         Je n’ai pas encore mis en place un plan d’action adapté au diagnostic réalisé
       </li>
 
@@ -41,7 +41,7 @@
       </li>
 
       <li v-else>
-        <v-icon color="grey darken--3" class="mr-2">$information-line</v-icon>
+        <v-icon color="grey darken-1" class="mr-2">$information-line</v-icon>
         Je n’ai pas encore réalisé des mesures de mon gaspillage alimentaire
       </li>
 
@@ -50,7 +50,7 @@
         Je suis volontaire pour l’expérimentation autour de la réservation de repas
       </li>
       <li v-else>
-        <v-icon color="grey darken--3" class="mr-2">$information-line</v-icon>
+        <v-icon color="grey darken-1" class="mr-2">$information-line</v-icon>
         Je ne suis pas volontaire pour l’expérimentation autour de la réservation de repas
       </li>
     </ul>

--- a/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/WasteMeasureSummary.vue
@@ -1,11 +1,104 @@
 <template>
   <div class="fr-text">
-    Waste summary
+    <ul>
+      <li v-if="diagnostic.hasWasteDiagnostic">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        J’ai réalisé un diagnostic sur les causes probables de gaspillage alimentaire
+      </li>
+      <li v-else>
+        <v-icon color="primary" class="mr-2">$information-line</v-icon>
+        Je n’ai pas encore réalisé un diagnostic sur les causes probables de gaspillage alimentaire
+      </li>
+
+      <li v-if="diagnostic.hasWastePlan">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        J’ai mis en place un plan d’action adapté au diagnostic réalisé
+      </li>
+      <li v-else>
+        <v-icon color="primary" class="mr-2">$information-line</v-icon>
+        Je n’ai pas encore mis en place un plan d’action adapté au diagnostic réalisé
+      </li>
+
+      <li v-if="appliedWasteActions">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        J’ai mis en place les actions suivantes :
+        <ul class="mt-2">
+          <li class="fr-text-xs ml-9 mb-1" v-for="(action, index) in appliedWasteActions" :key="`${action}-${index}`">
+            {{ action }}
+          </li>
+        </ul>
+      </li>
+
+      <li v-if="diagnostic.hasWasteMeasures">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        J’ai réalisé des mesures de mon gaspillage alimentaire :
+        <ul class="mt-2">
+          <li class="fr-text-xs ml-9 mb-1" v-for="measure in wasteMeasures" :key="measure.label">
+            {{ measure.label }} :
+            <span class="font-weight-bold">{{ measure.value }}</span>
+          </li>
+        </ul>
+      </li>
+
+      <li v-else>
+        <v-icon color="grey darken--3" class="mr-2">$information-line</v-icon>
+        Je n’ai pas encore réalisé des mesures de mon gaspillage alimentaire
+      </li>
+
+      <li v-if="canteen.reservationExpeParticipant">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        Je suis volontaire pour l’expérimentation autour de la réservation de repas
+      </li>
+      <li v-else>
+        <v-icon color="grey darken--3" class="mr-2">$information-line</v-icon>
+        Je ne suis pas volontaire pour l’expérimentation autour de la réservation de repas
+      </li>
+    </ul>
   </div>
 </template>
 
 <script>
+import wasteActions from "@/data/waste-actions.json"
+
 export default {
   name: "WasteMeasureSummary",
+  props: {
+    diagnostic: {
+      type: Object,
+      required: true,
+    },
+    canteen: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    appliedWasteActions() {
+      if (!this.diagnostic.wasteActions?.length) return null
+      return [
+        ...this.diagnostic.wasteActions.map((x) => wasteActions[x]),
+        ...[this.diagnostic.otherWasteAction],
+      ].filter((x) => !!x)
+    },
+    wasteMeasures() {
+      const diag = this.diagnostic
+      return [
+        { label: "Reste de pain", value: diag.breadLeftovers ? `${diag.breadLeftovers} kg/an` : "—" },
+        { label: "Reste plateau", value: diag.servedLeftovers ? `${diag.servedLeftovers} kg/an` : "—" },
+        { label: "Reste en production", value: diag.unservedLeftovers ? `${diag.unservedLeftovers} kg/an` : "—" },
+        { label: "Reste de composantes", value: diag.sideLeftovers ? `${diag.sideLeftovers} kg/an` : "—" },
+      ]
+    },
+  },
 }
 </script>
+
+<style scoped>
+ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+li {
+  margin-bottom: 14px;
+}
+</style>


### PR DESCRIPTION
- Pour cette PR, j'ai décidé de montrer également lorsqu'une mesure n'est pas mis en place avec l'icône `close` couleur _primary_.
- Je n'ai pas mis en place le lien "en savoir plus" dans la partie liée à l'expérimentation car je ne sais pas où ça pointe. J'ai ajouté un commentaire sur le Figma, on ajoutera le lien dans un deuxième temps.

Quelques exemples d'affichage

![image](https://github.com/betagouv/ma-cantine/assets/1225929/5eb6c4f9-7394-40df-a989-34824a63fbbf)

![image](https://github.com/betagouv/ma-cantine/assets/1225929/1b5f4e7a-2cb7-40ae-8a18-b9737611d75a)

![image](https://github.com/betagouv/ma-cantine/assets/1225929/fbde03e3-681b-4e26-bdcb-608a1e0e00a6)



