### PR TITLE
Formatter les fichiers de template TD

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,6 @@
     "editor.defaultFormatter": "ms-python.black-formatter"
   },
   "black-formatter.args": ["--line-length=119"],
-  "black-formatter.path": ["./venv/bin/black"]
+  "black-formatter.path": ["./venv/bin/black"],
+  "emmet.includeLanguages": {"django-html": "html"}
 }

--- a/api/templates/teledeclaration_campaign_2024/canteen.html
+++ b/api/templates/teledeclaration_campaign_2024/canteen.html
@@ -1,37 +1,58 @@
-
 <h3>Informations de mon établissement</h3>
 <ul>
-{% if canteen.name %}
-    <li><span>Nom</span> : {{ canteen.name }}</li>
-{% endif %}
-{% if canteen.siret %}
-    <li><span>SIRET</span> : {{ canteen.siret }}</li>
-{% endif %}
-{% if canteen.production_type %}
-    <li><span>Mode de production</span> : {{ canteen.production_type }}</li>
-{% endif %}
-{% if canteen.city_insee_code %}
-    <li><span>Code Insee</span> : {{ canteen.city_insee_code }}</li>
-{% endif %}
-{% if canteen.central_producer_siret %}
-    <li><span>SIRET de la cuisine centrale</span> : {{ canteen.central_producer_siret }}</li>
-{% endif %}
-{% if canteen.daily_meal_count %}
-    <li><span>Nombre de repas par jour</span> : {{ canteen.daily_meal_count }}</li>
-{% endif %}
-{% if canteen.yearly_meal_count %}
-    <li><span>Nombre de repas par an</span> : {{ canteen.yearly_meal_count }}</li>
-{% endif %}
-{% if canteen.sectors %}
-    <li><span>Secteurs d'activité</span> : {{ canteen.sectors }}</li>
-{% endif %}
-{% if canteen.line_ministry %}
-    <li><span>Ministère de tutelle</span> : {{ canteen.line_ministry }}</li>
-{% endif %}
-{% if canteen.management_type %}
-    <li><span>Mode de gestion</span> : {{ canteen.management_type }}</li>
-{% endif %}
-{% if canteen.economic_model %}
-    <li><span>Type d'établissement</span> : {{ canteen.economic_model }}</li>
-{% endif %}
+    {% if canteen.name %}
+        <li>
+            <span>Nom</span> : {{ canteen.name }}
+        </li>
+    {% endif %}
+    {% if canteen.siret %}
+        <li>
+            <span>SIRET</span> : {{ canteen.siret }}
+        </li>
+    {% endif %}
+    {% if canteen.production_type %}
+        <li>
+            <span>Mode de production</span> : {{ canteen.production_type }}
+        </li>
+    {% endif %}
+    {% if canteen.city_insee_code %}
+        <li>
+            <span>Code Insee</span> : {{ canteen.city_insee_code }}
+        </li>
+    {% endif %}
+    {% if canteen.central_producer_siret %}
+        <li>
+            <span>SIRET de la cuisine centrale</span> : {{ canteen.central_producer_siret }}
+        </li>
+    {% endif %}
+    {% if canteen.daily_meal_count %}
+        <li>
+            <span>Nombre de repas par jour</span> : {{ canteen.daily_meal_count }}
+        </li>
+    {% endif %}
+    {% if canteen.yearly_meal_count %}
+        <li>
+            <span>Nombre de repas par an</span> : {{ canteen.yearly_meal_count }}
+        </li>
+    {% endif %}
+    {% if canteen.sectors %}
+        <li>
+            <span>Secteurs d'activité</span> : {{ canteen.sectors }}
+        </li>
+    {% endif %}
+    {% if canteen.line_ministry %}
+        <li>
+            <span>Ministère de tutelle</span> : {{ canteen.line_ministry }}
+        </li>
+    {% endif %}
+    {% if canteen.management_type %}
+        <li>
+            <span>Mode de gestion</span> : {{ canteen.management_type }}
+        </li>
+    {% endif %}
+    {% if canteen.economic_model %}
+        <li>
+            <span>Type d'établissement</span> : {{ canteen.economic_model }}
+        </li>
+    {% endif %}
 </ul>

--- a/api/templates/teledeclaration_campaign_2024/diagnostic_mode_description.html
+++ b/api/templates/teledeclaration_campaign_2024/diagnostic_mode_description.html
@@ -1,24 +1,20 @@
-
 {% if teledeclaration_mode == "SATELLITE_WITHOUT_APPRO" %}
-<p>
-    Les données d'approvisionnement ont été déclarées par la cuisine centrale{% if central_kitchen_name %} « {{ central_kitchen_name }} »{% endif %}{% if central_kitchen_siret %} (SIRET : {{ central_kitchen_siret }}){% endif %}.
-</p>
+    <p>
+        Les données d'approvisionnement ont été déclarées par la cuisine centrale
+        {% if central_kitchen_name %}« {{ central_kitchen_name }} »{% endif %}
+        {% if central_kitchen_siret %}(SIRET : {{ central_kitchen_siret }}){% endif %}
+        .
+    </p>
 {% elif teledeclaration_mode == "CENTRAL_ALL" %}
