### PR TITLE
RGAA 8.7 Dans chaque page web, chaque changement de langue est-il indiqué dans le code source (hors cas particuliers) ?

### DIFF
--- a/frontend/src/components/DsfrPagination.vue
+++ b/frontend/src/components/DsfrPagination.vue
@@ -6,8 +6,9 @@
     v-on="$listeners"
     @input="(v) => $emit('input', v)"
     previous-aria-label="Page précédente"
-    current-page-aria-label="Page actuelle"
+    current-page-aria-label="Page actuelle, page {0}"
     next-aria-label="Page suivante"
+    page-aria-label="Aller à la page {0}"
   ></v-pagination>
 </template>
 


### PR DESCRIPTION
Figured out the {0} notation to get the page number from here https://vuetifyjs.com/en/features/internationalization/#custom-vuetify-components

ça donne des bons noms accessibles (vu ici avec Firefox's "inspect accessibility properties" feature) :

## après

![Screenshot 2024-03-07 at 22 23 07](https://github.com/betagouv/ma-cantine/assets/9282816/43542d12-3c6b-48e7-9131-d949e3351e9e)


## avant
![Screenshot 2024-03-07 at 22 25 36](https://github.com/betagouv/ma-cantine/assets/9282816/759aa5b9-86d7-449f-8c96-e4a454e275d6)

