### PR TITLE
Réduction de la taille de la réponse à la liste de `actionableCanteens` 

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -6,6 +6,7 @@ from .canteen import (  # noqa: F401
     ManagingTeamSerializer,
     CanteenPreviewSerializer,
     SatelliteCanteenSerializer,
+    CanteenActionsListSerializer,
     CanteenActionsSerializer,
     CanteenStatusSerializer,
     CanteenTeledeclarationSerializer,

--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -357,6 +357,20 @@ class ManagingTeamSerializer(serializers.ModelSerializer):
         fields = ("id", "managers", "manager_invitations")
 
 
+class CanteenActionsListSerializer(serializers.ModelSerializer):
+    action = serializers.CharField(allow_null=True)
+
+    class Meta:
+        model = Canteen
+        fields = (
+            "id",
+            "name",
+            "action",
+            "production_type",
+        )
+        read_only_fields = fields
+
+
 class CanteenActionsSerializer(serializers.ModelSerializer):
     # TODO: is it worth moving the job of fetching the specific diag required to the front?
     diagnostics = FullDiagnosticSerializer(many=True, read_only=True, source="diagnostic_set")

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -889,7 +889,7 @@ class TestCanteenApi(APITestCase):
         for index, (canteen, action) in zip(range(len(expected_actions)), expected_actions):
             self.assertEqual(returned_canteens[index]["id"], canteen.id)
             self.assertEqual(returned_canteens[index]["action"], action)
-            self.assertIn("sectors", returned_canteens[index])
+            self.assertIn("productionType", returned_canteens[index])
         self.assertTrue(body["hasPendingActions"])
 
     @override_settings(ENABLE_TELEDECLARATION=True)

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -31,6 +31,7 @@ from api.serializers import (
     CanteenPreviewSerializer,
     ManagingTeamSerializer,
     SatelliteCanteenSerializer,
+    CanteenActionsListSerializer,
     CanteenActionsSerializer,
     CanteenStatusSerializer,
     ElectedCanteenSerializer,
@@ -1189,7 +1190,7 @@ class UnlinkSatelliteView(APIView):
 class ActionableCanteensListView(ListAPIView):
     permission_classes = [IsAuthenticated]
     model = Canteen
-    serializer_class = CanteenActionsSerializer
+    serializer_class = CanteenActionsListSerializer
     pagination_class = CanteenActionsPagination
     filter_backends = [
         django_filters.DjangoFilterBackend,
@@ -1250,9 +1251,7 @@ class ActionableCanteensListView(ListAPIView):
         )
 
         # prep complete diag action
-        complete_diagnostics = Diagnostic.objects.filter(
-            pk=OuterRef("diagnostic_for_year"), value_total_ht__gt=0, diagnostic_type__isnull=False
-        )
+        complete_diagnostics = Diagnostic.objects.filter(pk=OuterRef("diagnostic_for_year"), value_total_ht__gt=0)
         user_canteens = user_canteens.annotate(has_complete_diag=Exists(Subquery(complete_diagnostics)))
         # prep TD action
         tds = Teledeclaration.objects.filter(


### PR DESCRIPTION
Aujourd'hui on utilise les mêmes serializers pour obtenir un seul _actionableCanteen_ que pour obtenir la liste entière. La liste peut être très grande et très lente à s’exécuter et parser, donc un nouveau serializer peut aider pour alléger cette partie.
