### PR TITLE
Bug fix : enlever le bon satellite

### DIFF
--- a/frontend/src/components/SatelliteTable.vue
+++ b/frontend/src/components/SatelliteTable.vue
@@ -82,7 +82,7 @@
       <template v-slot:[`item.unlink`]="{ item }" v-if="allowUnlinking">
         <v-dialog v-model="unlinkConfirmationOpen" width="500">
           <template v-slot:activator="{ on, attrs }">
-            <v-btn plain class="text-decoration-underline" v-bind="attrs" v-on="on">
+            <v-btn plain class="text-decoration-underline" v-bind="attrs" v-on="on" @click="unlinkItem = item">
               <v-icon small class="mr-1 mb-n1">$close-line</v-icon>
               Enlever
             </v-btn>
@@ -94,7 +94,7 @@
             </v-card-title>
 
             <v-card-text>
-              La cantine ne fera plus parti de celles fournies par votre établissement.
+              La cantine « {{ unlinkItem.name }} » ne fera plus parti de celles fournies par votre établissement.
             </v-card-text>
 
             <v-divider></v-divider>
@@ -104,7 +104,7 @@
               <v-btn outlined text @click="unlinkConfirmationOpen = false" class="mr-2">
                 Non, revenir en arrière
               </v-btn>
-              <v-btn outlined color="red darken-2" text @click="unlinkSatellite(item.id)">
+              <v-btn outlined color="red darken-2" text @click="unlinkSatellite(unlinkItem.id)">
                 Oui, enlever la cantine
               </v-btn>
             </v-card-actions>
@@ -198,6 +198,7 @@ export default {
       user: this.$store.state.loggedUser,
       messageJoinCanteen: null,
       unlinkConfirmationOpen: false,
+      unlinkItem: undefined,
     }
   },
   computed: {

--- a/frontend/src/components/SatelliteTable.vue
+++ b/frontend/src/components/SatelliteTable.vue
@@ -80,41 +80,38 @@
         </router-link>
       </template>
       <template v-slot:[`item.unlink`]="{ item }" v-if="allowUnlinking">
-        <v-dialog v-model="unlinkConfirmationOpen" width="500">
-          <template v-slot:activator="{ on, attrs }">
-            <v-btn plain class="text-decoration-underline" v-bind="attrs" v-on="on" @click="unlinkItem = item">
-              <v-icon small class="mr-1 mb-n1">$close-line</v-icon>
-              Enlever
-            </v-btn>
-          </template>
-
-          <v-card class="text-left">
-            <v-card-title class="font-weight-bold">
-              Voulez-vous vraiment enlever cette cantine de vos satellites ?
-            </v-card-title>
-
-            <v-card-text>
-              La cantine « {{ unlinkItem.name }} » ne fera plus parti de celles fournies par votre établissement.
-            </v-card-text>
-
-            <v-divider></v-divider>
-
-            <v-card-actions class="pa-4">
-              <v-spacer></v-spacer>
-              <v-btn outlined text @click="unlinkConfirmationOpen = false" class="mr-2">
-                Non, revenir en arrière
-              </v-btn>
-              <v-btn outlined color="red darken-2" text @click="unlinkSatellite(unlinkItem.id)">
-                Oui, enlever la cantine
-              </v-btn>
-            </v-card-actions>
-          </v-card>
-        </v-dialog>
+        <v-btn plain class="text-decoration-underline" @click="unlinkConfirmation(item)">
+          <v-icon small class="mr-1 mb-n1">$close-line</v-icon>
+          Enlever
+        </v-btn>
       </template>
       <template v-slot:[`no-data`]>
         Vous n'avez pas renseigné des satellites
       </template>
     </v-data-table>
+    <v-dialog v-model="unlinkConfirmationOpen" width="500">
+      <v-card class="text-left" v-if="unlinkItem">
+        <v-card-title class="font-weight-bold">
+          Voulez-vous vraiment enlever cette cantine de vos satellites ?
+        </v-card-title>
+
+        <v-card-text>
+          La cantine « {{ unlinkItem.name }} » ne fera plus parti de celles fournies par votre établissement.
+        </v-card-text>
+
+        <v-divider></v-divider>
+
+        <v-card-actions class="pa-4">
+          <v-spacer></v-spacer>
+          <v-btn outlined text @click="unlinkConfirmationOpen = false" class="mr-2">
+            Non, revenir en arrière
+          </v-btn>
+          <v-btn outlined color="red darken-2" text @click="unlinkSatellite(unlinkItem.id)">
+            Oui, enlever la cantine
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 
@@ -311,6 +308,10 @@ export default {
           this.joinDialog = false
         })
         .catch((e) => this.$store.dispatch("notifyServerError", e))
+    },
+    unlinkConfirmation(item) {
+      this.unlinkItem = item
+      this.unlinkConfirmationOpen = true
     },
     unlinkSatellite(satelliteId) {
       const headers = {

--- a/frontend/src/components/SatelliteTable.vue
+++ b/frontend/src/components/SatelliteTable.vue
@@ -195,7 +195,7 @@ export default {
       user: this.$store.state.loggedUser,
       messageJoinCanteen: null,
       unlinkConfirmationOpen: false,
-      unlinkItem: undefined,
+      unlinkItem: null,
     }
   },
   computed: {


### PR DESCRIPTION
Aujourd'hui, sur la page satellites, le bouton "Enlever" enleve le dernier satellite. J'imagine c'est parce que tous les dialogs créés sont donnés le même `v-model`, et alors le dernier créé est ouvert.

Cette PR ajoute le nom de la cantine dans le dialog de confirmation, et repare ce bug.

![Screenshot 2024-03-15 at 16-45-14 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/b203790b-73ac-4fdd-a189-1cff4d6f3bb6)

![Screenshot 2024-03-15 at 16-54-38 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/1a17a494-c08a-40ee-b756-9bcef4acb0bd)
