### PR TITLE
RGAA 11.10 Dans chaque formulaire, le contrôle de saisie est-il utilisé de manière pertinente (hors cas particuliers) ?

### DIFF
--- a/frontend/src/components/DsfrAutocomplete.vue
+++ b/frontend/src/components/DsfrAutocomplete.vue
@@ -13,6 +13,7 @@
       v-on="$listeners"
       persistent-placeholder
       @input="(v) => $emit('input', v)"
+      :aria-describedby="errorMessageId"
       auto-select-first
       :search-input.sync="searchInput"
       @change="searchInput = ''"
@@ -21,7 +22,7 @@
 
       <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
       <template v-slot:message="{ key, message }">
-        <p :key="key" class="mb-0">{{ message }}</p>
+        <p :id="errorMessageId" :key="key" class="mb-0">{{ message }}</p>
       </template>
     </v-autocomplete>
   </div>
@@ -42,6 +43,11 @@ export default {
       searchInput: null,
       inputId: null,
     }
+  },
+  computed: {
+    errorMessageId() {
+      return this.inputId && `${this.inputId}-error`
+    },
   },
   methods: {
     removeInnerLabel() {

--- a/frontend/src/components/DsfrCombobox.vue
+++ b/frontend/src/components/DsfrCombobox.vue
@@ -13,6 +13,7 @@
       v-on="$listeners"
       persistent-placeholder
       @input="(v) => $emit('input', v)"
+      :aria-describedby="errorMessageId"
       hide-no-data
       auto-select-first
       :return-object="false"
@@ -25,7 +26,7 @@
 
       <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
       <template v-slot:message="{ key, message }">
-        <p :key="key" class="mb-0">{{ message }}</p>
+        <p :id="errorMessageId" :key="key" class="mb-0">{{ message }}</p>
       </template>
     </v-combobox>
   </div>
@@ -47,6 +48,9 @@ export default {
   computed: {
     value() {
       return this.$refs["combobox"].value
+    },
+    errorMessageId() {
+      return this.inputId && `${this.inputId}-error`
     },
   },
   methods: {

--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-radio-group class="my-0" ref="radio" v-bind="$attrs" v-on="$listeners" @change="(v) => $emit('input', v)">
+  <v-radio-group class="my-0" ref="radiogroup" v-bind="$attrs" v-on="$listeners" @change="(v) => $emit('input', v)">
     <template v-slot:label>
       <span class="d-block mb-2">
         <span :class="legendClass">
@@ -29,7 +29,7 @@
 
     <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
     <template v-slot:message="{ key, message }">
-      <p :key="key" class="mb-0">{{ message }}</p>
+      <p :id="errorMessageId" :key="key" class="mb-0">{{ message }}</p>
     </template>
   </v-radio-group>
 </template>
@@ -85,11 +85,26 @@ export default {
     optional() {
       return !this.hideOptional && !validators._includesRequiredValidator(this.$attrs.rules)
     },
+    errorMessageId() {
+      return `${this.inputId}-error`
+    },
   },
   methods: {
     validate() {
-      return this.$refs["radio"].validate()
+      return this.$refs["radiogroup"].validate()
     },
+    assignInputId() {
+      this.inputId = this.$refs?.["radiogroup"]?.$refs?.["label"].id
+    },
+    assignDescribedby() {
+      this.$refs["radiogroup"].$el
+        .querySelector("[role=radiogroup]")
+        .setAttribute("aria-describedby", this.errorMessageId)
+    },
+  },
+  mounted() {
+    this.assignInputId()
+    this.assignDescribedby()
   },
 }
 </script>

--- a/frontend/src/components/DsfrSelect.vue
+++ b/frontend/src/components/DsfrSelect.vue
@@ -13,11 +13,12 @@
       v-on="$listeners"
       persistent-placeholder
       @input="(v) => $emit('input', v)"
+      :aria-describedby="errorMessageId"
     >
       <template v-slot:label><span></span></template>
       <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
       <template v-slot:message="{ key, message }">
-        <p :key="key" class="mb-0">{{ message }}</p>
+        <p :id="errorMessageId" :key="key" class="mb-0">{{ message }}</p>
       </template>
     </v-select>
   </div>
@@ -39,6 +40,9 @@ export default {
   computed: {
     value() {
       return this.$refs["select"].value
+    },
+    errorMessageId() {
+      return this.inputId && `${this.inputId}-error`
     },
   },
   methods: {

--- a/frontend/src/components/DsfrTextField.vue
+++ b/frontend/src/components/DsfrTextField.vue
@@ -20,6 +20,7 @@
       persistent-placeholder
       @input="(v) => $emit('input', v)"
       :aria-describedby="errorMessageId"
+      :aria-invalid="hasError"
     >
       <template v-slot:label><span></span></template>
 
@@ -39,6 +40,9 @@
 import validators from "@/validators"
 
 export default {
+  inject: {
+    form: { default: null },
+  },
   inheritAttrs: false,
   props: {
     labelClasses: {
@@ -50,7 +54,10 @@ export default {
     },
   },
   data() {
-    return { inputId: null }
+    return {
+      inputId: null,
+      hasError: null,
+    }
   },
   computed: {
     lazyValue() {
@@ -72,7 +79,9 @@ export default {
       if (labels && labels.length > 0) for (const label of labels) label.parentNode.removeChild(label)
     },
     validate() {
-      return this.$refs["text-field"].validate()
+      const result = this.$refs["text-field"].validate()
+      this.hasError = result !== true
+      return result
     },
     assignInputId() {
       this.inputId = this.$refs?.["text-field"]?.$refs?.["input"].id
@@ -81,6 +90,13 @@ export default {
   mounted() {
     this.removeInnerLabel()
     this.assignInputId()
+    if (this.form) this.form.register(this)
+    else if (this.$attrs.rules?.length)
+      console.warn(`component ${this.inputId} with validation rules not in a form, a11y markup may not work`)
+  },
+  beforeDestroy() {
+    // https://github.com/vuetifyjs/vuetify/issues/3464#issuecomment-370240024
+    if (this.form) this.form.unregister(this)
   },
 }
 </script>

--- a/frontend/src/components/DsfrTextField.vue
+++ b/frontend/src/components/DsfrTextField.vue
@@ -19,6 +19,7 @@
       v-on="$listeners"
       persistent-placeholder
       @input="(v) => $emit('input', v)"
+      :aria-describedby="errorMessageId"
     >
       <template v-slot:label><span></span></template>
 
@@ -28,7 +29,7 @@
 
       <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
       <template v-slot:message="{ key, message }">
-        <p :key="key" class="mb-0">{{ message }}</p>
+        <p :id="errorMessageId" :key="key" class="mb-0">{{ message }}</p>
       </template>
     </v-text-field>
   </div>
@@ -60,6 +61,9 @@ export default {
     },
     optional() {
       return !this.hideOptional && !validators._includesRequiredValidator(this.$attrs.rules)
+    },
+    errorMessageId() {
+      return this.inputId && `${this.inputId}-error`
     },
   },
   methods: {

--- a/frontend/src/components/DsfrTextarea.vue
+++ b/frontend/src/components/DsfrTextarea.vue
@@ -14,12 +14,13 @@
       v-on="$listeners"
       persistent-placeholder
       @input="(v) => $emit('input', v)"
+      :aria-describedby="errorMessageId"
     >
       <template v-slot:label><span></span></template>
 
       <!-- For RGAA 8.9 error messages should also be in p tags, by default in vuetify 2 they're in divs -->
       <template v-slot:message="{ key, message }">
-        <p :key="key" class="mb-0">{{ message }}</p>
+        <p :id="errorMessageId" :key="key" class="mb-0">{{ message }}</p>
       </template>
     </v-textarea>
   </div>
@@ -46,6 +47,9 @@ export default {
     },
     optional() {
       return !validators._includesRequiredValidator(this.$attrs.rules)
+    },
+    errorMessageId() {
+      return this.inputId && `${this.inputId}-error`
     },
   },
   methods: {

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -76,225 +76,227 @@
     </div>
     <v-expand-transition>
       <v-sheet class="pa-6 text-left mt-2" v-show="showFilters" rounded :outlined="showFilters">
-        <v-row class="mb-0">
-          <v-col cols="12" sm="6" md="4">
-            <label
-              for="select-region"
-              :class="{
-                'text-body-2': true,
-                'active-filter-label': !!filters.region.value,
-              }"
-            >
-              Région
-            </label>
-            <DsfrAutocomplete
-              v-model="filters.region.value"
-              :items="regions"
-              clearable
-              hide-details
-              id="select-region"
-              placeholder="Toutes les régions"
-              class="mt-1"
-              auto-select-first
-              :filter="locationFilter"
-            />
-          </v-col>
-          <v-col cols="12" sm="6" md="4">
-            <label
-              for="select-department"
-              :class="{
-                'text-body-2': true,
-                'active-filter-label': !!filters.department.value,
-              }"
-            >
-              Département
-            </label>
-            <DsfrAutocomplete
-              v-model="filters.department.value"
-              :items="departments"
-              clearable
-              hide-details
-              id="select-department"
-              placeholder="Tous les départements"
-              class="mt-1"
-              auto-select-first
-              :filter="locationFilter"
-            />
-          </v-col>
-          <v-col cols="12" sm="6" md="4">
-            <label
-              for="select-commune"
-              :class="{
-                'text-body-2': true,
-                'active-filter-label': !!filters.city_insee_code.value,
-              }"
-            >
-              Commune
-            </label>
-            <CityField
-              :inseeCode.sync="filters.city_insee_code.value"
-              clearable
-              hide-details
-              id="select-commune"
-              placeholder="Toutes les communes"
-              class="mt-1"
-            />
-          </v-col>
-          <v-col cols="12" sm="6" md="4">
-            <label
-              for="select-sector"
-              :class="{
-                'text-body-2': true,
-                'active-filter-label': filters.sectors.value && !!filters.sectors.value.length,
-              }"
-            >
-              Secteur d'activité
-            </label>
-            <DsfrSelect
-              v-model="filters.sectors.value"
-              multiple
-              :items="sectors"
-              clearable
-              hide-details
-              id="select-sector"
-              placeholder="Tous les secteurs"
-              class="mt-1"
-            />
-          </v-col>
-          <v-col cols="12" sm="4" md="3">
-            <label
-              for="select-management-type"
-              :class="{ 'text-body-2': true, 'active-filter-label': !!filters.management_type.value }"
-            >
-              Mode de gestion
-            </label>
-            <DsfrSelect
-              v-model="filters.management_type.value"
-              :items="managementTypes"
-              clearable
-              hide-details
-              id="select-management-type"
-              class="mt-1"
-              placeholder="Tous les modes"
-            />
-          </v-col>
-          <v-col cols="12" sm="6" md="5">
-            <label
-              for="select-production-type"
-              :class="{ 'text-body-2': true, 'active-filter-label': !!filters.production_type.value }"
-            >
-              Type d'établissement
-            </label>
-            <DsfrSelect
-              v-model="filters.production_type.value"
-              :items="productionTypes"
-              clearable
-              hide-details
-              id="select-production-type"
-              class="mt-1"
-              placeholder="Tous les cantines"
-            />
-          </v-col>
-        </v-row>
-        <v-row class="align-end my-0">
-          <v-col cols="12" sm="8" md="6">
-            <fieldset>
-              <legend
+        <v-form>
+          <v-row class="mb-0">
+            <v-col cols="12" sm="6" md="4">
+              <label
+                for="select-region"
                 :class="{
                   'text-body-2': true,
-                  'active-filter-label': !!filters.min_portion_bio.value || !!filters.min_portion_combined.value,
+                  'active-filter-label': !!filters.region.value,
                 }"
               >
-                Dans les assiettes, part de...
-              </legend>
-              <div class="d-flex align-stretch mt-1">
-                <v-col class="pa-0 pr-1 d-flex flex-column">
-                  <DsfrTextField
-                    label="bio minimum"
-                    labelClasses="caption pl-1"
-                    :value="filters.min_portion_bio.value"
-                    ref="min_portion_bio"
-                    :rules="[validators.nonNegativeOrEmpty, validators.lteOrEmpty(100)]"
-                    @change="onChangeIntegerFilter('min_portion_bio')"
-                    hide-details="auto"
-                    append-icon="mdi-percent"
-                    placeholder="0"
-                    :hideOptional="true"
-                  />
-                </v-col>
-                <v-col class="pa-0 pl-1 d-flex flex-column">
-                  <DsfrTextField
-                    label="bio, qualité et durables min"
-                    labelClasses="caption pl-1"
-                    :value="filters.min_portion_combined.value"
-                    ref="min_portion_combined"
-                    :rules="[validators.nonNegativeOrEmpty, validators.lteOrEmpty(100)]"
-                    @change="onChangeIntegerFilter('min_portion_combined')"
-                    hide-details="auto"
-                    placeholder="0"
-                    append-icon="mdi-percent"
-                    :hideOptional="true"
-                  />
-                </v-col>
-              </div>
-            </fieldset>
-          </v-col>
-          <v-col cols="12" sm="4" md="3">
-            <fieldset>
-              <legend
+                Région
+              </label>
+              <DsfrAutocomplete
+                v-model="filters.region.value"
+                :items="regions"
+                clearable
+                hide-details
+                id="select-region"
+                placeholder="Toutes les régions"
+                class="mt-1"
+                auto-select-first
+                :filter="locationFilter"
+              />
+            </v-col>
+            <v-col cols="12" sm="6" md="4">
+              <label
+                for="select-department"
                 :class="{
                   'text-body-2': true,
-                  'active-filter-label': !!filters.min_daily_meal_count.value || !!filters.max_daily_meal_count.value,
+                  'active-filter-label': !!filters.department.value,
                 }"
               >
-                Repas par jour
-              </legend>
-              <div class="d-flex">
-                <div>
-                  <DsfrTextField
-                    label="Min"
-                    labelClasses="caption"
-                    :value="filters.min_daily_meal_count.value"
-                    ref="min_daily_meal_count"
-                    :rules="[validators.nonNegativeOrEmpty]"
-                    @change="onChangeIntegerFilter('min_daily_meal_count')"
-                    hide-details="auto"
-                    :hideOptional="true"
-                  />
+                Département
+              </label>
+              <DsfrAutocomplete
+                v-model="filters.department.value"
+                :items="departments"
+                clearable
+                hide-details
+                id="select-department"
+                placeholder="Tous les départements"
+                class="mt-1"
+                auto-select-first
+                :filter="locationFilter"
+              />
+            </v-col>
+            <v-col cols="12" sm="6" md="4">
+              <label
+                for="select-commune"
+                :class="{
+                  'text-body-2': true,
+                  'active-filter-label': !!filters.city_insee_code.value,
+                }"
+              >
+                Commune
+              </label>
+              <CityField
+                :inseeCode.sync="filters.city_insee_code.value"
+                clearable
+                hide-details
+                id="select-commune"
+                placeholder="Toutes les communes"
+                class="mt-1"
+              />
+            </v-col>
+            <v-col cols="12" sm="6" md="4">
+              <label
+                for="select-sector"
+                :class="{
+                  'text-body-2': true,
+                  'active-filter-label': filters.sectors.value && !!filters.sectors.value.length,
+                }"
+              >
+                Secteur d'activité
+              </label>
+              <DsfrSelect
+                v-model="filters.sectors.value"
+                multiple
+                :items="sectors"
+                clearable
+                hide-details
+                id="select-sector"
+                placeholder="Tous les secteurs"
+                class="mt-1"
+              />
+            </v-col>
+            <v-col cols="12" sm="4" md="3">
+              <label
+                for="select-management-type"
+                :class="{ 'text-body-2': true, 'active-filter-label': !!filters.management_type.value }"
+              >
+                Mode de gestion
+              </label>
+              <DsfrSelect
+                v-model="filters.management_type.value"
+                :items="managementTypes"
+                clearable
+                hide-details
+                id="select-management-type"
+                class="mt-1"
+                placeholder="Tous les modes"
+              />
+            </v-col>
+            <v-col cols="12" sm="6" md="5">
+              <label
+                for="select-production-type"
+                :class="{ 'text-body-2': true, 'active-filter-label': !!filters.production_type.value }"
+              >
+                Type d'établissement
+              </label>
+              <DsfrSelect
+                v-model="filters.production_type.value"
+                :items="productionTypes"
+                clearable
+                hide-details
+                id="select-production-type"
+                class="mt-1"
+                placeholder="Tous les cantines"
+              />
+            </v-col>
+          </v-row>
+          <v-row class="align-end my-0">
+            <v-col cols="12" sm="8" md="6">
+              <fieldset>
+                <legend
+                  :class="{
+                    'text-body-2': true,
+                    'active-filter-label': !!filters.min_portion_bio.value || !!filters.min_portion_combined.value,
+                  }"
+                >
+                  Dans les assiettes, part de...
+                </legend>
+                <div class="d-flex align-stretch mt-1">
+                  <v-col class="pa-0 pr-1 d-flex flex-column">
+                    <DsfrTextField
+                      label="bio minimum"
+                      labelClasses="caption pl-1"
+                      :value="filters.min_portion_bio.value"
+                      ref="min_portion_bio"
+                      :rules="[validators.nonNegativeOrEmpty, validators.lteOrEmpty(100)]"
+                      @change="onChangeIntegerFilter('min_portion_bio')"
+                      hide-details="auto"
+                      append-icon="mdi-percent"
+                      placeholder="0"
+                      :hideOptional="true"
+                    />
+                  </v-col>
+                  <v-col class="pa-0 pl-1 d-flex flex-column">
+                    <DsfrTextField
+                      label="bio, qualité et durables min"
+                      labelClasses="caption pl-1"
+                      :value="filters.min_portion_combined.value"
+                      ref="min_portion_combined"
+                      :rules="[validators.nonNegativeOrEmpty, validators.lteOrEmpty(100)]"
+                      @change="onChangeIntegerFilter('min_portion_combined')"
+                      hide-details="auto"
+                      placeholder="0"
+                      append-icon="mdi-percent"
+                      :hideOptional="true"
+                    />
+                  </v-col>
                 </div>
-                <span class="mx-2 align-self-center">-</span>
-                <div>
-                  <DsfrTextField
-                    label="Max"
-                    labelClasses="caption"
-                    :value="filters.max_daily_meal_count.value"
-                    ref="max_daily_meal_count"
-                    :rules="[validators.nonNegativeOrEmpty]"
-                    @change="onChangeIntegerFilter('max_daily_meal_count')"
-                    hide-details="auto"
-                    :hideOptional="true"
-                  />
+              </fieldset>
+            </v-col>
+            <v-col cols="12" sm="4" md="3">
+              <fieldset>
+                <legend
+                  :class="{
+                    'text-body-2': true,
+                    'active-filter-label': !!filters.min_daily_meal_count.value || !!filters.max_daily_meal_count.value,
+                  }"
+                >
+                  Repas par jour
+                </legend>
+                <div class="d-flex">
+                  <div>
+                    <DsfrTextField
+                      label="Min"
+                      labelClasses="caption"
+                      :value="filters.min_daily_meal_count.value"
+                      ref="min_daily_meal_count"
+                      :rules="[validators.nonNegativeOrEmpty]"
+                      @change="onChangeIntegerFilter('min_daily_meal_count')"
+                      hide-details="auto"
+                      :hideOptional="true"
+                    />
+                  </div>
+                  <span class="mx-2 align-self-center">-</span>
+                  <div>
+                    <DsfrTextField
+                      label="Max"
+                      labelClasses="caption"
+                      :value="filters.max_daily_meal_count.value"
+                      ref="max_daily_meal_count"
+                      :rules="[validators.nonNegativeOrEmpty]"
+                      @change="onChangeIntegerFilter('max_daily_meal_count')"
+                      hide-details="auto"
+                      :hideOptional="true"
+                    />
+                  </div>
                 </div>
