### PR TITLE
Rendre accessible à nouveau la fonctionnalité de comparison

### DIFF
--- a/frontend/src/views/DashboardManager/ComparisonSection.vue
+++ b/frontend/src/views/DashboardManager/ComparisonSection.vue
@@ -1,0 +1,212 @@
+<template>
+  <div class="text-left mt-10" v-if="statistics">
+    <h2 class="mt-10 mb-2 fr-h2">
+      Où en sont les cantines similaires à la mienne ?
+    </h2>
+    <p class="fr-text">Pour les cantines {{ groupingDescription }} :</p>
+
+    <div>
+      <v-row class="mt-10 mb-2 px-3 align-center">
+        <h3 class="fr-h4 mb-2">Qualité de produits en {{ year }}</h3>
+      </v-row>
+      <div v-if="statistics.diagnosticsCount === 0">
+        <p class="fr-text mt-8 caption">
+          Aucune cantine n'a renseigné des données relatives à la loi EGAlim pour l'année {{ year }}.
+        </p>
+      </div>
+      <div v-else>
+        <p class="fr-text mb-8">
+          Parmi les {{ statistics.diagnosticsCount }} cantines qui ont commencé un diagnostic&nbsp;:
+        </p>
+        <v-row class="px-2">
+          <v-col class="pl-0 pr-1" cols="12" sm="6" md="4">
+            <v-card class="fill-height text-center pt-4 pb-2 px-3 d-flex flex-column" outlined>
+              <v-img max-width="30" contain src="/static/images/badges/appro.svg" class="mx-auto" alt=""></v-img>
+              <v-card-text class="grey--text text--darken-2 px-1">
+                <span class="text-h5 font-weight-black" style="line-height: inherit;">
+                  {{ statistics.approPercent }} %
+                </span>
+                <span class="text-body-2">
+                  ont réussi l'objectif d'approvisionnement EGAlim
+                </span>
+              </v-card-text>
+              <v-card-actions class="px-1">
+                <router-link :to="{ name: 'KeyMeasurePage', params: { id: approMeasure.id } }" class="text-body-2">
+                  La mesure
+                </router-link>
+              </v-card-actions>
+            </v-card>
+          </v-col>
+          <v-col class="px-1" cols="12" sm="6" md="3">
+            <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
+              <v-card-text>
+                <span class="text-h5 font-weight-black">{{ statistics.bioPercent }} %</span>
+                <span class="text-body-2">
+                  bio moyen
+                </span>
+              </v-card-text>
+              <div class="mt-2">
+                <v-img
+                  contain
+                  src="/static/images/quality-labels/logo_bio_eurofeuille.png"
+                  alt="Logo Agriculture Biologique"
+                  title="Logo Agriculture Biologique"
+                  max-height="35"
+                />
+              </div>
+            </v-card>
+          </v-col>
+          <v-col class="pl-1 pr-0" cols="12" sm="6" md="5">
+            <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
+              <v-card-text>
+                <span class="text-h5 font-weight-black">{{ statistics.sustainablePercent }} %</span>
+                <span class="text-body-2">
+                  durables et de qualité (hors bio) moyen
+                </span>
+              </v-card-text>
+              <div class="d-flex mt-2 justify-center flex-wrap">
+                <v-img
+                  contain
+                  v-for="label in labels"
+                  :key="label.title"
+                  :src="`/static/images/quality-labels/${label.src}`"
+                  :alt="label.title"
+                  :title="label.title"
+                  class="px-1"
+                  max-height="40"
+                  max-width="40"
+                />
+              </div>
+            </v-card>
+          </v-col>
+        </v-row>
+        <h3 class="fr-h4 font-weight-bold mt-10 mb-2">
+          Ces cantines ont aussi réalisé les mesures suivantes en {{ year }}
+        </h3>
+        <p class="fr-text mb-8">
+          Parmi les mêmes {{ statistics.diagnosticsCount }} cantines qui ont commencé un diagnostic&nbsp;:
+        </p>
+        <v-row class="my-8">
+          <v-col cols="12" sm="6" md="5" v-for="measure in otherMeasures" :key="measure.id" class="mb-4">
+            <BadgeCard :measure="measure" :percentageAchieved="statistics[measure.badgeId + 'Percent']" />
+          </v-col>
+        </v-row>
+      </div>
+    </div>
+    <v-row class="px-3">
+      <v-btn outlined color="primary" class="mr-2" :to="{ name: 'CanteensHome', query: translatedParams }">
+        Les cantines
+      </v-btn>
+      <v-btn outlined color="primary" :to="{ name: 'PublicCanteenStatisticsPage', query: params }">
+        Tous les chiffres
+      </v-btn>
+    </v-row>
+  </div>
+</template>
+
+<script>
+import keyMeasures from "@/data/key-measures.json"
+import labels from "@/data/quality-labels.json"
+import { lastYear } from "@/utils"
+import Constants from "@/constants"
+import BadgeCard from "@/views/PublicCanteenStatisticsPage/BadgeCard"
+
+export default {
+  components: {
+    BadgeCard,
+  },
+  props: ["canteen"],
+  data() {
+    return {
+      year: lastYear(),
+      statistics: null,
+      approMeasure: keyMeasures.find((measure) => measure.badgeId === "appro"),
+      otherMeasures: keyMeasures.filter((measure) => measure.badgeId !== "appro"),
+      labels,
+    }
+  },
+  computed: {
+    regionalQueryString() {
+      if (!this.department && !this.searchSectors.length) return
+      let query = `year=${this.year}`
+      if (this.department) {
+        query += `&department=${this.department}`
+      }
+      if (this.searchSectors.length) {
+        query += `&sectors=${this.searchSectors.join("&sectors=")}`
+      }
+      return query
+    },
+    department() {
+      return this.canteen.department
+    },
+    allSectors() {
+      return this.$store.state.sectors
+    },
+    canteenSectorCategories() {
+      const canteenSectors = this.canteen.sectors.map((sectorId) => this.allSectors.find((s) => s.id === sectorId))
+      const categories = canteenSectors.map((s) => s.category)
+      const uniqueCategories = categories.filter((c, idx, self) => c && self.indexOf(c) === idx)
+      return uniqueCategories
+    },
+    searchSectors() {
+      return this.allSectors
+        .filter((sector) => this.canteenSectorCategories.includes(sector.category))
+        .map((sector) => sector.id)
+    },
+    groupingDescription() {
+      let description = ""
+      if (this.department) {
+        description += `dans le département ${this.department}`
+        if (this.sectorSpecifierText) {
+          description += " et "
+        }
+      }
+      if (this.sectorSpecifierText) {
+        description += this.sectorSpecifierText
+      }
+      return description
+    },
+    sectorSpecifierText() {
+      if (this.searchSectors.length === 0) return ""
+      let string = ""
+      if (this.canteenSectorCategories.length === 1) {
+        string += "avec la catégorie de secteur"
+      } else {
+        string += "avec les catégories de secteur"
+      }
+      const categoriesDisplayString = this.canteenSectorCategories
+        .map((c) => Constants.SectorCategoryTranslations[c])
+        .join(", ")
+      string += " " + categoriesDisplayString
+      return string
+    },
+    params() {
+      return {
+        year: this.year,
+        department: this.department,
+        sectors: this.searchSectors.join(","),
+      }
+    },
+    translatedParams() {
+      return {
+        departement: this.department,
+        secteurs: this.searchSectors,
+      }
+    },
+  },
+  methods: {
+    loadStatistics() {
+      if (!this.regionalQueryString) return
+      fetch(`/api/v1/canteenStatistics/?${this.regionalQueryString}`)
+        .then((response) => response.json())
+        .then((data) => {
+          this.statistics = data
+        })
+    },
+  },
+  mounted() {
+    this.loadStatistics()
+  },
+}
+</script>

