### PR TITLE
Bug fix : améliorer le message d'erreur avec un mauvais format du fichier import achatss

### DIFF
--- a/api/tests/files/corrupt_purchase_import.csv
+++ b/api/tests/files/corrupt_purchase_import.csv
@@ -1,0 +1,2 @@
+"cantine SIRET,""description"",""fournisseur"",""date"",""prix HT"",""famille"",""caractÃ©ristiques"",""definition de local"""
+"82399356058716,""weird formatting"",""Le bon traiteur"",""2022-05-02"",""90.11"",""PRODUITS_LAITIERS"",""LOCAL"",""REGION"""

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -166,6 +166,19 @@ class TestPurchaseImport(APITestCase):
         )
 
     @authenticate
+    def test_import_corrupt_purchases_file(self):
+        """
+        A reasonable error should be thrown
+        """
+        CanteenFactory.create(siret="82399356058716", managers=[authenticate.user])
+        with open("./api/tests/files/corrupt_purchase_import.csv") as purchase_file:
+            response = self.client.post(reverse("import_purchases"), {"file": purchase_file})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Purchase.objects.count(), 0)
+        errors = response.json()["errors"]
+        self.assertEqual(errors.pop(0)["message"], "Format fichier : 7-8 colonnes attendues, 1 trouvées.")
+
+    @authenticate
     def test_warn_duplicate_file(self):
         """
         Tests that the system will warn of duplicate file upload

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -136,6 +136,7 @@ class ImportPurchasesView(APIView):
 
         csvreader = csv.reader(io.StringIO("".join(chunk)), self.dialect)
         for row_number, row in enumerate(csvreader, start=1):
+            siret = None
             # If header, pass
             if row_number == 1 and row[0].lower().__contains__("siret"):
                 continue


### PR DESCRIPTION
Pris d'un exemple réel https://ma-cantine.agriculture.gouv.fr/admin/data/importfailure/2029/change/

closes #3672 