### PR TITLE
Bouton « revenir à l'étape précédente » sauvegarde le payload

### DIFF
--- a/frontend/src/views/DiagnosticTunnel/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/index.vue
@@ -17,7 +17,14 @@
         </v-col>
         <v-col class="text-right py-0">
           <p class="mb-0">
-            <v-btn text plain class="text-decoration-underline px-0" color="primary" @click="saveAndQuit">
+            <v-btn
+              text
+              plain
+              class="text-decoration-underline px-0"
+              color="primary"
+              @click="saveAndQuit"
+              :disabled="!formIsValid"
+            >
               Sauvegarder et quitter
               <v-icon color="primary" size="1rem" class="ml-0 mb-1">
                 $close-line

--- a/frontend/src/views/DiagnosticTunnel/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/index.vue
@@ -70,12 +70,14 @@
         </v-btn>
         <p v-if="step && step.isSynthesis" class="mb-0"><router-link :to="firstStepLink">Modifier</router-link></p>
         <p v-else class="mb-0">
-          <router-link v-if="previousStep && formIsValid" :to="stepLink(previousStep)">
+          <v-btn
+            text
+            @click="previousAction"
+            :disabled="disablePreviousButton"
+            :class="disablePreviousButton ? 'fr-text grey--text text-darken-2' : 'fr-text primary--text'"
+          >
             Revenir à l'étape précédente
-          </router-link>
-          <a v-else class="grey--text text-darken-2" role="link" aria-disabled="true">
-            Revenir à l'étape précédente
-          </a>
+          </v-btn>
         </p>
       </div>
     </div>
@@ -201,6 +203,9 @@ export default {
       const synthesisUrl = "complet"
       return this.steps.filter((s) => s.urlSlug !== synthesisUrl)
     },
+    disablePreviousButton() {
+      return !this.previousStep || !this.formIsValid
+    },
   },
   methods: {
     updateSteps(steps) {
@@ -247,6 +252,21 @@ export default {
             name: "MyProgress",
             params: { measure: this.nextTunnel.id },
           })
+        } else {
+          this.$router.push({
+            name: "DashboardManager",
+            params: {
+              canteenUrlComponent: this.canteenUrlComponent,
+            },
+          })
+        }
+      })
+    },
+    previousAction() {
+      if (!this.formIsValid) return
+      this.saveDiagnostic().then(() => {
+        if (this.previousStep) {
+          this.$router.push({ query: { étape: this.previousStep.urlSlug } })
         } else {
           this.$router.push({
             name: "DashboardManager",

--- a/frontend/src/views/DiagnosticTunnel/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/index.vue
@@ -276,9 +276,11 @@ export default {
           this.$router.push({ query: { étape: this.previousStep.urlSlug } })
         } else {
           this.$router.push({
-            name: "DashboardManager",
+            name: "MyProgress",
             params: {
               canteenUrlComponent: this.canteenUrlComponent,
+              year: this.year,
+              measure: this.measureId,
             },
           })
         }


### PR DESCRIPTION


1- Le bouton « revenir à l'étape précédente » sauvegarde le payload
2- Le bouton « sauvegarder et quitter » est désactivé si `formIsValid` est faux