--- a/frontend/src/views/DashboardManager/ComparisonSection.vue
+++ b/frontend/src/views/DashboardManager/ComparisonSection.vue
@@ -10,7 +10,7 @@
         <h3 class="fr-h4 mb-2">Qualité de produits en {{ year }}</h3>
       </v-row>
       <div v-if="statistics.diagnosticsCount === 0">
-        <p class="fr-text mt-8 caption">
+        <p class="fr-text mb-8">
           Aucune cantine n'a renseigné des données relatives à la loi EGAlim pour l'année {{ year }}.
         </p>
       </div>
@@ -107,7 +107,6 @@
 <script>
 import keyMeasures from "@/data/key-measures.json"
 import labels from "@/data/quality-labels.json"
-import { lastYear } from "@/utils"
 import Constants from "@/constants"
 import BadgeCard from "@/views/PublicCanteenStatisticsPage/BadgeCard"
 
@@ -115,10 +114,9 @@ export default {
   components: {
     BadgeCard,
   },
-  props: ["canteen"],
+  props: ["canteen", "year"],
   data() {
     return {
-      year: lastYear(),
       statistics: null,
       approMeasure: keyMeasures.find((measure) => measure.badgeId === "appro"),
       otherMeasures: keyMeasures.filter((measure) => measure.badgeId !== "appro"),
@@ -205,8 +203,10 @@ export default {
         })
     },
   },
-  mounted() {
-    this.loadStatistics()
+  watch: {
+    year(newYear) {
+      if (newYear) this.loadStatistics()
+    },
   },
 }
 </script>

