### PR TITLE
Ajout de l'email de l'utilisateur.ice dans le reply-to des messages de support

### DIFF
--- a/api/tests/test_inquiry.py
+++ b/api/tests/test_inquiry.py
@@ -108,6 +108,7 @@ class TestInquiry(APITestCase):
         self.assertEqual(email.to[0], "contact@example.com")
         self.assertEqual(email.subject, title)
         self.assertEqual(email.body, body)
+        self.assertIn("test@example.com", email.reply_to)
 
 
 class TestEmail(APITestCase):

--- a/api/views/inquiry.py
+++ b/api/views/inquiry.py
@@ -29,7 +29,7 @@ class InquiryView(APIView):
             for key, value in meta.items():
                 body += f"\n{key} : {value}"
 
-            utils.send_mail(message=body, subject=title, to=[settings.CONTACT_EMAIL])
+            utils.send_mail(message=body, subject=title, to=[settings.CONTACT_EMAIL], reply_to=[email])
 
             return JsonResponse({}, status=status.HTTP_200_OK)
         except ValidationError as e:


### PR DESCRIPTION
Cette PR permettra a Crisp de pouvoir répondre aux emails venant du formulaire support.