### PR TITLE
Ajout des vérifications supplémentaires pour les opérations concernant la TD

### DIFF
--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -48,6 +48,8 @@ class TeledeclarationCreateView(APIView):
         diagnostic_id = data.get("diagnostic_id")
         if not diagnostic_id:
             raise ValidationError("diagnosticId manquant")
+        if not settings.ENABLE_TELEDECLARATION:
+            raise PermissionDenied("La campagne de télédéclaration n'est pas ouverte.")
 
         td = TeledeclarationCreateView._teledeclare_diagnostic(diagnostic_id, request.user)
         data = FullDiagnosticSerializer(td.diagnostic).data

--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime
 from django.http import JsonResponse, HttpResponse
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.template.loader import get_template
@@ -102,8 +103,17 @@ class TeledeclarationCancelView(APIView):
 
     def post(self, request, *args, **kwargs):
         try:
+            if not settings.ENABLE_TELEDECLARATION:
+                raise PermissionDenied("La campagne de télédéclaration n'est pas ouverte.")
+
             teledeclaration_id = kwargs.get("pk")
             teledeclaration = Teledeclaration.objects.get(pk=teledeclaration_id)
+
+            acceptedYear = datetime.now().year - 1
+            if teledeclaration.year != acceptedYear:
+                raise PermissionDenied(
+                    f"Seules les télédéclarations pour l'année {acceptedYear} peuvent être annulées"
+                )
 
             if request.user not in teledeclaration.canteen.managers.all():
                 raise PermissionDenied()


### PR DESCRIPTION
La création et annulation des télédéclarations ne sont plus possibles si :
- On n'est pas en campagne de TD,
- La télédéclaration concerne une année différente de n-1