### PR TITLE
Ajouter "optionnel" automatiquement selon les validators utilisés

### DIFF
--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -1,10 +1,12 @@
 <template>
   <v-radio-group class="my-0" ref="radio" v-bind="$attrs" v-on="$listeners" @change="(v) => $emit('input', v)">
     <template v-slot:label>
-      <span :class="legendClass">
-        {{ $attrs.label }}
+      <span class="d-block mb-2">
+        <span :class="legendClass">
+          {{ $attrs.label }}
+        </span>
+        <span v-if="optional" class="fr-hint-text">Optionnel</span>
       </span>
-      <span v-if="optional" class="fr-hint-text my-2">Optionnel</span>
     </template>
     <v-row v-if="optionsRow" class="my-0">
       <v-col cols="12" sm="6" class="py-2" v-for="item in items" :key="item.value">
@@ -40,7 +42,7 @@ export default {
   props: {
     labelClasses: {
       type: String,
-      default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
+      default: "mb-2 text-sm-subtitle-1 text-body-2 text-left d-block",
     },
     optionClasses: {
       type: String,

--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -4,7 +4,7 @@
       <span :class="legendClass">
         {{ $attrs.label }}
       </span>
-      <span class="fr-hint-text my-2" v-if="optional">Optionnel</span>
+      <span v-if="optional" class="fr-hint-text my-2">Optionnel</span>
     </template>
     <v-row v-if="optionsRow" class="my-0">
       <v-col cols="12" sm="6" class="py-2" v-for="item in items" :key="item.value">
@@ -33,6 +33,8 @@
 </template>
 
 <script>
+import validators from "@/validators"
+
 export default {
   inheritAttrs: false,
   props: {
@@ -44,8 +46,7 @@ export default {
       type: String,
       default: "",
     },
-    optional: {
-      type: Boolean,
+    hideOptional: {
       default: false,
     },
     yesNo: {
@@ -78,6 +79,9 @@ export default {
       const inactiveColor = " grey--text"
       const color = this.$attrs.disabled ? inactiveColor : activeColor
       return this.labelClasses + color
+    },
+    optional() {
+      return !this.hideOptional && !validators._includesRequiredValidator(this.$attrs.rules)
     },
   },
   methods: {

--- a/frontend/src/components/DsfrTextField.vue
+++ b/frontend/src/components/DsfrTextField.vue
@@ -3,6 +3,7 @@
     <label :for="inputId" :class="labelClasses">
       <span v-if="$attrs.label">
         {{ $attrs.label }}
+        <span v-if="optional" class="fr-hint-text">Optionnel</span>
       </span>
       <slot name="label"></slot>
     </label>
@@ -39,6 +40,9 @@ export default {
       required: false,
       default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
     },
+    hideOptional: {
+      default: false,
+    },
   },
   data() {
     return { inputId: null }
@@ -49,6 +53,9 @@ export default {
     },
     value() {
       return this.$refs["text-field"].value
+    },
+    optional() {
+      return !this.hideOptional && !this.$attrs.rules?.some((f) => f.name === "required")
     },
   },
   methods: {

--- a/frontend/src/components/DsfrTextField.vue
+++ b/frontend/src/components/DsfrTextField.vue
@@ -33,6 +33,8 @@
 </template>
 
 <script>
+import validators from "@/validators"
+
 export default {
   inheritAttrs: false,
   props: {
@@ -55,7 +57,7 @@ export default {
       return this.$refs["text-field"].value
     },
     optional() {
-      return !this.hideOptional && !this.$attrs.rules?.some((f) => f.name === "required")
+      return !this.hideOptional && !validators._includesRequiredValidator(this.$attrs.rules)
     },
   },
   methods: {

--- a/frontend/src/components/DsfrTextField.vue
+++ b/frontend/src/components/DsfrTextField.vue
@@ -1,9 +1,11 @@
 <template>
   <div>
     <label :for="inputId" :class="labelClasses" v-if="$attrs.label || $slots.label">
-      <span v-if="$attrs.label">
+      <span v-if="$attrs.label" :class="{ 'grey--text': $attrs.disabled }">
         {{ $attrs.label }}
-        <span v-if="optional" class="fr-hint-text">Optionnel</span>
+        <span v-if="optional" :class="{ 'fr-hint-text': true, 'grey--text': $attrs.disabled }">
+          Optionnel
+        </span>
       </span>
       <slot name="label"></slot>
     </label>

--- a/frontend/src/components/DsfrTextField.vue
+++ b/frontend/src/components/DsfrTextField.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <label :for="inputId" :class="labelClasses">
+    <label :for="inputId" :class="labelClasses" v-if="$attrs.label || $slots.label">
       <span v-if="$attrs.label">
         {{ $attrs.label }}
         <span v-if="optional" class="fr-hint-text">Optionnel</span>

--- a/frontend/src/components/DsfrTextarea.vue
+++ b/frontend/src/components/DsfrTextarea.vue
@@ -26,6 +26,8 @@
 </template>
 
 <script>
+import validators from "@/validators"
+
 export default {
   inheritAttrs: false,
   props: {
@@ -43,7 +45,7 @@ export default {
       return this.$refs["textarea"].value
     },
     optional() {
-      return !this.$attrs.rules?.some((f) => f.name === "required")
+      return !validators._includesRequiredValidator(this.$attrs.rules)
     },
   },
   methods: {

--- a/frontend/src/components/DsfrTextarea.vue
+++ b/frontend/src/components/DsfrTextarea.vue
@@ -2,7 +2,9 @@
   <div>
     <label :for="inputId" :class="labelClasses" v-if="$attrs.label">
       {{ $attrs.label }}
+      <span v-if="optional" class="fr-hint-text">Optionnel</span>
     </label>
+    <slot name="label"></slot>
     <v-textarea
       dense
       ref="textarea"
@@ -39,6 +41,9 @@ export default {
   computed: {
     value() {
       return this.$refs["textarea"].value
+    },
+    optional() {
+      return !this.$attrs.rules?.some((f) => f.name === "required")
     },
   },
   methods: {

--- a/frontend/src/components/GeneralContactForm.vue
+++ b/frontend/src/components/GeneralContactForm.vue
@@ -4,7 +4,7 @@
       <v-col>
         <v-form v-model="formIsValid" ref="form" @submit.prevent>
           <DsfrEmail v-model="fromEmail" />
-          <DsfrTextField v-model="name" label="Prénom et nom (facultatif)" />
+          <DsfrTextField v-model="name" label="Prénom et nom" />
           <DsfrSelect
             v-model="inquiryType"
             :items="inquiryOptions"

--- a/frontend/src/components/SatelliteTable.vue
+++ b/frontend/src/components/SatelliteTable.vue
@@ -20,7 +20,7 @@
               </p>
               <DsfrTextarea
                 v-model="messageJoinCanteen"
-                label="Message (optionnel)"
+                label="Message"
                 hide-details="auto"
                 rows="2"
                 class="mt-2 body-2"

--- a/frontend/src/validators.js
+++ b/frontend/src/validators.js
@@ -16,6 +16,11 @@ function isBase10Number(input) {
 const GENERIC_BASE_10_ERROR = "Une valeur numérique est attendue"
 
 export default {
+  // this isn't a validation function, but a helper function, hence the underscore
+  _includesRequiredValidator(validatorArray) {
+    const requiredValidators = ["required", "greaterThanZero", "email"]
+    return (validatorArray || []).some((v) => requiredValidators.includes(v.name))
+  },
   required(input) {
     const errorMessage = "Ce champ ne peut pas être vide"
     if (typeof input === "undefined") return errorMessage

--- a/frontend/src/views/AccountSummaryPage/PasswordChangeEditor.vue
+++ b/frontend/src/views/AccountSummaryPage/PasswordChangeEditor.vue
@@ -14,7 +14,6 @@
               :rules="[validators.required]"
               hide-details="auto"
               v-model="oldPassword"
-              placeholder="Entrez votre mot de passe actuel"
             />
           </v-col>
           <v-col cols="12">
@@ -24,7 +23,6 @@
               :rules="[validators.required]"
               hide-details="auto"
               v-model="newPassword"
-              placeholder="Entrez votre nouveau mot de passe"
             />
           </v-col>
           <v-col cols="12">
@@ -33,9 +31,8 @@
               type="password"
               hide-details="auto"
               v-model="newPasswordConfirmation"
-              :rules="[validators.matchPassword]"
+              :rules="[validators.required, validators.matchPassword]"
               validate-on-blur
-              placeholder="Confirmez votre nouveau mot de passe"
             />
           </v-col>
         </v-row>

--- a/frontend/src/views/AccountSummaryPage/PasswordChangeEditor.vue
+++ b/frontend/src/views/AccountSummaryPage/PasswordChangeEditor.vue
@@ -31,7 +31,7 @@
               type="password"
               hide-details="auto"
               v-model="newPasswordConfirmation"
-              :rules="[validators.required, validators.matchPassword]"
+              :rules="[validators.matchPassword, validators.required]"
               validate-on-blur
             />
           </v-col>

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -206,6 +206,7 @@
             v-model.number="canteen.satelliteCanteensCount"
             prepend-icon="$community-fill"
             labelClasses="body-2 mb-2"
+            :hideOptional="true"
           />
         </v-col>
 

--- a/frontend/src/views/CanteenEditor/CanteenGeneratePoster.vue
+++ b/frontend/src/views/CanteenEditor/CanteenGeneratePoster.vue
@@ -11,7 +11,7 @@
     <v-form ref="form" v-model="formIsValid" id="poster-form" @submit.prevent class="mb-4">
       <DsfrTextarea
         v-model="customText"
-        label="Plus de détail (facultatif)"
+        label="Plus de détail"
         counter
         :rules="[(v) => !v || v.length <= 700 || '700 caractères maximum']"
       />

--- a/frontend/src/views/CanteenEditor/PublicationForm/index.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/index.vue
@@ -55,10 +55,14 @@
     <div v-if="receivesGuests">
       <h2 class="mt-8 mb-2" v-if="isPublished">Modifier la publication</h2>
       <v-form ref="form" @submit.prevent>
-        <label for="general">
-          Décrivez si vous le souhaitez le fonctionnement, l'organisation, l'historique de votre établissement...
-        </label>
-        <DsfrTextarea id="general" class="my-2" rows="5" counter="500" v-model="canteen.publicationComments" />
+        <DsfrTextarea
+          id="general"
+          label="Décrivez si vous le souhaitez le fonctionnement, l'organisation, l'historique de votre établissement..."
+          class="my-2"
+          rows="5"
+          counter="500"
+          v-model="canteen.publicationComments"
+        />
         <PublicationField class="mb-4" :canteen="canteen" v-model="acceptPublication" />
       </v-form>
       <v-sheet rounded color="grey lighten-4 pa-3 my-6" class="d-flex">

--- a/frontend/src/views/CanteenEditor/SiretCheck.vue
+++ b/frontend/src/views/CanteenEditor/SiretCheck.vue
@@ -57,7 +57,7 @@
               </p>
               <DsfrTextarea
                 v-model="messageJoinCanteen"
-                label="Message (optionnel)"
+                label="Message"
                 hide-details="auto"
                 rows="2"
                 class="mt-2 body-2"
@@ -84,7 +84,7 @@
           validate-on-blur
           label="SIRET"
           v-model="siret"
-          :rules="[validators.length(14), validators.luhn, siretSatelliteValidator()]"
+          :rules="[validators.required, validators.length(14), validators.luhn, siretSatelliteValidator()]"
           labelClasses="body-2 mb-2"
           style="max-width: 30rem;"
         />

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -372,7 +372,7 @@
         </p>
         <v-form v-model="formIsValid" ref="form" @submit.prevent>
           <DsfrEmail v-model="fromEmail" />
-          <DsfrTextField v-model="name" label="Prénom et nom (facultatif)" />
+          <DsfrTextField v-model="name" label="Prénom et nom" />
           <DsfrTextarea v-model="message" label="Message" :rules="[validators.required]" />
         </v-form>
         <v-row class="pa-2">

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -219,6 +219,7 @@
                     hide-details="auto"
                     append-icon="mdi-percent"
                     placeholder="0"
+                    :hideOptional="true"
                   />
                 </v-col>
                 <v-col class="pa-0 pl-1 d-flex flex-column">
@@ -232,6 +233,7 @@
                     hide-details="auto"
                     placeholder="0"
                     append-icon="mdi-percent"
+                    :hideOptional="true"
                   />
                 </v-col>
               </div>
@@ -257,6 +259,7 @@
                     :rules="[validators.nonNegativeOrEmpty]"
                     @change="onChangeIntegerFilter('min_daily_meal_count')"
                     hide-details="auto"
+                    :hideOptional="true"
                   />
                 </div>
                 <span class="mx-2 align-self-center">-</span>
@@ -269,6 +272,7 @@
                     :rules="[validators.nonNegativeOrEmpty]"
                     @change="onChangeIntegerFilter('max_daily_meal_count')"
                     hide-details="auto"
+                    :hideOptional="true"
                   />
                 </div>
               </div>

--- a/frontend/src/views/CanteensPage/ContactForm.vue
+++ b/frontend/src/views/CanteensPage/ContactForm.vue
@@ -51,7 +51,7 @@
     </div>
     <v-form v-model="formIsValid" ref="form" @submit.prevent>
       <DsfrEmail v-model="fromEmail" />
-      <DsfrTextField v-model="name" label="Prénom et nom (facultatif)" />
+      <DsfrTextField v-model="name" label="Prénom et nom" />
       <DsfrTextarea v-model="message" label="Message" :rules="[validators.required]" />
       <p class="caption text-left grey--text text--darken-1 mt-n1 mb-6">
         Ne partagez pas d'informations sensibles (par ex. mot de passe, numéro de carte bleue, etc).

--- a/frontend/src/views/DiagnosticTunnel/InformationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/InformationMeasureSteps/index.vue
@@ -66,19 +66,13 @@
       yesNo
     />
     <div v-else-if="stepUrlSlug === 'lien-communication'">
-      <fieldset>
-        <legend>
-          Lien vers le support de communication
-          <span class="fr-hint-text mt-2">Optionnel</span>
-        </legend>
-        <DsfrTextField
-          :rules="[validators.urlOrEmpty]"
-          v-model="payload.communicationSupportUrl"
-          placeholder="https://"
-          validate-on-blur
-          class="mt-2"
-        />
-      </fieldset>
+      <DsfrTextField
+        label="Lien vers le support de communication"
+        :rules="[validators.urlOrEmpty]"
+        v-model="payload.communicationSupportUrl"
+        placeholder="https://"
+        validate-on-blur
+      />
     </div>
   </v-form>
 </template>

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -12,14 +12,12 @@
         v-model="payload.hasWasteDiagnostic"
         label="J’ai réalisé un diagnostic sur les causes probables de gaspillage alimentaire"
         yesNo
-        optional
         hide-details
       />
       <DsfrRadio
         v-model="payload.hasWastePlan"
         label="J’ai mis en place un plan d’action adapté au diagnostic réalisé"
         yesNo
-        optional
         hide-details
         :disabled="!payload.hasWasteDiagnostic"
         :readonly="!payload.hasWasteDiagnostic"

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -55,6 +55,7 @@
                   suffix="kg"
                   :readonly="!payload.hasWasteMeasures"
                   :disabled="!payload.hasWasteMeasures"
+                  :hideOptional="true"
                 />
               </v-col>
               <v-col cols="12" md="6" class="pb-0">
@@ -71,6 +72,7 @@
                   suffix="jours"
                   :readonly="!payload.hasWasteMeasures"
                   :disabled="!payload.hasWasteMeasures"
+                  :hideOptional="true"
                 />
               </v-col>
               <v-col cols="12" md="6" class="pb-0">
@@ -82,6 +84,7 @@
                   suffix="kg/an"
                   :readonly="!payload.hasWasteMeasures"
                   :disabled="!payload.hasWasteMeasures"
+                  :hideOptional="true"
                 />
               </v-col>
               <v-col cols="12" md="6" class="pb-0">
@@ -93,6 +96,7 @@
                   suffix="kg/an"
                   :readonly="!payload.hasWasteMeasures"
                   :disabled="!payload.hasWasteMeasures"
+                  :hideOptional="true"
                 />
               </v-col>
               <v-col cols="12" md="6" class="pb-0">
@@ -104,6 +108,7 @@
                   suffix="kg/an"
                   :readonly="!payload.hasWasteMeasures"
                   :disabled="!payload.hasWasteMeasures"
+                  :hideOptional="true"
                 />
               </v-col>
               <v-col cols="12" md="6" class="pb-0">
@@ -115,6 +120,7 @@
                   suffix="kg/an"
                   :readonly="!payload.hasWasteMeasures"
                   :disabled="!payload.hasWasteMeasures"
+                  :hideOptional="true"
                 />
               </v-col>
             </v-row>
@@ -223,16 +229,17 @@
     <div v-else-if="stepUrlSlug === 'autres'">
       <v-row>
         <v-col cols="12" sm="9" md="7">
-          <fieldset>
-            <legend class="my-3">
-              Autres commentaires
-              <span class="fr-hint-text mt-2">
-                Optionnel : toute précision que vous souhaiteriez apporter sur votre situation et/ou sur vos actions
-                mises en place pour lutter contre le gaspillage alimentaire
-              </span>
-            </legend>
-            <DsfrTextarea v-model="payload.otherWasteComments" rows="3" class="mt-6" />
-          </fieldset>
+          <DsfrTextarea v-model="payload.otherWasteComments" id="otherWasteComments" rows="3" class="mt-6">
+            <template v-slot:label>
+              <label for="otherWasteComments" class="mb-3">
+                Autres commentaires
+                <span class="fr-hint-text mt-2">
+                  Optionnel : toute précision que vous souhaiteriez apporter sur votre situation et/ou sur vos actions
+                  mises en place pour lutter contre le gaspillage alimentaire
+                </span>
+              </label>
+            </template>
+          </DsfrTextarea>
         </v-col>
       </v-row>
     </div>

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -166,61 +166,41 @@
           />
         </v-col>
         <v-col cols="12" sm="6">
-          <fieldset :disabled="!payload.hasDonationAgreement">
-            <v-row>
-              <v-col cols="12" md="6" class="pb-0">
-                <label for="donationFrequency">
-                  Fréquence de dons
-                  <span :class="`fr-hint-text my-2 ${payload.hasDonationAgreement ? '' : 'grey--text'}`">
-                    Optionnel
-                  </span>
-                </label>
-                <DsfrTextField
-                  id="donationFrequency"
-                  :value="payload.donationFrequency"
-                  @input="(x) => (payload.donationFrequency = integerInputValue(x))"
-                  :rules="payload.hasDonationAgreement ? [validators.nonNegativeOrEmpty, validators.isInteger] : []"
-                  validate-on-blur
-                  suffix="dons/an"
-                  :readonly="!payload.hasDonationAgreement"
-                  :disabled="!payload.hasDonationAgreement"
-                />
-              </v-col>
-              <v-col cols="12" md="6" class="pb-0">
-                <label for="donationQuantity">
-                  Quantité de denrées données
-                  <span :class="`fr-hint-text my-2 ${payload.hasDonationAgreement ? '' : 'grey--text'}`">
-                    Optionnel
-                  </span>
-                </label>
-                <DsfrTextField
-                  id="donationQuantity"
-                  v-model.number="payload.donationQuantity"
-                  :rules="
-                    payload.hasDonationAgreement ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []
-                  "
-                  validate-on-blur
-                  suffix="kg/an"
-                  :readonly="!payload.hasDonationAgreement"
-                  :disabled="!payload.hasDonationAgreement"
-                />
-              </v-col>
-              <v-col cols="12" class="pb-0">
-                <label for="donationFoodType">
-                  Type de denrées données
-                  <span :class="`fr-hint-text my-2 ${payload.hasDonationAgreement ? '' : 'grey--text'}`">
-                    Optionnel
-                  </span>
-                </label>
-                <DsfrTextField
-                  id="donationFoodType"
-                  v-model="payload.donationFoodType"
-                  :readonly="!payload.hasDonationAgreement"
-                  :disabled="!payload.hasDonationAgreement"
-                />
-              </v-col>
-            </v-row>
-          </fieldset>
+          <v-row>
+            <v-col cols="12" md="6" class="pb-0">
+              <DsfrTextField
+                label="Fréquence de dons"
+                :value="payload.donationFrequency"
+                @input="(x) => (payload.donationFrequency = integerInputValue(x))"
+                :rules="payload.hasDonationAgreement ? [validators.nonNegativeOrEmpty, validators.isInteger] : []"
+                validate-on-blur
+                suffix="dons/an"
+                :readonly="!payload.hasDonationAgreement"
+                :disabled="!payload.hasDonationAgreement"
+              />
+            </v-col>
+            <v-col cols="12" md="6" class="pb-0">
+              <DsfrTextField
+                label="Quantité de denrées données"
+                v-model.number="payload.donationQuantity"
+                :rules="
+                  payload.hasDonationAgreement ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []
+                "
+                validate-on-blur
+                suffix="kg/an"
+                :readonly="!payload.hasDonationAgreement"
+                :disabled="!payload.hasDonationAgreement"
+              />
+            </v-col>
+            <v-col cols="12" class="pb-0">
+              <DsfrTextField
+                label="Type de denrées données"
+                v-model="payload.donationFoodType"
+                :readonly="!payload.hasDonationAgreement"
+                :disabled="!payload.hasDonationAgreement"
+              />
+            </v-col>
+          </v-row>
         </v-col>
       </v-row>
     </div>

--- a/frontend/src/views/DiagnosticsImporter/HelpForm.vue
+++ b/frontend/src/views/DiagnosticsImporter/HelpForm.vue
@@ -16,7 +16,7 @@
           <DsfrTextField v-model="name" label="Prénom et nom" />
         </v-col>
       </v-row>
-      <DsfrTextarea v-model="message" label="Message (facultatif)" />
+      <DsfrTextarea v-model="message" label="Message" />
       <v-file-input
         v-model="unusualFile"
         label="Fichier"

--- a/frontend/src/views/GeneratePosterPage/index.vue
+++ b/frontend/src/views/GeneratePosterPage/index.vue
@@ -50,7 +50,7 @@
           <v-col cols="12">
             <DsfrTextarea
               v-model="customText"
-              label="Plus de détail (facultatif)"
+              label="Plus de détail"
               counter
               :rules="[(v) => !v || v.length <= 700 || '700 caractères maximum']"
             />

--- a/frontend/src/views/NewPartner.vue
+++ b/frontend/src/views/NewPartner.vue
@@ -7,7 +7,7 @@
       notre base de données.
     </p>
     <p class="text-caption">
-      Sauf mention contraire “(optionnel)” dans le label, tous les champs sont obligatoires
+      Sauf mention contraire tous les champs sont obligatoires
     </p>
     <v-form v-model="formIsValid" ref="form" @submit.prevent class="mt-8">
       <v-row>
@@ -123,17 +123,17 @@
           <DsfrEmail v-model="partner.contactEmail" />
         </v-col>
         <v-col cols="12" sm="6">
-          <DsfrTextField v-model="partner.contactName" label="Prénom et nom (optionnel)" />
+          <DsfrTextField v-model="partner.contactName" label="Prénom et nom" />
         </v-col>
         <v-col cols="12" sm="6">
           <DsfrTextField
-            label="Numéro téléphone (optionnel)"
+            label="Numéro téléphone"
             v-model="partner.contactPhoneNumber"
             :rules="[validators.isEmptyOrPhoneNumber]"
           />
         </v-col>
       </v-row>
-      <DsfrTextarea v-model="partner.contactMessage" label="Commentaires sur votre demande (optionnel)" :rows="2" />
+      <DsfrTextarea v-model="partner.contactMessage" label="Commentaires sur votre demande" :rows="2" />
       <v-checkbox :rules="[validators.checked]" class="mb-6">
         <template v-slot:label>
           <span class="body-2 grey--text text--darken-3">

--- a/frontend/src/views/NewPartner.vue
+++ b/frontend/src/views/NewPartner.vue
@@ -7,7 +7,7 @@
       notre base de données.
     </p>
     <p class="text-caption">
-      Sauf mention contraire tous les champs sont obligatoires
+      Sauf mention contraire "Optionnel" dans le label, tous les champs sont obligatoires
     </p>
     <v-form v-model="formIsValid" ref="form" @submit.prevent class="mt-8">
       <v-row>


### PR DESCRIPTION
Je n'ai pas encore MAJ tous les composants. Je me demande si c'est mieux de le faire une fois qu'on a besoin, ou si c'est mieux de rendre les composants cohérent et anticiper le besoin ?

J'ai laissé les "Optionnel"s dans le tunnel appro car il y a des icons pour le vue mobile.

J'ai aussi fait :
- des refactos comme la suppression des fieldsets sans legend/fieldsets avec qu'un champ
- reparer un bug expliqué dans le commit message : https://github.com/betagouv/ma-cantine/commit/a5a6277467c7956899142786bbc9fb1302b12075
- supprimer quelques placeholders qui sont pas nécessaires