### PR TITLE
Réparer le fil d'Ariane

### DIFF
--- a/frontend/src/components/BreadcrumbsNav.vue
+++ b/frontend/src/components/BreadcrumbsNav.vue
@@ -13,7 +13,7 @@
       <div class="fr-collapse" id="breadcrumb-1" v-show="$vuetify.breakpoint.smAndUp || expanded">
         <ol class="fr-breadcrumb__list pl-0">
           <li>
-            <router-link class="fr-breadcrumb__link" :to="homePage.to">{{ homePage.title }}</router-link>
+            <router-link class="fr-breadcrumb__link" :to="{ name: 'LandingPage' }">Accueil</router-link>
           </li>
           <li v-for="link in breadcrumbLinks" :key="link.title">
             <router-link class="fr-breadcrumb__link" :to="link.to">{{ link.title }}</router-link>
@@ -56,24 +56,6 @@ export default {
     }
   },
   computed: {
-    homePage() {
-      const loggedUser = this.$store.state.loggedUser
-      if (loggedUser && loggedUser.isDev)
-        return {
-          title: "Développement et APIs",
-          to: { name: "DeveloperPage" },
-        }
-      if (loggedUser && !loggedUser.isDev) {
-        return {
-          title: "Mon tableau de bord",
-          to: { name: "ManagementPage" },
-        }
-      }
-      return {
-        title: "Accueil",
-        to: { name: "LandingPage" },
-      }
-    },
     pageTitle() {
       return this.title || this.breadcrumbRoutes.find((r) => r.name === this.$route.name)?.meta?.title
     },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -290,7 +290,7 @@ const routes = [
     name: "ManagementPage",
     component: ManagementPage,
     meta: {
-      title: "Gérer mes cantines",
+      title: "Mon tableau de bord",
       authenticationRequired: true,
     },
   },

--- a/frontend/src/views/BlogsPage/BlogPage.vue
+++ b/frontend/src/views/BlogsPage/BlogPage.vue
@@ -1,10 +1,7 @@
 <template>
   <div id="blog-page">
     <div v-if="blogPost">
-      <BreadcrumbsNav
-        :title="blogPost.title"
-        :links="[{ to: { name: 'CommunityPage' } }, { to: { name: 'BlogsHome' } }]"
-      />
+      <BreadcrumbsNav :title="blogPost.title" :links="[{ to: { name: 'BlogsHome' } }]" />
       <v-card elevation="0" class="text-center text-md-left my-10">
         <v-row v-if="$vuetify.breakpoint.smAndDown">
           <v-col cols="12">

--- a/frontend/src/views/CanteenEditor/index.vue
+++ b/frontend/src/views/CanteenEditor/index.vue
@@ -51,8 +51,8 @@ export default {
       return !this.isNewCanteen && !window.ENABLE_DASHBOARD
     },
     breadcrumbLinks() {
-      if (this.isNewCanteen) return []
-      return [{ to: { name: "DashboardManager" }, title: this.canteen.name }]
+      if (this.isNewCanteen) return [{ to: { name: "ManagementPage" } }]
+      return [{ to: { name: "ManagementPage" } }, { to: { name: "DashboardManager" }, title: this.canteen.name }]
     },
   },
   methods: {

--- a/frontend/src/views/DiagnosticsImporter/DiagnosticImportPage.vue
+++ b/frontend/src/views/DiagnosticsImporter/DiagnosticImportPage.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="text-left">
-    <BreadcrumbsNav :links="[{ to: { name: 'DiagnosticsImporter' } }]" :title="type.title" />
+    <BreadcrumbsNav
+      :links="[{ to: { name: 'ManagementPage' } }, { to: { name: 'DiagnosticsImporter' } }]"
+      :title="type.title"
+    />
 
     <v-row class="my-4 mx-0">
       <v-icon large class="mr-4" color="black">{{ type.icon }}</v-icon>

--- a/frontend/src/views/DiagnosticsImporter/index.vue
+++ b/frontend/src/views/DiagnosticsImporter/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="text-left">
-    <BreadcrumbsNav />
+    <BreadcrumbsNav :links="[{ to: { name: 'ManagementPage' } }]" />
     <h1 class="font-weight-black text-h4 my-6">Importer vos données</h1>
     <p>
       Vous êtes en mesure d'exporter vos données en format CSV ? Utilisez notre outil d'import pour ajouter vos cantines

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="text-left">
-    <BreadcrumbsNav :links="[{ to: { name: 'DashboardManager' }, title: canteen ? canteen.name : 'Dashboard' }]" />
+    <BreadcrumbsNav
+      :links="[
+        { to: { name: 'ManagementPage' } },
+        { to: { name: 'DashboardManager' }, title: canteen ? canteen.name : 'Dashboard' },
+      ]"
+    />
     <v-row>
       <v-col cols="12" md="10">
         <ProductionTypeTag v-if="canteen" :canteen="canteen" class="mt-n2" />


### PR DESCRIPTION
On a supposé que la page d'accueil pour l'utilisateur (ie "Mon tableau de bord" ou "Developpement et APIs") etait la bonne racine pour le site. Mais dans plusieurs cas il y a pas trop de sens :

![Screenshot 2024-01-22 at 17-06-28 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/ffecaba4-64e4-4237-b84e-61d818c05aa1)
![Screenshot 2024-01-22 at 17-06-54 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/d410de4c-d23e-4dd0-a7f5-10a0cc0674ed)
![Screenshot 2024-01-22 at 17-35-07 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/208ed953-2dfa-40ef-af4d-9f582d80836d)
![Screenshot 2024-01-22 at 17-35-25 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/200e989a-d113-46f8-8a04-fe24cea30675)
(ce dernier est une page blog, mais la page blogshome ne contient pas le lien vers la page communauté, dit "Webinaires")

En fait, ama, que la vraie page d'accueil est une racine universel.