-<p>
-    Vous avez choisi de déclarer ces données au nom de toutes vos cantines satellites.
-</p>
+    <p>Vous avez choisi de déclarer ces données au nom de toutes vos cantines satellites.</p>
 {% elif teledeclaration_mode == "CENTRAL_APPRO" %}
-<p>
-    Vous avez choisi de déclarer les données d'approvisionnement au nom de toutes vos cantines satellites.
-</p>
+    <p>Vous avez choisi de déclarer les données d'approvisionnement au nom de toutes vos cantines satellites.</p>
 {% endif %}
 {% if teledeclaration_mode == "CENTRAL_ALL" or teledeclaration_mode == "CENTRAL_APPRO" %}
     {% if satellites %}
         Cette télédéclaration concerne les cuisines satellites :
         <ul>
-        {% for satellite in satellites %}
-        <li>{{ satellite.name }} (SIRET : {{ satellite.siret }})</li>
-        {% endfor %}
+            {% for satellite in satellites %}<li>{{ satellite.name }} (SIRET : {{ satellite.siret }})</li>{% endfor %}
         </ul>
     {% endif %}
 {% endif %}

--- a/api/templates/teledeclaration_campaign_2024/index.html
+++ b/api/templates/teledeclaration_campaign_2024/index.html
@@ -1,29 +1,23 @@
 {% load static %}
 <html>
-    <head>
-        {% include "./style.html" %}
-    </head>
+    <head>{% include "./style.html" %}</head>
     <body>
         <div class="image-container">
-            <img src="{% static '../../../web/static/images/logo_transparent_white.png' %}" alt="ma cantine" height="30" width="142" />
+            <img src="{% static '../../../web/static/images/logo_transparent_white.png' %}"
+                 alt="ma cantine"
+                 height="30"
+                 width="142" />
         </div>
         <h1>Justificatif pour télédéclaration {{ year }}</h1>
         <h2>Télédéclaration faite le {{ date|date:"l j F Y" }} par {{ applicant }}</h2>
-
         {% include "./canteen.html" %}
-
         {% if teledeclaration_mode != "SATELLITE_WITHOUT_APPRO" %}
-            <h3>
-                Vous avez choisi la télédéclaration {{ diagnostic_type }}.
-            </h3>
+            <h3>Vous avez choisi la télédéclaration {{ diagnostic_type }}.</h3>
         {% endif %}
-
         <p>
             L'arrêté du 14 septembre 2022 rend obligatoire la saisie et la transmission des données d'achat de l'année n-1 à l'administration.
         </p>
-
         {% include "./diagnostic_mode_description.html" %}
-
         <p>
             Pour l'année {{ year }}, les données suivantes ont été télédéclarées le
             {{ date|date:"l j F Y" }} via la plateforme numérique « ma cantine » :
@@ -33,23 +27,21 @@
             {% if not diagnostic_type == "complète" %}
                 {% include "./measure_quality_simple.html" %}
             {% else %}
-            <!-- COMPLETE DECLARATION -->
+                <!-- COMPLETE DECLARATION -->
                 {% include "./measure_quality_complete.html" %}
             {% endif %}
         {% endif %}
         {% if teledeclaration_mode != "CENTRAL_APPRO" %}
             <div class="other-measures">
-
                 {% include "./measure_waste.html" %}
                 {% include "./measure_diversification.html" %}
                 {% include "./measure_plastic.html" %}
                 {% include "./measure_info.html" %}
-
             </div>
         {% endif %}
-
         <hr />
-
-        <p>En savoir plus de la loi EGAlim : <a href="https://ma-cantine.agriculture.gouv.fr/">https://ma-cantine.agriculture.gouv.fr/</a></p>
+        <p>
+            En savoir plus de la loi EGAlim : <a href="https://ma-cantine.agriculture.gouv.fr/">https://ma-cantine.agriculture.gouv.fr/</a>
+        </p>
     </body>
 </html>

--- a/api/templates/teledeclaration_campaign_2024/measure_diversification.html
+++ b/api/templates/teledeclaration_campaign_2024/measure_diversification.html
@@ -1,51 +1,54 @@
 {% load static %}
 <h3>Diversification des sources de protéines et menus végétariens</h3>
-
 {% if has_diversification_plan %}
-<div>
-<p>
-    <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-    Plan de diversification en place
-</p>
-{% if diversification_plan_actions %}
-. Ce plan comporte les actions suivantes :
-<ul>
-    {% for action in diversification_plan_actions %}
-    <li>{{ action }}</li>
-    {% endfor %}
-</ul>
+    <div>
+        <p>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Plan de diversification en place
+        </p>
+        {% if diversification_plan_actions %}
+            . Ce plan comporte les actions suivantes :
+            <ul>
+                {% for action in diversification_plan_actions %}<li>{{ action }}</li>{% endfor %}
+            </ul>
+        {% endif %}
+    </div>
 {% endif %}
-</div>
-{% endif %}
-
 {% if vegetarian_weekly_recurrence == "Jamais" %}
     <div>
-        <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
+        <img src="{% static '../../../web/static/images/close-outline.png' %}"
+             height="14"
+             width="14" />
         Fréquence hebdomadaire des menus végétariens : {{ vegetarian_weekly_recurrence }}
     </div>
 {% elif vegetarian_weekly_recurrence %}
     <div>
