### PR TITLE
Modification du paramètre 'sectors' dans l'extraction

### DIFF
--- a/data/factories/sector.py
+++ b/data/factories/sector.py
@@ -7,4 +7,3 @@ class SectorFactory(factory.django.DjangoModelFactory):
         model = Sector
 
     name = factory.Faker("text", max_nb_chars=20)
-    category = factory.Faker("text", max_nb_chars=20)

--- a/data/factories/sector.py
+++ b/data/factories/sector.py
@@ -7,3 +7,4 @@ class SectorFactory(factory.django.DjangoModelFactory):
         model = Sector
 
     name = factory.Faker("text", max_nb_chars=20)
+    category = factory.Faker("text", max_nb_chars=20)

--- a/data/schemas/CHANGELOG_CANTINES.MD
+++ b/data/schemas/CHANGELOG_CANTINES.MD
@@ -2,6 +2,11 @@
 
 Tous les changements notables apportés aux jeux de données exposés sur data.gouv.fr vont être documentés ici.
 
+## 2024-03-29
+
+### Modification
+* Colonne 'sectors' : le format passe de `[{'id': 27, 'name': 'Secondaire lycée agricole', 'category': 'education', 'hasLineMinistry': False}, {'id': 87, 'name': 'Ecole primaire (maternelle et élémentaire)', 'category': 'education', 'hasLineMinistry': False}]` à `"[""Secondaire lycées agricole"", ""Ecole primaire (maternelle et élémentaire""]"` afin d'être compatible au format et alléger la colonne
+
 ## 2024-02-16
 
 ### Ajout

--- a/data/schemas/CHANGELOG_TELEDECLARATION.MD
+++ b/data/schemas/CHANGELOG_TELEDECLARATION.MD
@@ -1,0 +1,10 @@
+# Changelog
+
+Tous les changements notables apportés aux jeux de données exposés sur data.gouv.fr vont être documentés ici.
+
+## 2024-03-29
+
+### Modification
+
+* Renommage des colonnes commençants pas 'cantine_' en 'canteen_'
+* Colonne 'canteen_sectors' : le format passe de `[{'id': 27, 'name': 'Secondaire lycée agricole', 'category': 'education', 'hasLineMinistry': False}, {'id': 87, 'name': 'Ecole primaire (maternelle et élémentaire)', 'category': 'education', 'hasLineMinistry': False}]` à `"[""Secondaire lycées agricole"", ""Ecole primaire (maternelle et élémentaire""]"` afin d'être compatible au format et alléger la colonne

--- a/data/schemas/schema_cantine.json
+++ b/data/schemas/schema_cantine.json
@@ -164,7 +164,8 @@
     {
       "description": "Liste définissant les secteurs d'activités de la cantine. Chaque élément de cette liste est défini par quatre paramètres :  id, name, category, has_line_ministry (ministère de tutelle).",
       "example": [
-        "{'id': 12, 'name': 'Ecole primaire (maternelle et élémentaire)', 'category': 'education', 'has_line_ministry': false}"
+        "education - Secondaire collège",
+        "education - Ecole primaire (maternelle et élémentaire)"
       ],
       "name": "sectors",
       "title": "Secteurs",

--- a/data/schemas/schema_cantine.json
+++ b/data/schemas/schema_cantine.json
@@ -205,5 +205,6 @@
       "title": "Actif sur Ma Cantine",
       "type": "boolean"
     }
-  ]
+  ],
+  "title": "Schéma des établissements de restauration collective"
 }

--- a/data/schemas/schema_cantine.json
+++ b/data/schemas/schema_cantine.json
@@ -169,7 +169,7 @@
       ],
       "name": "sectors",
       "title": "Secteurs",