-              </div>
-            </fieldset>
-          </v-col>
-        </v-row>
-        <v-row class="mt-0">
-          <v-col cols="12" sm="6" md="5">
-            <label for="select-badge" :class="{ 'text-body-2': true, 'active-filter-label': !!filters.badge.value }">
-              Mesure EGAlim réalisée
-            </label>
-            <DsfrSelect
-              v-model="filters.badge.value"
-              :items="badges"
-              clearable
-              hide-details
-              id="select-badge"
-              class="mt-1"
-              placeholder="Tous les cantines"
-            />
-          </v-col>
-        </v-row>
+              </fieldset>
+            </v-col>
+          </v-row>
+          <v-row class="mt-0">
+            <v-col cols="12" sm="6" md="5">
+              <label for="select-badge" :class="{ 'text-body-2': true, 'active-filter-label': !!filters.badge.value }">
+                Mesure EGAlim réalisée
+              </label>
+              <DsfrSelect
+                v-model="filters.badge.value"
+                :items="badges"
+                clearable
+                hide-details
+                id="select-badge"
+                class="mt-1"
+                placeholder="Tous les cantines"
+              />
+            </v-col>
+          </v-row>
+        </v-form>
       </v-sheet>
     </v-expand-transition>
     <div v-if="loading" class="pa-12">


### PR DESCRIPTION
Nos messages d'erreur pour les champs ne sont pas assez informatifs, car le lien entre le champ en erreur et le message n'est pas fait. Il y a deux solutions:

- ajouter le nom du champ dans le message d'erreur
- utiliser `aria-describedby` pour faire le lien entre le message et le champ. Dans ce cas faut aussi mettre `aria-invalid` sur le champ en erreur

J'ai opté pour la deuxième option car ça nécessite moins de changement du code et comportement visuel actuel.

Deuxième PR:

- [ ] copier le aria-invalid fonctionnalité aux autres champs de saisi
- [ ] appliquer les mêmes règles aux pages d'authentification
- [ ] Auditer l'utilisation de v-checkbox (refacto pour utiliser un composant, et après voir si besoin de ce changement aussi)