### PR TITLE
RGAA 10.8 Pour chaque page web, les contenus cachés ont-ils vocation à être ignorés par les technologies d’assistance ?

### DIFF
--- a/frontend/src/components/CanteenPublication.vue
+++ b/frontend/src/components/CanteenPublication.vue
@@ -202,7 +202,7 @@
     </div>
 
     <div v-if="canteen && shouldDisplayGraph">
-      <h2 class="font-weight-black text-h6 grey--text text--darken-4 mt-12 mb-2">
+      <h2 id="appro-heading" class="font-weight-black text-h6 grey--text text--darken-4 mt-12 mb-2">
         Évolution des produits dans nos assiettes sur les années
       </h2>
       <div>

--- a/frontend/src/components/DsfrAccordion.vue
+++ b/frontend/src/components/DsfrAccordion.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-expansion-panels hover accordion tile flat>
+    <v-expansion-panel v-for="item in items" :key="item.title">
+      <v-expansion-panel-header class="px-3" expand-icon="mdi-plus" disable-icon-rotate v-slot="{ open }">
+        <h3 class="fr-text" :class="open && 'font-weight-bold'">
+          {{ item.title }}
+        </h3>
+      </v-expansion-panel-header>
+      <v-expansion-panel-content class="my-2">
+        <component :is="item.contentComponent" v-if="item.contentComponent" />
+        <p v-else-if="item.content" class="mb-0">{{ item.content }}</p>
+        <slot v-else />
+      </v-expansion-panel-content>
+    </v-expansion-panel>
+  </v-expansion-panels>
+</template>
+
+<script>
+export default {
+  name: "DsfrAccordion",
+  props: {
+    // items is an array of objects containing 'title'
+    // and one of 'contentComponent', 'content', or falls back to a slot
+    items: Array,
+  },
+}
+</script>
+
+<style>
+.v-expansion-panel {
+  box-shadow: inset 0 1px 0 0 #ddd, 0 1px 0 0 #ddd;
+}
+</style>

--- a/frontend/src/components/DsfrAccordion.vue
+++ b/frontend/src/components/DsfrAccordion.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-expansion-panels hover accordion tile flat>
+  <v-expansion-panels hover accordion tile flat class="dsfr-accordion">
     <v-expansion-panel v-for="item in items" :key="item.title">
       <v-expansion-panel-header class="px-3" expand-icon="mdi-plus" disable-icon-rotate v-slot="{ open }">
         <h3 class="fr-text" :class="open && 'font-weight-bold'">
@@ -27,7 +27,7 @@ export default {
 </script>
 
 <style>
-.v-expansion-panel {
+.dsfr-accordion .v-expansion-panel {
   box-shadow: inset 0 1px 0 0 #ddd, 0 1px 0 0 #ddd;
 }
 </style>

--- a/frontend/src/components/MultiYearSummaryStatistics.vue
+++ b/frontend/src/components/MultiYearSummaryStatistics.vue
@@ -6,12 +6,34 @@
         :series="series"
         role="img"
         :aria-labelledby="headingId"
-        aria-describedby="text"
+        aria-describedby="multi-year-graph-description"
         v-if="years.length"
-        :height="this.height || 'auto'"
-        :width="this.width || '100%'"
+        :height="height || 'auto'"
+        :width="width || '100%'"
       />
-      <p id="text" class="d-none">{{ description }}</p>
+      <DsfrAccordion :items="[{ title: 'Description de la graphique' }]" :style="`width: ${width}`">
+        <div id="multi-year-graph-description">
+          <p>
+            Les pourcentages d'achats par année pour cette cantine sont :
+          </p>
+          <ol class="mb-4">
+            <li v-for="(year, idx) in years" :key="year">
+              {{ year }} : {{ seriesData.bio[idx] }} % bio, {{ seriesData.sustainable[idx] }} % de qualité et durable
+              (hors bio)
+            </li>
+          </ol>
+          <p class="mb-0">
+            Rappel de l'objectif : Les repas servis comportent au moins {{ applicableRules.qualityThreshold }} % de
+            produits de qualité et durables dont au moins {{ applicableRules.bioThreshold }} % issus de l'agriculture
+            biologique ou en conversion, pour les cantines
+            {{
+              applicableRules.hasQualityException
+                ? `dans la région « ${regionDisplayName} »`
+                : "en France métropolitaine"
+            }}.
+          </p>
+        </div>
+      </DsfrAccordion>
     </div>
     <p v-else class="my-4 text-left">Données non renseignées</p>
   </div>
@@ -19,7 +41,8 @@
 
 <script>
 import VueApexCharts from "vue-apexcharts"
-import { getPercentage, hasDiagnosticApproData, getSustainableTotal } from "@/utils"
+import DsfrAccordion from "@/components/DsfrAccordion"
+import { getPercentage, hasDiagnosticApproData, getSustainableTotal, regionDisplayName } from "@/utils"
 
 const VALUE_DESCRIPTION = "Pourcentage d'achats"
 const BIO = "Bio"
@@ -29,6 +52,7 @@ const OTHER = "Hors EGAlim"
 export default {
   components: {
     VueApexCharts,
+    DsfrAccordion,
   },
   props: {
     diagnostics: Object,
@@ -82,16 +106,6 @@ export default {
           color: "#ccc",
         },
       ]
-    },
-    description() {
-      let description = `${VALUE_DESCRIPTION}. `
-      this.years.forEach((year, idx) => {
-        description += `${year} : `
-        description += `${percentageFormatter(this.seriesData.bio[idx])} ${BIO}, ${percentageFormatter(
-          this.seriesData.sustainable[idx]
-        )} ${SUSTAINABLE}. `
-      })
-      return description
     },
     chartOptions() {
       const legendPosition = this.legendPosition || (this.$vuetify.breakpoint.smAndUp ? "right" : "top")
@@ -151,6 +165,9 @@ export default {
           shared: true,
         },
       }
+    },
+    regionDisplayName() {
+      return regionDisplayName(this.applicableRules.regionForQualityException)
     },
   },
   methods: {

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,6 +1,7 @@
 import Constants from "@/constants"
 import jsonBadges from "@/badges"
 import jsonDepartments from "@/departments.json"
+import jsonRegions from "@/regions.json"
 
 export const timeAgo = (date, displayPrefix = false) => {
   if (typeof date === "string") {
@@ -352,6 +353,7 @@ export const applicableDiagnosticRules = (canteen) => {
     bioThreshold,
     qualityThreshold,
     hasQualityException,
+    regionForQualityException: hasQualityException && canteen.region,
   }
 }
 
@@ -675,4 +677,8 @@ export const readyToTeledeclare = (canteen, diagnostic, sectors) => {
 // were interpreted as false. Since then, we ask for an explicit false value.
 export const diagnosticUsesNullAsFalse = (diagnostic) => {
   return diagnostic.year < 2023
+}
+
+export const regionDisplayName = (regionCode) => {
+  return jsonRegions.find((r) => r.regionCode === regionCode).regionName
 }


### PR DESCRIPTION
- [ ] changer Les autres graphiques pour utiliser l'accordéon 

> L'alternative au graphique svg interactif est masquée aux technologies d'assistance. Pour y remédier prévoir un bouton plier/déplier permetant d'afficher cette alternative.

Je refactorise des pages qui utilisent les expansion panels dans une autre PR

![Screenshot 2024-03-11 at 18-14-18 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/b3d77b5e-5106-470d-8275-3c6c07ed7cf4)

![Screenshot 2024-03-11 at 18-14-02 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/64109977-a198-4e10-96b6-36682499c9ed)
