### PR TITLE
Bug fix : Prend en considération les diagnostics et TD de la cuisine centrale pour les actions

### DIFF
--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -975,6 +975,49 @@ class TestCanteenApi(APITestCase):
         returned_canteens = response.json()["results"]
         self.assertEqual(returned_canteens[0]["action"], "40_teledeclare")
 
+    @override_settings(ENABLE_TELEDECLARATION=True)
+    @authenticate
+    def test_get_actions_satellite(self):
+        """
+        If a satellite's CC has teledeclared there is no pending action for the satellite
+        """
+        central_kitchen = CanteenFactory.create(
+            production_type=Canteen.ProductionType.CENTRAL,
+            publication_status=Canteen.PublicationStatus.PUBLISHED,
+            management_type=Canteen.ManagementType.DIRECT,
+            yearly_meal_count=1000,
+            daily_meal_count=12,
+            siret="96766910375238",
+            city_insee_code="69123",
+            satellite_canteens_count=1,
+            economic_model=Canteen.EconomicModel.PUBLIC,
+        )
+        central_kitchen.managers.add(authenticate.user)
+        satellite = CanteenFactory.create(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+            publication_status=Canteen.PublicationStatus.PUBLISHED,
+            management_type=Canteen.ManagementType.DIRECT,
+            yearly_meal_count=10,
+            daily_meal_count=2,
+            siret="99569440745111",
+            city_insee_code="69123",
+            economic_model=Canteen.EconomicModel.PUBLIC,
+            central_producer_siret="96766910375238",
+        )
+        satellite.managers.add(authenticate.user)
+        diagnostic = DiagnosticFactory.create(
+            year=2021,
+            canteen=central_kitchen,
+            value_total_ht=1000,
+            central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
+        )
+        Teledeclaration.create_from_diagnostic(diagnostic, authenticate.user)
+
+        response = self.client.get(reverse("list_actionable_canteens", kwargs={"year": 2021}))
+        returned_canteens = response.json()["results"]
+        satellite_action = next(x for x in returned_canteens if x["id"] == satellite.id)["action"]
+        self.assertEqual(satellite_action, "95_nothing")
+
     @authenticate
     def test_get_canteens_with_purchases_no_diagnostics_for_year(self):
         """

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -1214,11 +1214,16 @@ class ActionableCanteensListView(ListAPIView):
             .order_by()
             .values("central_producer_siret")  # sets the groupBy for the aggregation
         )
+        central_kitchen = Canteen.objects.filter(siret=OuterRef("central_producer_siret")).values("id")
         # count by id per central prod siret, then fetch that count
         satellites_count = satellites.annotate(count=Count("id")).values("count")
-        user_canteens = queryset.annotate(nb_satellites_in_db=Subquery(satellites_count))
+        user_canteens = queryset.annotate(
+            nb_satellites_in_db=Subquery(satellites_count), central_kitchen_id=Subquery(central_kitchen[:1])
+        )
         # prep add diag actions
-        diagnostics = Diagnostic.objects.filter(canteen=OuterRef("pk"), year=year)
+        diagnostics = Diagnostic.objects.filter(
+            Q(canteen=OuterRef("pk")) | Q(canteen=OuterRef("central_kitchen_id")), year=year
+        )
         user_canteens = user_canteens.annotate(diagnostic_for_year=Subquery(diagnostics.values("id")))
         purchases_for_year = Purchase.objects.filter(canteen=OuterRef("pk"), date__year=year)
         user_canteens = user_canteens.annotate(has_purchases_for_year=Exists(purchases_for_year))
@@ -1254,7 +1259,9 @@ class ActionableCanteensListView(ListAPIView):
         user_canteens = user_canteens.annotate(has_complete_diag=Exists(Subquery(complete_diagnostics)))
         # prep TD action
         tds = Teledeclaration.objects.filter(
-            canteen=OuterRef("pk"), year=year, status=Teledeclaration.TeledeclarationStatus.SUBMITTED
+            Q(canteen=OuterRef("pk")) | Q(canteen=OuterRef("central_kitchen_id")),
+            year=year,
+            status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
         )
         user_canteens = user_canteens.annotate(has_td=Exists(Subquery(tds)))
         # annotate with action


### PR DESCRIPTION
Aujourd'hui on ne prend pas en compte les bilans ou télédéclarations des cuisines centrales pour les satellites lors du calcul des actions.

Cette PR vise à inclure ces données.