### PR TITLE
Enlever package pas utilisé

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,6 @@ factory-boy==3.3.0
 Faker==22.2.0
 filelock==3.13.1
 freezegun==1.4.0
-future==0.18.3
 html-tag-names==0.1.2
 html-void-elements==0.1.0
 html2text==2020.1.16


### PR DESCRIPTION
[Future](https://github.com/PythonCharmers/python-future)
Il a été ajouté avec ça : https://github.com/betagouv/ma-cantine/commit/cbde7b3d758b0acf8db1005fd09f7c33bb3b6bc9
Mais je vois pas des instances de `futur` dans le base de code.

Est-ce que tu penses que ça va de l'enlever ?