### PR TITLE
:lady_beetle: Ajout du `resetValidation` dans les champs custom

### DIFF
--- a/frontend/src/components/DsfrCombobox.vue
+++ b/frontend/src/components/DsfrCombobox.vue
@@ -62,7 +62,7 @@ export default {
       return this.$refs["combobox"].validate()
     },
     resetValidation() {
-      return this.$refs["text-field"].resetValidation()
+      return this.$refs["combobox"].resetValidation()
     },
     assignInputId() {
       this.inputId = this.$refs?.["combobox"]?.$refs?.["input"].id

--- a/frontend/src/components/DsfrCombobox.vue
+++ b/frontend/src/components/DsfrCombobox.vue
@@ -61,6 +61,9 @@ export default {
     validate() {
       return this.$refs["combobox"].validate()
     },
+    resetValidation() {
+      return this.$refs["text-field"].resetValidation()
+    },
     assignInputId() {
       this.inputId = this.$refs?.["combobox"]?.$refs?.["input"].id
     },

--- a/frontend/src/components/DsfrCurrencyField.vue
+++ b/frontend/src/components/DsfrCurrencyField.vue
@@ -28,6 +28,9 @@ export default {
     validate() {
       return this.$refs["text-field"].validate()
     },
+    resetValidation() {
+      return this.$refs["text-field"].resetValidation()
+    },
   },
 }
 </script>

--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -103,6 +103,9 @@ export default {
       this.assignValidity()
       return result
     },
+    resetValidation() {
+      return this.$refs["radiogroup"].resetValidation()
+    },
     assignInputId() {
       this.inputId = this.$refs?.["radiogroup"]?.$refs?.["label"].id
     },

--- a/frontend/src/components/DsfrSearchField.vue
+++ b/frontend/src/components/DsfrSearchField.vue
@@ -47,6 +47,9 @@ export default {
     validate() {
       return this.$refs["text-field"].validate()
     },
+    resetValidation() {
+      return this.$refs["text-field"].resetValidation()
+    },
   },
 }
 </script>

--- a/frontend/src/components/DsfrSelect.vue
+++ b/frontend/src/components/DsfrSelect.vue
@@ -53,6 +53,9 @@ export default {
     validate() {
       return this.$refs["select"].validate()
     },
+    resetValidation() {
+      return this.$refs["select"].resetValidation()
+    },
     assignInputId() {
       this.inputId = this.$refs?.["select"]?.$refs?.["input"].id
     },

--- a/frontend/src/components/DsfrTextField.vue
+++ b/frontend/src/components/DsfrTextField.vue
@@ -86,6 +86,9 @@ export default {
     assignInputId() {
       this.inputId = this.$refs?.["text-field"]?.$refs?.["input"].id
     },
+    resetValidation() {
+      return this.$refs["text-field"].resetValidation()
+    },
   },
   mounted() {
     this.removeInnerLabel()

--- a/frontend/src/components/DsfrTextarea.vue
+++ b/frontend/src/components/DsfrTextarea.vue
@@ -69,6 +69,9 @@ export default {
       this.hasError = result !== true
       return result
     },
+    resetValidation() {
+      return this.$refs["textarea"].resetValidation()
+    },
     assignInputId() {
       this.inputId = this.$refs?.["textarea"]?.$refs?.["input"].id
     },


### PR DESCRIPTION
Cette erreur a été vu dans la page pour ajouter des achats lors qu'on cliquait sur "Valider et ajouter un nouveau" :

![image](https://github.com/betagouv/ma-cantine/assets/1225929/ebf5546d-11da-44db-b75e-d19a6f9d9edc)

La raison derrière est que nos composants custom n'ont pas surchargé la méthode `resetValidation`.

### Problème
 
1- Lors qu'on clique sur "Valider et ajouter un nouveau" on sauvegarde l'achat, et puis on reste dans la même page, mais avec le formulaire en blanc. Ça vient de ce bout de code : 
```javascript
if (!stayOnPage) this.$router.push({ name: "PurchasesHome" }).then(notify)
else {
      ...
      this.$refs.form.resetValidation()
      ...
}
```
2- La ligne `this.$refs.form.resetValidation()` itère sur les champs du formulaire et appelle `resetValidation` sur chaqu'un. Voici le code vuetify : 
```javascript
resetValidation () {
      this.inputs.forEach(input => input.resetValidation())
      this.resetErrorBag()
}
```
3- Lors que ça arrive à nos champs custom, `resetValidation` n'existe pas. Donc l'erreur est levée. 

### Solution

Simplement ajouter la méthode pour chaque champ custom et faire en sorte qu'elle fasse l'appel au composant pertinent.