### PR TITLE
RGAA 11.5 Dans chaque formulaire, les champs de même nature sont-ils regroupés, si nécessaire ?

### DIFF
--- a/frontend/src/components/DsfrAutocomplete.vue
+++ b/frontend/src/components/DsfrAutocomplete.vue
@@ -21,7 +21,7 @@
 
       <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
       <template v-slot:message="{ key, message }">
-        <p :key="key">{{ message }}</p>
+        <p :key="key" class="mb-0">{{ message }}</p>
       </template>
     </v-autocomplete>
   </div>

--- a/frontend/src/components/DsfrCombobox.vue
+++ b/frontend/src/components/DsfrCombobox.vue
@@ -25,7 +25,7 @@
 
       <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
       <template v-slot:message="{ key, message }">
-        <p :key="key">{{ message }}</p>
+        <p :key="key" class="mb-0">{{ message }}</p>
       </template>
     </v-combobox>
   </div>

--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -8,7 +8,7 @@
     </template>
     <v-row v-if="optionsRow">
       <v-col v-for="item in items" :key="item.value">
-        <v-radio :label="item.label || item.text" :value="item.value"></v-radio>
+        <v-radio :label="item.label || item.text" :value="item.value" :class="optionClasses"></v-radio>
       </v-col>
     </v-row>
     <v-radio
@@ -17,6 +17,7 @@
       :key="item.value"
       :label="item.label || item.text"
       :value="item.value"
+      :class="optionClasses"
     ></v-radio>
 
     <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
@@ -34,6 +35,11 @@ export default {
       type: String,
       required: false,
       default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
+    },
+    optionClasses: {
+      type: String,
+      required: false,
+      default: "",
     },
     optional: {
       type: Boolean,

--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -1,7 +1,7 @@
 <template>
   <v-radio-group class="my-0" ref="radio" v-bind="$attrs" v-on="$listeners" @change="(v) => $emit('input', v)">
     <template v-slot:label>
-      <span :class="labelClasses">
+      <span :class="legendClass">
         {{ $attrs.label }}
       </span>
       <span class="fr-hint-text my-2" v-if="optional">Optionnel</span>
@@ -33,7 +33,7 @@ export default {
     labelClasses: {
       type: String,
       required: false,
-      default: "mb-2 text-sm-subtitle-1 text-body-2 text-left grey--text text--darken-4",
+      default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
     },
     optional: {
       type: Boolean,
@@ -63,6 +63,12 @@ export default {
         ]
       }
       return this.$attrs["items"]
+    },
+    legendClass() {
+      const activeColor = " grey--text text--darken-4"
+      const inactiveColor = " grey--text"
+      const color = this.$attrs.disabled ? inactiveColor : activeColor
+      return this.labelClasses + color
     },
   },
   methods: {

--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -6,19 +6,24 @@
       </span>
       <span class="fr-hint-text my-2" v-if="optional">Optionnel</span>
     </template>
-    <v-row v-if="optionsRow">
-      <v-col v-for="item in items" :key="item.value">
-        <v-radio :label="item.label || item.text" :value="item.value" :class="optionClasses"></v-radio>
+    <v-row v-if="optionsRow" class="my-0">
+      <v-col cols="12" sm="6" class="py-2" v-for="item in items" :key="item.value">
+        <v-radio :value="item.value" :class="optionClasses">
+          <template v-slot:label>
+            <span :class="optionClasses">
+              {{ item.label || item.text }}
+            </span>
+          </template>
+        </v-radio>
       </v-col>
     </v-row>
-    <v-radio
-      v-else
-      v-for="item in items"
-      :key="item.value"
-      :label="item.label || item.text"
-      :value="item.value"
-      :class="optionClasses"
-    ></v-radio>
+    <v-radio v-else v-for="item in items" :key="item.value" :value="item.value" :class="optionClasses">
+      <template v-slot:label>
+        <span :class="optionClasses">
+          {{ item.label || item.text }}
+        </span>
+      </template>
+    </v-radio>
 
     <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
     <template v-slot:message="{ key, message }">

--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -27,7 +27,7 @@
 
     <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
     <template v-slot:message="{ key, message }">
-      <p :key="key">{{ message }}</p>
+      <p :key="key" class="mb-0">{{ message }}</p>
     </template>
   </v-radio-group>
 </template>

--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -1,20 +1,17 @@
 <template>
-  <div>
-    <fieldset id="radio-hint" aria-labelledby="radio-hint-legend radio-hint-messages">
-      <legend v-if="$attrs.label" class="mb-2" id="radio-hint-legend">
+  <v-radio-group class="my-0" ref="radio" v-bind="$attrs" v-on="$listeners" @change="(v) => $emit('input', v)">
+    <template v-slot:label>
+      <span :class="labelClasses">
         {{ $attrs.label }}
-        <span v-if="$attrs.hint">{{ $attrs.hint }}</span>
-      </legend>
-      <v-radio-group class="my-0" ref="radio" v-bind="$attrs" v-on="$listeners" @change="(v) => $emit('input', v)">
-        <v-radio v-for="item in $attrs.items" :key="item.value" :label="item.text" :value="item.value"></v-radio>
+      </span>
+    </template>
+    <v-radio v-for="item in $attrs.items" :key="item.value" :label="item.text" :value="item.value"></v-radio>
 
-        <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
-        <template v-slot:message="{ key, message }">
-          <p :key="key">{{ message }}</p>
-        </template>
-      </v-radio-group>
-    </fieldset>
-  </div>
+    <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
+    <template v-slot:message="{ key, message }">
+      <p :key="key">{{ message }}</p>
+    </template>
+  </v-radio-group>
 </template>
 
 <script>
@@ -24,7 +21,7 @@ export default {
     labelClasses: {
       type: String,
       required: false,
-      default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
+      default: "mb-2 text-sm-subtitle-1 text-body-2 text-left grey--text text--darken-4",
     },
   },
   data() {
@@ -36,16 +33,9 @@ export default {
     },
   },
   methods: {
-    removeInnerLabel() {
-      const labels = this.$refs["radio"].$el.getElementsByTagName("legend")
-      if (labels && labels.length > 0) for (const label of labels) label.parentNode.removeChild(label)
-    },
     validate() {
       return this.$refs["radio"].validate()
     },
-  },
-  mounted() {
-    this.removeInnerLabel()
   },
 }
 </script>

