### PR TITLE
Downgrade urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -132,7 +132,7 @@ tzdata==2023.3
 tzlocal==5.2
 uritemplate==4.1.1
 uritools==4.0.2
-urllib3==2.0.7
+urllib3==1.26.18
 vine==5.1.0
 virtualenv==20.25.0
 wcwidth==0.2.12


### PR DESCRIPTION
Malgré ce que j'ai vu avant (https://github.com/betagouv/ma-cantine/pull/3650) sur la version urllib utilisé par botocore, aujourd'hui j'ai des problèmes en locale pour installer les requirements

```
The conflict is caused by:
    The user requested urllib3==2.0.7
    botocore 1.34.54 depends on urllib3<1.27 and >=1.25.4; python_version < "3.10"
```