-        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
+        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+             height="14"
+             width="14" />
         Fréquence hebdomadaire des menus végétariens : {{ vegetarian_weekly_recurrence }}
     </div>
     {% if vegetarian_menu_type %}
-    <div>
-        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-        Type de menu végétarien : {{ vegetarian_menu_type }}
-    </div>
+        <div>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Type de menu végétarien : {{ vegetarian_menu_type }}
+        </div>
     {% endif %}
-
     {% if vegetarian_menu_bases %}
-    <div>
-        <p>
-            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-            Le plat principal du menu végétarien est majoritairement à base de :
-        </p>
-        <ul>
-            {% for base in vegetarian_menu_bases %}
-            <li>{{ base }}</li>
-            {% endfor %}
-        </ul>
-    </div>
+        <div>
+            <p>
+                <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                     height="14"
+                     width="14" />
+                Le plat principal du menu végétarien est majoritairement à base de :
+            </p>
+            <ul>
+                {% for base in vegetarian_menu_bases %}<li>{{ base }}</li>{% endfor %}
+            </ul>
+        </div>
     {% endif %}
 {% endif %}

--- a/api/templates/teledeclaration_campaign_2024/measure_info.html
+++ b/api/templates/teledeclaration_campaign_2024/measure_info.html
@@ -1,58 +1,64 @@
 {% load static %}
 <h3>Information des usagers et convives</h3>
 <div>
-{% if communicates_on_food_plan %}
-<p>
-    <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-    Communique sur le plan alimentaire
-</p>
-{% else %}
-<p>
-    <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
-    Ne communique pas sur le plan alimentaire
-</p>
-{% endif %}
+    {% if communicates_on_food_plan %}
+        <p>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Communique sur le plan alimentaire
+        </p>
+    {% else %}
+        <p>
+            <img src="{% static '../../../web/static/images/close-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Ne communique pas sur le plan alimentaire
+        </p>
+    {% endif %}
 </div>
-
 {% if communication_frequency %}
-<div>
-    <p>
-        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-        Fréquence de cette communication : {{ communication_frequency }}
-    </p>
-</div>
+    <div>
+        <p>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Fréquence de cette communication : {{ communication_frequency }}
+        </p>
+    </div>
 {% endif %}
-
 {% if communication_supports %}
-<div>
-    <p>
-        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-        L'information sur la qualité des approvisionnements se fait :
-    </p>
-    <ul>
-        {% for support in communication_supports %}
-        <li>{{ support }}</li>
-        {% endfor %}
-    </ul>
-</div>
+    <div>
+        <p>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
+            L'information sur la qualité des approvisionnements se fait :
+        </p>
+        <ul>
+            {% for support in communication_supports %}<li>{{ support }}</li>{% endfor %}
+        </ul>
+    </div>
 {% endif %}
-
 <p>
-{% if communicates_on_food_quality %}
-<img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-Communique sur les démarches qualité/durables/équitables
-{% else %}
-<img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
-Ne communique pas sur les démarches qualité/durables/équitables
-{% endif %}
+    {% if communicates_on_food_quality %}
+        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+             height="14"
+             width="14" />
+        Communique sur les démarches qualité/durables/équitables
+    {% else %}
+        <img src="{% static '../../../web/static/images/close-outline.png' %}"
+             height="14"
+             width="14" />
+        Ne communique pas sur les démarches qualité/durables/équitables
+    {% endif %}
 </p>
-
 {% if communication_support_url %}
-<p>
-    <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-    Lien vers le support de communication :
-    <a href="{{ communication_support_url }}">
-        {{ communication_support_url }}
-    </a>
-</p>
+    <p>
+        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+             height="14"
+             width="14" />
+        Lien vers le support de communication :
+        <a href="{{ communication_support_url }}">{{ communication_support_url }}</a>
+    </p>
 {% endif %}

--- a/api/templates/teledeclaration_campaign_2024/measure_plastic.html
+++ b/api/templates/teledeclaration_campaign_2024/measure_plastic.html
@@ -1,57 +1,70 @@
 {% load static %}
 <h3>Substitution des plastiques</h3>
 <div>
-{% if cooking_plastic_substituted %}
-<p>
-    <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-    Contenants de cuisson en plastique remplacés
-</p>
-{% else %}
-<p>
-    <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
-    Contenants de cuisson en plastique non remplacés
-</p>
-{% endif %}
-
+    {% if cooking_plastic_substituted %}
+        <p>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Contenants de cuisson en plastique remplacés
+        </p>
+    {% else %}
+        <p>
+            <img src="{% static '../../../web/static/images/close-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Contenants de cuisson en plastique non remplacés
+        </p>
+    {% endif %}
 </div>
 <div>
-{% if serving_plastic_substituted %}
-<p>
-    <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-    Contenants de service en plastique remplacés
-</p>
-{% else %}
-<p>
-    <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
-    Contenants de service en plastique non remplacés
-</p>
-{% endif %}
+    {% if serving_plastic_substituted %}
+        <p>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Contenants de service en plastique remplacés
+        </p>
+    {% else %}
+        <p>
+            <img src="{% static '../../../web/static/images/close-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Contenants de service en plastique non remplacés
+        </p>
+    {% endif %}
 </div>
-
 <div>
