### PR TITLE
Fix du bug utilisant le mauvais diagnostic dans la preview

### DIFF
--- a/frontend/src/components/TeledeclarationPreview/index.vue
+++ b/frontend/src/components/TeledeclarationPreview/index.vue
@@ -155,7 +155,7 @@ export default {
       return this.canteenForTD ? this.$store.getters.getCanteenUrlComponent(this.canteenForTD) : null
     },
     centralKitchenDiagostic() {
-      return this.canteenForTD.centralKitchenDiagnostics?.find((x) => x.year === this.diagnostic.year)
+      return this.canteenForTD.centralKitchenDiagnostics?.find((x) => x.year === this.diagnosticForTD.year)
     },
     showApproItems() {
       if (this.canteenForTD.productionType === "site_cooked_elsewhere" && this.centralKitchenDiagostic) {


### PR DESCRIPTION
Le composant `TeledeclarationPreview` a deux modalités :
- Lors qu'on essaie de télédéclarer une seule cantine (et donc on passe le paramètre `diagnostic`), ou
- Lors qu'on veut télédéclarer plusieurs cantines (et donc on passe le tableau `diagnostics`)

À l'intérieur du composant, on doit utiliser `diagnosticForTD` pour référencer le diagnostic en cours dans les deux cas. Or, aujourd'hui cette ligne ne le fait pas :
```javascript
centralKitchenDiagostic() {
  return this.canteenForTD.centralKitchenDiagnostics?.find((x) => x.year === this.diagnostic.year)
},
```
Ce qui fait que dans certaines conditions, la télédéclaration en masse ne marche pas.