### PR TITLE
Autofill avec les informations des achats pour le tunnel de l'appro

### DIFF
--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
@@ -317,7 +317,8 @@ export default {
       this.populateSimplifiedDiagnostic()
     },
     sum(fields) {
-      return fields.reduce((acc, field) => acc + (this.payload[field] || 0), 0)
+      const sum = fields.reduce((acc, field) => acc + (this.payload[field] || 0), 0)
+      return +sum.toFixed(2)
     },
     fieldHasError(fieldName) {
       if (fieldName.startsWith(this.meatFieldPrefix) && !!this.meatTotalErrorMessage) return true

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
@@ -1,5 +1,16 @@
 <template>
   <div>
+    <div class="mb-16" v-if="displayPurchaseHints">
+      <DsfrCallout icon="$money-euro-box-fill">
+        <div>
+          <p>
+            Vous avez effectué des achats en {{ diagnostic.year }}. Cliquez ci-dessous pour remplir vos informations
+            d'approvisionnement à partir de ces achats.
+          </p>
+          <v-btn outlined color="primary" @click="autofillWithPurchases">Remplir automatiquement</v-btn>
+        </div>
+      </DsfrCallout>
+    </div>
     <FormErrorCallout v-if="hasError" :errorMessages="errorMessages" />
     <DsfrCurrencyField
       v-model.number="payload.valueTotalHt"
@@ -35,6 +46,7 @@ import DsfrCurrencyField from "@/components/DsfrCurrencyField"
 import PurchaseHint from "@/components/KeyMeasureDiagnostic/PurchaseHint"
 import ErrorHelper from "./ErrorHelper"
 import FormErrorCallout from "@/components/FormErrorCallout"
+import DsfrCallout from "@/components/DsfrCallout"
 import { toCurrency } from "@/utils"
 import validators from "@/validators"
 
@@ -42,7 +54,7 @@ const DEFAULT_TOTAL_ERROR = "Le total doit être plus que la somme des valeurs p
 
 export default {
   name: "QualityTotalStep",
-  components: { DsfrCurrencyField, PurchaseHint, ErrorHelper, FormErrorCallout },
+  components: { DsfrCurrencyField, PurchaseHint, ErrorHelper, FormErrorCallout, DsfrCallout },
   props: {
     diagnostic: {
       type: Object,
@@ -174,6 +186,14 @@ export default {
     onPurchaseAutofill() {
       this.updatePayload()
       this.$nextTick(this.$refs.totalField.validate)
+    },
+    autofillWithPurchases() {
+      Object.assign(this.payload, { diagnosticType: "COMPLETE" }, this.purchasesSummary)
+      this.$emit("full-tunnel-autofill", { payload: this.payload })
+      this.$store.dispatch("notify", {
+        status: "success",
+        message: "Vos achats on été rapportés dans votre bilan.",
+      })
     },
   },
   mounted() {

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
@@ -4,10 +4,11 @@
       <DsfrCallout icon="$money-euro-box-fill">
         <div>
           <p>
-            Vous avez effectué des achats en {{ diagnostic.year }}. Cliquez ci-dessous pour remplir vos informations
-            d'approvisionnement à partir de ces achats.
+            Vous avez effectué des achats en {{ diagnostic.year }} pour un total de
+            <span class="font-weight-bold">{{ toCurrency(purchasesSummary.valueTotalHt) }}</span>
+            . Voulez-vous compléter votre bilan avec les montants de ces achats ?
           </p>
-          <v-btn outlined color="primary" @click="autofillWithPurchases">Remplir automatiquement</v-btn>
+          <v-btn outlined color="primary" @click="autofillWithPurchases">Compléter avec mes achats</v-btn>
         </div>
       </DsfrCallout>
     </div>
@@ -125,6 +126,7 @@ export default {
       this.checkTotal()
       if (!this.hasError) this.$emit("update-payload", { payload: this.payload })
     },
+    toCurrency,
     checkTotal() {
       if (this.payload.valueTotalHt < 0) {
         return // this error is handled by vuetify validation

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
@@ -4,9 +4,9 @@
       <DsfrCallout icon="$money-euro-box-fill">
         <div>
           <p>
-            Vous avez effectué des achats en {{ diagnostic.year }} pour un total de
+            Vous avez renseigné un total de
             <span class="font-weight-bold">{{ toCurrency(purchasesSummary.valueTotalHt) }}</span>
-            . Voulez-vous compléter votre bilan avec les montants de ces achats ?
+            d'achats en {{ diagnostic.year }}. Voulez-vous compléter votre bilan avec les montants de ces achats ?
           </p>
           <v-btn outlined color="primary" @click="autofillWithPurchases">Compléter avec mes achats</v-btn>
         </div>

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/index.vue
@@ -34,6 +34,7 @@
         :payload="payload"
         :purchasesSummary="purchasesSummary"
         v-on:update-payload="updatePayloadFromComponent"
+        v-on:full-tunnel-autofill="onFullTunnelAutofill"
       />
     </div>
   </v-form>
@@ -166,6 +167,10 @@ export default {
     updatePayload() {
       const payloadToSend = getObjectDiff(this.originalValues, this.payload)
       this.$emit("update-payload", { payload: payloadToSend, formIsValid: this.formIsValid })
+    },
+    onFullTunnelAutofill(e) {
+      this.$set(this, "payload", e.payload)
+      this.$emit("full-tunnel-autofill", { payload: this.payload })
     },
     fetchPurchasesSummary() {
       fetch(`/api/v1/canteenPurchasesSummary/${this.canteen.id}?year=${this.diagnostic.year}`)

--- a/frontend/src/views/DiagnosticTunnel/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/index.vue
@@ -51,6 +51,7 @@
           :diagnostic="diagnostic"
           :stepUrlSlug="stepUrlSlug"
           v-on:update-payload="updatePayload"
+          v-on:full-tunnel-autofill="onFullTunnelAutofill"
           v-on:update-steps="updateSteps"
         />
       </div>
@@ -359,6 +360,10 @@ export default {
     },
     quit() {
       this.$router.push(this.quitLink)
+    },
+    onFullTunnelAutofill(e) {
+      this.updatePayload({ payload: e.payload, formIsValid: true })
+      this.saveAndQuit()
     },
     stepLink(step) {
       return { query: { étape: step.urlSlug } }

--- a/frontend/src/views/DiagnosticTunnel/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/index.vue
@@ -23,7 +23,7 @@
               class="text-decoration-underline px-0"
               color="primary"
               @click="step.isSynthesis ? quit() : saveAndQuit()"
-              :disabled="!formIsValid"
+              :disabled="!formIsValid && !isSynthesis"
             >
               {{ step.isSynthesis ? "Quitter" : "Sauvegarder et quitter" }}
               <v-icon color="primary" size="1rem" class="ml-0 mb-1">
@@ -79,7 +79,12 @@
       </div>
       <v-spacer v-if="$vuetify.breakpoint.smAndUp" />
       <div class="d-block d-sm-flex align-center flex-row-reverse">
-        <v-btn :disabled="!formIsValid" @click="continueAction" color="primary" class="ml-0 ml-sm-4 mb-4 mb-sm-0">
+        <v-btn
+          :disabled="!formIsValid && !isSynthesis"
+          @click="continueAction"
+          color="primary"
+          class="ml-0 ml-sm-4 mb-4 mb-sm-0"
+        >
           {{ continueActionText }}
         </v-btn>
         <p v-if="step && step.isSynthesis" class="mb-0"><router-link :to="firstStepLink">Modifier</router-link></p>
@@ -363,7 +368,10 @@ export default {
     },
     onFullTunnelAutofill(e) {
       this.updatePayload({ payload: e.payload, formIsValid: true })
-      this.saveAndQuit()
+      const synthesisStep = this.steps.find((x) => x.isSynthesis)
+      return this.saveDiagnostic()
+        .then(this.$nextTick)
+        .then(() => this.$router.push({ query: { étape: synthesisStep.urlSlug } }))
     },
     stepLink(step) {
       return { query: { étape: step.urlSlug } }


### PR DESCRIPTION
Permet de remplir les données d'approvisionnement avec un seul click en créant un diagnostic complet.

[Screencast from 22-01-24 15:10:00.webm](https://github.com/betagouv/ma-cantine/assets/1225929/be090e99-e792-413a-b4f9-fe2d05af1be7)
