### PR TITLE
Cache le tag "Données manquantes" pour un diagnostic déjà télédéclaré

### DIFF
--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -29,10 +29,10 @@ export default {
   },
   computed: {
     body() {
+      if (this.hasActiveTeledeclaration) return "Bilan télédéclaré"
       if (this.currentYear) return "Année en cours"
       if (this.missingData) return "Données à compléter"
       if (this.readyToTeledeclare) return "Bilan à télédéclarer"
-      if (this.hasActiveTeledeclaration) return "Bilan télédéclaré"
       return null
     },
     mode() {

--- a/frontend/src/views/DashboardManager/DiversificationCard.vue
+++ b/frontend/src/views/DashboardManager/DiversificationCard.vue
@@ -9,7 +9,7 @@
       </h3>
     </v-card-title>
     <v-card-text v-if="needsData">
-      <DataInfoBadge v-if="!hasActiveTeledeclaration" :missingData="true" class="py-0 ml-8" />
+      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
     </v-card-text>
     <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -56,7 +56,8 @@ export default {
       return keyMeasures.find((x) => x.id === this.measureId)
     },
     needsData() {
-      return !this.delegatedToCentralKitchen && this.level === Constants.Levels.UNKNOWN
+      const hasActiveTeledeclaration = this.diagnostic?.teledeclaration?.status === "SUBMITTED"
+      return !hasActiveTeledeclaration && !this.delegatedToCentralKitchen && this.level === Constants.Levels.UNKNOWN
     },
     level() {
       if (this.delegatedToSatellite) return null
@@ -97,9 +98,6 @@ export default {
       const isSatellite = this.canteen.productionType === "site_cooked_elsewhere"
       const usesCentralDiag = isSatellite && this.diagnostic?.canteenId === this.canteen.centralKitchen?.id
       return usesCentralDiag && this.diagnostic?.centralKitchenDiagnosticMode === "ALL"
-    },
-    hasActiveTeledeclaration() {
-      return this.diagnostic?.teledeclaration?.status === "SUBMITTED"
     },
   },
 }

--- a/frontend/src/views/DashboardManager/DiversificationCard.vue
+++ b/frontend/src/views/DashboardManager/DiversificationCard.vue
@@ -9,7 +9,7 @@
       </h3>
     </v-card-title>
     <v-card-text v-if="needsData">
-      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
+      <DataInfoBadge v-if="!hasActiveTeledeclaration" :missingData="true" class="py-0 ml-8" />
     </v-card-text>
     <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -97,6 +97,9 @@ export default {
       const isSatellite = this.canteen.productionType === "site_cooked_elsewhere"
       const usesCentralDiag = isSatellite && this.diagnostic?.canteenId === this.canteen.centralKitchen?.id
       return usesCentralDiag && this.diagnostic?.centralKitchenDiagnosticMode === "ALL"
+    },
+    hasActiveTeledeclaration() {
+      return this.diagnostic?.teledeclaration?.status === "SUBMITTED"
     },
   },
 }

--- a/frontend/src/views/DashboardManager/FoodWasteCard.vue
+++ b/frontend/src/views/DashboardManager/FoodWasteCard.vue
@@ -7,7 +7,7 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="needsData">
-      <DataInfoBadge v-if="!hasActiveTeledeclaration" :missingData="true" class="py-0 ml-8" />
+      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
     </v-card-text>
     <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -54,7 +54,8 @@ export default {
       return keyMeasures.find((x) => x.id === this.measureId)
     },
     needsData() {
-      return !this.delegatedToCentralKitchen && this.level === Constants.Levels.UNKNOWN
+      const hasActiveTeledeclaration = this.diagnostic?.teledeclaration?.status === "SUBMITTED"
+      return !hasActiveTeledeclaration && !this.delegatedToCentralKitchen && this.level === Constants.Levels.UNKNOWN
     },
     level() {
       if (this.delegatedToSatellite) return null
@@ -91,9 +92,6 @@ export default {
       const isSatellite = this.canteen.productionType === "site_cooked_elsewhere"
       const usesCentralDiag = isSatellite && this.diagnostic?.canteenId === this.canteen.centralKitchen?.id
       return usesCentralDiag && this.diagnostic?.centralKitchenDiagnosticMode === "ALL"
-    },
-    hasActiveTeledeclaration() {
-      return this.diagnostic?.teledeclaration?.status === "SUBMITTED"
     },
   },
 }

--- a/frontend/src/views/DashboardManager/FoodWasteCard.vue
+++ b/frontend/src/views/DashboardManager/FoodWasteCard.vue
@@ -7,7 +7,7 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="needsData">
-      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
+      <DataInfoBadge v-if="!hasActiveTeledeclaration" :missingData="true" class="py-0 ml-8" />
     </v-card-text>
     <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -91,6 +91,9 @@ export default {
       const isSatellite = this.canteen.productionType === "site_cooked_elsewhere"
       const usesCentralDiag = isSatellite && this.diagnostic?.canteenId === this.canteen.centralKitchen?.id
       return usesCentralDiag && this.diagnostic?.centralKitchenDiagnosticMode === "ALL"
+    },
+    hasActiveTeledeclaration() {
+      return this.diagnostic?.teledeclaration?.status === "SUBMITTED"
     },
   },
 }

