### PR TITLE
Suit la redirection du backend après un logout

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -359,9 +359,7 @@ export default {
       return child.authenticationState === true
     },
     logout() {
-      return this.$store.dispatch("logout").then(() => {
-        this.$router.push({ name: "LandingPage" })
-      })
+      return this.$store.dispatch("logout")
     },
   },
 }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -874,11 +874,10 @@ export default new Vuex.Store({
         })
     },
 
-    logout(context) {
+    logout() {
       return fetch("/se-deconnecter", { method: "POST", headers })
-        .then(verifyResponse)
-        .then(() => {
-          return context.dispatch("fetchInitialData")
+        .then((response) => {
+          if (response.redirected) window.location.href = response.url
         })
         .catch((e) => {
           throw e


### PR DESCRIPTION
Suite à la màj de Django 5.0, le logout doit impérativement se faire avec un POST. 

Cette PR suit la redirection du 302 envoyé par le backend pour respecter le setting `LOGOUT_REDIRECT_URL = "/"`