-{% if plastic_bottles_substituted %}
-<p>
-    <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-    Bouteilles en plastique remplacées
-</p>
-{% else %}
-<p>
-    <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
-    Bouteilles en plastique non remplacées
-</p>
-{% endif %}
+    {% if plastic_bottles_substituted %}
+        <p>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Bouteilles en plastique remplacées
+        </p>
+    {% else %}
+        <p>
+            <img src="{% static '../../../web/static/images/close-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Bouteilles en plastique non remplacées
+        </p>
+    {% endif %}
 </div>
-
 <div>
-{% if plastic_tableware_substituted %}
-<p>
-    <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-    Ustensils en plastique remplacés
-</p>
-{% else %}
-<p>
-    <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
-    Ustensils en plastique non remplacés
-</p>
-{% endif %}
+    {% if plastic_tableware_substituted %}
+        <p>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Ustensils en plastique remplacés
+        </p>
+    {% else %}
+        <p>
+            <img src="{% static '../../../web/static/images/close-outline.png' %}"
+                 height="14"
+                 width="14" />
+            Ustensils en plastique non remplacés
+        </p>
+    {% endif %}
 </div>

--- a/api/templates/teledeclaration_campaign_2024/measure_quality_simple.html
+++ b/api/templates/teledeclaration_campaign_2024/measure_quality_simple.html
@@ -1,50 +1,50 @@
 <ul>
-  <li>
-      <span>Valeur totale en HT des achats alimentaires</span> : {{ value_total_ht|floatformat:2 }} €
-  </li>
-  <li>
-      <span>Valeur en HT des achats alimentaires en Bio</span> : {% if not value_bio_ht is None %}{{ value_bio_ht|floatformat:2 }}{% else %}—{% endif %} €
-  </li>
-  <li>
-      <span>Valeur en HT de mes achats SIQO (AOP/AOC, IGP, STG, Label Rouge)</span> : {% if not value_sustainable_ht is None %}{{ value_sustainable_ht|floatformat:2 }}{% else %}—{% endif %} €
-  </li>
-  <li>
-      <span>Valeur en HT de mes autres achats EGAlim</span> : {% if not value_egalim_others_ht is None %}{{ value_egalim_others_ht|floatformat:2 }}{% else %}—{% endif %} €
-  </li>
-  <li>
-      <span>Valeur en HT de mes achats prenant en compte les coûts imputés aux externalités environnementales ou leurs performances en matière environnementale</span> :
-      {% if not value_externality_performance_ht is None %}{{ value_externality_performance_ht|floatformat:2 }}{% else %}—{% endif %} €
-  </li>
+    <li>
+        <span>Valeur totale en HT des achats alimentaires</span> : {{ value_total_ht|floatformat:2 }} €
+    </li>
+    <li>
+        <span>Valeur en HT des achats alimentaires en Bio</span> : {% if not value_bio_ht is None %}{{ value_bio_ht|floatformat:2 }}{% else %}—{% endif %} €
+    </li>
+    <li>
+        <span>Valeur en HT de mes achats SIQO (AOP/AOC, IGP, STG, Label Rouge)</span> : {% if not value_sustainable_ht is None %}{{ value_sustainable_ht|floatformat:2 }}{% else %}—{% endif %} €
+    </li>
+    <li>
+        <span>Valeur en HT de mes autres achats EGAlim</span> : {% if not value_egalim_others_ht is None %}{{ value_egalim_others_ht|floatformat:2 }}{% else %}—{% endif %} €
+    </li>
+    <li>
+        <span>Valeur en HT de mes achats prenant en compte les coûts imputés aux externalités environnementales ou leurs performances en matière environnementale</span> :
+        {% if not value_externality_performance_ht is None %}{{ value_externality_performance_ht|floatformat:2 }}{% else %}—{% endif %} €
+    </li>
 </ul>
 
 <p>
-  Viandes et volailles
+    Viandes et volailles
 </p>
 <ul>
-  <li>
-      <span>Valeur totale en HT des achats en viandes et volailles fraiches ou surgelées</span> :
-      {% if not value_meat_poultry_ht is None %}{{ value_meat_poultry_ht|floatformat:2 }}{% else %}—{% endif %} €
-  </li>
-  <li>
-      <span>Valeur en HT des achats en viandes et volailles fraiches ou surgelées EGAlim</span> :
-      {% if not value_meat_poultry_egalim_ht is None %}{{ value_meat_poultry_egalim_ht|floatformat:2 }}{% else %}—{% endif %} €
-  </li>
-  <li>
-      <span>Valeur en HT des achats en viandes et volailles fraiches ou surgelées provenance France</span> :
-      {% if not value_meat_poultry_france_ht is None %}{{ value_meat_poultry_france_ht|floatformat:2 }}{% else %}—{% endif %} €
-  </li>
+    <li>
+        <span>Valeur totale en HT des achats en viandes et volailles fraiches ou surgelées</span> :
+        {% if not value_meat_poultry_ht is None %}{{ value_meat_poultry_ht|floatformat:2 }}{% else %}—{% endif %} €
+    </li>
+    <li>
+        <span>Valeur en HT des achats en viandes et volailles fraiches ou surgelées EGAlim</span> :
+        {% if not value_meat_poultry_egalim_ht is None %}{{ value_meat_poultry_egalim_ht|floatformat:2 }}{% else %}—{% endif %} €
+    </li>
+    <li>
+        <span>Valeur en HT des achats en viandes et volailles fraiches ou surgelées provenance France</span> :
+        {% if not value_meat_poultry_france_ht is None %}{{ value_meat_poultry_france_ht|floatformat:2 }}{% else %}—{% endif %} €
+    </li>
 </ul>
 
 <p>
