### PR TITLE
[! après #3645] Reorganiser les infos dans la TD pour être plus logique et MAJ le typographie

### DIFF
--- a/api/templates/teledeclaration_campaign_2024/canteen.html
+++ b/api/templates/teledeclaration_campaign_2024/canteen.html
@@ -1,55 +1,66 @@
-<h3>Informations de mon établissement</h3>
+<h2>Informations de mon établissement</h2>
 <ul>
+
     {% if canteen.name %}
         <li>
             <span>Nom</span> : {{ canteen.name }}
         </li>
     {% endif %}
+
     {% if canteen.siret %}
         <li>
             <span>SIRET</span> : {{ canteen.siret }}
         </li>
     {% endif %}
+
     {% if canteen.production_type %}
         <li>
             <span>Mode de production</span> : {{ canteen.production_type }}
         </li>
     {% endif %}
+
     {% if canteen.city_insee_code %}
         <li>
             <span>Code Insee</span> : {{ canteen.city_insee_code }}
         </li>
     {% endif %}
+
     {% if canteen.central_producer_siret %}
         <li>
             <span>SIRET de la cuisine centrale</span> : {{ canteen.central_producer_siret }}
         </li>
     {% endif %}
+
     {% if canteen.daily_meal_count %}
         <li>
             <span>Nombre de repas par jour</span> : {{ canteen.daily_meal_count }}
         </li>
     {% endif %}
+
     {% if canteen.yearly_meal_count %}
         <li>
             <span>Nombre de repas par an</span> : {{ canteen.yearly_meal_count }}
         </li>
     {% endif %}
+
     {% if canteen.sectors %}
         <li>
             <span>Secteurs d'activité</span> : {{ canteen.sectors }}
         </li>
     {% endif %}
+
     {% if canteen.line_ministry %}
         <li>
             <span>Ministère de tutelle</span> : {{ canteen.line_ministry }}
         </li>
     {% endif %}
+
     {% if canteen.management_type %}
         <li>
             <span>Mode de gestion</span> : {{ canteen.management_type }}
         </li>
     {% endif %}
+
     {% if canteen.economic_model %}
         <li>
             <span>Type d'établissement</span> : {{ canteen.economic_model }}

--- a/api/templates/teledeclaration_campaign_2024/diagnostic_mode_description.html
+++ b/api/templates/teledeclaration_campaign_2024/diagnostic_mode_description.html
@@ -1,20 +1,25 @@
 {% if teledeclaration_mode == "SATELLITE_WITHOUT_APPRO" %}
     <p>
         Les données d'approvisionnement ont été déclarées par la cuisine centrale
+
         {% if central_kitchen_name %}« {{ central_kitchen_name }} »{% endif %}
+
         {% if central_kitchen_siret %}(SIRET : {{ central_kitchen_siret }}){% endif %}
         .
     </p>
-{% elif teledeclaration_mode == "CENTRAL_ALL" %}
-    <p>Vous avez choisi de déclarer ces données au nom de toutes vos cantines satellites.</p>
-{% elif teledeclaration_mode == "CENTRAL_APPRO" %}
-    <p>Vous avez choisi de déclarer les données d'approvisionnement au nom de toutes vos cantines satellites.</p>
-{% endif %}
-{% if teledeclaration_mode == "CENTRAL_ALL" or teledeclaration_mode == "CENTRAL_APPRO" %}
+{% elif teledeclaration_mode == "CENTRAL_ALL" or teledeclaration_mode == "CENTRAL_APPRO" %}
+
+    {% if teledeclaration_mode == "CENTRAL_ALL" %}
+        <p>Vous avez choisi de déclarer ces données au nom de toutes vos cantines satellites.</p>
+    {% elif teledeclaration_mode == "CENTRAL_APPRO" %}
+        <p>Vous avez choisi de déclarer les données d'approvisionnement au nom de toutes vos cantines satellites.</p>
+    {% endif %}
+
     {% if satellites %}
         Cette télédéclaration concerne les cuisines satellites :
         <ul>
             {% for satellite in satellites %}<li>{{ satellite.name }} (SIRET : {{ satellite.siret }})</li>{% endfor %}
         </ul>
+        {% comment %} TODO: What about CC with site? {% endcomment %}
     {% endif %}
 {% endif %}

--- a/api/templates/teledeclaration_campaign_2024/index.html
+++ b/api/templates/teledeclaration_campaign_2024/index.html
@@ -11,32 +11,29 @@
                  height="60" />
         </div>
         <h1>Justificatif pour télédéclaration {{ year }}</h1>
-        <h2>Télédéclaration faite le {{ date|date:"l j F Y" }} par {{ applicant }}</h2>
+        <p>Télédéclaration faite le {{ date|date:"l j F Y" }} par {{ applicant }}</p>
         {% include "./canteen.html" %}
-
-        {% if teledeclaration_mode != "SATELLITE_WITHOUT_APPRO" %}
-            <h3>Vous avez choisi la télédéclaration {{ diagnostic_type }}.</h3>
-        {% endif %}
-        <p>
-            L'arrêté du 14 septembre 2022 rend obligatoire la saisie et la transmission des données d'achat de l'année n-1 à l'administration.
-        </p>
         {% include "./diagnostic_mode_description.html" %}
+        <h2>Informations de mon service</h2>
         <p>
-            Pour l'année {{ year }}, les données suivantes ont été télédéclarées le
-            {{ date|date:"l j F Y" }} via la plateforme numérique « ma cantine » :
+            Pour l'année {{ year }}, les données suivantes ont été télédéclarées
+            via la plateforme numérique « ma cantine » :
         </p>
-        <!-- SIMPLIFIED DECLARATION -->
 
         {% if teledeclaration_mode != "SATELLITE_WITHOUT_APPRO" %}
+            {% comment %} Has teledeclared appro data {% endcomment %}
+            <h3>Qualité des produits</h3>
+            <p>Vous avez choisi la télédéclaration {{ diagnostic_type }}.</p>
+
             {% if not diagnostic_type == "complète" %}
                 {% include "./measure_quality_simple.html" %}
             {% else %}
-                <!-- COMPLETE DECLARATION -->
                 {% include "./measure_quality_complete.html" %}
             {% endif %}
         {% endif %}
 
         {% if teledeclaration_mode != "CENTRAL_APPRO" %}
+            {% comment %} Has teledeclared data for the other measures {% endcomment %}
             <div class="other-measures">
                 {% include "./measure_waste.html" %}
                 {% include "./measure_diversification.html" %}
@@ -45,6 +42,9 @@
             </div>
         {% endif %}
         <hr />
+        <p>
+            L'arrêté du 14 septembre 2022 rend obligatoire la saisie et la transmission des données d'achat de l'année n-1 à l'administration.
+        </p>
         <p>
             En savoir plus de la loi EGAlim : <a href="https://ma-cantine.agriculture.gouv.fr/">https://ma-cantine.agriculture.gouv.fr/</a>
         </p>

--- a/api/templates/teledeclaration_campaign_2024/style.html
+++ b/api/templates/teledeclaration_campaign_2024/style.html
@@ -15,25 +15,29 @@
     }
 
     h1 {
-        font-family: 'Marianne-Bold';
+        font-family: 'Marianne-Bold', Arial, Helvetica, sans-serif;
+        font-weight: 700;
         font-size: 24px;
         margin: 32px 0px 16px 0px;
     }
 
     h2 {
-        font-family: 'Marianne-Bold';
+        font-family: 'Marianne-Bold', Arial, Helvetica, sans-serif;
+        font-weight: 700;
         font-size: 16px;
         margin: 16px 0px;
     }
 
     h3 {
-        font-family: 'Marianne-Bold';
+        font-family: 'Marianne-Bold', Arial, Helvetica, sans-serif;
+        font-weight: 700;
         font-size: 14px;
         margin: 32px 0 8px;
     }
 
     li span {
-        font-family: 'Marianne-Bold';
+        font-family: 'Marianne-Bold', Arial, Helvetica, sans-serif;
+        font-weight: 700;
     }
 
     p,

