### PR TITLE
MAJ tunnel complèt et page achat pour bloquer quelques combinations famille produit et caractéristique

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -330,6 +330,26 @@ export default Object.freeze({
       ],
     },
   },
+  CharacteristicFamilyExceptions: {
+    BIO: [],
+    LABEL_ROUGE: ["BOISSONS"],
+    AOCAOP_IGP_STG: ["VIANDES_VOLAILLES"],
+    HVE: ["AUTRES", "BOISSONS"],
+    PECHE_DURABLE: [
+      "FRUITS_ET_LEGUMES",
+      "CHARCUTERIE",
+      "VIANDES_VOLAILLES",
+      "PRODUITS_LAITIERS",
+      "BOULANGERIE",
+      "AUTRES",
+      "BOISSONS",
+    ],
+    RUP: ["PRODUITS_DE_LA_MER"],
+    COMMERCE_EQUITABLE: [],
+    FERMIER: ["FRUITS_ET_LEGUMES", "PRODUITS_DE_LA_MER", "BOULANGERIE", "AUTRES", "BOISSONS"],
+    EXTERNALITES: [],
+    PERFORMANCE: [],
+  },
   TrackingParams: ["mtm_source", "mtm_campaign", "mtm_medium"],
   Jobs: [
     {

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
@@ -63,7 +63,7 @@
           />
         </div>
         <p v-else class="fr-text-sm grey--text text--darken-1 mt-2">
-          Non applicable pour cette famille de produits
+          Non applicable
         </p>
       </v-col>
     </v-row>

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
@@ -63,7 +63,7 @@
           />
         </div>
         <p v-else class="fr-text-sm grey--text text--darken-1 mt-2">
-          Il y a pas de produits de cette famille pour cette caractéristique
+          Non applicable pour cette famille de produits
         </p>
       </v-col>
     </v-row>

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/FamilyFieldsStep.vue
@@ -35,30 +35,36 @@
     <FormErrorCallout v-if="hasError" :errorMessages="errorMessages" />
     <v-row>
       <v-col v-for="(family, fId) in families" :key="fId" cols="12" md="6" class="py-2">
-        <label :for="fId" class="fr-text">
+        <label :for="fId" :class="`fr-text ${!validFamily(fId) ? 'grey--text text--darken-1' : ''}`">
           {{ family.text }}
         </label>
-
-        <DsfrCurrencyField
-          :id="fId"
-          :rules="[
-            validators.nonNegativeOrEmpty,
-            validators.decimalPlaces(2),
-            validators.lteOrEmpty(payload.valueTotalHt),
-          ]"
-          solo
-          v-model.number="payload[diagnosticKey(fId)]"
-          @blur="fieldUpdate(diagnosticKey(fId))"
-          class="mt-2"
-          :error="fieldHasError(diagnosticKey(fId))"
-        />
-        <PurchaseHint
-          v-if="displayPurchaseHints"
-          v-model="payload[diagnosticKey(fId)]"
-          :purchaseType="family.shortText + ' pour cette caractéristique'"
-          :amount="purchasesSummary[diagnosticKey(fId)]"
-          @autofill="fieldUpdate(diagnosticKey(fId))"
-        />
+        <div v-if="validFamily(fId)">
+          <DsfrCurrencyField
+            :id="fId"
+            :rules="[
+              validators.nonNegativeOrEmpty,
+              validators.decimalPlaces(2),
+              validators.lteOrEmpty(payload.valueTotalHt),
+            ]"
+            solo
+            v-model.number="payload[diagnosticKey(fId)]"
+            @blur="fieldUpdate(diagnosticKey(fId))"
+            class="mt-2"
+            :error="fieldHasError(diagnosticKey(fId))"
+            :disabled="!validFamily(fId)"
+            :readonly="!validFamily(fId)"
+          />
+          <PurchaseHint
+            v-if="displayPurchaseHints && validFamily(fId)"
+            v-model="payload[diagnosticKey(fId)]"
+            :purchaseType="family.shortText + ' pour cette caractéristique'"
+            :amount="purchasesSummary[diagnosticKey(fId)]"
+            @autofill="fieldUpdate(diagnosticKey(fId))"
+          />
+        </div>
+        <p v-else class="fr-text-sm grey--text text--darken-1 mt-2">
+          Il y a pas de produits de cette famille pour cette caractéristique
+        </p>
       </v-col>
     </v-row>
   </div>
@@ -142,6 +148,10 @@ export default {
         this.meatTotalErrorMessage,
         this.fishTotalErrorMessage,
       ].filter((x) => !!x)