-      "type": "array"
+      "type": "string"
     },
     {
       "description": "Statut de publication de la cantine. Il existe 3 statuts différents : published (cantine publiée), draft (brouillon), deleted (cantine supprimée)",

--- a/data/schemas/schema_cantine.json
+++ b/data/schemas/schema_cantine.json
@@ -163,10 +163,10 @@
     },
     {
       "description": "Liste définissant les secteurs d'activités de la cantine. Chaque élément de cette liste est défini par quatre paramètres :  id, name, category, has_line_ministry (ministère de tutelle).",
-      "example": "[education : Secondaire collège + education : Ecole primaire (maternelle et élémentaire)]",
+      "example": "[\"Secondaire collège\", \"Ecole primaire (maternelle et élémentaire)\"]",
       "name": "sectors",
       "title": "Secteurs",
-      "type": "string"
+      "type": "array"
     },
     {
       "description": "Statut de publication de la cantine. Il existe 3 statuts différents : published (cantine publiée), draft (brouillon), deleted (cantine supprimée)",

--- a/data/schemas/schema_cantine.json
+++ b/data/schemas/schema_cantine.json
@@ -163,10 +163,7 @@
     },
     {
       "description": "Liste définissant les secteurs d'activités de la cantine. Chaque élément de cette liste est défini par quatre paramètres :  id, name, category, has_line_ministry (ministère de tutelle).",
-      "example": [
-        "education - Secondaire collège",
-        "education - Ecole primaire (maternelle et élémentaire)"
-      ],
+      "example": "[education : Secondaire collège + education : Ecole primaire (maternelle et élémentaire)]",
       "name": "sectors",
       "title": "Secteurs",
       "type": "string"

--- a/data/schemas/schema_teledeclaration.json
+++ b/data/schemas/schema_teledeclaration.json
@@ -149,10 +149,10 @@
     },
     {
       "description": "Liste définissant les secteurs d'activités de la cantine. Chaque élément de cette liste est défini par quatre paramètres :  id, name, category, has_line_ministry (ministère de tutelle).",
-      "example": "[education : Secondaire collège + education : Ecole primaire (maternelle et élémentaire)]",
+      "example": "[\"education : Secondaire collège\", \"education : Ecole primaire (maternelle et élémentaire)\"]",
       "name": "canteen_sectors",
       "title": "Secteurs cantines",
-      "type": "string"
+      "type": "array"
     },
     {
       "description": "Ministère de tutelle de la cantine, s'il y en a un",

--- a/data/schemas/schema_teledeclaration.json
+++ b/data/schemas/schema_teledeclaration.json
@@ -148,39 +148,6 @@
       "type": "string"
     },
     {
-      "arrayItem": {
-        "constraints": {
-          "enum": [
-            "Secondaire lycée (hors agricole)",
-            "Secondaire Lycée agricole",
-            "Autres établissements du secteur public",
-            "Restaurants administratifs des collectivités territoriales",
-            "Restaurants des prisons",
-            "Restaurants administratifs d’Etat (RA)",
-            "Restaurants des armées / police / gendarmerie",
-            "Autres établissements non listés",
-            "Restaurants inter-entreprises",
-            "Autres établissements de loisirs",
-            "Autres établissements sociaux et médicaux sociaux",
-            "IME / ITEP",
-            "ESAT / Etablissements spécialisés",
-            "Autres établissements de soins",
-            "Cliniques",
-            "Autres structures d’enseignement",
-            "Ecole primaire (maternelle et élémentaire)",
-            "Restaurants d’entreprises",
-            "Centre de vacances / sportif",
-            "Crèche",
-            "EHPAD/ maisons de retraite / foyers de personnes âgées",
-            "Restaurants inter-administratifs d’Etat (RIA)",
-            "Hôpitaux",
-            "Supérieur et Universitaire",
-            "Secondaire collège"
-          ],
-          "required": false
-        },
-        "type": "string"
-      },
       "description": "Liste définissant les secteurs d'activités de la cantine. Chaque élément de cette liste est défini par quatre paramètres :  id, name, category, has_line_ministry (ministère de tutelle).",
       "example": "[\"Secondaire collège\", \"Ecole primaire (maternelle et élémentaire)\"]",
       "name": "canteen_sectors",

--- a/data/schemas/schema_teledeclaration.json
+++ b/data/schemas/schema_teledeclaration.json
@@ -85,6 +85,13 @@
       "type": "string"
     },
     {
+      "description": "Libellé de l'EPCI dans laquelle se trouve la cantine",
+      "example": "CC Communauté Lesneven Côte des Légendes",
+      "name": "epci_lib",
+      "title": "Libellé EPCI",
+      "type": "string"
+    },
+    {
       "description": "Code Insee du département dans lequel se trouve la cantine",
       "example": "50",
       "name": "canteen_department",

--- a/data/schemas/schema_teledeclaration.json
+++ b/data/schemas/schema_teledeclaration.json
@@ -66,7 +66,7 @@
     {
       "description": "Identifiant du [Système d'Identification du Répertoire des Etablissements](https://fr.wikipedia.org/wiki/Syst%C3%A8me_d%27identification_du_r%C3%A9pertoire_des_%C3%A9tablissements) (SIRET) qui identifie la cuisine centrale a la quelle la cantine est rattachée",
       "example": "",
-      "name": "cantine_central_kitchen_siret",
+      "name": "canteen_central_kitchen_siret",
       "title": "Identifiant de la cuisine centrale",
       "type": "string"
     },
@@ -122,28 +122,28 @@
     {
       "description": "Nombre de cantines satellites pour une cantine qui produit les repas sur place",
       "example": "0",
-      "name": "cantine_satellite_canteens_count",
+      "name": "canteen_satellite_canteens_count",
       "title": "Nombre de cantines satellites",
       "type": "integer"
     },
     {
       "description": "Modèle économique de la cantine. Il existe 2 types différents : public (cantine publique), private (cantine privée).",
       "example": "public",
-      "name": "cantine_economic_model",
+      "name": "canteen_economic_model",
       "title": "Modèle Economique de la cantine",
       "type": "string"
     },
     {
       "description": "Gestionnaire de la cantine. La cantine peut-être gérée directement ou de manière concédée. Si la valeur est 'concédée', la délégation peut être totale ou partielle",
       "example": "conceded",
-      "name": "cantine_management_type",
+      "name": "canteen_management_type",
       "title": "Type de Management de la cantine",
       "type": "string"
     },
     {
       "description": "Lieu de production et de service des repas. Il existe 4 types différents : central (cuisine centrale sans lieu de consommation), central_serving (cuisine centrale qui accueille aussi des convives sur place), site (cantine qui produit les repas sur place), site_cooked_elsewhere (cantine qui sert des repas preparés par une cuisine centrale, appelé également satellite). Dans ce dernier cas, le champ central_producer_siret renseigne l'identifiant SIRET de la cuisine préparant les repas. Dans le cas d'une cantine qui cuisine pour d'autres cantines, le champ satellite_canteens_count renseigne le nombre de cantines satellites.",
       "example": "central",
-      "name": "cantine_production_type",
+      "name": "canteen_production_type",
       "title": "Type de Production de la cantine",
       "type": "string"
     },

--- a/data/schemas/schema_teledeclaration.json
+++ b/data/schemas/schema_teledeclaration.json
@@ -144,7 +144,7 @@
       "description": "Liste définissant les secteurs d'activités de la cantine. Chaque élément de cette liste est défini par quatre paramètres :  id, name, category, has_line_ministry (ministère de tutelle).",
       "example": "[education : Secondaire collège + education : Ecole primaire (maternelle et élémentaire)]",
       "name": "canteen_sectors",
-      "title": "Secteurs",
+      "title": "Secteurs cantines",
       "type": "string"
     },
     {

--- a/data/schemas/schema_teledeclaration.json
+++ b/data/schemas/schema_teledeclaration.json
@@ -73,21 +73,21 @@
     {
       "description": "Code insee de la commune dans laquelle se trouve la cantine",
       "example": "29456",
-      "name": "city_insee_code",
+      "name": "canteen_city_insee_code",
       "title": "Conde Insee Commune",
       "type": "string"
     },
     {
       "description": "Code insee de l'EPCI dans laquelle se trouve la cantine",
       "example": "50570242900793",
-      "name": "epci",
+      "name": "canteen_epci",
       "title": "Code Insee EPCI",
       "type": "string"
     },
     {
       "description": "Libellé de l'EPCI dans laquelle se trouve la cantine",
       "example": "CC Communauté Lesneven Côte des Légendes",
-      "name": "epci_lib",
+      "name": "canteen_epci_lib",
       "title": "Libellé EPCI",
       "type": "string"
     },
@@ -148,8 +148,41 @@
       "type": "string"
     },
     {
+      "arrayItem": {
+        "constraints": {
+          "enum": [
+            "Secondaire lycée (hors agricole)",
+            "Secondaire Lycée agricole",
+            "Autres établissements du secteur public",
+            "Restaurants administratifs des collectivités territoriales",
+            "Restaurants des prisons",
+            "Restaurants administratifs d’Etat (RA)",
+            "Restaurants des armées / police / gendarmerie",
+            "Autres établissements non listés",
+            "Restaurants inter-entreprises",
+            "Autres établissements de loisirs",
+            "Autres établissements sociaux et médicaux sociaux",
+            "IME / ITEP",
+            "ESAT / Etablissements spécialisés",
+            "Autres établissements de soins",
+            "Cliniques",
+            "Autres structures d’enseignement",
+            "Ecole primaire (maternelle et élémentaire)",
+            "Restaurants d’entreprises",
+            "Centre de vacances / sportif",
+            "Crèche",
+            "EHPAD/ maisons de retraite / foyers de personnes âgées",
+            "Restaurants inter-administratifs d’Etat (RIA)",
+            "Hôpitaux",
+            "Supérieur et Universitaire",
+            "Secondaire collège"
+          ],
+          "required": false
+        },
+        "type": "string"
+      },
       "description": "Liste définissant les secteurs d'activités de la cantine. Chaque élément de cette liste est défini par quatre paramètres :  id, name, category, has_line_ministry (ministère de tutelle).",
-      "example": "[\"education : Secondaire collège\", \"education : Ecole primaire (maternelle et élémentaire)\"]",
+      "example": "[\"Secondaire collège\", \"Ecole primaire (maternelle et élémentaire)\"]",
       "name": "canteen_sectors",
       "title": "Secteurs cantines",
       "type": "array"

--- a/data/schemas/schema_teledeclaration.json
+++ b/data/schemas/schema_teledeclaration.json
@@ -143,7 +143,8 @@
     {
       "description": "Liste définissant les secteurs d'activités de la cantine. Chaque élément de cette liste est défini par quatre paramètres :  id, name, category, has_line_ministry (ministère de tutelle).",
       "example": [
-        "{'id': 12, 'name': 'Ecole primaire (maternelle et élémentaire)', 'category': 'education', 'has_line_ministry': false}"
+        "education - Secondaire collège",
+        "education - Ecole primaire (maternelle et élémentaire)"
       ],
       "name": "canteen_sectors",
       "title": "Secteurs",

--- a/data/schemas/schema_teledeclaration.json
+++ b/data/schemas/schema_teledeclaration.json
@@ -148,7 +148,7 @@
       ],
       "name": "canteen_sectors",
       "title": "Secteurs",
-      "type": "array"
+      "type": "string"
     },
     {
       "description": "Ministère de tutelle de la cantine, s'il y en a un",

--- a/data/schemas/schema_teledeclaration.json
+++ b/data/schemas/schema_teledeclaration.json
@@ -71,6 +71,13 @@
       "type": "string"
     },
     {
+      "description": "Code insee de la commune dans laquelle se trouve la cantine",
+      "example": "29456",
+      "name": "city_insee_code",
+      "title": "Conde Insee Commune",
+      "type": "string"
+    },
+    {
       "description": "Code insee de l'EPCI dans laquelle se trouve la cantine",
       "example": "50570242900793",
       "name": "epci",
@@ -134,12 +141,13 @@
       "type": "string"
     },
     {
-      "description": "Liste définissant les secteurs d'activités concernés par le télédéclaration. Chaque élément de cette liste est défini par quatre paramètres :  id, name, category, has_line_ministry (ministère de tutelle).",
+      "description": "Liste définissant les secteurs d'activités de la cantine. Chaque élément de cette liste est défini par quatre paramètres :  id, name, category, has_line_ministry (ministère de tutelle).",
+      "example": [
+        "{'id': 12, 'name': 'Ecole primaire (maternelle et élémentaire)', 'category': 'education', 'has_line_ministry': false}"
+      ],
       "name": "canteen_sectors",
       "title": "Secteurs",
-      "type": "array",
-      "delimiter": ",",
-      "example": ["{'id': 12, 'name': 'Ecole primaire (maternelle et élémentaire)', 'category': 'education', 'has_line_ministry': false}"]
+      "type": "array"
     },
     {
       "description": "Ministère de tutelle de la cantine, s'il y en a un",
@@ -150,25 +158,29 @@
     },
     {
       "description": "Type de télédéclaration: soit simple, soit détaillée. Une télédéclaration détaillée propose au gérant plus de champs pour chaque qualité de produits",
+      "enum": [
+        "SIMPLE",
+        "COMPLETE"
+      ],
+      "example": "SIMPLE",
       "name": "teledeclaration_type",
       "title": "Type de télédéclaration",
-      "type": "string",
-      "enum": ["SIMPLE", "COMPLETE"],
-      "example": "SIMPLE"
+      "type": "string"
     },
     {
       "description": "Part des achats bio dans les achats alimentaires de l'année (ratio basé sur le montant des achats en € HT)",
+      "example": 0.1,
       "name": "teledeclaration_ratio_bio",
       "title": "Télédéclaration Ratio Bio",
-      "type": "number",
-      "example": 0.1
+      "type": "number"
     },
     {
       "description": "Part des achats EGAlim dans les achats alimentaires de l'année",
+      "example": 0.3,
       "name": "teledeclaration_ratio_egalim_hors_bio",
       "title": "Télédéclaration Ratio Egalim",
-      "type": "number",
-      "example": 0.3
+      "type": "number"
     }