--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -38,12 +38,10 @@ export default {
   props: {
     labelClasses: {
       type: String,
-      required: false,
       default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
     },
     optionClasses: {
       type: String,
-      required: false,
       default: "",
     },
     optional: {

--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -4,8 +4,20 @@
       <span :class="labelClasses">
         {{ $attrs.label }}
       </span>
+      <span class="fr-hint-text my-2" v-if="optional">Optionnel</span>
     </template>
-    <v-radio v-for="item in $attrs.items" :key="item.value" :label="item.text" :value="item.value"></v-radio>
+    <v-row v-if="optionsRow">
+      <v-col v-for="item in items" :key="item.value">
+        <v-radio :label="item.label || item.text" :value="item.value"></v-radio>
+      </v-col>
+    </v-row>
+    <v-radio
+      v-else
+      v-for="item in items"
+      :key="item.value"
+      :label="item.label || item.text"
+      :value="item.value"
+    ></v-radio>
 
     <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
     <template v-slot:message="{ key, message }">
@@ -23,6 +35,18 @@ export default {
       required: false,
       default: "mb-2 text-sm-subtitle-1 text-body-2 text-left grey--text text--darken-4",
     },
+    optional: {
+      type: Boolean,
+      default: false,
+    },
+    yesNo: {
+      type: Boolean,
+      default: false,
+    },
+    optionsRow: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return { inputId: null }
@@ -30,6 +54,15 @@ export default {
   computed: {
     value() {
       return this.$refs["radio"].value
+    },
+    items() {
+      if (this.yesNo) {
+        return [
+          { label: "Oui", value: true },
+          { label: "Non", value: false },
+        ]
+      }
+      return this.$attrs["items"]
     },
   },
   methods: {

--- a/frontend/src/components/DsfrSelect.vue
+++ b/frontend/src/components/DsfrSelect.vue
@@ -17,7 +17,7 @@
       <template v-slot:label><span></span></template>
       <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
       <template v-slot:message="{ key, message }">
-        <p :key="key">{{ message }}</p>
+        <p :key="key" class="mb-0">{{ message }}</p>
       </template>
     </v-select>
   </div>

--- a/frontend/src/components/DsfrTextField.vue
+++ b/frontend/src/components/DsfrTextField.vue
@@ -22,7 +22,7 @@
 
       <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
       <template v-slot:message="{ key, message }">
-        <p :key="key">{{ message }}</p>
+        <p :key="key" class="mb-0">{{ message }}</p>
       </template>
     </v-text-field>
   </div>
@@ -33,7 +33,6 @@ export default {
   inheritAttrs: false,
   props: {
     labelClasses: {
-      type: String,
       required: false,
       default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
     },

--- a/frontend/src/components/DsfrTextarea.vue
+++ b/frontend/src/components/DsfrTextarea.vue
@@ -17,7 +17,7 @@
 
       <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
       <template v-slot:message="{ key, message }">
-        <p :key="key">{{ message }}</p>
+        <p :key="key" class="mb-0">{{ message }}</p>
       </template>
     </v-textarea>
   </div>

--- a/frontend/src/components/KeyMeasureDiagnostic/DiversificationMeasure.vue
+++ b/frontend/src/components/KeyMeasureDiagnostic/DiversificationMeasure.vue
@@ -28,35 +28,27 @@
       />
     </fieldset>
 
-    <fieldset>
-      <legend class="text-left my-3">J'ai mis en place un menu végétarien dans ma cantine :</legend>
-      <v-radio-group class="my-0" v-model="diagnostic.vegetarianWeeklyRecurrence" hide-details>
-        <v-radio
-          class="ml-8"
-          v-for="item in frequency"
-          :key="item.value"
-          :label="item.label"
-          :value="item.value"
-          :readonly="readonly"
-          :disabled="readonly"
-        ></v-radio>
-      </v-radio-group>
-    </fieldset>
+    <DsfrRadio
+      label="J'ai mis en place un menu végétarien dans ma cantine :"
+      v-model="diagnostic.vegetarianWeeklyRecurrence"
+      hide-details
+      :items="frequency"
+      :readonly="readonly"
+      :disabled="readonly"
+      optionClasses="ml-8"
+      class="mt-3"
+    />
 
-    <fieldset class="mt-3">
-      <legend class="text-left my-3">Le menu végétarien proposé est :</legend>
-      <v-radio-group class="my-0" v-model="diagnostic.vegetarianMenuType" hide-details>
-        <v-radio
-          class="ml-8"
-          v-for="item in menuTypes"
-          :key="item.value"
-          :label="item.label"
-          :value="item.value"
-          :readonly="readonly"
-          :disabled="readonly"
-        ></v-radio>
-      </v-radio-group>
-    </fieldset>
+    <DsfrRadio
+      label="Le menu végétarien proposé est :"
+      v-model="diagnostic.vegetarianMenuType"
+      hide-details
+      :items="menuTypes"
+      :readonly="readonly"
+      :disabled="readonly"
+      optionClasses="ml-8"
+      class="mt-3"
+    />
 
     <fieldset class="mt-3">
       <legend class="text-left mb-2 mt-3">
@@ -119,6 +111,7 @@
 <script>
 import { applicableDiagnosticRules } from "@/utils"
 import ExpeVegetarian from "@/components/KeyMeasureDiagnostic/ExpeModals/ExpeVegetarian"
+import DsfrRadio from "@/components/DsfrRadio"
 import Constants from "@/constants"
 
 export default {
@@ -130,7 +123,7 @@ export default {
     },
     canteen: Object,
   },
-  components: { ExpeVegetarian },
+  components: { ExpeVegetarian, DsfrRadio },
   data() {
     return {
       showExpeModal: false,

--- a/frontend/src/components/KeyMeasureDiagnostic/InformationMeasure.vue
+++ b/frontend/src/components/KeyMeasureDiagnostic/InformationMeasure.vue
@@ -8,20 +8,16 @@
       :disabled="readonly"
     />
 
-    <fieldset class="mt-3 mb-4">
-      <legend class="text-left my-3">Je fais cette information :</legend>
-      <v-radio-group class="my-0" v-model="diagnostic.communicationFrequency" hide-details>
-        <v-radio
-          class="ml-8"
-          v-for="item in communicationFrequencies"
-          :key="item.value"
-          :label="item.label"
-          :value="item.value"
-          :readonly="readonly"
-          :disabled="readonly"
-        ></v-radio>
-      </v-radio-group>
-    </fieldset>
+    <DsfrRadio
+      label="Je fais cette information :"
+      v-model="diagnostic.communicationFrequency"
+      hide-details
+      :items="communicationFrequencies"
+      :readonly="readonly"
+      :disabled="readonly"
+      optionClasses="ml-8"
+      class="mt-3"
+    />
 
     <fieldset class="mt-3 mb-4">
       <legend class="text-left my-3">J'informe sur la qualité des approvisionnements :</legend>
@@ -82,10 +78,11 @@
 <script>
 import validators from "@/validators"
 import DsfrTextField from "@/components/DsfrTextField"
+import DsfrRadio from "@/components/DsfrRadio"
 import Constants from "@/constants"
 
 export default {
-  components: { DsfrTextField },
+  components: { DsfrTextField, DsfrRadio },
   props: {
     diagnostic: Object,
     readonly: {

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -52,10 +52,10 @@
       <h2 class="mb-4" v-if="isNewCanteen">Étape 2/2 : Compléter les informations</h2>
       <v-row>
         <v-col cols="12" md="8">
-          <p>SIRET</p>
-          <p class="grey--text text--darken-2">
+          <p class="mb-2">SIRET</p>
+          <p class="grey--text text--darken-2 d-flex align-center">
             {{ siret || canteen.siret }}
-            <v-btn small @click="goToStep(0)">Modifier</v-btn>
+            <v-btn small @click="goToStep(0)" class="ml-2">Modifier</v-btn>
           </p>
 
           <DsfrTextField
@@ -135,6 +135,7 @@
         <v-col cols="12">
           <DsfrRadio
             label="Mon établissement..."
+            labelClasses="body-2 mb-2 grey--text text--darken-4"
             :items="productionTypes"
             v-model="canteen.productionType"
             :rules="[validators.required]"
@@ -306,6 +307,7 @@
         <v-col cols="12" sm="6" md="3">
           <DsfrRadio
             label="Type d'établissement"
+            labelClasses="body-2 mb-2 grey--text text--darken-4"
             :items="economicModels"
             v-model="canteen.economicModel"
             :rules="[validators.required]"
@@ -315,6 +317,7 @@
         <v-col cols="12" sm="6" md="3">
           <DsfrRadio
             label="Mode de gestion"
+            labelClasses="body-2 mb-2 grey--text text--darken-4"
             :items="managementTypes"
             v-model="canteen.managementType"
             :rules="[validators.required]"

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -74,7 +74,7 @@
     </div>
     <v-expand-transition>
       <v-sheet class="pa-6 text-left mt-2" v-show="showFilters" rounded :outlined="showFilters">
-        <v-row>
+        <v-row class="mb-0">
           <v-col cols="12" sm="6" md="4">
             <label
               for="select-region"
@@ -194,102 +194,86 @@
             />
           </v-col>
         </v-row>
-        <v-row class="align-end mt-0">
+        <v-row class="align-end my-0">
           <v-col cols="12" sm="8" md="6">
-            <label class="text-body-2">
-              Dans les assiettes, part de...
-            </label>
-            <div class="d-flex align-stretch mt-1">
-              <v-col class="pa-0 pr-1 d-flex flex-column">
-                <label
-                  :class="{
-                    caption: true,
-                    'pl-1': true,
-                    'active-filter-label': !!filters.min_portion_bio.value,
-                  }"
-                  id="value-percentages-bio"
-                >
-                  bio minimum
-                </label>
-                <v-spacer></v-spacer>
-                <DsfrTextField
-                  :value="filters.min_portion_bio.value"
-                  ref="min_portion_bio"
-                  :rules="[validators.nonNegativeOrEmpty, validators.lteOrEmpty(100)]"
-                  @change="onChangeIntegerFilter('min_portion_bio')"
-                  hide-details="auto"
-                  append-icon="mdi-percent"
-                  placeholder="0"
-                  aria-describedby="value-percentages-bio"
-                />
-              </v-col>
-              <v-col class="pa-0 pl-1 d-flex flex-column">
-                <label
-                  :class="{
-                    caption: true,
-                    'pl-1': true,
-                    'active-filter-label': !!filters.min_portion_combined.value,
-                  }"
-                  id="value-percentages-bio-qualite"
-                >
-                  bio, qualité et durables min
-                </label>
-                <v-spacer></v-spacer>
-                <DsfrTextField
-                  :value="filters.min_portion_combined.value"
-                  ref="min_portion_combined"
-                  :rules="[validators.nonNegativeOrEmpty, validators.lteOrEmpty(100)]"
-                  @change="onChangeIntegerFilter('min_portion_combined')"
-                  hide-details="auto"
-                  placeholder="0"
-                  append-icon="mdi-percent"
-                  aria-describedby="value-percentages-bio-qualite"
-                />
-              </v-col>
-            </div>
+            <fieldset>
+              <legend
+                :class="{
+                  'text-body-2': true,
+                  'active-filter-label': !!filters.min_portion_bio.value || !!filters.min_portion_combined.value,
+                }"
+              >
+                Dans les assiettes, part de...
+              </legend>
+              <div class="d-flex align-stretch mt-1">
+                <v-col class="pa-0 pr-1 d-flex flex-column">
+                  <DsfrTextField
+                    label="bio minimum"
+                    labelClasses="caption pl-1"
+                    :value="filters.min_portion_bio.value"
+                    ref="min_portion_bio"
+                    :rules="[validators.nonNegativeOrEmpty, validators.lteOrEmpty(100)]"
+                    @change="onChangeIntegerFilter('min_portion_bio')"
+                    hide-details="auto"
+                    append-icon="mdi-percent"
+                    placeholder="0"
+                  />
+                </v-col>
+                <v-col class="pa-0 pl-1 d-flex flex-column">
+                  <DsfrTextField
+                    label="bio, qualité et durables min"
+                    labelClasses="caption pl-1"
+                    :value="filters.min_portion_combined.value"
+                    ref="min_portion_combined"
+                    :rules="[validators.nonNegativeOrEmpty, validators.lteOrEmpty(100)]"
+                    @change="onChangeIntegerFilter('min_portion_combined')"
+                    hide-details="auto"
+                    placeholder="0"
+                    append-icon="mdi-percent"
+                  />
+                </v-col>
+              </div>
+            </fieldset>
           </v-col>
           <v-col cols="12" sm="4" md="3">
-            <label
-              :class="{
-                'text-body-2': true,
-                'active-filter-label': !!filters.min_daily_meal_count.value || !!filters.max_daily_meal_count.value,
-              }"
-              id="meal-count"
-            >
-              Repas par jour
-            </label>
-            <div class="d-flex">
-              <div>
-                <label class="caption" for="min-meal-count-field">
-                  Min
-                </label>
-                <DsfrTextField
-                  :value="filters.min_daily_meal_count.value"
-                  ref="min_daily_meal_count"
-                  :rules="[validators.nonNegativeOrEmpty]"
-                  @change="onChangeIntegerFilter('min_daily_meal_count')"
-                  hide-details="auto"
-                  id="min-meal-count-field"
-                  aria-describedby="meal-count"
-                />
+            <fieldset>
+              <legend
+                :class="{
+                  'text-body-2': true,
+                  'active-filter-label': !!filters.min_daily_meal_count.value || !!filters.max_daily_meal_count.value,
+                }"
+              >
+                Repas par jour
+              </legend>
+              <div class="d-flex">
+                <div>
+                  <DsfrTextField
+                    label="Min"
+                    labelClasses="caption"
+                    :value="filters.min_daily_meal_count.value"
+                    ref="min_daily_meal_count"
+                    :rules="[validators.nonNegativeOrEmpty]"
+                    @change="onChangeIntegerFilter('min_daily_meal_count')"
+                    hide-details="auto"
+                  />
+                </div>
+                <span class="mx-2 align-self-center">-</span>
+                <div>
+                  <DsfrTextField
+                    label="Max"
+                    labelClasses="caption"
+                    :value="filters.max_daily_meal_count.value"
+                    ref="max_daily_meal_count"
+                    :rules="[validators.nonNegativeOrEmpty]"
+                    @change="onChangeIntegerFilter('max_daily_meal_count')"
+                    hide-details="auto"
+                  />
+                </div>
               </div>
-              <span class="mx-2 align-self-center">-</span>
-              <div>
-                <label class="caption" for="max-meal-count-field">
-                  Max
-                </label>
-                <DsfrTextField
-                  :value="filters.max_daily_meal_count.value"
-                  ref="max_daily_meal_count"
-                  :rules="[validators.nonNegativeOrEmpty]"
-                  @change="onChangeIntegerFilter('max_daily_meal_count')"
-                  hide-details="auto"
-                  aria-describedby="meal-count"
-                  id="max-meal-count-field"
-                />
-              </div>
-            </div>
+            </fieldset>
           </v-col>
+        </v-row>
+        <v-row class="mt-0">
           <v-col cols="12" sm="6" md="5">
             <label for="select-badge" :class="{ 'text-body-2': true, 'active-filter-label': !!filters.badge.value }">
               Mesure EGAlim réalisée

--- a/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
@@ -8,25 +8,23 @@
         @tunnel-autofill="onTunnelAutofill"
         class="mb-xs-6 mb-xl-16"
       />
-      <fieldset>
-        <legend class="text-left my-3">
-          J'ai mis en place un menu végétarien dans ma cantine :
-          <span class="fr-hint-text mt-2">Optionnel</span>
-        </legend>
-        <v-radio-group class="my-0" v-model="payload.vegetarianWeeklyRecurrence" hide-details @change="calculateSteps">
-          <v-radio v-for="item in frequency" :key="item.value" :label="item.label" :value="item.value"></v-radio>
-        </v-radio-group>
-      </fieldset>
+      <DsfrRadio
+        label="J'ai mis en place un menu végétarien dans ma cantine :"
+        :items="frequency"
+        v-model="payload.vegetarianWeeklyRecurrence"
+        @change="calculateSteps"
+        hide-details
+        optional
+      />
     </div>
-    <fieldset v-else-if="stepUrlSlug === 'options'">
-      <legend class="text-left my-3">
-        Le menu végétarien proposé est :
-        <span class="fr-hint-text mt-2">Optionnel</span>
-      </legend>
-      <v-radio-group class="my-0" v-model="payload.vegetarianMenuType" hide-details>
-        <v-radio v-for="item in menuTypes" :key="item.value" :label="item.label" :value="item.value"></v-radio>
-      </v-radio-group>
-    </fieldset>
+    <DsfrRadio
+      v-else-if="stepUrlSlug === 'options'"
+      label="Le menu végétarien proposé est :"
+      :items="menuTypes"
+      v-model="payload.vegetarianMenuType"
+      hide-details
+      optional
+    />
     <fieldset v-else-if="stepUrlSlug === 'composition'">
       <legend class="text-left mb-2 mt-3">
         Le plat principal de mon menu végétarien est majoritairement à base de :
@@ -44,22 +42,15 @@
       />
     </fieldset>
     <div v-else-if="stepUrlSlug === 'plan'">
-      <fieldset>
-        <legend class="text-left my-3">
-          J'ai mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base de
-          protéines végétales
-        </legend>
-        <v-radio-group class="my-0" v-model="payload.hasDiversificationPlan" hide-details>
-          <v-row>
-            <v-col>
-              <v-radio label="Oui" :value="true"></v-radio>
-            </v-col>
-            <v-col>
-              <v-radio label="Non" :value="false"></v-radio>
-            </v-col>
-          </v-row>
-        </v-radio-group>
-      </fieldset>
+      <DsfrRadio
+        label="J'ai mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base de
+          protéines végétales"
+        v-model="payload.hasDiversificationPlan"
+        hide-details
+        optionsRow
+        yesNo
+        optional
+      />
       <fieldset class="my-3">
         <legend class="text-left mb-1 mt-3" :class="{ 'grey--text': !payload.hasDiversificationPlan }">
           Ce plan comporte, par exemple, les actions suivantes (voir guide du CNRC) :
@@ -83,6 +74,7 @@
 </template>
 
 <script>
+import DsfrRadio from "@/components/DsfrRadio"
 import LastYearAutofillOption from "../LastYearAutofillOption"
 import Constants from "@/constants"
 import { applicableDiagnosticRules } from "@/utils"
@@ -102,7 +94,7 @@ export default {
       type: String,
     },
   },
-  components: { LastYearAutofillOption },
+  components: { DsfrRadio, LastYearAutofillOption },
   data() {
     return {
       steps: [],

--- a/frontend/src/views/DiagnosticTunnel/InformationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/InformationMeasureSteps/index.vue
@@ -134,16 +134,6 @@ export default {
           urlSlug: "complet",
         },
       ],
-      boolOptions: [
-        {
-          label: "Oui",
-          value: true,
-        },
-        {
-          label: "Non",
-          value: false,
-        },
-      ],
       payload: {},
       fields: [
         "communicatesOnFoodQuality",

--- a/frontend/src/views/DiagnosticTunnel/InformationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/InformationMeasureSteps/index.vue
@@ -8,31 +8,24 @@
         @tunnel-autofill="onTunnelAutofill"
         class="mb-xs-6 mb-xl-16"
       />
-      <fieldset>
-        <legend class="my-3">
-          J’informe mes convives sur la part de produits de qualité et durables entrant dans la composition des repas
-          servis, et sur les démarches d’acquisition de produits issus d’un PAT (projet alimentaire territorial)
-        </legend>
-        <v-radio-group class="my-0" v-model="payload.communicatesOnFoodQuality" hide-details>
-          <v-radio v-for="item in boolOptions" :key="item.value" :label="item.label" :value="item.value"></v-radio>
-        </v-radio-group>
-      </fieldset>
-      <fieldset class="mt-8" :disabled="!payload.communicatesOnFoodQuality">
-        <legend>
-          Je fais cette information
-          <span class="fr-hint-text my-2">Optionnel</span>
-        </legend>
-        <v-radio-group class="my-0" v-model="payload.communicationFrequency" hide-details>
-          <v-radio
-            v-for="item in communicationFrequencies"
-            :key="item.value"
-            :label="item.label"
-            :value="item.value"
-            :disabled="!payload.communicatesOnFoodQuality"
-            :readonly="!payload.communicatesOnFoodQuality"
-          ></v-radio>
-        </v-radio-group>
-      </fieldset>
+      <DsfrRadio
+        label="J’informe mes convives sur la part de produits de qualité et durables entrant dans la composition des repas
+          servis, et sur les démarches d’acquisition de produits issus d’un PAT (projet alimentaire territorial)"
+        v-model="payload.communicatesOnFoodQuality"
+        hide-details
+        optional
+        yesNo
+      />
+      <DsfrRadio
+        label="Je fais cette information"
+        v-model="payload.communicationFrequency"
+        hide-details
+        optional
+        :items="communicationFrequencies"
+        :disabled="!payload.communicatesOnFoodQuality"
+        :readonly="!payload.communicatesOnFoodQuality"
+        class="mt-8"
+      />
     </div>
     <div v-else-if="stepUrlSlug === 'mode-information'">
       <fieldset>
@@ -64,14 +57,14 @@
         </v-row>
       </fieldset>
     </div>
-    <div v-else-if="stepUrlSlug === 'qualite-nutritionnelle'">
-      <fieldset>
-        <legend class="my-3">J’informe les convives sur la qualité nutritionnelle des repas</legend>
-        <v-radio-group class="my-0" v-model="payload.communicatesOnFoodPlan" hide-details>
-          <v-radio v-for="item in boolOptions" :key="item.value" :label="item.label" :value="item.value"></v-radio>
-        </v-radio-group>
-      </fieldset>
-    </div>
+    <DsfrRadio
+      v-else-if="stepUrlSlug === 'qualite-nutritionnelle'"
+      label="J’informe les convives sur la qualité nutritionnelle des repas"
+      v-model="payload.communicatesOnFoodPlan"
+      hide-details
+      optional
+      yesNo
+    />
     <div v-else-if="stepUrlSlug === 'lien-communication'">
       <fieldset>
         <legend>
@@ -93,6 +86,7 @@
 <script>
 import LastYearAutofillOption from "../LastYearAutofillOption"
 import DsfrTextField from "@/components/DsfrTextField"
+import DsfrRadio from "@/components/DsfrRadio"
 import validators from "@/validators"
 import Constants from "@/constants"
 
@@ -111,7 +105,7 @@ export default {
       type: String,
     },
   },
-  components: { LastYearAutofillOption, DsfrTextField },
+  components: { LastYearAutofillOption, DsfrTextField, DsfrRadio },
   data() {
     return {
       formIsValid: true,

--- a/frontend/src/views/DiagnosticTunnel/NoPlasticMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/NoPlasticMeasureSteps/index.vue
@@ -8,40 +8,38 @@
         @tunnel-autofill="onTunnelAutofill"
         class="mb-xs-6 mb-xl-16"
       />
-      <fieldset>
-        <legend class="mb-3">
-          Je n’utilise plus de contenants alimentaires de cuisson / de réchauffe en plastique
-        </legend>
-        <v-radio-group class="my-0" v-model="payload.cookingPlasticSubstituted" hide-details>
-          <v-radio v-for="item in boolOptions" :key="item.value" :label="item.label" :value="item.value"></v-radio>
-        </v-radio-group>
-      </fieldset>
-      <fieldset class="mt-8">
-        <legend class="mb-3">
-          Je n’utilise plus de contenants alimentaires de service en plastique
-        </legend>
-        <v-radio-group class="my-0" v-model="payload.servingPlasticSubstituted" hide-details>
-          <v-radio v-for="item in boolOptions" :key="item.value" :label="item.label" :value="item.value"></v-radio>
-        </v-radio-group>
-      </fieldset>
+      <DsfrRadio
+        label="Je n’utilise plus de contenants alimentaires de cuisson / de réchauffe en plastique"
+        v-model="payload.cookingPlasticSubstituted"
+        hide-details
+        optional
+        :items="boolOptions"
+      />
+      <DsfrRadio
+        label="Je n’utilise plus de contenants alimentaires de service en plastique"
+        v-model="payload.servingPlasticSubstituted"
+        hide-details
+        optional
+        :items="boolOptions"
+        class="mt-8"
+      />
     </div>
     <div v-else-if="stepUrlSlug === 'ustensils-et-contenants'">
-      <fieldset>
-        <legend class="mb-3">
-          Je ne mets plus à disposition des convives des bouteilles d’eau plate en plastique
-        </legend>
-        <v-radio-group class="my-0" v-model="payload.plasticBottlesSubstituted" hide-details>
-          <v-radio v-for="item in boolOptions" :key="item.value" :label="item.label" :value="item.value"></v-radio>
-        </v-radio-group>
-      </fieldset>
-      <fieldset class="mt-8">
-        <legend class="mb-3">
-          Je ne mets plus à disposition des convives des ustensiles à usage unique en matière plastique
-        </legend>
-        <v-radio-group class="my-0" v-model="payload.plasticTablewareSubstituted" hide-details>
-          <v-radio v-for="item in boolOptions" :key="item.value" :label="item.label" :value="item.value"></v-radio>
-        </v-radio-group>
-      </fieldset>
+      <DsfrRadio
+        label="Je ne mets plus à disposition des convives des bouteilles d’eau plate en plastique"
+        v-model="payload.plasticBottlesSubstituted"
+        hide-details
+        optional
+        :items="boolOptions"
+      />
+      <DsfrRadio
+        label="Je ne mets plus à disposition des convives des ustensiles à usage unique en matière plastique"
+        v-model="payload.plasticTablewareSubstituted"
+        hide-details
+        optional
+        :items="boolOptions"
+        class="mt-8"
+      />
     </div>
     <component v-else :is="step.componentName" :canteen="canteen" :diagnostic="payload" />
   </v-form>
@@ -49,6 +47,7 @@
 
 <script>
 import LastYearAutofillOption from "../LastYearAutofillOption"
+import DsfrRadio from "@/components/DsfrRadio"
 
 export default {
   name: "NoPlasticMeasureSteps",
@@ -65,7 +64,7 @@ export default {
       type: String,
     },
   },
-  components: { LastYearAutofillOption },
+  components: { LastYearAutofillOption, DsfrRadio },
   data() {
     return {
       formIsValid: true,

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/index.vue
@@ -2,19 +2,19 @@
   <v-form v-model="formIsValid" @submit.prevent>
     <div v-if="payload">
       <div v-if="stepUrlSlug === 'mode-de-saisie'">
-        <fieldset>
-          <legend class="text-left my-3">
-            Selon le niveau d’information disponible, vous pouvez choisir entre les deux types de saisie suivantes.
-          </legend>
-          <v-radio-group class="my-0" v-model="payload.diagnosticType" hide-details>
-            <v-radio v-for="type in diagnosticTypes" :key="type.key" :label="type.label" :value="type.key">
-              <template v-slot:label>
-                <span class="grey--text text--darken-3 font-weight-bold">{{ type.label }}</span>
-                <span class="fr-text-sm ml-3">{{ type.help }}</span>
-              </template>
-            </v-radio>
-          </v-radio-group>
-        </fieldset>
+        <v-radio-group class="my-0" v-model="payload.diagnosticType" hide-details>
+          <template v-slot:label>
+            <span class="fr-text grey--text text--darken-4">
+              Selon le niveau d’information disponible, vous pouvez choisir entre les deux types de saisie suivantes.
+            </span>
+          </template>
+          <v-radio v-for="type in diagnosticTypes" :key="type.key" :label="type.label" :value="type.key">
+            <template v-slot:label>
+              <span class="grey--text text--darken-3 font-weight-bold">{{ type.label }}</span>
+              <span class="fr-text-sm ml-3">{{ type.help }}</span>
+            </template>
+          </v-radio>
+        </v-radio-group>
       </div>
       <component
         v-else-if="step.characteristicId"

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -8,44 +8,34 @@
         @tunnel-autofill="onTunnelAutofill"
         class="mb-xs-6 mb-xl-16"
       />
-      <fieldset>
-        <legend class="my-3">
-          J’ai réalisé un diagnostic sur les causes probables de gaspillage alimentaire
-        </legend>
-        <v-radio-group class="my-0" v-model="payload.hasWasteDiagnostic" hide-details>
-          <v-radio
-            v-for="item in boolOptions"
-            :key="`hasWasteDiagnostic-${item.value}`"
-            :label="item.label"
-            :value="item.value"
-          ></v-radio>
-        </v-radio-group>
-      </fieldset>
-      <fieldset class="mt-8" :disabled="!payload.hasWasteDiagnostic">
-        <legend class="mb-3">J’ai mis en place un plan d’action adapté au diagnostic réalisé</legend>
-        <v-radio-group class="my-0" v-model="payload.hasWastePlan" hide-details>
-          <v-radio
-            v-for="item in boolOptions"
-            :key="`hasWastePlan-${item.value}`"
-            :label="item.label"
-            :value="item.value"
-            :disabled="!payload.hasWasteDiagnostic"
-            :readonly="!payload.hasWasteDiagnostic"
-          ></v-radio>
-        </v-radio-group>
-      </fieldset>
+      <DsfrRadio
+        v-model="payload.hasWasteDiagnostic"
+        label="J’ai réalisé un diagnostic sur les causes probables de gaspillage alimentaire"
+        yesNo
+        optional
+        hide-details
+      />
+      <DsfrRadio
+        v-model="payload.hasWastePlan"
+        label="J’ai mis en place un plan d’action adapté au diagnostic réalisé"
+        yesNo
+        optional
+        hide-details
+        :disabled="!payload.hasWasteDiagnostic"
+        :readonly="!payload.hasWasteDiagnostic"
+        class="mt-8"
+      />
     </div>
     <div v-else-if="stepUrlSlug === 'mesure-gaspillage'">
       <v-row>
         <v-col cols="12" sm="6">
-          <fieldset>
-            <legend class="my-3">
-              J’ai réalisé des mesures de mon gaspillage alimentaire
-            </legend>
-            <v-radio-group class="my-0" v-model="payload.hasWasteMeasures" hide-details>
-              <v-radio v-for="item in boolOptions" :key="item.value" :label="item.label" :value="item.value"></v-radio>
-            </v-radio-group>
-          </fieldset>
+          <DsfrRadio
+            v-model="payload.hasWasteMeasures"
+            label="J’ai réalisé des mesures de mon gaspillage alimentaire"
+            yesNo
+            optional
+            hide-details
+          />
         </v-col>
         <v-col cols="12" sm="6">
           <fieldset :disabled="!payload.hasWasteMeasures">
@@ -158,14 +148,13 @@
     <div v-else-if="stepUrlSlug === 'dons-alimentaires'">
       <v-row>
         <v-col cols="12" sm="6">
-          <fieldset>
-            <legend class="my-3">
-              Je propose une ou des conventions de dons à des associations habilitées d’aide alimentaire
-            </legend>
-            <v-radio-group class="my-0" v-model="payload.hasDonationAgreement" hide-details>
-              <v-radio v-for="item in boolOptions" :key="item.value" :label="item.label" :value="item.value"></v-radio>
-            </v-radio-group>
-          </fieldset>
+          <DsfrRadio
+            v-model="payload.hasDonationAgreement"
+            label="Je propose une ou des conventions de dons à des associations habilitées d’aide alimentaire"
+            yesNo
+            optional
+            hide-details
+          />
         </v-col>
         <v-col cols="12" sm="6">
           <fieldset :disabled="!payload.hasDonationAgreement">
@@ -301,6 +290,7 @@ import validators from "@/validators"
 import LastYearAutofillOption from "../LastYearAutofillOption"
 import DsfrTextField from "@/components/DsfrTextField"
 import DsfrTextarea from "@/components/DsfrTextarea"
+import DsfrRadio from "@/components/DsfrRadio"
 import ExpeReservation from "@/components/KeyMeasureDiagnostic/ExpeModals/ExpeReservation"
 import Constants from "@/constants"
 
@@ -323,6 +313,7 @@ export default {
     LastYearAutofillOption,
     DsfrTextField,
     DsfrTextarea,
+    DsfrRadio,
     ExpeReservation,
   },
   data() {
@@ -365,16 +356,6 @@ export default {
       otherActionEnabled: !!this.diagnostic.otherWasteAction,
       wasteActions: Constants.WasteActions,
       steps,
-      boolOptions: [
-        {
-          label: "Oui",
-          value: true,
-        },
-        {
-          label: "Non",
-          value: false,
-        },
-      ],
       payload: {},
       fields: [
         "hasWasteDiagnostic",

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -170,33 +170,37 @@
       </v-col>
       <v-col cols="12" md="9" lg="10">
         <v-card v-if="isCentralKitchen" class="pa-6 mb-4 mr-1" style="background: #f5f5fe">
-          <fieldset class="fr-text">
-            <legend class="font-weight-bold">
-              Pour mes cantines satellites, je saisis :
-            </legend>
-            <v-radio-group
-              v-model="centralKitchenDiagnosticMode"
-              :readonly="hasActiveTeledeclaration"
-              :disabled="hasActiveTeledeclaration"
-              class="py-0"
-              hide-details
-              row
-              @change="handleModeChange"
-            >
-              <v-radio
+          <v-radio-group
+            v-model="centralKitchenDiagnosticMode"
+            :readonly="hasActiveTeledeclaration"
+            :disabled="hasActiveTeledeclaration"
+            class="py-0 mt-0"
+            hide-details
+            @change="handleModeChange"
+          >
+            <template v-slot:label>
+              <span class="fr-text font-weight-bold grey--text text--darken-4">
+                Pour mes cantines satellites, je saisis :
+              </span>
+            </template>
+            <v-row class="my-0">
+              <v-col
+                cols="12"
+                md="6"
                 v-for="type in centralKitchenDiagnosticModes"
                 :key="type.key"
-                :label="type.shortLabel"
-                :value="type.key"
+                class="py-0 pt-md-2"
               >
-                <template v-slot:label>
-                  <span class="fr-text mr-2 mr-lg-8 grey--text text--darken-4">
-                    {{ type.shortLabel }}
-                  </span>
-                </template>
-              </v-radio>
-            </v-radio-group>
-          </fieldset>
+                <v-radio :label="type.shortLabel" :value="type.key">
+                  <template v-slot:label>
+                    <span class="fr-text mr-2 mr-lg-8 grey--text text--darken-4">
+                      {{ type.shortLabel }}
+                    </span>
+                  </template>
+                </v-radio>
+              </v-col>
+            </v-row>
+          </v-radio-group>
         </v-card>
         <DsfrTabsVue
           v-model="tab"

--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -107,22 +107,15 @@
                 </v-menu>
               </v-col>
             </v-row>
-            <fieldset>
-              <legend class="body-2 my-3">Famille de produit</legend>
-              <v-radio-group v-model="purchase.family" class="my-0">
-                <v-row>
-                  <v-col cols="12" sm="6" class="py-1" v-for="item in productFamilies" :key="item">
-                    <v-radio :value="item" class="mt-2" @change="familyChange">
-                      <template v-slot:label>
-                        <span class="body-2 grey--text text--darken-4">
-                          {{ getProductFamilyDisplayText(item) }}
-                        </span>
-                      </template>
-                    </v-radio>
-                  </v-col>
-                </v-row>
-              </v-radio-group>
-            </fieldset>
+            <DsfrRadio
+              label="Famille de produit"
+              v-model="purchase.family"
+              :items="productFamilies"
+              @change="familyChange"
+              optionsRow
+              labelClasses="body-2 my-3"
+              optionClasses="body-2 grey--text text--darken-4"
+            />
           </v-col>
           <v-col cols="12" md="4">
             <label class="body-2">Facture</label>
@@ -260,10 +253,20 @@ import DsfrTextField from "@/components/DsfrTextField"
 import DsfrAutocomplete from "@/components/DsfrAutocomplete"
 import DsfrSelect from "@/components/DsfrSelect"
 import DsfrCombobox from "@/components/DsfrCombobox"
+import DsfrRadio from "@/components/DsfrRadio"
 
 export default {
   name: "PurchasePage",
-  components: { FileDrop, FilePreview, BreadcrumbsNav, DsfrTextField, DsfrAutocomplete, DsfrSelect, DsfrCombobox },
+  components: {
+    FileDrop,
+    FilePreview,
+    BreadcrumbsNav,
+    DsfrTextField,
+    DsfrAutocomplete,
+    DsfrSelect,
+    DsfrCombobox,
+    DsfrRadio,
+  },
   data() {
     return {
       originalPurchase: null,
@@ -274,7 +277,10 @@ export default {
       menu: false,
       modal: false,
       showDeleteDialog: false,
-      productFamilies: Object.keys(Constants.ProductFamilies),
+      productFamilies: Object.keys(Constants.ProductFamilies).map((f) => ({
+        value: f,
+        label: this.getProductFamilyDisplayText(f),
+      })),
       characteristics: Object.keys(Constants.Characteristics),
       backLink: { name: "PurchasesHome" },
       localDefinitions: Object.values(Constants.LocalDefinitions),


### PR DESCRIPTION
L'ancien pattern de combiner fieldset et v-radio-group ne marche pas très bien car vuetify gère quelques trucs d'a11y si on utilise v-radio-group bien.

- [x] Refactoriser tous les v-radio-group pour utiliser DsfrRadio
- [x] Regrouper les champs de filtres nos cantines
- [x] Voir si il y a d'autres instances de choses qu'on pourrait regrouper
- [ ] Refactoriser les checklists ? (Ajd elles ont plutôt bien fait je crois, mais le style dans le tunnel est different que radio, et on repete bcp le même boiler plate - p-e dans une deuxième PR après autres changements a11y qui vont avoir un impact)
- [ ] Améliorer le styling pour être plus proche au DSFR (dans une deuxième PR, pour tous les composants DsfrX ?)