### PR TITLE
Supprimer le bloque de la combinaison de HVE et boissons

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -334,7 +334,7 @@ export default Object.freeze({
     BIO: [],
     LABEL_ROUGE: ["BOISSONS"],
     AOCAOP_IGP_STG: ["VIANDES_VOLAILLES"],
-    HVE: ["AUTRES", "BOISSONS"],
+    HVE: ["AUTRES"],
     PECHE_DURABLE: [
       "FRUITS_ET_LEGUMES",
       "CHARCUTERIE",


### PR DESCRIPTION
On n'est pas sur si on veut l'avoir pour le moment : https://www.notion.so/Dans-la-TD-d-taill-pour-la-famille-charcuterie-ou-l-gumes-griser-les-champs-qui-sont-inutiles-feb670affacd485e845c1e6c7248fb5f