### PR TITLE
3456 le compte des cantines filtrées par epci dans la page ma collectivité est faux

### DIFF
--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -454,21 +454,21 @@ class TestCanteenStatsApi(APITestCase):
     @requests_mock.Mocker()
     def test_epci(self, mock):
         """
-        Test that can get canteens with postcodes that are in EPCIs requested
+        Test that can get canteens with cities that are in EPCIs requested
         """
-        # test multiple postcodes for 1 epci
-        CanteenFactory.create(postal_code="12345", publication_status=Canteen.PublicationStatus.PUBLISHED)
-        CanteenFactory.create(postal_code="67890", publication_status=Canteen.PublicationStatus.PUBLISHED)
+        # test multiple cities for 1 epci
+        CanteenFactory.create(city_insee_code="12345", publication_status=Canteen.PublicationStatus.PUBLISHED)
+        CanteenFactory.create(city_insee_code="67890", publication_status=Canteen.PublicationStatus.PUBLISHED)
         # 'belongs to' epci 2
-        CanteenFactory.create(postal_code="11223", publication_status=Canteen.PublicationStatus.PUBLISHED)
-        CanteenFactory.create(postal_code="11224", publication_status=Canteen.PublicationStatus.PUBLISHED)
+        CanteenFactory.create(city_insee_code="11223", publication_status=Canteen.PublicationStatus.PUBLISHED)
+        CanteenFactory.create(city_insee_code="11224", publication_status=Canteen.PublicationStatus.PUBLISHED)
         # shouldn't be included
-        CanteenFactory.create(postal_code="00000", publication_status=Canteen.PublicationStatus.PUBLISHED)
+        CanteenFactory.create(city_insee_code="00000", publication_status=Canteen.PublicationStatus.PUBLISHED)
         epcis = ["1", "2"]
         # mock the API response for these two 'EPCI's
         api_url = "https://geo.api.gouv.fr/epcis"
-        mock.get(api_url + "/1/communes", json=[{"codesPostaux": ["12345", "67890"]}])
-        mock.get(api_url + "/2/communes", json=[{"codesPostaux": ["11223"]}, {"codesPostaux": ["11224"]}])
+        mock.get(api_url + "/1/communes", json=[{"code": "12345"}, {"code": "67890"}])
+        mock.get(api_url + "/2/communes", json=[{"code": "11223"}, {"code": "11224"}])
 
         response = self.client.get(reverse("canteen_statistics"), {"year": 2021, "epci": epcis})
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -903,26 +903,26 @@ class CanteenStatisticsView(APIView):
         departments = request.query_params.getlist("department")
         sector_categories = request.query_params.getlist("sectors")
         epcis = request.query_params.getlist("epci")
-        postal_codes = None
+        city_insee_codes = None
         year = request.query_params.get("year")
         if not year:
             return JsonResponse({"error": "Expected year"}, status=status.HTTP_400_BAD_REQUEST)
 
         data = {}
         try:
-            postal_codes = CanteenStatisticsView._get_postal_codes(epcis)
+            city_insee_codes = CanteenStatisticsView._get_city_insee_codes(epcis)
         except Exception as e:
             logger.warning(f"Error when fetching postcodes for EPCI for canteen stats: {str(e)}")
             data["epci_error"] = "Une erreur est survenue"
 
-        canteens = CanteenStatisticsView._filter_canteens(regions, departments, postal_codes, sector_categories)
+        canteens = CanteenStatisticsView._filter_canteens(regions, departments, city_insee_codes, sector_categories)
         data["canteen_count"] = canteens.count()
         data["published_canteen_count"] = canteens.filter(
             publication_status=Canteen.PublicationStatus.PUBLISHED
         ).count()
 
         diagnostics = CanteenStatisticsView._filter_diagnostics(
-            year, regions, departments, postal_codes, sector_categories
+            year, regions, departments, city_insee_codes, sector_categories
         )
 
         appro_share_query = diagnostics.filter(value_total_ht__gt=0)
@@ -972,20 +972,20 @@ class CanteenStatisticsView(APIView):
         data["sector_categories"] = sector_categories
         return JsonResponse(camelize(data), status=status.HTTP_200_OK)
 
-    def _get_postal_codes(epcis):
-        postal_codes = []
+    def _get_city_insee_codes(epcis):
+        city_insee_codes = []
         for e in epcis:
-            response = requests.get(f"https://geo.api.gouv.fr/epcis/{e}/communes?fields=codesPostaux", timeout=5)
+            response = requests.get(f"https://geo.api.gouv.fr/epcis/{e}/communes?fields=code", timeout=5)
             response.raise_for_status()
             body = response.json()
             for commune in body:
-                postal_codes += commune["codesPostaux"]
-        return postal_codes
+                city_insee_codes.append(commune["code"])
+        return city_insee_codes
 
-    def _filter_canteens(regions, departments, postal_codes, sectors):
+    def _filter_canteens(regions, departments, city_insee_codes, sectors):
         canteens = Canteen.objects
-        if postal_codes:
-            canteens = canteens.filter(postal_code__in=postal_codes)
+        if city_insee_codes:
+            canteens = canteens.filter(city_insee_code__in=city_insee_codes)
         elif departments:
             canteens = canteens.filter(department__in=departments)
         elif regions:
@@ -995,10 +995,10 @@ class CanteenStatisticsView(APIView):
             canteens = canteens.filter(sectors__in=sectors)
         return canteens.distinct()
 
-    def _filter_diagnostics(year, regions, departments, postal_codes, sectors):
+    def _filter_diagnostics(year, regions, departments, city_insee_codes, sectors):
         diagnostics = Diagnostic.objects.filter(year=year)
-        if postal_codes:
-            diagnostics = diagnostics.filter(canteen__postal_code__in=postal_codes)
+        if city_insee_codes:
+            diagnostics = diagnostics.filter(canteen__city_insee_code__in=city_insee_codes)
         elif departments:
             diagnostics = diagnostics.filter(canteen__department__in=departments)
         elif regions:

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -912,7 +912,7 @@ class CanteenStatisticsView(APIView):
         try:
             city_insee_codes = CanteenStatisticsView._get_city_insee_codes(epcis)
         except Exception as e:
-            logger.warning(f"Error when fetching postcodes for EPCI for canteen stats: {str(e)}")
+            logger.warning(f"Error when fetching INSEE codes for EPCI for canteen stats: {str(e)}")
             data["epci_error"] = "Une erreur est survenue"
 
         canteens = CanteenStatisticsView._filter_canteens(regions, departments, city_insee_codes, sector_categories)

--- a/data/factories/canteen.py
+++ b/data/factories/canteen.py
@@ -11,7 +11,7 @@ class CanteenFactory(factory.django.DjangoModelFactory):
 
     name = factory.Faker("text", max_nb_chars=20)
     city = factory.Faker("city")
-    postal_code = factory.Faker("postcode")
+    city_insee_code = factory.Faker("postcode")
     daily_meal_count = factory.Faker("pyint")
 
     @factory.post_generation


### PR DESCRIPTION
En faisant la modif, j'ai appris que pour une liste "+=" correspond a extend() et pas append(). Il faut donc une liste a droite de l'opérateur (ce qui n'étais plus le cas ici).