-  ]
+  ],
+  "title": "Schéma des télédéclarations d'achats alimentaires pour la restauration collective"
 }

--- a/data/schemas/schema_teledeclaration.json
+++ b/data/schemas/schema_teledeclaration.json
@@ -142,10 +142,7 @@
     },
     {
       "description": "Liste définissant les secteurs d'activités de la cantine. Chaque élément de cette liste est défini par quatre paramètres :  id, name, category, has_line_ministry (ministère de tutelle).",
-      "example": [
-        "education - Secondaire collège",
-        "education - Ecole primaire (maternelle et élémentaire)"
-      ],
+      "example": "[education : Secondaire collège + education : Ecole primaire (maternelle et élémentaire)]",
       "name": "canteen_sectors",
       "title": "Secteurs",
       "type": "string"

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -38,7 +38,7 @@ class TestExtractionOpenData(TestCase):
         canteen.sectors.clear()
         Teledeclaration.create_from_diagnostic(diagnostic_2022, applicant)
         etl_td.extract_dataset()
-        self.assertEqual(etl_td.get_dataset().iloc[0]["canteen_sectors"], "[]", "The sectors should be an empty list")
+        self.assertEqual(etl_td.get_dataset().iloc[0]["canteen_sectors"], [], "The sectors should be an empty list")
 
         canteen = CanteenFactory.create()
         complete_diagnostic = CompleteDiagnosticFactory.create(canteen=canteen, year=2022, diagnostic_type=None)
@@ -79,10 +79,10 @@ class TestExtractionOpenData(TestCase):
         )
         self.assertEqual(len(canteens.columns), len(schema_cols), "The columns should match the schema.")
 
