### PR TITLE
Liens de modification dans les sidebar de la télédéclaration permettant à l'utilisateur de renseigner les données manquantes

### DIFF
--- a/frontend/src/components/NotificationSnackbar.vue
+++ b/frontend/src/components/NotificationSnackbar.vue
@@ -35,7 +35,7 @@ export default {
   name: "Notification",
   computed: {
     color() {
-      const colors = { success: "green", error: "red", warning: "amber darken-2" }
+      const colors = { success: "green", error: "red", warning: "orange darken-4" }
       if (!this.show) return "white"
       return Object.prototype.hasOwnProperty.call(colors, this.notification.status)
         ? colors[this.notification.status]

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -456,6 +456,16 @@ export default {
       return !this.isNewCanteen && window.ENABLE_DASHBOARD
     },
   },
+  mounted() {
+    if (this.$route.query && this.$route.query["valider"]) {
+      this.$nextTick(() => {
+        const status = "warning"
+        const message = "Merci de vérifier les champs en rouge ci dessous"
+        const title = null
+        if (!this.$refs.form.validate()) this.$store.dispatch("notify", { title, message, status })
+      })
+    }
+  },
   beforeMount() {
     if (this.isNewCanteen) return
 
@@ -502,7 +512,10 @@ export default {
       this.goToStep(1)
     },
     goToStep(index, addHistory = true) {
-      const params = { path: this.$route.path, query: { etape: this.steps[index] } }
+      const params = {
+        path: this.$route.path,
+        query: { ...(this.$route.query || {}), ...{ etape: this.steps[index] } },
+      }
       if (addHistory) this.$router.push(params).catch(() => {})
       else this.$router.replace(params).catch(() => {})
     },

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -99,9 +99,41 @@
             <DataInfoBadge class="my-2" :missingData="true" />
             <p>Pour télédéclarer, veuillez :</p>
             <ul>
-              <li v-if="missingApproData">Compléter le volet d’approvisionnement</li>
-              <li v-if="missingCanteenData">Compléter les données de votre établissement</li>
-              <li v-if="hasSatelliteInconsistency">Mettre à jour vos satellites</li>
+              <li v-if="missingApproData" class="mb-2">
+                <router-link
+                  :to="{
+                    name: 'DiagnosticTunnel',
+                    params: {
+                      canteenUrlComponent: this.canteenUrlComponent,
+                      year: year,
+                      measureId: 'qualite-des-produits',
+                    },
+                  }"
+                >
+                  Compléter le volet d’approvisionnement
+                </router-link>
+              </li>
+              <li v-if="missingCanteenData" class="mb-2">
+                <router-link
+                  :to="{
+                    name: 'CanteenForm',
+                    params: { canteenUrlComponent: this.canteenUrlComponent },
+                    query: { valider: true },
+                  }"
+                >
+                  Compléter les données de votre établissement
+                </router-link>
+              </li>
+              <li v-if="hasSatelliteInconsistency" class="mb-2">
+                <router-link
+                  :to="{
+                    name: 'SatelliteManagement',
+                    params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
+                  }"
+                >
+                  Mettre à jour vos satellites
+                </router-link>
+              </li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Avec cette PR la liste des points bloquants pour télédéclarer devient actionnable avec des liens emportant l'user dans la view où le problème peut être réglé.

De plus, lors que le problème concerne des données de l'établissement, on passe un query param `valider:true` pour déclencher la validation immédiatement, rendant visible les champs avec une erreur.

Comme dernier point, on a changé la couleur de la notification warning (jusqu'à là pas utilisée) pour avoir plus de contrast.

Démo : 

[Screencast from 12-02-24 18:13:56.webm](https://github.com/betagouv/ma-cantine/assets/1225929/a4d7372f-a4fd-4efe-88d5-57b24422e1b7)
