### PR TITLE
Améliorer le message d'erreur de validation des nombres entiers

### DIFF
--- a/frontend/src/validators.js
+++ b/frontend/src/validators.js
@@ -37,7 +37,7 @@ export default {
   },
   greaterThanZero(input) {
     const errorMessage = "Ce champ doit contenir une chiffre supérieure à zéro"
-    if (!isBase10Number(input)) return NUMBER_FORMAT_ERROR
+    if (!input || !isBase10Number(input)) return errorMessage
     if (parseFloat(input) > 0) return true
     return errorMessage
   },

--- a/frontend/src/validators.js
+++ b/frontend/src/validators.js
@@ -165,7 +165,7 @@ export default {
     return (input) => {
       const number = Number(input)
       if (number) {
-        if (!isBase10Number(input)) return "Pour un nombre décimale, veuillez utiliser un point, par exemple 100.95"
+        if (!isBase10Number(input)) return "Pour un nombre décimal, veuillez utiliser un point, par exemple 100.95"
         const tofixed = number.toFixed(max)
         if (number !== Number(tofixed)) {
           return `${max} décimales attendues, par exemple ${tofixed}`
@@ -182,7 +182,7 @@ export default {
   },
   isInteger(input) {
     if (input) {
-      if (!isBase10Number(input)) return "Un nombre entier attendu, sans espaces, virgules, et autres caractères"
+      if (!isBase10Number(input)) return "Un nombre entier est attendu : sans espaces, virgules, ni caractères spéciaux"
       if (!Number.isInteger(input)) return "Un nombre entier attendu"
     }
     return true

--- a/frontend/src/validators.js
+++ b/frontend/src/validators.js
@@ -10,7 +10,10 @@ function isBase10Number(input) {
   return +input === parseFloat(input)
 }
 
-const NUMBER_FORMAT_ERROR = "Pour un nombre décimale, veuillez utiliser un point, par exemple 100.95"
+// this error is a graceful fallback that users ideally wouldn't see :
+// numerical value validators should always be called with isInteger or decimalPlaces first, to allow those
+// validators to return a helpful error message for the number format expected if !isBase10Number
+const GENERIC_BASE_10_ERROR = "Une valeur numérique est attendue"
 
 export default {
   required(input) {
@@ -37,7 +40,8 @@ export default {
   },
   greaterThanZero(input) {
     const errorMessage = "Ce champ doit contenir une chiffre supérieure à zéro"
-    if (!input || !isBase10Number(input)) return errorMessage
+    if (!input) return errorMessage
+    if (!isBase10Number(input)) return GENERIC_BASE_10_ERROR
     if (parseFloat(input) > 0) return true
     return errorMessage
   },
@@ -47,7 +51,7 @@ export default {
     const isEmpty = !input || input.length === 0
     if (isEmpty) return true
 
-    if (!isBase10Number(input)) return NUMBER_FORMAT_ERROR
+    if (!isBase10Number(input)) return GENERIC_BASE_10_ERROR
 
     const isNonNegative = parseFloat(input) >= 0
     if (isNonNegative) return true
@@ -161,11 +165,11 @@ export default {
     return (input) => {
       const number = Number(input)
       if (number) {
+        if (!isBase10Number(input)) return "Pour un nombre décimale, veuillez utiliser un point, par exemple 100.95"
         const tofixed = number.toFixed(max)
         if (number !== Number(tofixed)) {
           return `${max} décimales attendues, par exemple ${tofixed}`
         }
-        if (!isBase10Number(input)) return NUMBER_FORMAT_ERROR
       }
       return true
     }
@@ -177,10 +181,10 @@ export default {
     }
   },
   isInteger(input) {
-    if (input && !Number.isInteger(input)) {
-      return "Un nombre entier attendu"
+    if (input) {
+      if (!isBase10Number(input)) return "Un nombre entier attendu, sans espaces, virgules, et autres caractères"
+      if (!Number.isInteger(input)) return "Un nombre entier attendu"
     }
-    if (!isBase10Number(input)) return NUMBER_FORMAT_ERROR
     return true
   },
 }

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -164,7 +164,7 @@
           <DsfrTextField
             id="yearly-meals"
             hide-details="auto"
-            :rules="[validators.greaterThanZero, validators.isInteger, greaterThanDailyMealCount]"
+            :rules="[validators.isInteger, validators.greaterThanZero, greaterThanDailyMealCount]"
             validate-on-blur
             v-model.number="canteen.yearlyMealCount"
             prepend-icon="$restaurant-fill"


### PR DESCRIPTION
I added the check for is base 10 a while back, but unfortunately the error message assumed that the number expected was decimal. This PR fixes that.

I haven't gone through all uses of isInteger and decimalPlaces, I suggest that is done in a second PR or as and when we spot them. Basically, these two should be the first in a list of validators so that the appropriate number format error message shows up. I wanted, however, to keep the base 10 check in all validators with numbers so that if the isInteger or decimalPlaces validators are forgotten, we still have the check.

Let me know though if you'd like to discuss approach more, maybe it would be better to not expect us/future devs to remember and throw a bigger error. Or an error just to the console ? As a reminder to use isInteger or decimalPlaces first.