### PR TITLE
Bug fix : rendre le header clickable quand il y a des notifications sur l'écran

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -236,7 +236,7 @@ ul.no-bullets {
   position: fixed;
   z-index: 1000;
   height: fit-content;
-  width: 100%;
+  right: 0;
 
   .v-snack__wrapper {
     margin: 2px;

--- a/frontend/src/components/NotificationSnackbar.vue
+++ b/frontend/src/components/NotificationSnackbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-snackbar class="notification-snackbar" timeout="-1" :color="color" :value="show" right>
+  <v-snackbar class="notification-snackbar" timeout="-1" :color="color" :value="show">
     <div class="d-flex">
       <v-icon small class="mr-3" width="20" @click="$store.dispatch('removeNotification', notification)">
         {{ icon }}
@@ -57,5 +57,6 @@ export default {
 .notification-snackbar {
   position: relative;
   height: unset;
+  width: unset;
 }
 </style>

--- a/frontend/src/components/NotificationSnackbar.vue
+++ b/frontend/src/components/NotificationSnackbar.vue
@@ -1,7 +1,7 @@
 <template>
   <v-snackbar class="notification-snackbar" timeout="-1" :color="color" :value="show">
     <div class="d-flex">
-      <v-icon small class="mr-3" width="20" @click="$store.dispatch('removeNotification', notification)">
+      <v-icon small class="mr-3" width="20">
         {{ icon }}
       </v-icon>
       <div class="flex-grow-1 d-flex flex-column justify-center white--text">


### PR DESCRIPTION
Aujourd'hui sur staging le div est de width 100% et cache les trucs en dessous.

![Screenshot 2024-04-22 at 18-52-16 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/b7ab8684-66a6-4a48-9898-7070b2ffa661)
