### PR TITLE
Enlever la selection de la page en haut

### DIFF
--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -36,7 +36,7 @@
         </v-col>
       </v-row>
     </v-card>
-    <v-sheet class="px-6" elevation="0">
+    <v-sheet class="py-2" elevation="0">
       <v-row>
         <v-col cols="12" md="7" class="pt-0">
           <form role="search" class="d-block d-sm-flex align-end" onsubmit="return false">
@@ -54,7 +54,7 @@
       </v-row>
     </v-sheet>
 
-    <div class="d-flex align-center mt-4 pl-0 pl-md-6">
+    <div class="d-flex align-center mt-4 pl-0">
       <v-badge :value="hasActiveFilter" color="#CE614A" dot overlap offset-x="-2">
         <h2 class="text-body-1 font-weight-black" style="background-color: #fff; width: max-content">
           Filtres
@@ -73,7 +73,7 @@
       <v-divider v-if="!showFilters"></v-divider>
     </div>
     <v-expand-transition>
-      <v-sheet class="pa-6 text-left mt-2 ml-6" v-show="showFilters" rounded :outlined="showFilters">
+      <v-sheet class="pa-6 text-left mt-2" v-show="showFilters" rounded :outlined="showFilters">
         <v-row>
           <v-col cols="12" sm="6" md="4">
             <label
@@ -318,13 +318,12 @@
       </v-btn>
     </div>
     <div v-else>
-      <!-- TODO: align this better now that we don't have top pagination -->
-      <p class="mt-3 mb-n4 text-body-2 grey--text" v-if="resultsCountText">
-        {{ resultsCountText }}
-      </p>
       <v-row class="my-2" align="end">
-        <v-col cols="3" v-if="$vuetify.breakpoint.smAndUp"></v-col>
-        <v-spacer v-if="$vuetify.breakpoint.smAndUp"></v-spacer>
+        <v-col>
+          <p class="mb-0 text-body-2 grey--text text-left" v-if="resultsCountText">
+            {{ resultsCountText }}
+          </p>
+        </v-col>
         <v-col id="ordering" cols="12" sm="3" class="d-flex align-end">
           <DsfrSelect
             v-model="orderBy"

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -318,6 +318,7 @@
       </v-btn>
     </div>
     <div v-else>
+      <!-- TODO: align this better now that we don't have top pagination -->
       <p class="mt-3 mb-n4 text-body-2 grey--text" v-if="resultsCountText">
         {{ resultsCountText }}
       </p>

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -324,10 +324,6 @@
       <v-row class="my-2" align="end">
         <v-col cols="3" v-if="$vuetify.breakpoint.smAndUp"></v-col>
         <v-spacer v-if="$vuetify.breakpoint.smAndUp"></v-spacer>
-        <v-col cols="12" sm="6">
-          <DsfrPagination v-model="page" :length="Math.ceil(publishedCanteenCount / limit)" :total-visible="7" />
-        </v-col>
-        <v-spacer></v-spacer>
         <v-col id="ordering" cols="12" sm="3" class="d-flex align-end">
           <DsfrSelect
             v-model="orderBy"


### PR DESCRIPTION
Suite à une réflexion personnelle, je trouve que le nombre de pages en prod est moche, et je veux l'enlever. Aussi, j'ai remarqué que les filtres ne sont pas alignés à gauche avec les cartes. @arthurkleindesign tu penses quoi de ce nouveau vu ? 

On garde bien sur la selection de pages en bas de resultats

## Nouveau vu
![Screenshot 2024-02-27 at 17-17-43 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/2c4428bb-039c-4b08-a481-70577f9c8f12)

## Ancien
![Screenshot 2024-02-27 at 17-21-54 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/4e6241e0-45a7-4cf8-b2ed-ae5ac6a8befa)

Et aujourd'hui en prod

![Screenshot 2024-02-27 at 17-24-03 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/f27a2372-7217-4e2a-bca1-da54e791b226)

Et aujourd'hui en prod avec un filtre

![Screenshot 2024-02-27 at 17-25-04 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/806d65fa-b6c9-4c6e-bb4e-93a1d2f14fe1)
