### PR TITLE
Fix du problème de scroll (tunnel)

### DIFF
--- a/frontend/src/views/DiagnosticTunnel/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/index.vue
@@ -32,9 +32,10 @@
     </div>
     <div
       v-if="diagnostic"
-      class="mx-auto constrained px-4 py-10 flex-grow-1 d-flex flex-column justify-center"
+      class="mx-auto constrained px-4 py-10 flex-grow-1 d-flex flex-column"
       style="width: 100%; overflow-y: scroll; overflow-x: hidden;"
     >
+      <v-spacer />
       <component
         :is="`${measure.baseComponent}Steps`"
         :canteen="canteen"
@@ -43,6 +44,7 @@
         v-on:update-payload="updatePayload"
         v-on:update-steps="updateSteps"
       />
+      <v-spacer />
     </div>
     <div class="footer pa-2" style="width: 100%">
       <div class="d-flex mx-auto constrained align-center">


### PR DESCRIPTION
Closes #3221

Le bug est décrit dans cette question SO : https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container

J'ai choisi de mettre les `<v-spacer>`s au lieu d'utiliser le wrapping div par simplicité et lisibilité.