--- a/frontend/src/views/DashboardManager/ComparisonSection.vue
+++ b/frontend/src/views/DashboardManager/ComparisonSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="text-left mt-10" v-if="statistics">
-    <h2 class="mt-10 mb-2 fr-h2">
+    <h2 class="mt-10 mb-4 fr-h2">
       Où en sont les cantines similaires à la mienne ?
     </h2>
     <p class="fr-text">Pour les cantines {{ groupingDescription }} :</p>
@@ -108,6 +108,7 @@
 import keyMeasures from "@/data/key-measures.json"
 import labels from "@/data/quality-labels.json"
 import Constants from "@/constants"
+import departments from "@/departments.json"
 import BadgeCard from "@/views/PublicCanteenStatisticsPage/BadgeCard"
 
 export default {
@@ -124,7 +125,7 @@ export default {
     }
   },
   computed: {
-    regionalQueryString() {
+    statsQueryString() {
       if (!this.department && !this.searchSectors.length) return
       let query = `year=${this.year}`
       if (this.department) {
@@ -137,6 +138,14 @@ export default {
     },
     department() {
       return this.canteen.department
+    },
+    departmentString() {
+      if (!this.department) return ""
+      const depInfo = departments.find((d) => d.departmentCode === this.department)
+      if (depInfo?.departmentName) {
+        return `« ${depInfo.departmentName} »`
+      }
+      return this.department
     },
     allSectors() {
       return this.$store.state.sectors
@@ -155,7 +164,7 @@ export default {
     groupingDescription() {
       let description = ""
       if (this.department) {
-        description += `dans le département ${this.department}`
+        description += `dans le département ${this.departmentString}`
         if (this.sectorSpecifierText) {
           description += " et "
         }
@@ -195,8 +204,8 @@ export default {
   },
   methods: {
     loadStatistics() {
-      if (!this.regionalQueryString) return
-      fetch(`/api/v1/canteenStatistics/?${this.regionalQueryString}`)
+      if (!this.statsQueryString) return
+      fetch(`/api/v1/canteenStatistics/?${this.statsQueryString}`)
         .then((response) => response.json())
         .then((data) => {
           this.statistics = data

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-row style="position: relative;">
+    <v-row v-if="year" style="position: relative;">
       <v-col cols="12" md="4" class="d-flex flex-column">
         <v-row>
           <v-col cols="8">
@@ -170,7 +170,7 @@ export default {
     const years = customDiagnosticYears(this.canteen.diagnostics)
     return {
       lastYear: lastYear(),
-      year: lastYear(),
+      year: null,
       diagnosticYears: years,
       allowedYears: years.map((year) => ({ text: year, value: year })),
       showTeledeclarationPreview: false,
@@ -295,7 +295,14 @@ export default {
     if (this.$route.query?.year && this.diagnosticYears.indexOf(+this.$route.query.year) > -1) {
       this.year = +this.$route.query.year
       this.$router.replace({ query: {} })
+    } else {
+      this.year = lastYear()
     }
+  },
+  watch: {
+    year(newYear) {
+      this.$emit("year-update", newYear)
+    },
   },
 }
 </script>

--- a/frontend/src/views/DashboardManager/index.vue
+++ b/frontend/src/views/DashboardManager/index.vue
@@ -13,7 +13,7 @@
 
     <div v-if="canteen">
       <div class="mt-4">
-        <EgalimProgression :canteen="canteen" />
+        <EgalimProgression :canteen="canteen" @year-update="updateYear" />
       </div>
 
       <h2 class="mt-10 mb-2 fr-h2">
@@ -56,7 +56,7 @@
           <TeamWidget :canteen="canteen" />
         </v-col>
       </v-row>
-      <ComparisonSection :canteen="canteen" />
+      <ComparisonSection :canteen="canteen" :year="year" />
     </div>
     <v-row v-else>
       <v-col cols="12" sm="6" md="4" height="100%" class="d-flex flex-column">
@@ -113,6 +113,7 @@ export default {
   data() {
     return {
       canteen: null,
+      year: null,
       showCanteenSelection: false,
     }
   },
@@ -154,6 +155,9 @@ export default {
             status: "error",
           })
         })
+    },
+    updateYear(year) {
+      this.year = year
     },
   },
   mounted() {

--- a/frontend/src/views/DashboardManager/index.vue
+++ b/frontend/src/views/DashboardManager/index.vue
@@ -16,48 +16,47 @@
         <EgalimProgression :canteen="canteen" />
       </div>
 
-      <div v-if="canteen">
-        <h2 class="mt-10 mb-2 fr-h2">
-          Mon établissement
-        </h2>
-        <p class="fr-text-sm">
-          Accédez ci-dessous aux différents outils de gestion de votre établissement sur la plateforme « ma cantine ».
-        </p>
-        <v-row v-if="isCentralWithSite">
-          <v-col cols="12" md="6">
-            <SatellitesWidget :canteen="canteen" />
-          </v-col>
-          <v-col cols="12" md="6">
-            <PublicationWidget :canteen="canteen" />
-          </v-col>
-          <v-col cols="12">
-            <PurchasesWidget :canteen="canteen" />
-          </v-col>
-          <v-col cols="12" md="8">
-            <CanteenInfoWidget :canteen="canteen" />
-          </v-col>
-          <v-col cols="12" md="4">
-            <TeamWidget :canteen="canteen" />
-          </v-col>
-        </v-row>
-        <v-row v-else>
-          <v-col cols="12" md="8">
-            <PurchasesWidget :canteen="canteen" />
-          </v-col>
-          <v-col v-if="!canteen.isCentralCuisine" cols="12" md="4">
-            <PublicationWidget :canteen="canteen" />
-          </v-col>
-          <v-col v-else cols="12" md="4">
-            <SatellitesWidget :canteen="canteen" />
-          </v-col>
-          <v-col cols="12" md="8">
-            <CanteenInfoWidget :canteen="canteen" />
-          </v-col>
-          <v-col cols="12" md="4">
-            <TeamWidget :canteen="canteen" />
-          </v-col>
-        </v-row>
-      </div>
+      <h2 class="mt-10 mb-2 fr-h2">
+        Mon établissement
+      </h2>
+      <p class="fr-text-sm">
+        Accédez ci-dessous aux différents outils de gestion de votre établissement sur la plateforme « ma cantine ».
+      </p>
+      <v-row v-if="isCentralWithSite">
+        <v-col cols="12" md="6">
+          <SatellitesWidget :canteen="canteen" />
+        </v-col>
+        <v-col cols="12" md="6">
+          <PublicationWidget :canteen="canteen" />
+        </v-col>
+        <v-col cols="12">
+          <PurchasesWidget :canteen="canteen" />
+        </v-col>
+        <v-col cols="12" md="8">
+          <CanteenInfoWidget :canteen="canteen" />
+        </v-col>
+        <v-col cols="12" md="4">
+          <TeamWidget :canteen="canteen" />
+        </v-col>
+      </v-row>
+      <v-row v-else>
+        <v-col cols="12" md="8">
+          <PurchasesWidget :canteen="canteen" />
+        </v-col>
+        <v-col v-if="!canteen.isCentralCuisine" cols="12" md="4">
+          <PublicationWidget :canteen="canteen" />
+        </v-col>
+        <v-col v-else cols="12" md="4">
+          <SatellitesWidget :canteen="canteen" />
+        </v-col>
+        <v-col cols="12" md="8">
+          <CanteenInfoWidget :canteen="canteen" />
+        </v-col>
+        <v-col cols="12" md="4">
+          <TeamWidget :canteen="canteen" />
+        </v-col>
+      </v-row>
+      <ComparisonSection :canteen="canteen" />
     </div>
     <v-row v-else>
       <v-col cols="12" sm="6" md="4" height="100%" class="d-flex flex-column">
@@ -96,6 +95,7 @@ import PublicationWidget from "./PublicationWidget"
 import SatellitesWidget from "./SatellitesWidget"
 import CanteenInfoWidget from "./CanteenInfoWidget"
 import TeamWidget from "./TeamWidget"
+import ComparisonSection from "./ComparisonSection"
 import ProductionTypeTag from "@/components/ProductionTypeTag"
 
 export default {
@@ -107,6 +107,7 @@ export default {
     SatellitesWidget,
     CanteenInfoWidget,
     TeamWidget,
+    ComparisonSection,
     ProductionTypeTag,
   },
   data() {


### PR DESCRIPTION
Dans l'ancien parcours, on avait une page "Améliorer ma cantine".

En dessous, il y avait un partie pour se situer parmi les autres cantines dans le même département et secteur.

Avant supprimer le code avec #3600 je le reprends pour faire une proposition de le remettre dans le nouveau parcours. Le code est le même que `CanteenEditor/DashboardPage`, que avec des petits changements:
- utiliser les classes typo de dsfr (`fr-...`)
- des très petits trucs pour nettoyer le code
- convertir le code du departement en nom
- utiliser l'année selectionnée dans EgalimProgression pour l'année stats

Est-ce qu'il y a de valeur comme ça pour le premier temps, ou est-ce qu'on veut designer le truc un peu plus ? P-e il y a des quick wins du texte ou layout. @arthurkleindesign tu penses quoi ?

![Screenshot 2024-02-20 at 19-38-11 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/d5c7f61b-3bbb-415a-bf39-8a69bac97b30)

