### PR TITLE
Fix des bugs lors de l'import des achats

### DIFF
--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -161,6 +161,10 @@ class TestPurchaseImport(APITestCase):
         errors = body["errors"]
         self.assertEqual(errors.pop(0)["message"], "Ce fichier a déjà été utilisé pour un import")
         self.assertEqual(body["count"], 0)
+        self.assertTrue(body["duplicateFile"])
+        self.assertEqual(len(body["duplicatePurchases"]), 2)
+        self.assertEqual(body["duplicatePurchaseCount"], 2)
+
         # no additional purchases created
         self.assertEqual(Purchase.objects.count(), 2)
 

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -160,9 +160,7 @@ class TestPurchaseImport(APITestCase):
         body = response.json()
         errors = body["errors"]
         self.assertEqual(errors.pop(0)["message"], "Ce fichier a déjà été utilisé pour un import")
-        self.assertEqual(body["count"], 2)
-        purchases = body["purchases"]
-        self.assertIn("Pommes, rouges", str(purchases))
+        self.assertEqual(body["count"], 0)
         # no additional purchases created
         self.assertEqual(Purchase.objects.count(), 2)
 

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -13,8 +13,7 @@ from rest_framework.views import APIView
 from rest_framework.exceptions import PermissionDenied
 from api.permissions import IsAuthenticated
 from data.models import Purchase, Canteen
-from api.serializers import PurchaseSerializer
-from .utils import normalise_siret, camelize
+from .utils import normalise_siret
 
 logger = logging.getLogger(__name__)
 
@@ -188,13 +187,9 @@ class ImportPurchasesView(APIView):
         self.purchases.append(purchase)
 
     def _get_success_response(self):
-        serialized_purchases = (
-            [] if len(self.errors) else [camelize(PurchaseSerializer(purchase).data) for purchase in self.purchases]
-        )
         return JsonResponse(
             {
-                "purchases": serialized_purchases,
-                "count": len(serialized_purchases),
+                "count": 0 if self.errors else len(self.purchases),
                 "errors": self.errors,
                 "seconds": time.time() - self.start,
             },

--- a/frontend/src/views/PurchasesImporter.vue
+++ b/frontend/src/views/PurchasesImporter.vue
@@ -49,15 +49,15 @@
       </v-alert>
       <div v-if="duplicateFile">
         <p class="orange--text text--darken-4">
-          Ce fichier a déjà été utilisé pour importer {{ purchaseCount }}
-          <span v-if="purchaseCount > 1">achats.</span>
+          Ce fichier a déjà été utilisé pour importer {{ duplicatePurchaseCount }}
+          <span v-if="duplicatePurchaseCount > 1">achats.</span>
           <span v-else>achat.</span>
         </p>
-        <p class="orange--text text--darken-4" v-if="purchaseCount > 10">
+        <p class="orange--text text--darken-4" v-if="duplicatePurchaseCount > 10">
           Les premiers dix achats sont affichés ci-dessous.
         </p>
         <p class="orange--text text--darken-4" v-else>Les achats sont affichés ci-dessous.</p>
-        <PurchasesTable :purchases="purchases" :hide-default-footer="true" class="mb-6" />
+        <PurchasesTable :purchases="duplicatePurchases" :hide-default-footer="true" class="mb-6" />
       </div>
       <div v-else-if="errors && errors.length">
         <p class="red--text text--darken-4" v-if="purchaseCount === 0">
@@ -163,6 +163,7 @@ export default {
       errors: undefined,
       seconds: undefined,
       importInProgress: false,
+      duplicatePurchases: null,
       documentation: [
         {
           name: "SIRET de la cantine ayant réalisé l'achat",
@@ -232,9 +233,9 @@ export default {
           this.file = null
           this.purchaseCount = json.count
           this.errors = json.errors
-          if (this.errors.length && this.errors[0].message === "Ce fichier a déjà été utilisé pour un import") {
-            this.duplicateFile = true
-          }
+          this.duplicateFile = json.duplicateFile
+          this.duplicatePurchases = json.duplicatePurchases
+          this.duplicatePurchaseCount = json.duplicatePurchaseCount
           this.seconds = json.seconds
           this.$store.dispatch("notify", {
             message: `Fichier traité en ${Math.round(this.seconds)} secondes`,

--- a/frontend/src/views/PurchasesImporter.vue
+++ b/frontend/src/views/PurchasesImporter.vue
@@ -219,7 +219,6 @@ export default {
       validators,
       isStaff: user.isStaff,
       duplicateFile: false,
-      purchases: null,
     }
   },
   methods: {
@@ -232,7 +231,6 @@ export default {
           this.importInProgress = false
           this.file = null
           this.purchaseCount = json.count
-          this.purchases = json.purchases
           this.errors = json.errors
           if (this.errors.length && this.errors[0].message === "Ce fichier a déjà été utilisé pour un import") {
             this.duplicateFile = true


### PR DESCRIPTION
Closes #3568

La réponse du `views/purchaseimport.py` ne prenait pas en compte les erreurs, et retournait des achats qui n'ont pas été créés. Ceci fait que la UI montre un message imprécis après l'achat (voir #3568)
