### PR TITLE
Reparer bug quand on accède aux sous-titres

### DIFF
--- a/frontend/src/views/VideoTutorial.vue
+++ b/frontend/src/views/VideoTutorial.vue
@@ -11,6 +11,8 @@
         controls
         class="player"
         :id="`video-${mainVideo.id}`"
+        crossorigin="anonymous"
+        preload="metadata"
       >
         <source :src="mainVideo.video" />
         <track v-if="mainVideo.subtitles" label="Français" kind="subtitles" srclang="fr" :src="mainVideo.subtitles" />


### PR DESCRIPTION
Pour l'erreur, regarde le console ici : https://ma-cantine-demo.cleverapps.io/webinaires/1--Test%20accessibilit%C3%A9

En vrai je suis pas certaine si ça resoudre le pb complètement... quand je teste en utilisant le code suivant on n'a plus ce pb, mai je vois toujours pas les sous-titres

Et pour l'attribut preload : https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Video#preload

```
        <video id="video" crossorigin="anonymous" controls preload="metadata">
          <source
            src="https://cellar-c2.services.clever-cloud.com/ma-cantine-egalim-demo/media/videos/ma_cantine__Importer_ses_achats_1.mp4"
            type="video/mp4"
          />
          <track
            label="Français"
            kind="subtitles"
            srclang="fr"
            src="https://cellar-c2.services.clever-cloud.com/ma-cantine-egalim-demo/media/subtitles/ma_cantine__Importer_ses_achats_1.vtt"
            default
          />
        </video>
```