### PR TITLE
Gestion d'erreurs provenant du backend

### DIFF
--- a/frontend/src/views/DiagnosticTunnel/InformationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/InformationMeasureSteps/index.vue
@@ -111,6 +111,7 @@ export default {
       communicationSupports: this.diagnostic.communicationSupports,
       otherCommunicationSupport: this.diagnostic.otherCommunicationSupport,
       communicatesOnFoodPlan: this.diagnostic.communicatesOnFoodPlan,
+      communicationSupportUrl: this.diagnostic.communicationSupportUrl,
     }
     return {
       formIsValid: true,


### PR DESCRIPTION
Ceci est une version très basique de cette gestion qui pourrait être amélioré par la suite, mais qu'est déjà suffisante pour une v1.

Les erreurs provenant du backend sont affichés dans le `notify` dans le cas de souci de validation.

[Screencast from 30-11-23 16:23:14.webm](https://github.com/betagouv/ma-cantine/assets/1225929/bbc76653-9cab-469b-afce-afa572d209f4)