### PR TITLE
Cache la bannière pour les webinaires dans les vues fullscreen

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,7 +5,7 @@
       <AppHeader class="mx-auto constrained" v-else-if="!fullscreen" />
 
       <v-main id="contenu" style="width: 100%" :class="{ 'mb-10': !isWidget, 'fill-height': fullscreen }">
-        <WebinaireBanner @hide="hideBanner" v-if="showWebinaireBanner" />
+        <WebinaireBanner @hide="hideBanner" v-if="showWebinaireBanner && !fullscreen" />
         <v-container fluid :fill-height="!initialDataLoaded || fullscreen" :class="{ 'pa-0': fullscreen }">
           <v-progress-circular
             indeterminate


### PR DESCRIPTION
Avant : 
![image](https://github.com/betagouv/ma-cantine/assets/1225929/f73d234f-dea8-4d91-b66b-3aa07c722ab2)

Après : 
![image](https://github.com/betagouv/ma-cantine/assets/1225929/9a97293d-84b4-4412-872e-7268d48849bc)
