### PR TITLE
RGAA 3.1 Dans chaque page web, l’information ne doit pas être donnée uniquement par la couleur. Cette règle est-elle respectée ?

### DIFF
--- a/frontend/src/components/ApproGraph.vue
+++ b/frontend/src/components/ApproGraph.vue
@@ -87,12 +87,12 @@ export default {
             },
             {
               x: this.applicableRules.bioThreshold,
-              borderColor: "#297254",
+              borderColor: "#21402c",
               label: {
                 offsetY: -14,
                 orientation: "horizontal",
                 style: {
-                  color: "#297254",
+                  color: "#21402c",
                   background: "#fff",
                 },
                 text: `${this.applicableRules.bioThreshold} %`,
@@ -107,7 +107,7 @@ export default {
         {
           name: `Bio : ${this.bioPercentage} %`,
           data: [this.bioPercentage],
-          color: "#297254",
+          color: "#21402c",
         },
         {
           name: `Durable et de qualité : ${this.sustainablePercentage} %`,

--- a/frontend/src/components/MultiYearSummaryStatistics.vue
+++ b/frontend/src/components/MultiYearSummaryStatistics.vue
@@ -47,7 +47,6 @@ import { getPercentage, hasDiagnosticApproData, getSustainableTotal, regionDispl
 const VALUE_DESCRIPTION = "Pourcentage d'achats"
 const BIO = "Bio"
 const SUSTAINABLE = "Qualité et durable (hors bio)"
-const OTHER = "Hors EGAlim"
 
 export default {
   components: {
@@ -92,18 +91,13 @@ export default {
         {
           name: BIO,
           data: this.seriesData.bio,
-          color: "#297254",
+          color: "#21402c",
         },
         {
           name: SUSTAINABLE,
           data: this.seriesData.sustainable,
           color: "#00A95F",
           foreColor: "#000",
-        },
-        {
-          name: OTHER,
-          data: this.seriesData.other,
-          color: "#ccc",
         },
       ]
     },


### PR DESCRIPTION
Couleurs utilisé : green-emeraude-main-632 et green-emeraude-200

En enlevant le gris "hors EGAlim" de l'ancien graphique, on pourrait atteindre un contraste de 3:1 entre les trois couleurs - vert foncé pour bio, vert clair pour durable, blanc du fond. Comme ça on n'a plus besoin de motifs.

![Screenshot 2024-04-30 at 19-38-52 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/a123ecff-242c-4d6d-8d58-7599e203475c)
![Screenshot 2024-04-30 at 19-46-52 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/3c165695-fec1-4795-ad2f-8e0c890a2cc9)


![Screenshot 2024-04-30 at 19-41-08 Web Accessibility Color Contrast Checker - Meet WCAG Conformance](https://github.com/betagouv/ma-cantine/assets/9282816/bdf4a64d-2326-4e27-b4a6-12bf41f52eb4)
![Screenshot 2024-04-30 at 19-40-50 Web Accessibility Color Contrast Checker - Meet WCAG Conformance](https://github.com/betagouv/ma-cantine/assets/9282816/6940081c-ab1b-472a-8530-1814c425dec2)
