### PR TITLE
Validation du champ other-waste-action (dépendant du checkbox)

### DIFF
--- a/frontend/src/views/DiagnosticTunnel/InformationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/InformationMeasureSteps/index.vue
@@ -48,9 +48,11 @@
           <v-text-field
             class="my-0 py-0"
             hide-details
+            ref="other-support-field"
             :disabled="!otherSupportEnabled"
             v-model="payload.otherCommunicationSupport"
             label="Autre : donnez plus d'informations"
+            :rules="otherSupportEnabled ? [validators.required] : []"
           ></v-text-field>
         </v-row>
       </fieldset>
@@ -171,9 +173,8 @@ export default {
   },
   watch: {
     otherSupportEnabled(val) {
-      if (!val) {
-        this.payload.otherCommunicationSupport = null
-      }
+      if (val) this.$nextTick().then(this.$refs["other-support-field"]?.validate)
+      else this.payload.otherCommunicationSupport = null
     },
     payload() {
       this.updatePayload()

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -117,9 +117,11 @@
         <v-checkbox v-model="otherActionEnabled" hide-details class="shrink mt-0" aria-label="Autre"></v-checkbox>
         <v-text-field
           class="my-0 py-0"
+          ref="other-action-field"
           hide-details
           :disabled="!otherActionEnabled"
           v-model="payload.otherWasteAction"
+          :rules="otherActionEnabled ? [validators.required] : []"
           label="Autre : donnez plus d'informations"
         ></v-text-field>
       </v-row>
@@ -398,6 +400,10 @@ export default {
     },
     formIsValid() {
       this.updatePayload()
+    },
+    otherActionEnabled(newValue) {
+      if (newValue) this.$nextTick().then(this.$refs["other-action-field"]?.validate)
+      else this.payload.otherWasteAction = null
     },
   },
 }


### PR DESCRIPTION
J'ai volontairement déclenché la validation dès l'activation du checkpoint car sinon les boutons sont désactivés sans qu'on sache pourquoi.

Closes #3238 

[Screencast from 27-11-23 23:19:34.webm](https://github.com/betagouv/ma-cantine/assets/1225929/6b05708c-6b36-4ae2-b68b-2648cea95abb)
