### PR TITLE
Admin, echec d'import : ajouter des filtres et recherche utilisateur et date

### DIFF
--- a/data/admin/importfailure.py
+++ b/data/admin/importfailure.py
@@ -13,3 +13,13 @@ class ImportFailureAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return True
+
+    search_fields = (
+        "user__first_name",
+        "user__last_name",
+        "user__email",
+        "user__username",
+        "creation_date",
+    )
+
+    list_filter = ["creation_date", "import_type"]


### PR DESCRIPTION
Pour rechercher par date, on pourrait mettre la date du format YYYY-MM-dd. C'est pas forcement très intuitif mais on pourrait expliquer à l'équipe ou l'utiliser nous mêmes. Je trouve le filtre pas très utile quand tu veux trouver un import d'il y a longtemps.
![Screenshot 2024-05-07 at 11-50-32 Sélectionnez l’objet échec d'import de masse à afficher Ma Cantine EGALIM - dev](https://github.com/betagouv/ma-cantine/assets/9282816/aa84f015-cdd6-46f6-8379-e9381e3a0c3b)
