### PR TITLE
[Tunnel] Montrer l'utilisateur une synthèse vide si le diag est télédéclaré et le tunnel n'a pas été commencé

### DIFF
--- a/frontend/src/views/MyProgress/ProgressTab.vue
+++ b/frontend/src/views/MyProgress/ProgressTab.vue
@@ -217,6 +217,7 @@ export default {
       return this.isApproTab && isCurrentYear && managesOwnPurchases && !dataProvidedByDiagnostic
     },
     hasData() {
+      if (this.hasActiveTeledeclaration) return true // if tunnel wasn't started, but diag was TD'd, show synthesis
       const hasMeasureData = hasStartedMeasureTunnel(this.displayDiagnostic, this.keyMeasure)
       return this.showPurchasesSection || hasMeasureData
     },


### PR DESCRIPTION
Ça règle le bug d'avoir le bouton commencer sur les volets non-commencés après avoir TDé

closes #3347  