-        self.assertIsInstance(
-            canteens["sectors"][0],
-            str,
-            "The sectors should be a string, in which different sectors are separated by '+'",
+        self.assertIsInstance(canteens["sectors"][0], list, "The sectors should be a list of sectors")
+        self.assertEqual(
+            list(canteens[canteens.id == canteen_1.id].iloc[0]["sectors"][0].keys()),
+            ["id", "name", "category", "hasLineMinistry"],
         )
 
         # Cheking the geo data transformations
@@ -121,7 +121,7 @@ class TestExtractionOpenData(TestCase):
         etl_canteen.extract_dataset()
         canteens = etl_canteen.get_dataset()
         self.assertEqual(
-            canteens[canteens.id == canteen_2.id].iloc[0]["sectors"], "[]", "The sectors should be a string"
+            canteens[canteens.id == canteen_2.id].iloc[0]["sectors"], [], "The sectors should be an empty list"
         )
 
         canteen_1.sectors.clear()

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -38,7 +38,9 @@ class TestExtractionOpenData(TestCase):
         canteen.sectors.clear()
         Teledeclaration.create_from_diagnostic(diagnostic_2022, applicant)
         etl_td.extract_dataset()
-        self.assertEqual(etl_td.get_dataset().iloc[0]["canteen_sectors"], [], "The sectors should be an empty list")
+        self.assertEqual(
+            etl_td.get_dataset().iloc[0]["canteen_sectors"], '"[]"', "The sectors should be an empty list"
+        )
 
         canteen = CanteenFactory.create()
         complete_diagnostic = CompleteDiagnosticFactory.create(canteen=canteen, year=2022, diagnostic_type=None)
@@ -79,11 +81,7 @@ class TestExtractionOpenData(TestCase):
         )
         self.assertEqual(len(canteens.columns), len(schema_cols), "The columns should match the schema.")
 
