### PR TITLE
Bug fix : synthèses satellite

### DIFF
--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -170,14 +170,17 @@ META_FIELDS = (
     "id",
     "canteen_id",
     "year",
-    "creation_date",
-    "modification_date",
     "diagnostic_type",
     "central_kitchen_diagnostic_mode",
 )
 
-TUNNEL_PROGRESS_FIELDS = (
+CREATION_META_FIELDS = (
+    "creation_date",
+    "modification_date",
     "creation_source",
+)
+
+TUNNEL_PROGRESS_FIELDS = (
     "tunnel_appro",
     "tunnel_waste",
     "tunnel_plastic",
@@ -280,6 +283,7 @@ class ManagerDiagnosticSerializer(serializers.ModelSerializer):
                 "creation_mtm_campaign",
                 "creation_mtm_medium",
             )
+            + CREATION_META_FIELDS
             + TUNNEL_PROGRESS_FIELDS
         )
 
@@ -319,7 +323,7 @@ class FullDiagnosticSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Diagnostic
-        fields = FIELDS + ("teledeclaration",) + TUNNEL_PROGRESS_FIELDS
+        fields = FIELDS + ("teledeclaration",) + CREATION_META_FIELDS + TUNNEL_PROGRESS_FIELDS
         read_only_fields = fields
 
 

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -239,7 +239,7 @@ class CentralKitchenDiagnosticSerializer(serializers.ModelSerializer):
     """
 
     class Meta:
-        fields = FIELDS
+        fields = FIELDS + TUNNEL_PROGRESS_FIELDS
         read_only_fields = fields
         model = Diagnostic
 

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -172,12 +172,12 @@ META_FIELDS = (
     "year",
     "creation_date",
     "modification_date",
-    "creation_source",
     "diagnostic_type",
     "central_kitchen_diagnostic_mode",
 )
 
 TUNNEL_PROGRESS_FIELDS = (
+    "creation_source",
     "tunnel_appro",
     "tunnel_waste",
     "tunnel_plastic",
@@ -239,7 +239,7 @@ class CentralKitchenDiagnosticSerializer(serializers.ModelSerializer):
     """
 
     class Meta:
-        fields = FIELDS + TUNNEL_PROGRESS_FIELDS
+        fields = FIELDS
         read_only_fields = fields
         model = Diagnostic
 


### PR DESCRIPTION
(ignore the misleading branch name, this affects all views, not just appro)

The ProgressTab file has multiple v-if/v-if-else but no fallback.
In the same file, `showSynthesis` depends on the result of `hasStartedMeasureTunnel`, defined in utils. The function is:

```
export const hasStartedMeasureTunnel = (diagnostic, keyMeasure) => {
  if (diagnostic?.creationSource === "TUNNEL") return !!diagnostic[keyMeasure.progressField]
  return !!diagnostic
}
```

Today, the diagnostic representation of a CC diag includes the `creationSource` field but not the progress fields. This means that if a CC starts a diagnostic with the tunnel, the satellite synthesis/syntheses (depending on APPRO/ALL from the CC) will be empty.

Before
![Screenshot 2023-12-08 at 15-36-04 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/a26eccc4-a987-4334-8355-7e1af5d5d9ba)

After
![Screenshot 2023-12-08 at 15-35-35 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/5d2ebcfe-b059-4f09-94e5-c2cc20aa2b19)
