### PR TITLE
Remplacer le lien stats pour tracking

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9,7 +9,7 @@ Vue.config.productionTip = false
 
 if (window.MATOMO_ID) {
   Vue.use(VueMatomo, {
-    host: "https://stats.data.gouv.fr",
+    host: "https://stats.beta.gouv.fr",
     siteId: window.MATOMO_ID,
     trackerFileName: "matomo",
     router: router,

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -411,7 +411,7 @@ if DEBUG:
 # CSP valid sources of Javascript
 CSP_SCRIPT_SRC = (
     "'self'",
-    "stats.data.gouv.fr",
+    "stats.beta.gouv.fr",
     "'unsafe-inline'",
     "client.crisp.chat",
 )
@@ -424,7 +424,7 @@ CSP_IMG_SRC = (
     "cellar-c2.services.clever-cloud.com",
     "voxusagers.numerique.gouv.fr",
     "'unsafe-inline'",
-    "stats.data.gouv.fr",
+    "stats.beta.gouv.fr",
     "www.w3.org",
     "data:",
     "image.crisp.chat",
@@ -444,7 +444,7 @@ if DEBUG:
 # CSP valid sources of AJAX, WebSockets, EventSources, etc
 CSP_CONNECT_SRC = (
     "'self'",
-    "stats.data.gouv.fr",
+    "stats.beta.gouv.fr",
     "ws:",
     "api-adresse.data.gouv.fr",
     "client.crisp.chat",

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -16,7 +16,7 @@
             _paq.push(['trackPageView']);
             _paq.push(['enableLinkTracking']);
             (function() {
-            var u="https://stats.data.gouv.fr/";
+            var u="https://stats.beta.gouv.fr/";
             _paq.push(['setTrackerUrl', u+'matomo.php']);
             _paq.push(['setSiteId', "{% matomo_id %}"]);
             var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];


### PR DESCRIPTION
Nouvel site : https://stats.beta.gouv.fr/index.php?module=CoreHome&action=index&idSite=78&period=day&date=yesterday#?period=day&date=yesterday&category=Dashboard_Dashboard&subcategory=1&idSite=78

Après le merge :

- [ ] mettre à jour le variable d'env MATOMO_ID avec le nouveau site id
- [ ] vérifier que tout est bon
- [ ] remplacer les autres liens dans le code vers les pages analyses stats.data.gouv.fr vers le nouveau site