-        self.assertIsInstance(canteens["sectors"][0], list, "The sectors should be a list of sectors")
-        self.assertEqual(
-            list(canteens[canteens.id == canteen_1.id].iloc[0]["sectors"][0].keys()),
-            ["id", "name", "category", "hasLineMinistry"],
-        )
+        self.assertIsInstance(canteens["sectors"][0], str, "The sectors should be a list of sectors")
 
         # Cheking the geo data transformations
         canteen_1.department = "29"
@@ -121,7 +119,7 @@ class TestExtractionOpenData(TestCase):
         etl_canteen.extract_dataset()
         canteens = etl_canteen.get_dataset()
         self.assertEqual(
-            canteens[canteens.id == canteen_2.id].iloc[0]["sectors"], [], "The sectors should be an empty list"
+            canteens[canteens.id == canteen_2.id].iloc[0]["sectors"], '"[]"', "The sectors should be an empty list"
         )
 
         canteen_1.sectors.clear()

--- a/data/tests/test_extraction_open_data.py
+++ b/data/tests/test_extraction_open_data.py
@@ -38,7 +38,7 @@ class TestExtractionOpenData(TestCase):
         canteen.sectors.clear()
         Teledeclaration.create_from_diagnostic(diagnostic_2022, applicant)
         etl_td.extract_dataset()
-        self.assertEqual(etl_td.get_dataset().iloc[0]["canteen_sectors"], [], "The sectors should be an empty list")
+        self.assertEqual(etl_td.get_dataset().iloc[0]["canteen_sectors"], "[]", "The sectors should be an empty list")
 
         canteen = CanteenFactory.create()
         complete_diagnostic = CompleteDiagnosticFactory.create(canteen=canteen, year=2022, diagnostic_type=None)
@@ -79,10 +79,10 @@ class TestExtractionOpenData(TestCase):
         )
         self.assertEqual(len(canteens.columns), len(schema_cols), "The columns should match the schema.")
 
-        self.assertIsInstance(canteens["sectors"][0], list, "The sectors should be a list of sectors")
-        self.assertEqual(
-            list(canteens[canteens.id == canteen_1.id].iloc[0]["sectors"][0].keys()),
-            ["id", "name", "category", "hasLineMinistry"],
+        self.assertIsInstance(
+            canteens["sectors"][0],
+            str,
+            "The sectors should be a string, in which different sectors are separated by '+'",
         )
 
         # Cheking the geo data transformations
@@ -121,7 +121,7 @@ class TestExtractionOpenData(TestCase):
         etl_canteen.extract_dataset()
         canteens = etl_canteen.get_dataset()
         self.assertEqual(
-            canteens[canteens.id == canteen_2.id].iloc[0]["sectors"], [], "The sectors should be an empty list"
+            canteens[canteens.id == canteen_2.id].iloc[0]["sectors"], "[]", "The sectors should be a string"
         )
 
         canteen_1.sectors.clear()

--- a/macantine/extract_open_data.py
+++ b/macantine/extract_open_data.py
@@ -375,7 +375,8 @@ class ETL_TD(ETL):
             ],
         }
 
