### PR TITLE
Ajout des logos et label dans les steps appro détaillés

### DIFF
--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
@@ -1,5 +1,21 @@
 <template>
   <div class="mt-n4">
+    <div class="d-flex mb-4 align-center">
+      <LogoBio v-if="characteristicId === 'BIO'" />
+      <div v-else v-for="label in qualityLabels(characteristicId)" :key="label.title || label.icon">
+        <img
+          v-if="label.src"
+          :src="`/static/images/quality-labels/${label.src}`"
+          :alt="label.title"
+          :title="label.title"
+          style="max-width: 50px;"
+        />
+        <v-icon class="mt-1" :color="label.color" v-else-if="label.icon">
+          {{ label.icon }}
+        </v-icon>
+      </div>
+      <h2 class="ml-4">{{ characteristicName }}</h2>
+    </div>
     <p v-if="groupId === 'egalim'">
       <strong>Produit ayant plusieurs labels</strong>
       : la valeur d’achat ne pourra être comptée que dans une seule des catégories. Par exemple, un produit à la fois
@@ -50,6 +66,8 @@ import DsfrCurrencyField from "@/components/DsfrCurrencyField"
 import PurchaseHint from "@/components/KeyMeasureDiagnostic/PurchaseHint"
 import Constants from "@/constants"
 import validators from "@/validators"
+import labels from "@/data/quality-labels.json"
+import LogoBio from "@/components/LogoBio"
 import { approTotals } from "@/utils"
 
 export default {
@@ -78,6 +96,7 @@ export default {
   components: {
     DsfrCurrencyField,
     PurchaseHint,
+    LogoBio,
   },
   data() {
     return {
@@ -88,6 +107,9 @@ export default {
   computed: {
     displayPurchaseHints() {
       return !!this.purchasesSummary
+    },
+    characteristicName() {
+      return Constants.TeledeclarationCharacteristics[this.characteristicId]?.text
     },
   },
   methods: {
@@ -157,6 +179,38 @@ export default {
       })
       fishEgalim = +fishEgalim.toFixed(2)
       return { fishEgalim }
+    },
+    qualityLabels(characteristicId) {
+      let singleLabel
+      let labelGroup
+      switch (characteristicId) {
+        case "LABEL_ROUGE":
+          singleLabel = labels.find((l) => l.src.startsWith("label-rouge"))
+          break
+        case "AOCAOP_IGP_STG":
+          labelGroup = [
+            labels.find((l) => l.src.startsWith("Logo-AOC")),
+            labels.find((l) => l.src.startsWith("IGP")),
+            labels.find((l) => l.src.startsWith("STG")),
+          ]
+          return labelGroup
+        case "HVE":
+          singleLabel = labels.find((l) => l.src.startsWith("hve"))
+          break
+        case "PECHE_DURABLE":
+          singleLabel = labels.find((l) => l.src.endsWith("peche-durable.png"))
+          break
+        case "RUP":
+          singleLabel = labels.find((l) => l.src.startsWith("rup"))
+          break
+        case "COMMERCE_EQUITABLE":
+          singleLabel = labels.find((l) => l.src.startsWith("commerce-equitable"))
+          break
+      }
+      singleLabel = singleLabel || Constants.MiscLabelIcons[characteristicId]
+      if (singleLabel) {
+        return [singleLabel]
+      }
     },
   },
 }

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
@@ -10,7 +10,7 @@
           :title="label.title"
           style="max-width: 50px;"
         />
-        <v-icon class="mt-1" :color="label.color" v-else-if="label.icon">
+        <v-icon class="mt-n1" :color="label.color" v-else-if="label.icon" size="44">
           {{ label.icon }}
         </v-icon>
       </div>


### PR DESCRIPTION
Le code est très similaire à celui d'`ExtendedQualityValues.vue`. Je ne l'ai pas refacto car ce fichier est voué à disparaître

![image](https://github.com/betagouv/ma-cantine/assets/1225929/ef397629-af0f-460d-aabc-3737afab82c1)

![image](https://github.com/betagouv/ma-cantine/assets/1225929/2dcc2f7c-532d-403d-bfde-8f0a3aa4b2c1)


