### PR TITLE
Enlever lien vers nos cantines sur la page chiffres térritoire

### DIFF
--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -107,12 +107,8 @@
             <p>
               <span class="text-h5 font-weight-bold">{{ statistics.publishedCanteenCount }}</span>
               cantine{{
-                statistics.publishedCanteenCount == 1
-                  ? " a publié ses données (répertoriée dans"
-                  : "s ont publié leurs données (répertoriées dans"
+                statistics.publishedCanteenCount == 1 ? " a publié ses données." : "s ont publié leurs données."
               }}
-              <!-- eslint-disable-next-line prettier/prettier-->
-              <router-link :to="{ name: 'CanteensHome' }">nos cantines</router-link>).
             </p>
           </div>
           <VueApexCharts


### PR DESCRIPTION
Décidé pendant le seminaire car les filtres sont differents entre les deux pages (pas de filtre EPCI alors on peut pas rediriger l'utilisateur vers la liste des cantines publiques dans le même circle, et il y a pas trop interêt pour la grande publique d'EPCI)