### PR TITLE
Après la dernière étape du tunnel, renvoie l'user sur le tableau de bord dans l'année correcte 

### DIFF
--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -88,10 +88,12 @@ export default {
     },
   },
   data() {
+    const years = diagnosticYears()
     return {
       lastYear: lastYear(),
       year: lastYear(),
-      allowedYears: diagnosticYears().map((year) => ({ text: year, value: year })),
+      diagnosticYears: years,
+      allowedYears: years.map((year) => ({ text: year, value: year })),
     }
   },
   computed: {
@@ -152,6 +154,12 @@ export default {
       }
       return this.canteenDiagnostic && hasDiagnosticApproData(this.canteenDiagnostic)
     },
+  },
+  mounted() {
+    if (this.$route.query?.year && this.diagnosticYears.indexOf(+this.$route.query.year) > -1) {
+      this.year = +this.$route.query.year
+      this.$router.replace({ query: {} })
+    }
   },
 }
 </script>

--- a/frontend/src/views/DiagnosticTunnel/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/index.vue
@@ -287,6 +287,9 @@ export default {
               params: {
                 canteenUrlComponent: this.canteenUrlComponent,
               },
+              query: {
+                year: this.year,
+              },
             })
           }
         })


### PR DESCRIPTION
Closes #3287 

Permet la spécification d'un query parameter facultatif pour spécifier l'année dans la page ma-progression 