-  Poissons, produits de la mer et de l'aquaculture
+    Poissons, produits de la mer et de l'aquaculture
 </p>
 <ul>
-  <li>
-      <span>Valeur totale en HT des achats en poissons, produits de la mer et de l'aquaculture</span> :
-      {% if not value_fish_ht is None %}{{ value_fish_ht|floatformat:2 }}{% else %}—{% endif %} €
-  </li>
-  <li>
-      <span>Valeur en HT des achats en poissons, produits de la mer et de l'aquaculture EGAlim</span> :
-      {% if not value_fish_egalim_ht is None %}{{ value_fish_egalim_ht|floatformat:2 }}{% else %}—{% endif %} €
-  </li>
+    <li>
+        <span>Valeur totale en HT des achats en poissons, produits de la mer et de l'aquaculture</span> :
+        {% if not value_fish_ht is None %}{{ value_fish_ht|floatformat:2 }}{% else %}—{% endif %} €
+    </li>
+    <li>
+        <span>Valeur en HT des achats en poissons, produits de la mer et de l'aquaculture EGAlim</span> :
+        {% if not value_fish_egalim_ht is None %}{{ value_fish_egalim_ht|floatformat:2 }}{% else %}—{% endif %} €
+    </li>
 </ul>

--- a/api/templates/teledeclaration_campaign_2024/measure_quality_simple.html
+++ b/api/templates/teledeclaration_campaign_2024/measure_quality_simple.html
@@ -3,48 +3,90 @@
         <span>Valeur totale en HT des achats alimentaires</span> : {{ value_total_ht|floatformat:2 }} €
     </li>
     <li>
-        <span>Valeur en HT des achats alimentaires en Bio</span> : {% if not value_bio_ht is None %}{{ value_bio_ht|floatformat:2 }}{% else %}—{% endif %} €
+        <span>Valeur en HT des achats alimentaires en Bio</span> :
+        {% if not value_bio_ht is None %}
+            {{ value_bio_ht|floatformat:2 }}
+        {% else %}
+            —
+        {% endif %}
+        €
     </li>
     <li>
-        <span>Valeur en HT de mes achats SIQO (AOP/AOC, IGP, STG, Label Rouge)</span> : {% if not value_sustainable_ht is None %}{{ value_sustainable_ht|floatformat:2 }}{% else %}—{% endif %} €
+        <span>Valeur en HT de mes achats SIQO (AOP/AOC, IGP, STG, Label Rouge)</span> :
+        {% if not value_sustainable_ht is None %}
+            {{ value_sustainable_ht|floatformat:2 }}
+        {% else %}
+            —
+        {% endif %}
+        €
     </li>
     <li>
-        <span>Valeur en HT de mes autres achats EGAlim</span> : {% if not value_egalim_others_ht is None %}{{ value_egalim_others_ht|floatformat:2 }}{% else %}—{% endif %} €
+        <span>Valeur en HT de mes autres achats EGAlim</span> :
+        {% if not value_egalim_others_ht is None %}
+            {{ value_egalim_others_ht|floatformat:2 }}
+        {% else %}
+            —
+        {% endif %}
+        €
     </li>
     <li>
         <span>Valeur en HT de mes achats prenant en compte les coûts imputés aux externalités environnementales ou leurs performances en matière environnementale</span> :
-        {% if not value_externality_performance_ht is None %}{{ value_externality_performance_ht|floatformat:2 }}{% else %}—{% endif %} €
+        {% if not value_externality_performance_ht is None %}
+            {{ value_externality_performance_ht|floatformat:2 }}
+        {% else %}
+            —
+        {% endif %}
+        €
     </li>
 </ul>
-
-<p>
-    Viandes et volailles
-</p>
+<p>Viandes et volailles</p>
 <ul>
     <li>
         <span>Valeur totale en HT des achats en viandes et volailles fraiches ou surgelées</span> :
-        {% if not value_meat_poultry_ht is None %}{{ value_meat_poultry_ht|floatformat:2 }}{% else %}—{% endif %} €
+        {% if not value_meat_poultry_ht is None %}
+            {{ value_meat_poultry_ht|floatformat:2 }}
+        {% else %}
+            —
+        {% endif %}
+        €
     </li>
     <li>
         <span>Valeur en HT des achats en viandes et volailles fraiches ou surgelées EGAlim</span> :
-        {% if not value_meat_poultry_egalim_ht is None %}{{ value_meat_poultry_egalim_ht|floatformat:2 }}{% else %}—{% endif %} €
+        {% if not value_meat_poultry_egalim_ht is None %}
+            {{ value_meat_poultry_egalim_ht|floatformat:2 }}
+        {% else %}
+            —
+        {% endif %}
+        €
     </li>
     <li>
         <span>Valeur en HT des achats en viandes et volailles fraiches ou surgelées provenance France</span> :
