### PR TITLE
Enlève la section des ressources personnalisées

### DIFF
--- a/frontend/src/views/DashboardManager/index.vue
+++ b/frontend/src/views/DashboardManager/index.vue
@@ -69,14 +69,6 @@
         </v-btn>
       </v-col>
     </v-row>
-
-    <h2 class="mt-10 mb-2 text-h6 font-weight-bold">
-      Mes ressources personalisées
-    </h2>
-    <p class="body-2">
-      Découvrez ci-dessous des articles et des outils pratiques, ainsi que des suggestions de partenaires et des
-      cantines inspirantes sur votre territoire qui correspondent à vos enjeux.
-    </p>
   </div>
 </template>
 


### PR DESCRIPTION
Closes #3066 

Pour l'instant je propose de ne pas montrer cette étape car on n'a pas de ressources personnalisés. 

Mettre les mêmes ressources que dans la page précédente me semble alourdir la page pour peu de gain, surtout que ce ne seront pas toujours appropriés. Les utilisateurs pourraient s'habituer à voir des choses pas très utiles dans cette section et à ne pas remarquer lors que les ressources soient bien adaptées.