### PR TITLE
Lien contact page vidéo

### DIFF
--- a/frontend/src/views/VideoTutorial.vue
+++ b/frontend/src/views/VideoTutorial.vue
@@ -34,7 +34,11 @@
         <router-link :to="{ name: 'AccessibilityDeclaration' }">déclaration d'accessibilité</router-link>
       </p>
     </v-alert>
-    <div v-if="suggestedVideos && suggestedVideos.length > 0">
+    <p v-else class="mt-4 text-right">
+      Question, problème ?
+      <router-link :to="{ name: 'ContactPage' }" class="grey--text text--darken-4">Contactez-nous</router-link>
+    </p>
+    <div v-if="suggestedVideos && suggestedVideos.length > 0" class="mt-6">
       <h2 class="text-h6 mb-4">Autres webinaires</h2>
       <v-row>
         <v-col cols="12" sm="6" md="4" v-for="video in suggestedVideos" :key="video.id">


### PR DESCRIPTION
Je pensais à ça dans le cadre du travail sur le sous-titrage et transcription des vidéos. Dans le cas où la vidéo a tous les éléments, je pense que c'est intéressant quand même d'avoir un lien vers la page contact si jamais il y a un pb avec le sous-titrage ou une incomprehension, vu que quelques vidéos contient des images de l'ancien parcours.

![Screenshot 2024-04-30 at 14-07-37 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/3556c829-f6e9-43ba-a202-bdd3578d8a22)
