### PR TITLE
Fix du bug avec les cuisines centrales

### DIFF
--- a/frontend/src/views/ManagementPage/CentralKitchenCard.vue
+++ b/frontend/src/views/ManagementPage/CentralKitchenCard.vue
@@ -87,7 +87,7 @@ export default {
       return window.ENABLE_TELEDECLARATION
     },
     canteenLink() {
-      if (window.ENABLE_DASHBOARD && window.ENVIRONMENT === "dev") {
+      if (window.ENABLE_DASHBOARD) {
         return {
           name: "DashboardManager",
           params: { canteenUrlComponent: this.$store.getters.getCanteenUrlComponent(this.canteen) },


### PR DESCRIPTION
Les cuisines centrales ne rentrent pas dans le nouveau parcours dans démo et prod.