### PR TITLE
:bug: Permet d'importer des fichier sans `local_definition`

### DIFF
--- a/api/tests/files/good_purchase_import_no_local_def.csv
+++ b/api/tests/files/good_purchase_import_no_local_def.csv
@@ -1,0 +1,3 @@
+canteen siret,description,fournisseur,date,prix HT,famille,caractéristiques
+82399356058716,"Pommes, rouges",Le bon traiteur ,2022-05-02,90.11, PRODUITS_LAITIERS ,"BIO"
+82399356058716,"Pommes, vertes",Le bon traiteur ,2022-05-03,910.11, PRODUITS_LAITIERS ,"BIO"

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -47,6 +47,26 @@ class TestPurchaseImport(APITestCase):
         self.assertEqual(Purchase.objects.first().import_source, filehash_md5)
 
     @authenticate
+    def test_import_with_no_local_definition(self):
+        """
+        Tests that can import a file without local definition
+        """
+        CanteenFactory.create(siret="82399356058716", managers=[authenticate.user])
+        with open("./api/tests/files/good_purchase_import_no_local_def.csv") as purchase_file:
+            response = self.client.post(reverse("import_purchases"), {"file": purchase_file})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Purchase.objects.count(), 2)
+        purchase = Purchase.objects.filter(description="Pommes, rouges").first()
+        self.assertEqual(purchase.canteen.siret, "82399356058716")
+        self.assertEqual(purchase.description, "Pommes, rouges")
+        self.assertEqual(purchase.provider, "Le bon traiteur")
+        self.assertEqual(purchase.price_ht, Decimal("90.11"))
+        self.assertEqual(purchase.date, date(2022, 5, 2))
+        self.assertEqual(purchase.family, Purchase.Family.PRODUITS_LAITIERS)
+        self.assertEqual(purchase.characteristics, [Purchase.Characteristic.BIO])
+        self.assertEqual(purchase.local_definition, None)
+
+    @authenticate
     def test_import_purchases_different_separators(self):
         """
         Tests that can import a well formatted purchases file


### PR DESCRIPTION
La dernière colonne du fichier d'import des achats est utilisée pour la définition de local. Or, cette colonne n'est obligatoire que si `LOCAL` fait partie des caractéristiques.