-        {% if not value_meat_poultry_france_ht is None %}{{ value_meat_poultry_france_ht|floatformat:2 }}{% else %}—{% endif %} €
+        {% if not value_meat_poultry_france_ht is None %}
+            {{ value_meat_poultry_france_ht|floatformat:2 }}
+        {% else %}
+            —
+        {% endif %}
+        €
     </li>
 </ul>
-
-<p>
-    Poissons, produits de la mer et de l'aquaculture
-</p>
+<p>Poissons, produits de la mer et de l'aquaculture</p>
 <ul>
     <li>
         <span>Valeur totale en HT des achats en poissons, produits de la mer et de l'aquaculture</span> :
-        {% if not value_fish_ht is None %}{{ value_fish_ht|floatformat:2 }}{% else %}—{% endif %} €
+        {% if not value_fish_ht is None %}
+            {{ value_fish_ht|floatformat:2 }}
+        {% else %}
+            —
+        {% endif %}
+        €
     </li>
     <li>
         <span>Valeur en HT des achats en poissons, produits de la mer et de l'aquaculture EGAlim</span> :
-        {% if not value_fish_egalim_ht is None %}{{ value_fish_egalim_ht|floatformat:2 }}{% else %}—{% endif %} €
+        {% if not value_fish_egalim_ht is None %}
+            {{ value_fish_egalim_ht|floatformat:2 }}
+        {% else %}
+            —
+        {% endif %}
+        €
     </li>
 </ul>

--- a/api/templates/teledeclaration_campaign_2024/measure_waste.html
+++ b/api/templates/teledeclaration_campaign_2024/measure_waste.html
@@ -1,94 +1,90 @@
 {% load static %}
 <h3>Lutte contre le gaspillage et dons alimentaires</h3>
-
 <p>
     {% if has_waste_diagnostic %}
-        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
+        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+             height="14"
+             width="14" />
         Diagnostic sur le gaspillage réalisé
     {% else %}
-        <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
+        <img src="{% static '../../../web/static/images/close-outline.png' %}"
+             height="14"
+             width="14" />
         Diagnostic sur le gaspillage manquant
     {% endif %}
 </p>
 <p>
     {% if has_waste_plan %}
-        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
+        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+             height="14"
+             width="14" />
         Plan d'action contre le gaspillage en place
     {% else %}
-        <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
+        <img src="{% static '../../../web/static/images/close-outline.png' %}"
+             height="14"
+             width="14" />
         Pas de plan d'action contre le gaspillage en place
     {% endif %}
 </p>
 <div>
     {% if waste_actions %}
         <p>
-            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
             Actions de lutte contre le gaspillage :
         </p>
         <ul>
-            {% for action in waste_actions %}
-                <li>{{ action }}</li>
-            {% endfor %}
+            {% for action in waste_actions %}<li>{{ action }}</li>{% endfor %}
         </ul>
     {% endif %}
 </div>
-
 <div>
     {% if has_donation_agreement %}
         <p>
-            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
             Propose des dons alimentaires
         </p>
         <ul>
-            {% if donation_frequency %}
-                <li>Fréquence de dons : {{donation_frequency}} dons/an</li>
-            {% endif %}
-            {% if donation_quantity %}
-                <li>Quantité des denrées données : {{donation_quantity}} kg/an</li>
-            {% endif %}
-            {% if donation_food_type %}
-                <li>Type de denrées données : {{donation_food_type}}</li>
-            {% endif %}
+            {% if donation_frequency %}<li>Fréquence de dons : {{ donation_frequency }} dons/an</li>{% endif %}
+            {% if donation_quantity %}<li>Quantité des denrées données : {{ donation_quantity }} kg/an</li>{% endif %}
+            {% if donation_food_type %}<li>Type de denrées données : {{ donation_food_type }}</li>{% endif %}
         </ul>
     {% endif %}
 </div>
 <div>
     {% if has_waste_measures %}
         <p>
-            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}"
+                 height="14"
+                 width="14" />
             Réalise des mesures contre le gaspillage alimentaire
         </p>
         <ul>
-            {% if total_leftovers %}
-                <li> Total des déchets alimentaires : {{ total_leftovers }} tonnes </li>
-            {% endif %}
+            {% if total_leftovers %}<li>Total des déchets alimentaires : {{ total_leftovers }} tonnes</li>{% endif %}
             {% if duration_leftovers_measurement %}
-                <li> Période de mesure : {{ duration_leftovers_measurement }} jours </li>
+                <li>Période de mesure : {{ duration_leftovers_measurement }} jours</li>
             {% endif %}
-            {% if bread_leftovers %}
-                <li> Reste de pain : {{ bread_leftovers }} kg/an </li>
-            {% endif %}
-            {% if served_leftovers %}
-                <li> Reste plateau : {{ served_leftovers }} kg/an </li>
-            {% endif %}
-            {% if unserved_leftovers %}
-                <li> Reste en production (non servi) : {{ unserved_leftovers }} kg/an </li>
-            {% endif %}
-            {% if side_leftovers %}
-                <li> Reste de composantes (entrée, plat dessert...) : {{ side_leftovers }} kg/an </li>
-            {% endif %}
+            {% if bread_leftovers %}<li>Reste de pain : {{ bread_leftovers }} kg/an</li>{% endif %}
+            {% if served_leftovers %}<li>Reste plateau : {{ served_leftovers }} kg/an</li>{% endif %}
+            {% if unserved_leftovers %}<li>Reste en production (non servi) : {{ unserved_leftovers }} kg/an</li>{% endif %}
+            {% if side_leftovers %}<li>Reste de composantes (entrée, plat dessert...) : {{ side_leftovers }} kg/an</li>{% endif %}
         </ul>
     {% else %}
         <p>
