### PR TITLE
Correction du bug qui effectuait une mauvaise validation coté frontend

### DIFF
--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/MeatFishStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/MeatFishStep.vue
@@ -280,7 +280,8 @@ export default {
       this.checkTotal()
     },
     sum(fields) {
-      return fields.reduce((acc, field) => acc + (this.payload[field] || 0), 0)
+      const sum = fields.reduce((acc, field) => acc + (this.payload[field] || 0), 0)
+      return +sum.toFixed(2)
     },
   },
   mounted() {


### PR DESCRIPTION
On avait déjà fait ce fix côté `FamilyFieldsStep` mais on l'avait oublié pour le fichier `MeatFishStep`

Je pense qu'on peut le cherry-pick ou faire une release après l'intégration de ce fix.