### PR TITLE
RGAA 12.3 La page « plan du site » est-elle pertinente ?

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -299,6 +299,7 @@ const routes = [
       title: "Actions en attente",
       authenticationRequired: true,
     },
+    sitemapGroup: Constants.SitemapGroups.ACTION,
   },
   {
     path: "/nouvelle-cantine",
@@ -537,6 +538,7 @@ const routes = [
     meta: {
       title: "Mesures de notre impact",
     },
+    sitemapGroup: Constants.SitemapGroups.SITE,
   },
   {
     path: "/webinaires/:webinaireUrlComponent",
@@ -569,7 +571,6 @@ if (window.ENABLE_DASHBOARD) {
       title: "Tableau de bord",
       authenticationRequired: true,
     },
-    sitemapGroup: Constants.SitemapGroups.DIAG,
   })
   routes.push({
     path: "/ma-progression/:canteenUrlComponent/:year/:measure",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -171,7 +171,6 @@ const routes = [
     meta: {
       title: "Les mesures phares",
     },
-    sitemapGroup: Constants.SitemapGroups.LAW,
   },
   {
     // if you change this path, update the visitor view count logic in the publication widget

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -184,7 +184,7 @@ const routes = [
         meta: {
           title: "Nos cantines",
         },
-        sitemapGroup: Constants.SitemapGroups.LAW,
+        sitemapGroup: Constants.SitemapGroups.ACTION,
       },
       {
         path: ":canteenUrlComponent",
@@ -528,6 +528,7 @@ const routes = [
     meta: {
       title: "Développement et APIs",
     },
+    sitemapGroup: Constants.SitemapGroups.ACTION,
   },
   {
     path: "/statistiques-plateforme/",
@@ -554,6 +555,7 @@ const routes = [
     beforeEnter: (_to, _from, next) => {
       store.state.loggedUser?.isElectedOfficial ? next() : next({ name: "ManagementPage" })
     },
+    sitemapGroup: Constants.SitemapGroups.DIAG,
   },
 ]
 

--- a/frontend/src/views/SiteMap.vue
+++ b/frontend/src/views/SiteMap.vue
@@ -55,6 +55,11 @@ export default {
         meta: { title: "Créer mon compte" },
         sitemapGroup: Constants.SitemapGroups.DIAG,
       })
+      sitemapRoutes.push({
+        href: "/s-identifier",
+        meta: { title: "S'identifier" },
+        sitemapGroup: Constants.SitemapGroups.DIAG,
+      })
     }
     return {
       sitemapGroups: Object.values(Constants.SitemapGroups).map((g) => {

--- a/frontend/src/views/SiteMap.vue
+++ b/frontend/src/views/SiteMap.vue
@@ -7,7 +7,7 @@
         <h2 class="my-2">{{ group.title }}</h2>
         <ul>
           <li v-for="link in group.links" :key="link.text">
-            <router-link :to="{ name: link.name }" :href="link.path">
+            <router-link :to="{ name: link.name, params: link.params }">
               {{ (link.meta || {}).title || link.name }}
             </router-link>
           </li>
@@ -21,6 +21,7 @@
 import { routes } from "@/router"
 import Constants from "@/constants"
 import BreadcrumbsNav from "@/components/BreadcrumbsNav"
+import keyMeasures from "@/data/key-measures.json"
 
 export default {
   name: "SiteMap",
@@ -37,6 +38,14 @@ export default {
       const hasViewRights = route.meta?.authenticationRequired ? isAuthenticated : true
       return !!route.sitemapGroup && hasViewRights
     })
+    sitemapRoutes.push(
+      ...keyMeasures.map((x) => ({
+        name: "KeyMeasurePage",
+        params: { id: x.id },
+        meta: { title: x.shortTitle },
+        sitemapGroup: Constants.SitemapGroups.LAW,
+      }))
+    )
     return {
       sitemapGroups: Object.values(Constants.SitemapGroups).map((g) => {
         return {

--- a/frontend/src/views/SiteMap.vue
+++ b/frontend/src/views/SiteMap.vue
@@ -7,9 +7,12 @@
         <h2 class="my-2">{{ group.title }}</h2>
         <ul>
           <li v-for="link in group.links" :key="link.text">
-            <router-link :to="{ name: link.name, params: link.params }">
+            <router-link v-if="link.name" :to="{ name: link.name, params: link.params }">
               {{ (link.meta || {}).title || link.name }}
             </router-link>
+            <a v-else :href="link.href">
+              {{ (link.meta || {}).title }}
+            </a>
           </li>
         </ul>
       </v-col>
@@ -46,6 +49,13 @@ export default {
         sitemapGroup: Constants.SitemapGroups.LAW,
       }))
     )
+    if (!isAuthenticated) {
+      sitemapRoutes.push({
+        href: "/creer-mon-compte",
+        meta: { title: "Créer mon compte" },
+        sitemapGroup: Constants.SitemapGroups.DIAG,
+      })
+    }
     return {
       sitemapGroups: Object.values(Constants.SitemapGroups).map((g) => {
         return {


### PR DESCRIPTION
L'ensemble des pages devrait être accessible depuis la page plan du site (ça veut dire que, par exemple, on n'a pas besoin d'ajouter toutes les pages cantines, car la page nos cantines donne accès à ces pages)