### PR TITLE
Arrondi au centime le plus proche dans l'import d'achats

### DIFF
--- a/api/tests/files/purchases_floating_number.csv
+++ b/api/tests/files/purchases_floating_number.csv
@@ -1,0 +1,2 @@
+canteen siret,description,fournisseur,date,prix HT,famille,caractéristiques,definition de local
+82399356058716,"Pommes, rouges",Le bon traiteur ,2022-05-02,90.11000000002, PRODUITS_LAITIERS ,"BIO, LOCAL", DEPARTMENT

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -179,3 +179,15 @@ class TestPurchaseImport(APITestCase):
         self.assertEqual(Purchase.objects.count(), 0)
         body = response.json()
         self.assertEqual(len(body["errors"]), 1)
+
+    @authenticate
+    def test_round_cents(self):
+        """
+        Cents should be rounded to the nearest two digits after the point
+        """
+        CanteenFactory.create(siret="82399356058716", managers=[authenticate.user])
+        with open("./api/tests/files/purchases_floating_number.csv") as purchase_file:
+            response = self.client.post(reverse("import_purchases"), {"file": purchase_file})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Purchase.objects.count(), 1)
+        self.assertEqual(Purchase.objects.first().price_ht, Decimal("90.11"))

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -170,7 +170,7 @@ class ImportPurchasesView(APIView):
         # We try to round the price. If we can't, we will let Django's field validation
         # manage the error - hence the `pass` in the exception handler
         try:
-            price = Decimal(price.strip()).quantize(Decimal(".01"), rounding=ROUND_HALF_DOWN)
+            price = Decimal(price).quantize(Decimal(".01"), rounding=ROUND_HALF_DOWN)
         except InvalidOperation:
             pass
 


### PR DESCRIPTION
Using [quantize](https://docs.python.org/3/library/decimal.html#decimal.Decimal.quantize) for the rounding (the recommended one for decimal types). Also using `ROUND_HALF_DOWN`, so basically : 

Decimal("12.345") >  Decimal('12.34')
Decimal("12.344") > Decimal('12.34')
