### PR TITLE
Ajout du no-plastic-summary pour la page « ma progression »

### DIFF
--- a/frontend/src/views/MyProgress/summary/NoPlasticMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/NoPlasticMeasureSummary.vue
@@ -3,38 +3,54 @@
     <ul>
       <li v-if="displayDiagnostic.cookingPlasticSubstituted">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
-        Je n’utilise plus de contenants alimentaires de cuisson / de réchauffe en plastique
+        <div>
+          Je n’utilise plus de contenants alimentaires de cuisson / de réchauffe en plastique
+        </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
-        J’utilise encore de contenants alimentaires de cuisson / de réchauffe en plastique
+        <div>
+          J’utilise encore de contenants alimentaires de cuisson / de réchauffe en plastique
+        </div>
       </li>
 
       <li v-if="displayDiagnostic.servingPlasticSubstituted">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
-        Je n’utilise plus de contenants alimentaires de service en plastique
+        <div>
+          Je n’utilise plus de contenants alimentaires de service en plastique
+        </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
-        J’utilise encore de contenants alimentaires de service en plastique
+        <div>
+          J’utilise encore de contenants alimentaires de service en plastique
+        </div>
       </li>
 
       <li v-if="displayDiagnostic.plasticBottlesSubstituted">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
-        Je ne mets plus à disposition des convives des bouteilles d’eau plate en plastique
+        <div>
+          Je ne mets plus à disposition des convives des bouteilles d’eau plate en plastique
+        </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
-        Je mets encore à disposition des convives des bouteilles d’eau plate en plastique
+        <div>
+          Je mets encore à disposition des convives des bouteilles d’eau plate en plastique
+        </div>
       </li>
 
       <li v-if="displayDiagnostic.plasticTablewareSubstituted">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
-        Je ne mets plus à disposition des convives des ustensiles à usage unique en matière plastique
+        <div>
+          Je ne mets plus à disposition des convives des ustensiles à usage unique en matière plastique
+        </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
-        Je mets encore à disposition des convives des ustensiles à usage unique en matière plastique
+        <div>
+          Je mets encore à disposition des convives des ustensiles à usage unique en matière plastique
+        </div>
       </li>
     </ul>
   </div>
@@ -65,5 +81,9 @@ ul {
 }
 li {
   margin-bottom: 14px;
+  display: flex;
+}
+li .v-icon {
+  align-items: baseline;
 }
 </style>

--- a/frontend/src/views/MyProgress/summary/NoPlasticMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/NoPlasticMeasureSummary.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fr-text">
-    <ul>
+    <ul role="list">
       <li v-if="displayDiagnostic.cookingPlasticSubstituted">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>

--- a/frontend/src/views/MyProgress/summary/NoPlasticMeasureSummary.vue
+++ b/frontend/src/views/MyProgress/summary/NoPlasticMeasureSummary.vue
@@ -1,11 +1,69 @@
 <template>
-  <div>
-    Plastic summary
+  <div class="fr-text">
+    <ul>
+      <li v-if="displayDiagnostic.cookingPlasticSubstituted">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        Je n’utilise plus de contenants alimentaires de cuisson / de réchauffe en plastique
+      </li>
+      <li v-else>
+        <v-icon color="primary" class="mr-2">$close-line</v-icon>
+        J’utilise encore de contenants alimentaires de cuisson / de réchauffe en plastique
+      </li>
+
+      <li v-if="displayDiagnostic.servingPlasticSubstituted">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        Je n’utilise plus de contenants alimentaires de service en plastique
+      </li>
+      <li v-else>
+        <v-icon color="primary" class="mr-2">$close-line</v-icon>
+        J’utilise encore de contenants alimentaires de service en plastique
+      </li>
+
+      <li v-if="displayDiagnostic.plasticBottlesSubstituted">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        Je ne mets plus à disposition des convives des bouteilles d’eau plate en plastique
+      </li>
+      <li v-else>
+        <v-icon color="primary" class="mr-2">$close-line</v-icon>
+        Je mets encore à disposition des convives des bouteilles d’eau plate en plastique
+      </li>
+
+      <li v-if="displayDiagnostic.plasticTablewareSubstituted">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        Je ne mets plus à disposition des convives des ustensiles à usage unique en matière plastique
+      </li>
+      <li v-else>
+        <v-icon color="primary" class="mr-2">$close-line</v-icon>
+        Je mets encore à disposition des convives des ustensiles à usage unique en matière plastique
+      </li>
+    </ul>
   </div>
 </template>
 
 <script>
 export default {
   name: "NoPlasticMeasureSummary",
+  props: {
+    diagnostic: {},
+    centralDiagnostic: {},
+  },
+  computed: {
+    usesCentralDiagnostic() {
+      return this.centralDiagnostic?.centralKitchenDiagnosticMode === "ALL"
+    },
+    displayDiagnostic() {
+      return this.usesCentralDiagnostic ? this.centralDiagnostic : this.diagnostic
+    },
+  },
 }
 </script>
+
+<style scoped>
+ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+li {
+  margin-bottom: 14px;
+}
+</style>


### PR DESCRIPTION
Quelques exemples : 

![image](https://github.com/betagouv/ma-cantine/assets/1225929/dd2da33d-56da-41a7-9b8f-a3f884c685de)

![image](https://github.com/betagouv/ma-cantine/assets/1225929/6ea7fde4-fb1d-4efb-8d0e-47d9b9037d17)