-    def transform_sectors(sectors: pd.Series) -> pd.Series:
+    def transform_sectors(self) -> pd.Series:
+        sectors = self.df["canteen_sectors"]
         sectors = sectors.apply(lambda x: list(map(lambda y: format_sector(y), x)))
         sectors = sectors.apply(lambda x: "[" + " + ".join(x) + "]")
         return sectors
@@ -420,7 +421,7 @@ class ETL_TD(ETL):
         logger.info("TD campagne : Filter by sector...")
         self._filter_by_sectors()
         logger.info("TD campagne : Transform sectors...")
-        self.df["canteen_sectors"] = self.transform_sectors(self.df["canteen_sectors"])
+        self.df["canteen_sectors"] = self.transform_sectors()
         logger.info("TD Campagne : Fill geo name...")
         self.transform_geo_data(geo_col_names=["canteen_department", "canteen_region"])
 

--- a/macantine/extract_open_data.py
+++ b/macantine/extract_open_data.py
@@ -130,6 +130,10 @@ def format_sector(sector: dict) -> str:
     return '""' + sector["name"] + '""'
 
 
+def format_list_sectors(sector) -> str:
+    return '"[' + ", ".join(sector) + ']"'
+
+
 def fetch_sector(sector_id, sectors):
     """
     Provide EPCI code for a city, given the insee code of the city
@@ -209,7 +213,7 @@ class ETL(ABC):
         # Fetching sectors information and aggreting in list in order to have only one row per canteen
         sectors = map_sectors()
         self.df["sectors"] = self.df["sectors"].apply(lambda x: fetch_sector(x, sectors))
-        canteens_sectors = self.df.groupby("id")["sectors"].apply(list).apply(lambda x: '"[' + ",".join(x) + ']"')
+        canteens_sectors = self.df.groupby("id")["sectors"].apply(list).apply(format_list_sectors)
         del self.df["sectors"]
 
         return self.df.merge(canteens_sectors, on="id")
@@ -375,7 +379,7 @@ class ETL_TD(ETL):
     def transform_sectors(self) -> pd.Series:
         sectors = self.df["canteen_sectors"]
         sectors = sectors.apply(lambda x: list(map(lambda y: format_sector(y), x)))
-        sectors = sectors.apply(lambda x: '"[' + ", ".join(x) + ']"')
+        sectors = sectors.apply(format_list_sectors)
         return sectors
 
     def extract_dataset(self):

--- a/macantine/extract_open_data.py
+++ b/macantine/extract_open_data.py
@@ -342,8 +342,19 @@ class ETL_TD(ETL):
         self.categories_to_aggregate = {
             "bio": ["_bio"],
             "sustainable": ["_sustainable", "_label_rouge", "_aocaop_igp_stg"],
-            "egalim_others": ["_egalim_others", "_hve", "_peche_durable", "_rup", "_fermier", "_commerce_equitable"],
-            "externality_performance": ["_externality_performance", "_performance", "_externalites"],
+            "egalim_others": [
+                "_egalim_others",
+                "_hve",
+                "_peche_durable",
+                "_rup",
+                "_fermier",
+                "_commerce_equitable",
+            ],
+            "externality_performance": [
+                "_externality_performance",
+                "_performance",
+                "_externalites",
+            ],
         }
 
     def extract_dataset(self):

--- a/macantine/extract_open_data.py
+++ b/macantine/extract_open_data.py
@@ -127,7 +127,8 @@ def fetch_epci_name(code_insee_epci, epcis_names):
 
 
 def format_sector(sector: dict) -> str:
-    return sector["category"] + " : " + sector["name"]
+    return '""' + sector["name"] + '""'
+    # return sector["category"] + " : " + sector["name"]
 
 
 def fetch_sector(sector_id, sectors):
@@ -280,9 +281,7 @@ class ETL_CANTEEN(ETL):
         super().__init__()
         self.dataset_name = "registre_cantines"
         self.schema = json.load(open("data/schemas/schema_cantine.json"))
-        self.schema_url = (
-            "https://raw.githubusercontent.com/betagouv/ma-cantine/staging/data/schemas/schema_cantine.json"
-        )
+        self.schema_url = "https://raw.githubusercontent.com/betagouv/ma-cantine/staging/data/schemas/schema_cantine.json"
 
     def extract_dataset(self):
         all_canteens_col = [i["name"] for i in self.schema["fields"]]
@@ -313,17 +312,23 @@ class ETL_CANTEEN(ETL):
 
         # Adding the active_on_ma_cantine column
         start = time.time()
-        non_active_canteens = Canteen.objects.filter(managers=None).values_list("id", flat=True)
+        non_active_canteens = Canteen.objects.filter(managers=None).values_list(
+            "id", flat=True
+        )
         end = time.time()
         logger.info(f"Time spent on active canteens : {end - start}")
-        self.df["active_on_ma_cantine"] = self.df["id"].apply(lambda x: x not in non_active_canteens)
+        self.df["active_on_ma_cantine"] = self.df["id"].apply(
+            lambda x: x not in non_active_canteens
+        )
 
         logger.info("Canteens : Extract sectors...")
         self.df = self._extract_sectors()
 
         bucket_url = os.environ.get("CELLAR_HOST")
         bucket_name = os.environ.get("CELLAR_BUCKET_NAME")
-        self.df["logo"] = self.df["logo"].apply(lambda x: f"{bucket_url}/{bucket_name}/media/{x}" if x else "")
+        self.df["logo"] = self.df["logo"].apply(
+            lambda x: f"{bucket_url}/{bucket_name}/media/{x}" if x else ""
+        )
 
         logger.info("Canteens : Clean dataset...")
         self._clean_dataset()
@@ -342,7 +347,9 @@ class ETL_CANTEEN(ETL):
                 col_name_campaign = f"declaration_donnees_{year}_en_cours"
             else:
                 col_name_campaign = f"declaration_donnees_{year}"
-            self.df[col_name_campaign] = self.df["id"].apply(lambda x: x in campaign_participation)
+            self.df[col_name_campaign] = self.df["id"].apply(
+                lambda x: x in campaign_participation
+            )
         end = time.time()
         logger.info(f"Time spent on campaign participations : {end - start}")
 
@@ -353,9 +360,7 @@ class ETL_TD(ETL):
         self.year = year
         self.dataset_name = f"campagne_td_{year}"
         self.schema = json.load(open("data/schemas/schema_teledeclaration.json"))
-        self.schema_url = (
-            "https://raw.githubusercontent.com/betagouv/ma-cantine/staging/data/schemas/schema_teledeclaration.json"
-        )
+        self.schema_url = "https://raw.githubusercontent.com/betagouv/ma-cantine/staging/data/schemas/schema_teledeclaration.json"
 
         self.categories_to_aggregate = {
             "bio": ["_bio"],
@@ -378,7 +383,7 @@ class ETL_TD(ETL):
     def transform_sectors(self) -> pd.Series:
         sectors = self.df["canteen_sectors"]
         sectors = sectors.apply(lambda x: list(map(lambda y: format_sector(y), x)))
-        sectors = sectors.apply(lambda x: "[" + " + ".join(x) + "]")
+        sectors = sectors.apply(lambda x: '"[' + ", ".join(x) + ']"')
         return sectors
 
     def extract_dataset(self):
@@ -409,12 +414,16 @@ class ETL_TD(ETL):
         self._aggregate_complete_td()
 
         self.df["teledeclaration_ratio_bio"] = (
-            self.df["teledeclaration.value_bio_ht"] / self.df["teledeclaration.value_total_ht"]
+            self.df["teledeclaration.value_bio_ht"]
+            / self.df["teledeclaration.value_total_ht"]
         )
         self.df["teledeclaration_ratio_egalim_hors_bio"] = (
-            self.df["teledeclaration.value_sustainable_ht"] / self.df["teledeclaration.value_total_ht"]
+            self.df["teledeclaration.value_sustainable_ht"]
+            / self.df["teledeclaration.value_total_ht"]
         )
-        self.df["teledeclaration_type"] = self.df["teledeclaration.diagnostic_type"]  # Renaming to match schema
+        self.df["teledeclaration_type"] = self.df[
+            "teledeclaration.diagnostic_type"
+        ]  # Renaming to match schema
 
         logger.info("TD campagne : Clean dataset...")
         self._clean_dataset()
@@ -432,9 +441,9 @@ class ETL_TD(ETL):
 
     def _aggregation_col(self, categ="bio", sub_categ=["_bio"]):
         pattern = "|".join(sub_categ)
-        self.df[f"teledeclaration.value_{categ}_ht"] = self.df.filter(regex=pattern).sum(
-            axis=1, numeric_only=True, skipna=True, min_count=1
-        )
+        self.df[f"teledeclaration.value_{categ}_ht"] = self.df.filter(
+            regex=pattern
+        ).sum(axis=1, numeric_only=True, skipna=True, min_count=1)
 
     def _aggregate_complete_td(self):
         """
