### PR TITLE
Supprimer les messages de warning avec les tests open data

### DIFF
--- a/api/tests/test_import_diagnostics.py
+++ b/api/tests/test_import_diagnostics.py
@@ -793,7 +793,9 @@ class TestImportDiagnosticsAPI(APITestCase):
         user.save()
         self.assertEqual(Teledeclaration.objects.count(), 0)
 
-        with patch.object(timezone, "now", return_value=datetime.datetime(2020, 4, 1, 11, 00, tzinfo=pytz.UTC)):
+        with patch.object(
+            timezone, "now", return_value=datetime.datetime(2020, 4, 1, 11, 00, tzinfo=pytz.timezone("Europe/Paris"))
+        ):
             with open("./api/tests/files/teledeclaration_simple.csv") as diag_file:
                 response = self.client.post(f"{reverse('import_diagnostics')}", {"file": diag_file})
 
@@ -815,7 +817,9 @@ class TestImportDiagnosticsAPI(APITestCase):
         user.email = "authenticate@example.com"
         user.save()
 
-        with patch.object(timezone, "now", return_value=datetime.datetime(2020, 4, 1, 11, 00, tzinfo=pytz.UTC)):
+        with patch.object(
+            timezone, "now", return_value=datetime.datetime(2020, 4, 1, 11, 00, tzinfo=pytz.timezone("Europe/Paris"))
+        ):
             with open("./api/tests/files/teledeclaration_error.csv") as diag_file:
                 response = self.client.post(f"{reverse('import_diagnostics')}", {"file": diag_file})
 

--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -76,7 +76,9 @@ class TestTeledeclarationApi(APITestCase):
         diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, diagnostic_type="SIMPLE")
         payload = {"diagnosticId": diagnostic.id}
 
-        with patch.object(timezone, "now", return_value=datetime.datetime(2021, 4, 1, 11, 00, tzinfo=pytz.UTC)):
+        with patch.object(
+            timezone, "now", return_value=datetime.datetime(2021, 4, 1, 11, 00, tzinfo=pytz.timezone("Europe/Paris"))
+        ):
             response = self.client.post(reverse("teledeclaration_create"), payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -136,7 +138,9 @@ class TestTeledeclarationApi(APITestCase):
         )
         payload = {"diagnosticId": diagnostic.id}
 
-        with patch.object(timezone, "now", return_value=datetime.datetime(2021, 4, 1, 11, 00, tzinfo=pytz.UTC)):
+        with patch.object(
+            timezone, "now", return_value=datetime.datetime(2021, 4, 1, 11, 00, tzinfo=pytz.timezone("Europe/Paris"))
+        ):
             response = self.client.post(reverse("teledeclaration_create"), payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/macantine/extract_open_data.py
+++ b/macantine/extract_open_data.py
@@ -21,16 +21,16 @@ logger = logging.getLogger(__name__)
 
 CAMPAIGN_DATES = {
     2021: {
-        "start_date": datetime.datetime(2022, 7, 16, 0, 0, tzinfo=pytz.UTC),
-        "end_date": datetime.datetime(2022, 12, 5, 0, 0, tzinfo=pytz.UTC),
+        "start_date": datetime.datetime(2022, 7, 16, 0, 0, tzinfo=pytz.timezone("Europe/Paris")),
+        "end_date": datetime.datetime(2022, 12, 5, 0, 0, tzinfo=pytz.timezone("Europe/Paris")),
     },
     2022: {
-        "start_date": datetime.datetime(2023, 2, 13, 0, 0, tzinfo=pytz.UTC),
-        "end_date": datetime.datetime(2023, 6, 30, 0, 0, tzinfo=pytz.UTC),
+        "start_date": datetime.datetime(2023, 2, 13, 0, 0, tzinfo=pytz.timezone("Europe/Paris")),
+        "end_date": datetime.datetime(2023, 6, 30, 0, 0, tzinfo=pytz.timezone("Europe/Paris")),
     },
     2023: {
-        "start_date": datetime.datetime(2024, 1, 9, 0, 0, tzinfo=pytz.UTC),
-        "end_date": datetime.datetime(2024, 3, 30, 0, 0, tzinfo=pytz.UTC),
+        "start_date": datetime.datetime(2024, 1, 9, 0, 0, tzinfo=pytz.timezone("Europe/Paris")),
+        "end_date": datetime.datetime(2024, 3, 30, 0, 0, tzinfo=pytz.timezone("Europe/Paris")),
     },
 }
 


### PR DESCRIPTION
Messages genre
`RuntimeWarning: DateTimeField Teledeclaration.creation_date received a naive datetime (2023-06-30 00:00:00) while time zone support is active.`

@qloridant est-ce que tu pourrais vérifier que ça casse rien ?

D'ailleurs, qu'est-ce que tu penses de déplacer `test_extraction_open_data` dans `macantine/tests` plutôt que `/data/tests` qui est censé de tester les modèles dans la BDD ?