--- a/frontend/src/views/DashboardManager/InformationCard.vue
+++ b/frontend/src/views/DashboardManager/InformationCard.vue
@@ -7,7 +7,7 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="needsData">
-      <DataInfoBadge v-if="!hasActiveTeledeclaration" :missingData="true" class="py-0 ml-8" />
+      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
     </v-card-text>
     <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -54,7 +54,8 @@ export default {
       return keyMeasures.find((x) => x.id === this.measureId)
     },
     needsData() {
-      return !this.delegatedToCentralKitchen && this.level === Constants.Levels.UNKNOWN
+      const hasActiveTeledeclaration = this.diagnostic?.teledeclaration?.status === "SUBMITTED"
+      return !hasActiveTeledeclaration && !this.delegatedToCentralKitchen && this.level === Constants.Levels.UNKNOWN
     },
     level() {
       if (this.delegatedToSatellite) return null
@@ -91,9 +92,6 @@ export default {
       const isSatellite = this.canteen.productionType === "site_cooked_elsewhere"
       const usesCentralDiag = isSatellite && this.diagnostic?.canteenId === this.canteen.centralKitchen?.id
       return usesCentralDiag && this.diagnostic?.centralKitchenDiagnosticMode === "ALL"
-    },
-    hasActiveTeledeclaration() {
-      return this.diagnostic?.teledeclaration?.status === "SUBMITTED"
     },
   },
 }

--- a/frontend/src/views/DashboardManager/InformationCard.vue
+++ b/frontend/src/views/DashboardManager/InformationCard.vue
@@ -7,7 +7,7 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="needsData">
-      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
+      <DataInfoBadge v-if="!hasActiveTeledeclaration" :missingData="true" class="py-0 ml-8" />
     </v-card-text>
     <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -91,6 +91,9 @@ export default {
       const isSatellite = this.canteen.productionType === "site_cooked_elsewhere"
       const usesCentralDiag = isSatellite && this.diagnostic?.canteenId === this.canteen.centralKitchen?.id
       return usesCentralDiag && this.diagnostic?.centralKitchenDiagnosticMode === "ALL"
+    },
+    hasActiveTeledeclaration() {
+      return this.diagnostic?.teledeclaration?.status === "SUBMITTED"
     },
   },
 }

--- a/frontend/src/views/DashboardManager/NoPlasticCard.vue
+++ b/frontend/src/views/DashboardManager/NoPlasticCard.vue
@@ -7,7 +7,7 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="needsData">
-      <DataInfoBadge v-if="!hasActiveTeledeclaration" :missingData="true" class="py-0 ml-8" />
+      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
     </v-card-text>
     <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -54,7 +54,8 @@ export default {
       return keyMeasures.find((x) => x.id === this.measureId)
     },
     needsData() {
-      return !this.delegatedToCentralKitchen && this.level === Constants.Levels.UNKNOWN
+      const hasActiveTeledeclaration = this.diagnostic?.teledeclaration?.status === "SUBMITTED"
+      return !hasActiveTeledeclaration && !this.delegatedToCentralKitchen && this.level === Constants.Levels.UNKNOWN
     },
     level() {
       if (this.delegatedToSatellite) return null
@@ -91,9 +92,6 @@ export default {
       const isSatellite = this.canteen.productionType === "site_cooked_elsewhere"
       const usesCentralDiag = isSatellite && this.diagnostic?.canteenId === this.canteen.centralKitchen?.id
       return usesCentralDiag && this.diagnostic?.centralKitchenDiagnosticMode === "ALL"
-    },
-    hasActiveTeledeclaration() {
-      return this.diagnostic?.teledeclaration?.status === "SUBMITTED"
     },
   },
 }

--- a/frontend/src/views/DashboardManager/NoPlasticCard.vue
+++ b/frontend/src/views/DashboardManager/NoPlasticCard.vue
@@ -7,7 +7,7 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="needsData">
-      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
+      <DataInfoBadge v-if="!hasActiveTeledeclaration" :missingData="true" class="py-0 ml-8" />
     </v-card-text>
     <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -91,6 +91,9 @@ export default {
       const isSatellite = this.canteen.productionType === "site_cooked_elsewhere"
       const usesCentralDiag = isSatellite && this.diagnostic?.canteenId === this.canteen.centralKitchen?.id
       return usesCentralDiag && this.diagnostic?.centralKitchenDiagnosticMode === "ALL"
+    },
+    hasActiveTeledeclaration() {
+      return this.diagnostic?.teledeclaration?.status === "SUBMITTED"
     },
   },
 }


### PR DESCRIPTION
Closes #3560

Ayant un diagnostic déjà télédéclaré, avant :
![image](https://github.com/betagouv/ma-cantine/assets/1225929/99d6bae8-8b3d-4a8c-a5c7-1809192192a8)


après :
![image](https://github.com/betagouv/ma-cantine/assets/1225929/63601af1-b472-47b4-8606-2083297c8f31)