--- a/api/templates/teledeclaration_campaign_2024/style.html
+++ b/api/templates/teledeclaration_campaign_2024/style.html
@@ -10,17 +10,12 @@
         src: url({% static '../../../web/static/fonts/Marianne-Bold.ttf' %}) format('truetype');
     }
 
-    @font-face {
-        font-family: 'Marianne-ExtraBold';
-        src: url({% static '../../../web/static/fonts/Marianne-ExtraBold.ttf' %}) format('truetype');
-    }
-
     body {
         font-family: 'Marianne', Arial, Helvetica, sans-serif;
     }
 
     h1 {
-        font-family: 'Marianne-ExtraBold';
+        font-family: 'Marianne-Bold';
         font-size: 24px;
         margin: 32px 0px 16px 0px;
     }
@@ -33,6 +28,8 @@
 
     h3 {
         font-family: 'Marianne-Bold';
+        font-size: 14px;
+        margin: 32px 0 8px;
     }
 
     li span {

--- a/api/urls.py
+++ b/api/urls.py
@@ -23,7 +23,12 @@ from api.views import EmailDiagnosticImportFileView
 from api.views import BlogPostsView, SectorListView, ChangePasswordView, BlogPostView
 from api.views import AddManagerView, RemoveManagerView
 from api.views import ImportSimpleDiagnosticsView, ImportCompleteDiagnosticsView
-from api.views import TeledeclarationCreateView, TeledeclarationCancelView, TeledeclarationPdfView
+from api.views import (
+    TeledeclarationCreateView,
+    TeledeclarationCancelView,
+    TeledeclarationPdfView,
+    TeledeclarationHTMLView,
+)
 from api.views import PublishCanteenView, UnpublishCanteenView, SendCanteenNotFoundEmail
 from api.views import UserCanteenPreviews, CanteenLocationsView
 from api.views import PartnerView, PartnersView, PartnerTypeListView
@@ -130,6 +135,11 @@ urlpatterns = {
         "teledeclaration/<int:pk>/document.pdf",
         TeledeclarationPdfView.as_view(),
         name="teledeclaration_pdf",
+    ),
+    path(
+        "teledeclaration/<int:pk>/document.html",
+        TeledeclarationHTMLView.as_view(),
+        name="teledeclaration_html",
     ),
     path("inquiry/", InquiryView.as_view(), name="inquiry"),
     path(

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -49,6 +49,7 @@ from .teledeclaration import (  # noqa: F401
     TeledeclarationCreateView,
     TeledeclarationCancelView,
     TeledeclarationPdfView,
+    TeledeclarationHTMLView,
 )
 from .inquiry import InquiryView  # noqa: F401
 from .purchase import (  # noqa: F401


### PR DESCRIPTION
Ça vient d'une réflexion personnelle, feel free to challenge, fell into a rabbit hole

Aussi nouveau endpoint un peu secret pour l'instant pour avoir un vu HTML du justificatif. Ça aide avec le debugging mais aussi au temps p-e l'accessibilité

[teledeclaration-2023--test-3--2024-01-11-17.pdf](https://github.com/betagouv/ma-cantine/files/14450571/teledeclaration-2023--test-3--2024-01-11-17.pdf)