@@ -447,6 +456,8 @@ class ETL_TD(ETL):
         """
         Filtering the sectors of the police and army so they do not appear publicly
         """
-        canteens_to_filter = Canteen.objects.filter(sectors__name="Restaurants des armées / police / gendarmerie")
+        canteens_to_filter = Canteen.objects.filter(
+            sectors__name="Restaurants des armées / police / gendarmerie"
+        )
         canteens_id_to_filter = [canteen.id for canteen in canteens_to_filter]
         self.df = self.df[~self.df["canteen_id"].isin(canteens_id_to_filter)]

--- a/macantine/extract_open_data.py
+++ b/macantine/extract_open_data.py
@@ -186,8 +186,6 @@ class ETL(ABC):
             self.df["epci"] = self.df["city_insee_code"].apply(lambda x: fetch_epci(x, epcis))
             epcis_names = map_epcis_code_name()
             self.df["epci_lib"] = self.df["epci"].apply(lambda x: fetch_epci_name(x, epcis_names))
-        else:
-            self.df["epci"] = None
 
     def _clean_dataset(self):
         columns = [i["name"].replace("canteen_", "canteen.") for i in self.schema["fields"]]

--- a/macantine/extract_open_data.py
+++ b/macantine/extract_open_data.py
@@ -128,7 +128,6 @@ def fetch_epci_name(code_insee_epci, epcis_names):
 
 def format_sector(sector: dict) -> str:
     return '""' + sector["name"] + '""'