-            <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
+            <img src="{% static '../../../web/static/images/close-outline.png' %}"
+                 height="14"
+                 width="14" />
             Pas de mesures contre le gaspillage alimentaire
         </p>
-        </div>
-    {% endif %}
-
-    <div>
-        {% if other_waste_comments %}
-            Commentaires concernant la lutte contre le gaspillage et dons alimentaires : <br />
-            « {{ other_waste_comments }} »
-        {% endif %}
     </div>
+{% endif %}
+<div>
+    {% if other_waste_comments %}
+        Commentaires concernant la lutte contre le gaspillage et dons alimentaires :
+        <br />
+        « {{ other_waste_comments }} »
+    {% endif %}
+</div>

--- a/api/templates/teledeclaration_campaign_2024/measure_waste.html
+++ b/api/templates/teledeclaration_campaign_2024/measure_waste.html
@@ -2,93 +2,93 @@
 <h3>Lutte contre le gaspillage et dons alimentaires</h3>
 
 <p>
-{% if has_waste_diagnostic %}
-<img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-Diagnostic sur le gaspillage réalisé
-{% else %}
-<img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
-Diagnostic sur le gaspillage manquant
-{% endif %}
+    {% if has_waste_diagnostic %}
+        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
+        Diagnostic sur le gaspillage réalisé
+    {% else %}
+        <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
+        Diagnostic sur le gaspillage manquant
+    {% endif %}
 </p>
 <p>
-{% if has_waste_plan %}
-<img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-Plan d'action contre le gaspillage en place
-{% else %}
-<img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
-Pas de plan d'action contre le gaspillage en place
-{% endif %}
+    {% if has_waste_plan %}
+        <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
+        Plan d'action contre le gaspillage en place
+    {% else %}
+        <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
+        Pas de plan d'action contre le gaspillage en place
+    {% endif %}
 </p>
 <div>
