### PR TITLE
Tunnel appro : Améliorer la gestion d'erreurs

### DIFF
--- a/frontend/src/validators.js
+++ b/frontend/src/validators.js
@@ -4,6 +4,12 @@ function email(input) {
   return errorMessage
 }
 
+function isBase10Number(input) {
+  // parseFloat("0x30") === 0 and +"0x30" === 48
+  // NaN === NaN is false
+  return +input === parseFloat(input)
+}
+
 export default {
   required(input) {
     const errorMessage = "Ce champ ne peut pas être vide"
@@ -29,17 +35,20 @@ export default {
   },
   greaterThanZero(input) {
     const errorMessage = "Ce champ doit contenir une chiffre supérieure à zéro"
+    if (!isBase10Number(input)) return errorMessage
     if (parseFloat(input) > 0) return true
     return errorMessage
   },
   nonNegativeOrEmpty(input) {
+    const errorMessage = "Ce champ doit contenir un nombre positif ou rester vide"
+    if (!isBase10Number(input)) return errorMessage
+
     const isEmpty = !input || input.length === 0
     if (isEmpty) return true
 
     const isNonNegative = parseFloat(input) >= 0
     if (isNonNegative) return true
 
-    const errorMessage = "Ce champ doit contenir un nombre positif ou rester vide"
     return errorMessage
   },
   lteOrEmpty(max) {

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/ErrorHelper.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/ErrorHelper.vue
@@ -13,14 +13,14 @@
 
         <DsfrCurrencyField
           id="total"
-          v-model.number="diagnostic.valueTotalHt"
-          @blur="$emit('check-total')"
+          v-model.number="payload.valueTotalHt"
+          @blur="$emit('update-payload', payload)"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field mt-2' : 'mt-2'"
         />
         <PurchaseHint
           v-if="displayPurchaseHints"
-          v-model="diagnostic.valueTotalHt"
-          @autofill="$emit('check-total')"
+          v-model="payload.valueTotalHt"
+          @autofill="$emit('update-payload', payload)"
           purchaseType="totaux"
           :amount="purchasesSummary.valueTotalHt"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
@@ -34,14 +34,14 @@
         </label>
         <DsfrCurrencyField
           id="bio"
-          v-model.number="diagnostic.valueBioHt"
-          @blur="$emit('check-total')"
+          v-model.number="payload.valueBioHt"
+          @blur="$emit('update-payload', payload)"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field mt-2' : 'mt-2'"
         />
         <PurchaseHint
           v-if="displayPurchaseHints"
-          v-model="diagnostic.valueBioHt"
-          @autofill="$emit('check-total')"
+          v-model="payload.valueBioHt"
+          @autofill="$emit('update-payload', payload)"
           purchaseType="bio"
           :amount="purchasesSummary.valueBioHt"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
@@ -55,14 +55,14 @@
         </label>
         <DsfrCurrencyField
           id="siqo"
-          v-model.number="diagnostic.valueSustainableHt"
-          @blur="$emit('check-total')"
+          v-model.number="payload.valueSustainableHt"
+          @blur="$emit('update-payload', payload)"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field mt-2' : 'mt-2'"
         />
         <PurchaseHint
           v-if="displayPurchaseHints"
-          v-model="diagnostic.valueSustainableHt"
-          @autofill="$emit('check-total')"
+          v-model="payload.valueSustainableHt"
+          @autofill="$emit('update-payload', payload)"
           purchaseType="SIQO"
           :amount="purchasesSummary.valueSustainableHt"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
@@ -76,14 +76,14 @@
         </label>
         <DsfrCurrencyField
           id="other"
-          v-model.number="diagnostic.valueEgalimOthersHt"
-          @blur="$emit('check-total')"
+          v-model.number="payload.valueEgalimOthersHt"
+          @blur="$emit('update-payload', payload)"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field mt-2' : 'mt-2'"
         />
         <PurchaseHint
           v-if="displayPurchaseHints"
-          v-model="diagnostic.valueEgalimOthersHt"
-          @autofill="$emit('check-total')"
+          v-model="payload.valueEgalimOthersHt"
+          @autofill="$emit('update-payload', payload)"
           purchaseType="« autre EGAlim »"
           :amount="purchasesSummary.valueEgalimOthersHt"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
@@ -98,14 +98,14 @@
         </label>
         <DsfrCurrencyField
           id="ext-perf"
-          v-model.number="diagnostic.valueExternalityPerformanceHt"
-          @blur="$emit('check-total')"
+          v-model.number="payload.valueExternalityPerformanceHt"
+          @blur="$emit('update-payload', payload)"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field mt-2' : 'mt-2'"
         />
         <PurchaseHint
           v-if="displayPurchaseHints"
-          v-model="diagnostic.valueExternalityPerformanceHt"
-          @autofill="$emit('check-total')"
+          v-model="payload.valueExternalityPerformanceHt"
+          @autofill="$emit('update-payload', payload)"
           purchaseType="« critères d'achat »"
           :amount="purchasesSummary.valueExternalityPerformanceHt"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
@@ -119,14 +119,14 @@
         </label>
         <DsfrCurrencyField
           id="meat-poultry"
-          v-model.number="diagnostic.valueMeatPoultryHt"
-          @blur="$emit('check-total')"
+          v-model.number="payload.valueMeatPoultryHt"
+          @blur="$emit('update-payload', payload)"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field mt-2' : 'mt-2'"
         />
         <PurchaseHint
           v-if="displayPurchaseHints"
-          v-model="diagnostic.valueMeatPoultryHt"
-          @autofill="$emit('check-total')"
+          v-model="payload.valueMeatPoultryHt"
+          @autofill="$emit('update-payload', payload)"
           purchaseType="totaux viandes et volailles"
           :amount="purchasesSummary.valueMeatPoultryHt"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
@@ -138,14 +138,14 @@
         </label>
         <DsfrCurrencyField
           id="meat-poultry-egalim"
-          v-model.number="diagnostic.valueMeatPoultryEgalimHt"
-          @blur="$emit('check-total')"
+          v-model.number="payload.valueMeatPoultryEgalimHt"
+          @blur="$emit('update-payload', payload)"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field mt-2' : 'mt-2'"
         />
         <PurchaseHint
           v-if="displayPurchaseHints"
-          v-model="diagnostic.valueMeatPoultryEgalimHt"
-          @autofill="$emit('check-total')"
+          v-model="payload.valueMeatPoultryEgalimHt"
+          @autofill="$emit('update-payload', payload)"
           purchaseType="viandes et volailles EGAlim"
           :amount="purchasesSummary.valueMeatPoultryEgalimHt"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
@@ -157,14 +157,14 @@
         </label>
         <DsfrCurrencyField
           id="meat-poultry-france"
-          v-model.number="diagnostic.valueMeatPoultryFranceHt"
-          @blur="$emit('check-total')"
+          v-model.number="payload.valueMeatPoultryFranceHt"
+          @blur="$emit('update-payload', payload)"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field mt-2' : 'mt-2'"
         />
         <PurchaseHint
           v-if="displayPurchaseHints"
-          v-model="diagnostic.valueMeatPoultryFranceHt"
-          @autofill="$emit('check-total')"
+          v-model="payload.valueMeatPoultryFranceHt"
+          @autofill="$emit('update-payload', payload)"
           purchaseType="viandes et volailles provenance France"
           :amount="purchasesSummary.valueMeatPoultryFranceHt"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
@@ -178,14 +178,14 @@
         </label>
         <DsfrCurrencyField
           id="fish"
-          v-model.number="diagnostic.valueFishHt"
-          @blur="$emit('check-total')"
+          v-model.number="payload.valueFishHt"
+          @blur="$emit('update-payload', payload)"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field mt-2' : 'mt-2'"
         />
         <PurchaseHint
           v-if="displayPurchaseHints"
-          v-model="diagnostic.valueFishHt"
-          @autofill="$emit('check-total')"
+          v-model="payload.valueFishHt"
+          @autofill="$emit('update-payload', payload)"
           purchaseType="totaux de poissons, produits de la mer et de l'aquaculture"
           :amount="purchasesSummary.valueFishHt"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
@@ -197,14 +197,14 @@
         </label>
         <DsfrCurrencyField
           id="fish-egalim"
-          v-model.number="diagnostic.valueFishEgalimHt"
-          @blur="$emit('check-total')"
+          v-model.number="payload.valueFishEgalimHt"
+          @blur="$emit('update-payload', payload)"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field mt-2' : 'mt-2'"
         />
         <PurchaseHint
           v-if="displayPurchaseHints"
-          v-model="diagnostic.valueFishEgalimHt"
-          @autofill="$emit('check-total')"
+          v-model="payload.valueFishEgalimHt"
+          @autofill="$emit('update-payload', payload)"
           purchaseType="poissons, produits de la mer et de l'aquaculture EGAlim"
           :amount="purchasesSummary.valueFishEgalimHt"
           :class="$vuetify.breakpoint.mdAndUp ? 'narrow-field' : ''"
@@ -233,6 +233,15 @@ export default {
     purchasesSummary: {
       type: Object,
     },
+  },
+  data() {
+    const payload = {}
+    this.showFields.forEach((field) => {
+      payload[field] = this.diagnostic[field]
+    })
+    return {
+      payload,
+    }
   },
   computed: {
     displayPurchaseHints() {

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
@@ -13,6 +13,7 @@
     </div>
     <DsfrCurrencyField
       v-model.number="payload.valueTotalHt"
+      :rules="[validators.greaterThanZero, validators.decimalPlaces(2)]"
       @blur="checkTotal"
       :error="hasError"
       label="Total (en € HT) de tous mes achats alimentaires"
@@ -42,6 +43,7 @@ import PurchaseHint from "@/components/KeyMeasureDiagnostic/PurchaseHint"
 import ErrorHelper from "./ErrorHelper"
 import DsfrCallout from "@/components/DsfrCallout"
 import { toCurrency } from "@/utils"
+import validators from "@/validators"
 
 const DEFAULT_TOTAL_ERROR = "Le total doit être plus que la somme des valeurs par label"
 
@@ -72,6 +74,9 @@ export default {
     }
   },
   computed: {
+    validators() {
+      return validators
+    },
     displayPurchaseHints() {
       return !!this.purchasesSummary
     },
@@ -112,6 +117,7 @@ export default {
       this.checkTotal()
     },
     checkTotal() {
+      if (!this.payload.valueTotalHt || this.payload.valueTotalHt < 0) return
       const d = this.payload
       const sumEgalim = this.sumAllEgalim()
       const total = d.valueTotalHt

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
@@ -2,7 +2,7 @@
   <div>
     <div v-if="hasError">
       <DsfrCallout v-if="errorMessages.length > 1" color="red lighten-1">
-        <p class="ma-0">Il y a des erreurs dans le formulaire :</p>
+        <p class="ma-0">Merci de vérifier les erreurs ci dessous :</p>
         <ul>
           <li v-for="message in errorMessages" :key="message">{{ message }}</li>
         </ul>

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
@@ -1,8 +1,14 @@
 <template>
   <div>
     <div v-if="hasError">
-      <DsfrCallout v-for="message in errorMessages" :key="message" color="red lighten-1">
-        <p class="ma-0">{{ message }}</p>
+      <DsfrCallout v-if="errorMessages.length > 1" color="red lighten-1">
+        <p class="ma-0">Il y a des erreurs dans le formulaire :</p>
+        <ul>
+          <li v-for="message in errorMessages" :key="message">{{ message }}</li>
+        </ul>
+      </DsfrCallout>
+      <DsfrCallout v-else color="red lighten-1">
+        <p class="ma-0">{{ errorMessages[0] }}</p>
       </DsfrCallout>
     </div>
     <DsfrCurrencyField


### PR DESCRIPTION
I've limited the scope of my changes to the total field for now, so that we can validate the changes before I make them to the other files.

Changes made
- I think it's bad practice for child components to modify props, so I've started the refactor on ErrorHelper to send changes to the payload via an event instead
- if a field fails validation for format reasons, then that error should be shown instead of the checkTotal error
- the number fields shouldn't silently do things like convert "80...70" to 80. Hence the `isBase10Number` check. More importantly, we need to be making sure that the decimal separator is behaving as we want it to, given that it could be a comma. I'm not conviced my fix so far is ideal, but at least it is erroring instead of silently converting things in the background.
- I've grouped the error messages together to take up less space and because I assume it is jarring to have multiple alerts for people using screen readers ([more on alerts](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Alert_Role))
- if the error helper was used (a value was updated from it) then keep all the fields on screen even after resolution. I think this is important given that so many errors come from sums of multiple fields.

![Screenshot 2023-11-22 at 12-16-08 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/c0627b9f-055d-4ff8-a1bd-e66445195056)
![Screenshot 2023-11-22 at 12-15-48 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/860de0b0-b2ae-4dd7-91c6-7ff362644561)
![Screenshot 2023-11-22 at 13-02-30 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/0ca4b78e-cb29-42d1-957a-889a54f24208)