### PR TITLE
Supprimer le sidebar maintenant que les pages doivent être accessible depuis le nouveau tableau de bord

### DIFF
--- a/frontend/src/components/BreadcrumbsNav.vue
+++ b/frontend/src/components/BreadcrumbsNav.vue
@@ -13,7 +13,7 @@
       <div class="fr-collapse" id="breadcrumb-1" v-show="$vuetify.breakpoint.smAndUp || expanded">
         <ol class="fr-breadcrumb__list pl-0">
           <li>
-            <router-link class="fr-breadcrumb__link" :to="homePage">Accueil</router-link>
+            <router-link class="fr-breadcrumb__link" :to="homePage.to">{{ homePage.title }}</router-link>
           </li>
           <li v-for="link in breadcrumbLinks" :key="link.title">
             <router-link class="fr-breadcrumb__link" :to="link.to">{{ link.title }}</router-link>
@@ -57,10 +57,16 @@ export default {
   },
   computed: {
     homePage() {
-      const loggedUser = this.$store.state.loggedUser
-      if (loggedUser && loggedUser.isDev) return { name: "DeveloperPage" }
-      if (loggedUser && !loggedUser.isDev) return { name: "ManagementPage" }
-      return { name: "LandingPage" }
+      const authenticationRequired = this.$route.meta?.authenticationRequired
+      if (authenticationRequired)
+        return {
+          title: "Mon tableau de bord",
+          to: { name: "ManagementPage" },
+        }
+      return {
+        title: "Acceuil",
+        to: { name: "LandingPage" },
+      }
     },
     pageTitle() {
       return this.title || this.breadcrumbRoutes.find((r) => r.name === this.$route.name)?.meta?.title

--- a/frontend/src/components/BreadcrumbsNav.vue
+++ b/frontend/src/components/BreadcrumbsNav.vue
@@ -57,12 +57,18 @@ export default {
   },
   computed: {
     homePage() {
-      const authenticationRequired = this.$route.meta?.authenticationRequired
-      if (authenticationRequired)
+      const loggedUser = this.$store.state.loggedUser
+      if (loggedUser && loggedUser.isDev)
+        return {
+          title: "Développement et APIs",
+          to: { name: "DeveloperPage" },
+        }
+      if (loggedUser && !loggedUser.isDev) {
         return {
           title: "Mon tableau de bord",
           to: { name: "ManagementPage" },
         }
+      }
       return {
         title: "Acceuil",
         to: { name: "LandingPage" },

--- a/frontend/src/components/SatelliteTable.vue
+++ b/frontend/src/components/SatelliteTable.vue
@@ -285,10 +285,6 @@ export default {
       this.$emit("mountedAndFetched")
     })
   },
-  created() {
-    // this fixes App.vue setting the title back on route change
-    this.$route.meta.title = document.title
-  },
 }
 /*
 Here is some suggested parent config to get you started with this component

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -336,6 +336,7 @@ const routes = [
         component: CanteenForm,
         meta: {
           authenticationRequired: true,
+          title: "Modifier ma cantine",
         },
       },
       {
@@ -344,6 +345,7 @@ const routes = [
         component: SatelliteManagement,
         meta: {
           authenticationRequired: true,
+          title: "Gérer mes satellites",
         },
       },
       {
@@ -352,6 +354,7 @@ const routes = [
         component: DiagnosticList,
         meta: {
           authenticationRequired: true,
+          title: "Mes diagnostics",
         },
       },
       {
@@ -360,6 +363,7 @@ const routes = [
         component: CanteenManagers,
         meta: {
           authenticationRequired: true,
+          title: "Gérer mon équipe",
         },
       },
       {
@@ -368,6 +372,7 @@ const routes = [
         component: CanteenGeneratePoster,
         meta: {
           authenticationRequired: true,
+          title: "Génerer mon affiche",
         },
       },
       {
@@ -376,6 +381,7 @@ const routes = [
         component: CanteenDeletion,
         meta: {
           authenticationRequired: true,
+          title: "Supprimer ma cantine",
         },
       },
       {
@@ -384,6 +390,7 @@ const routes = [
         component: PublicationForm,
         meta: {
           authenticationRequired: true,
+          title: "Ma publication",
         },
       },
       {
@@ -392,6 +399,7 @@ const routes = [
         component: PublishSatellites,
         meta: {
           authenticationRequired: true,
+          title: "Publier mes satellites",
         },
       },
       {
@@ -400,6 +408,7 @@ const routes = [
         component: DashboardPage,
         meta: {
           authenticationRequired: true,
+          title: "Améliorer ma cantine",
         },
       },
       {

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -295,6 +295,7 @@
         <ImagesField class="mt-0 mb-4" :imageArray.sync="canteen.images" id="images" />
       </div>
       <v-sheet rounded color="grey lighten-4 pa-3" class="d-flex">
+        <v-btn x-large outlined color="red" :to="{ name: 'CanteenDeletion' }">Supprimer</v-btn>
         <v-spacer></v-spacer>
         <v-btn x-large outlined color="primary" class="mr-4 align-self-center" :to="{ name: 'ManagementPage' }">
           Annuler

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -500,11 +500,11 @@ export default {
           this.$emit("updateCanteen", canteenJson)
           if (this.isNewCanteen) {
             const canteenUrlComponent = this.$store.getters.getCanteenUrlComponent(canteenJson)
-            const name = this.showSatelliteCanteensCount
-              ? "SatelliteManagement"
-              : window.ENABLE_DASHBOARD
-              ? "DashboardManager"
-              : "DiagnosticList"
+
+            let name = "DiagnosticList"
+            if (this.showSatelliteCanteensCount) name = "SatelliteManagement"
+            else if (window.ENABLE_DASHBOARD) name = "DashboardManager"
+
             this.$router.push({
               // form validation ensures that the count will be > 0
               name,

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="text-left">
-    <BreadcrumbsNav :links="[{ to: { name: 'ManagementPage' } }]" v-if="isNewCanteen" />
     <h1 class="font-weight-black text-h4 my-4">
       {{ isNewCanteen ? "Ajouter ma cantine" : "Modifier ma cantine" }}
     </h1>
@@ -320,7 +319,6 @@ import DsfrTextField from "@/components/DsfrTextField"
 import CityField from "./CityField"
 import DsfrSelect from "@/components/DsfrSelect"
 import DsfrCallout from "@/components/DsfrCallout"
-import BreadcrumbsNav from "@/components/BreadcrumbsNav"
 
 const LEAVE_WARNING = "Voulez-vous vraiment quitter cette page ? Votre cantine n'a pas été sauvegardée."
 
@@ -335,7 +333,6 @@ export default {
     DsfrSelect,
     DsfrCallout,
     SiretCheck,
-    BreadcrumbsNav,
   },
   props: {
     canteenUrlComponent: {

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -309,7 +309,7 @@
 
 <script>
 import validators from "@/validators"
-import { toBase64, getObjectDiff, sectorsSelectList, readCookie, lastYear } from "@/utils"
+import { toBase64, getObjectDiff, sectorsSelectList, readCookie } from "@/utils"
 import PublicationStateNotice from "./PublicationStateNotice"
 import TechnicalControlDialog from "./TechnicalControlDialog"
 import ImagesField from "./ImagesField"
@@ -500,25 +500,23 @@ export default {
           this.$emit("updateCanteen", canteenJson)
           if (this.isNewCanteen) {
             const canteenUrlComponent = this.$store.getters.getCanteenUrlComponent(canteenJson)
+            const name = this.showSatelliteCanteensCount
+              ? "SatelliteManagement"
+              : window.ENABLE_DASHBOARD
+              ? "DashboardManager"
+              : "DiagnosticList"
             this.$router.push({
               // form validation ensures that the count will be > 0
-              name: this.showSatelliteCanteensCount ? "SatelliteManagement" : "DiagnosticList",
+              name,
               params: { canteenUrlComponent },
             })
           } else {
-            // encourage TDs by redirecting to diagnostic page if relevant
-            const diag = this.canteen.diagnostics.find((d) => d.year == lastYear())
-            if (diag && diag.teledeclaration?.status !== "SUBMITTED") {
-              this.$router.push({
-                name: "DiagnosticModification",
-                params: {
-                  canteenUrlComponent: this.canteenUrlComponent,
-                  year: lastYear(),
-                },
-              })
-            } else {
-              this.$router.push({ name: "ManagementPage" })
-            }
+            this.$router.push({
+              name: window.ENABLE_DASHBOARD ? "DashboardManager" : "ManagementPage",
+              params: {
+                canteenUrlComponent: this.canteenUrlComponent,
+              },
+            })
           }
         })
         .catch((e) => {

--- a/frontend/src/views/CanteenEditor/index.vue
+++ b/frontend/src/views/CanteenEditor/index.vue
@@ -1,10 +1,18 @@
 <template>
   <div class="mt-n2">
     <v-row class="mt-2" v-if="isNewCanteen || canteen">
-      <v-col cols="12" sm="4" md="3" v-if="!isNewCanteen">
+      <v-col cols="12" sm="4" md="3" v-if="showNavigation">
         <CanteenNavigation :canteen="canteen" />
       </v-col>
-      <v-col cols="12" :sm="isNewCanteen ? 12 : 8" :md="isNewCanteen ? 12 : 9">
+      <v-col v-else cols="12" class="py-0">
+        <BreadcrumbsNav :links="breadcrumbLinks" />
+      </v-col>
+      <v-col
+        cols="12"
+        :sm="showNavigation ? 8 : 12"
+        :md="showNavigation ? 9 : 12"
+        :class="showNavigation ? '' : 'pt-0'"
+      >
         <router-view @updateCanteen="updateCanteen" :originalCanteen="canteen" :year="year"></router-view>
       </v-col>
     </v-row>
@@ -16,10 +24,11 @@
 
 <script>
 import CanteenNavigation from "@/components/CanteenNavigation"
+import BreadcrumbsNav from "@/components/BreadcrumbsNav"
 
 export default {
   name: "CanteenEditor",
-  components: { CanteenNavigation },
+  components: { CanteenNavigation, BreadcrumbsNav },
   data() {
     return {
       canteen: null,
@@ -37,6 +46,13 @@ export default {
   computed: {
     isNewCanteen() {
       return !this.canteenUrlComponent
+    },
+    showNavigation() {
+      return !this.isNewCanteen && !window.ENABLE_DASHBOARD
+    },
+    breadcrumbLinks() {
+      if (this.isNewCanteen) return []
+      return [{ to: { name: "DashboardManager" }, title: this.canteen.name }]
     },
   },
   methods: {

--- a/frontend/src/views/DashboardManager/CanteenInfoWidget.vue
+++ b/frontend/src/views/DashboardManager/CanteenInfoWidget.vue
@@ -63,6 +63,10 @@
           >
             Modifier mon établissement
           </v-btn>
+
+          <p class="mb-0 ml-2 fr-text-sm">
+            <router-link :to="{ name: 'CanteenDeletion' }">Supprimer</router-link>
+          </p>
         </v-card-actions>
       </v-col>
     </v-row>

--- a/frontend/src/views/DashboardManager/CanteenInfoWidget.vue
+++ b/frontend/src/views/DashboardManager/CanteenInfoWidget.vue
@@ -63,10 +63,6 @@
           >
             Modifier mon établissement
           </v-btn>
-
-          <p class="mb-0 ml-2 fr-text-sm">
-            <router-link :to="{ name: 'CanteenDeletion' }">Supprimer</router-link>
-          </p>
         </v-card-actions>
       </v-col>
     </v-row>

--- a/frontend/src/views/DashboardManager/PublicationWidget.vue
+++ b/frontend/src/views/DashboardManager/PublicationWidget.vue
@@ -32,20 +32,25 @@
       </p>
     </v-card-text>
     <v-spacer></v-spacer>
-    <v-card-actions class="mx-2 mb-2">
-      <v-btn
-        :to="{
-          name: 'PublicationForm',
-          params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
-        }"
-        color="primary"
-        :outlined="isPublished || !hasPublicationData"
-        :disabled="!isPublished && !hasPublicationData"
-      >
-        {{ isPublished ? "Éditer ma vitrine" : "Publier ma cantine" }}
-      </v-btn>
-      <p class="mb-0 ml-2 fr-text-sm">
-        <router-link :to="{ name: 'CanteenGeneratePoster' }">Génerer mon affiche</router-link>
+    <v-card-actions class="mx-2 mb-2 flex-md-wrap flex-lg-nowrap">
+      <p class="mb-0 mb-md-2 mb-lg-0 mr-2">
+        <v-btn
+          :to="{
+            name: 'PublicationForm',
+            params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
+          }"
+          color="primary"
+          class="px-3"
+          :outlined="isPublished || !hasPublicationData"
+          :disabled="!isPublished && !hasPublicationData"
+        >
+          {{ isPublished ? "Éditer ma vitrine" : "Publier ma cantine" }}
+        </v-btn>
+      </p>
+      <p class="mb-0">
+        <v-btn outlined color="primary" class="fr-btn--tertiary px-3" :to="{ name: 'CanteenGeneratePoster' }">
+          Génerer mon affiche
+        </v-btn>
       </p>
       <p v-if="!isPublished && !hasPublicationData" class="grey--text text--darken-1 fr-text-xs mb-0 ml-3">
         Pas de données

--- a/frontend/src/views/DashboardManager/PublicationWidget.vue
+++ b/frontend/src/views/DashboardManager/PublicationWidget.vue
@@ -44,6 +44,9 @@
       >
         {{ isPublished ? "Éditer ma vitrine" : "Publier ma cantine" }}
       </v-btn>
+      <p class="mb-0 ml-2 fr-text-sm">
+        <router-link :to="{ name: 'CanteenGeneratePoster' }">Génerer mon affiche</router-link>
+      </p>
       <p v-if="!isPublished && !hasPublicationData" class="grey--text text--darken-1 fr-text-xs mb-0 ml-3">
         Pas de données
       </p>

--- a/frontend/src/views/DashboardManager/SatellitesWidget.vue
+++ b/frontend/src/views/DashboardManager/SatellitesWidget.vue
@@ -44,6 +44,9 @@
       >
         {{ satellites.length ? "Modifier" : "Ajouter mes satellites" }}
       </v-btn>
+      <p class="mb-0 ml-2 fr-text-sm">
+        <router-link :to="{ name: 'PublishSatellites' }">Publier</router-link>
+      </p>
     </v-card-actions>
   </v-card>
 </template>

--- a/frontend/src/views/DashboardManager/SatellitesWidget.vue
+++ b/frontend/src/views/DashboardManager/SatellitesWidget.vue
@@ -34,18 +34,22 @@
     </v-card-text>
     <v-spacer />
     <v-card-actions class="ma-2">
-      <v-btn
-        :to="{
-          name: 'SatelliteManagement',
-          params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
-        }"
-        color="primary"
-        :outlined="!!satellites.length"
-      >
-        {{ satellites.length ? "Modifier" : "Ajouter mes satellites" }}
-      </v-btn>
-      <p class="mb-0 ml-2 fr-text-sm">
-        <router-link :to="{ name: 'PublishSatellites' }">Publier</router-link>
+      <p class="mb-0">
+        <v-btn
+          :to="{
+            name: 'SatelliteManagement',
+            params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
+          }"
+          color="primary"
+          :outlined="!!satellites.length"
+        >
+          {{ satellites.length ? "Modifier" : "Ajouter mes satellites" }}
+        </v-btn>
+      </p>
+      <p class="mb-0 ml-2">
+        <v-btn outlined color="primary" class="fr-btn--tertiary" :to="{ name: 'PublishSatellites' }">
+          Publier
+        </v-btn>
       </p>
     </v-card-actions>
   </v-card>


### PR DESCRIPTION
Les liens ajoutés sont des propositions, pas dans les maquettes. Peut-être ils vont bouger mais je pense comme ça au moins on les oublie pas sans attendre le développement de la partie "Ressources personnalisés".

@arthurkleindesign est-ce que tu est heureux avec les propositions suivantes dans un première temps ? Et après on pourrait iterer dessus dans un lot 2

## Publier mes satellites

Le lien
![Screenshot 2023-11-23 at 14-46-00 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/6f02099d-4a4f-4e08-ac2c-8ad2b1a023dc)

Qui dirige vers cette page
![Screenshot 2023-11-23 at 14-46-08 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/144e6e93-e952-45ee-8d9d-64a34b952aab)


## Génerer mon affiche

Le lien
![Screenshot 2023-11-23 at 14-47-09 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/595f9c91-5f2b-477f-b1ba-c780d40d5218)

Qui dirige vers le génerateur pour une cantine

## Supprimer ma cantine

Le lien
![Screenshot 2023-11-23 at 14-47-52 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/b7dc99ff-6414-4a4e-9995-649871bfe870)


Qui dirige vers cette page

![Screenshot 2023-11-23 at 14-48-03 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/ea5a9584-7a2c-48b6-ba74-2eace7d4ddf4)
