### PR TITLE
Default de zéro pour les données bio dans le widget 

### DIFF
--- a/frontend/src/views/CanteensPage/CanteenWidget.vue
+++ b/frontend/src/views/CanteensPage/CanteenWidget.vue
@@ -115,7 +115,7 @@ export default {
       return this.diagnostic?.year
     },
     bioPercent() {
-      return Math.round(this.diagnostic.percentageValueBioHt * 100)
+      return this.diagnostic.percentageValueBioHt ? Math.round(this.diagnostic.percentageValueBioHt * 100) : "0"
     },
     sustainablePercent() {
       return Math.round(getSustainableTotal(this.diagnostic) * 100)


### PR DESCRIPTION
Closes #3142 
Vu qu'on affiche zéro lors que "de qualité et durable" n'est pas connu, j'ai décidé de faire le même avec le bio. À discuter si dans un deuxième temps on affiche un em-dash ou une autre chose (hors scope de cette PR)

![image](https://github.com/betagouv/ma-cantine/assets/1225929/7769631e-18e5-44d8-a91e-02e4de5cbe39)