-    # return sector["category"] + " : " + sector["name"]
 
 
 def fetch_sector(sector_id, sectors):
@@ -187,7 +186,6 @@ class ETL(ABC):
             self.df["epci"] = self.df["city_insee_code"].apply(lambda x: fetch_epci(x, epcis))
             epcis_names = map_epcis_code_name()
             self.df["epci_lib"] = self.df["epci"].apply(lambda x: fetch_epci_name(x, epcis_names))
-
         else:
             self.df["epci"] = None
 
@@ -213,7 +211,7 @@ class ETL(ABC):
         # Fetching sectors information and aggreting in list in order to have only one row per canteen
         sectors = map_sectors()
         self.df["sectors"] = self.df["sectors"].apply(lambda x: fetch_sector(x, sectors))
-        canteens_sectors = self.df.groupby("id")["sectors"].apply(list).apply(lambda x: '"[' + "+".join(x) + ']"')
+        canteens_sectors = self.df.groupby("id")["sectors"].apply(list).apply(lambda x: '"[' + ",".join(x) + ']"')
         del self.df["sectors"]
 
         return self.df.merge(canteens_sectors, on="id")

--- a/macantine/extract_open_data.py
+++ b/macantine/extract_open_data.py
@@ -127,11 +127,11 @@ def fetch_epci_name(code_insee_epci, epcis_names):
 
 
 def format_sector(sector: dict) -> str:
-    return '""' + sector["name"] + '""'
+    return f'""{sector["name"]}""'
 
 
 def format_list_sectors(sector) -> str:
-    return '"[' + ", ".join(sector) + ']"'
+    return f'"[{", ".join(sector)}]"'
 
 
 def fetch_sector(sector_id, sectors):

--- a/macantine/extract_open_data.py
+++ b/macantine/extract_open_data.py
@@ -130,8 +130,8 @@ def format_sector(sector: dict) -> str:
     return f'""{sector["name"]}""'
 
 
-def format_list_sectors(sector) -> str:
-    return f'"[{", ".join(sector)}]"'
+def format_list_sectors(sectors) -> str:
+    return f'"[{", ".join(sectors)}]"'
 
 
 def fetch_sector(sector_id, sectors):

--- a/macantine/extract_open_data.py
+++ b/macantine/extract_open_data.py
@@ -239,7 +239,7 @@ class ETL(ABC):
             f"https://api.validata.etalab.studio/validate?schema={self.schema_url}&url={dataset_to_validate_url}&header_case=true"
         )
         report = json.loads(res.text)["report"]
-        if len(report["errors"]) > 0:
+        if len(report["errors"]) > 0 or report["stats"]["errors"] > 0:
             logger.error(f"The dataset {self.dataset_name} extraction has errors : ")
             logger.error(report["errors"])
             return 0

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -360,8 +360,8 @@ def export_datasets():
         logger.info(f"Starting {key} dataset extraction")
         etl.extract_dataset()
         etl.export_dataset(stage="to_validate")
-        logger.info(f"Validating {key} dataset. Dataset size : {etl.len_dataset()} lines")
         if os.environ["DEFAULT_FILE_STORAGE"] == "storages.backends.s3boto3.S3Boto3Storage":
+            logger.info(f"Validating {key} dataset. Dataset size : {etl.len_dataset()} lines")
             if etl.is_valid():
                 logger.info(f"Exporting {key} dataset to s3")
                 etl.export_dataset(stage="validated")


### PR DESCRIPTION
Ce changement est motivé par la prise en compte les erreurs de validation de *validata* au niveau de chaque ligne.
Or le format actuel pose des problèmes de détection automatique du séparateur (trop de virgules)

* Modification param sectors from ` [{'id': 27, 'name': 'Secondaire lycée agricole', 'category': 'education', 'hasLineMinistry': False}, {'id': 87, 'name': 'Ecole primaire (maternelle et élémentaire)', 'category': 'education', 'hasLineMinistry': False}] ` -> `"[""Secondaire lycées agricole"", ""Ecole primaire (maternelle et élémentaire""]"`
* Refacto log validation
* Ajouts titre dans schemas