-{% if waste_actions %}
-<p>
-    <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-    Actions de lutte contre le gaspillage :
-</p>
-<ul>
-    {% for action in waste_actions %}
-    <li>{{ action }}</li>
-    {% endfor %}
-</ul>
-{% endif %}
+    {% if waste_actions %}
+        <p>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
+            Actions de lutte contre le gaspillage :
+        </p>
+        <ul>
+            {% for action in waste_actions %}
+                <li>{{ action }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
 </div>
 
 <div>
-  {% if has_donation_agreement %}
-  <p>
-      <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-      Propose des dons alimentaires
-  </p>
-  <ul>
-      {% if donation_frequency %}
-      <li>Fréquence de dons : {{donation_frequency}} dons/an</li>
-      {% endif %}
-      {% if donation_quantity %}
-      <li>Quantité des denrées données : {{donation_quantity}} kg/an</li>
-      {% endif %}
-      {% if donation_food_type %}
-      <li>Type de denrées données : {{donation_food_type}}</li>
-      {% endif %}
-  </ul>
-  {% endif %}
-  </div>
-  <div>
-  {% if has_waste_measures %}
-  <p>
-      <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
-      Réalise des mesures contre le gaspillage alimentaire
-  </p>
-  <ul>
-      {% if total_leftovers %}
-      <li> Total des déchets alimentaires : {{ total_leftovers }} tonnes </li>
-      {% endif %}
-      {% if duration_leftovers_measurement %}
-      <li> Période de mesure : {{ duration_leftovers_measurement }} jours </li>
-      {% endif %}
-      {% if bread_leftovers %}
-      <li> Reste de pain : {{ bread_leftovers }} kg/an </li>
-      {% endif %}
-      {% if served_leftovers %}
-      <li> Reste plateau : {{ served_leftovers }} kg/an </li>
-      {% endif %}
-      {% if unserved_leftovers %}
-      <li> Reste en production (non servi) : {{ unserved_leftovers }} kg/an </li>
-      {% endif %}
-      {% if side_leftovers %}
-      <li> Reste de composantes (entrée, plat dessert...) : {{ side_leftovers }} kg/an </li>
-      {% endif %}
-  </ul>
-  {% else %}
-  <p>
-      <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
-      Pas de mesures contre le gaspillage alimentaire
-  </p>
-  </div>
-  {% endif %}
+    {% if has_donation_agreement %}
+        <p>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
+            Propose des dons alimentaires
+        </p>
+        <ul>
+            {% if donation_frequency %}
+                <li>Fréquence de dons : {{donation_frequency}} dons/an</li>
+            {% endif %}
+            {% if donation_quantity %}
+                <li>Quantité des denrées données : {{donation_quantity}} kg/an</li>
+            {% endif %}
+            {% if donation_food_type %}
+                <li>Type de denrées données : {{donation_food_type}}</li>
+            {% endif %}
+        </ul>
+    {% endif %}
+</div>
+<div>
+    {% if has_waste_measures %}
+        <p>
+            <img src="{% static '../../../web/static/images/checkmark-outline.png' %}" height="14" width="14" />
+            Réalise des mesures contre le gaspillage alimentaire
+        </p>
+        <ul>
+            {% if total_leftovers %}
+                <li> Total des déchets alimentaires : {{ total_leftovers }} tonnes </li>
+            {% endif %}
+            {% if duration_leftovers_measurement %}
+                <li> Période de mesure : {{ duration_leftovers_measurement }} jours </li>
+            {% endif %}
+            {% if bread_leftovers %}
+                <li> Reste de pain : {{ bread_leftovers }} kg/an </li>
+            {% endif %}
+            {% if served_leftovers %}
+                <li> Reste plateau : {{ served_leftovers }} kg/an </li>
+            {% endif %}
+            {% if unserved_leftovers %}
+                <li> Reste en production (non servi) : {{ unserved_leftovers }} kg/an </li>
+            {% endif %}
+            {% if side_leftovers %}
+                <li> Reste de composantes (entrée, plat dessert...) : {{ side_leftovers }} kg/an </li>
+            {% endif %}
+        </ul>
+    {% else %}
+        <p>
+            <img src="{% static '../../../web/static/images/close-outline.png' %}" height="14" width="14" />
+            Pas de mesures contre le gaspillage alimentaire
+        </p>
+        </div>
+    {% endif %}
 
-  <div>
-  {% if other_waste_comments %}
-  Commentaires concernant la lutte contre le gaspillage et dons alimentaires : <br />
-  « {{ other_waste_comments }} »
-  {% endif %}
-  </div>
+    <div>
+        {% if other_waste_comments %}
+            Commentaires concernant la lutte contre le gaspillage et dons alimentaires : <br />
+            « {{ other_waste_comments }} »
+        {% endif %}
+    </div>

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -215,3 +215,17 @@ Il faut néanmoins tenir en compte que la mise en page ne sera pas visible et qu
 Celery est un gestionnaire de tâches asynchrone utilisé par exemple pour l'envoi périodique de courriels de rappel et pour le remplissage des donn
 
 Pour staging/demo/prod, le chemin du fichier d'instantiation de Celery doit être spéficié dans la console CleverCloud sous la variable `CC_PYTHON_CELERY_MODULE=macantine.celery`. La fonctionnalité Celery Beat doit aussi être activée : `CC_PYTHON_CELERY_USE_BEAT=true`, ainsi que le timezone souhaité : `CELERY_TIMEZONE:'Europe/Paris'`
+
+### Visual Studio Code
+
+Des extensions qu'on trouve utile :
+
+- Django
+- EJS Beautify
+- EJS langauge support
+- ESLint
+- Prettier - Code formatter
+- Vue Language Features
+- Vetur
+- vuetify-vscode
+- Spell Right

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,9 @@ click==8.1.7
 click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.3.0
+colorama==0.4.6
 cryptography==42.0.0
+cssbeautifier==1.14.11
 cssselect2==0.7.0
 Deprecated==1.2.14
 dill==0.3.7
@@ -39,10 +41,12 @@ django-storages==1.14.2
 django-webpack-loader==3.0.1
 djangorestframework==3.14.0
 djangorestframework-camel-case==1.4.2
+djlint==1.34.1
 drf-base64==2.0
 drf-excel==2.4.0
 drf-spectacular==0.27.0
 drf-spectacular-sidecar==2024.2.1
+EditorConfig==0.12.3
 et-xmlfile==1.1.0
 exceptiongroup==1.1.3
 factory-boy==3.3.0
@@ -50,6 +54,8 @@ Faker==22.2.0
 filelock==3.13.1
 freezegun==1.4.0
 future==0.18.3
+html-tag-names==0.1.2
+html-void-elements==0.1.0
 html2text==2020.1.16
 html5lib==1.1
 identify==2.5.33
@@ -58,6 +64,8 @@ inflection==0.5.1
 iniconfig==2.0.0
 isort==5.13.2
 jmespath==1.0.1
+jsbeautifier==1.14.11
+json5==0.9.14
 jsonschema==4.20.0
 jsonschema-specifications==2023.11.2
 jwcrypto==1.5.1
@@ -73,7 +81,7 @@ openpyxl==3.1.2
 oscrypto==1.3.0
 packaging==23.2
 pandas==2.0.3
-pathspec==0.11.2
+pathspec==0.12.1
 pillow==10.2.0
 pipdeptree==2.13.2
 platformdirs==4.2.0
@@ -126,6 +134,7 @@ uritemplate==4.1.1
 uritools==4.0.2
 urllib3==1.26.18
 vine==5.1.0
+virtualenv==20.25.0
 wcwidth==0.2.12
 webencodings==0.5.1
 wrapt==1.16.0


### PR DESCRIPTION
Review https://github.com/betagouv/ma-cantine/pull/3557 d'abord, pour avoir le bon diff requirements

## Sur la décision de djlint

Il y a pas bcp d'options de formatter pour les templates django. Il y a :

- djlint
- djhtml
- [prettier-plugin-jinja-template](https://github.com/davidodenwald/prettier-plugin-jinja-template#readme)

J'ai pas testé la troisième car c'est installé avec npm, et dans notre structure c'est que les fichiers dans `/frontend` qui utilisent les packages npm.

djhtml est que un "indenter" et pas un formatter complet. En plus il y a pas de plugin vscode alors on peut pas avoir la fonctionnalié format on save.

Alors djlint.