+    },
+    possibleFamilies() {
+      const exceptions = Constants.CharacteristicFamilyExceptions[this.characteristicId]
+      return Object.keys(this.families).filter((id) => exceptions.indexOf(id) === -1)
     },
   },
   methods: {
@@ -344,6 +354,9 @@ export default {
         return `Le total ${familyText}${characteristicText}(${problemValue}) excède le total ${familyText}saisi ${stepText}(${totalValue})`
       }
       return `Les montants détaillés ${familyText}(${problemValue}) excédent le total ${familyText}saisi ${stepText}(${totalValue})`
+    },
+    validFamily(id) {
+      return this.possibleFamilies.indexOf(id) > -1
     },
   },
   mounted() {

--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -114,7 +114,9 @@
                   <v-col cols="12" sm="6" class="py-1" v-for="item in productFamilies" :key="item">
                     <v-radio :value="item" class="mt-2">
                       <template v-slot:label>
-                        <span class="body-2 grey--text text--darken-3">{{ getProductFamilyDisplayText(item) }}</span>
+                        <span class="body-2 grey--text text--darken-4">
+                          {{ getProductFamilyDisplayText(item) }}
+                        </span>
                       </template>
                     </v-radio>
                   </v-col>
@@ -152,10 +154,18 @@
                   :multiple="true"
                   :key="characteristic"
                   :value="characteristic"
+                  :disabled="disabledForFamily(characteristic)"
                 >
                   <template v-slot:label>
-                    <span class="body-2 grey--text text--darken-3">
+                    <span
+                      :class="
+                        `body-2 grey--text ${disabledForFamily(characteristic) ? 'text--darken-1' : 'text--darken-4'}`
+                      "
+                    >
                       {{ getCharacteristicDisplayText(characteristic) }}
+                      <span v-if="disabledForFamily(characteristic)">
+                        &nbsp;(pas applicable pour la famille de produit choisie)
+                      </span>
                     </span>
                   </template>
                 </v-checkbox>
@@ -268,6 +278,7 @@ export default {
       localDefinitions: Object.values(Constants.LocalDefinitions),
       productDescriptions: [],
       providers: [],
+      exceptions: Constants.CharacteristicFamilyExceptions,
     }
   },
   props: {
@@ -401,6 +412,11 @@ export default {
           this.providers = options.providers
         })
       }) // these lists are optional so don't bother with error messages if they fail to load
+    },
+    disabledForFamily(characteristic) {
+      if (!this.purchase.family) return
+      if (!this.exceptions[characteristic]) return
+      return this.exceptions[characteristic].indexOf(this.purchase.family) > -1
     },
   },
   mounted() {

--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -164,7 +164,7 @@
                     >
                       {{ getCharacteristicDisplayText(characteristic) }}
                       <span v-if="disabledForFamily(characteristic)">
-                        &nbsp;(pas applicable pour la famille de produit choisie)
+                        &nbsp;(non applicable)
                       </span>
                     </span>
                   </template>

--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -112,7 +112,7 @@
               <v-radio-group v-model="purchase.family" class="my-0">
                 <v-row>
                   <v-col cols="12" sm="6" class="py-1" v-for="item in productFamilies" :key="item">
-                    <v-radio :value="item" class="mt-2">
+                    <v-radio :value="item" class="mt-2" @change="familyChange">
                       <template v-slot:label>
                         <span class="body-2 grey--text text--darken-4">
                           {{ getProductFamilyDisplayText(item) }}
@@ -417,6 +417,23 @@ export default {
       if (!this.purchase.family) return
       if (!this.exceptions[characteristic]) return
       return this.exceptions[characteristic].indexOf(this.purchase.family) > -1
+    },
+    familyChange() {
+      this.$nextTick(() => {
+        if (!this.purchase.family) return
+        if (!this.purchase.characteristics) return
+        const characteristicsToRemove = []
+        this.purchase.characteristics.forEach((characteristic) => {
+          if (!this.exceptions[characteristic]) return
+          if (this.exceptions[characteristic].indexOf(this.purchase.family) > -1) {
+            characteristicsToRemove.push(characteristic)
+          }
+        })
+        characteristicsToRemove.forEach((char) => {
+          const idx = this.purchase.characteristics.indexOf(char)
+          this.purchase.characteristics.splice(idx, 1)
+        })
+      })
     },
   },
   mounted() {


### PR DESCRIPTION
~~NB: les régles ne sont pas encore finalisés, j'ai contacté Val pour avoir la dernière version.~~ On part sur 
[familles_produits_Egalim(1).xlsx](https://github.com/betagouv/ma-cantine/files/14139001/familles_produits_Egalim.1.xlsx), en changeant que les champs en noir.

![Screenshot 2024-02-01 at 18-15-05 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/85c570ae-ef4e-438b-a34c-11f1952f5c8d)
![Screenshot 2024-02-01 at 17-17-04 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/d2d956b1-880e-4781-8dba-486746a96b92)
![Screenshot 2024-02-01 at 17-16-57 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/73019da8-80ed-482d-bcc2-55e25c3d3a73)

Je propose qu'on définit les règles dans le backend en deuxième temps pour découper le travail de revue de code ?