### PR TITLE
Desactivation du bouton « comparer » lors qu'on n'a pas au moins deux ans de données

### DIFF
--- a/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
@@ -79,8 +79,6 @@ import EditableCommentsField from "../EditableCommentsField"
 import MultiYearSummaryStatistics from "@/components/MultiYearSummaryStatistics"
 import DsfrAccordion from "@/components/DsfrAccordion"
 
-const COMPARE_TAB = "Comparer"
-
 export default {
   name: "QualityMeasureResults",
   props: {
@@ -98,12 +96,21 @@ export default {
     DsfrAccordion,
   },
   data() {
-    const tabs = this.diagnosticSet.map((d) => +d.year)
+    const tabs = this.diagnosticSet.map((d) => ({
+      text: +d.year,
+      value: +d.year,
+      disabled: false,
+    }))
     tabs.sort((a, b) => b - a)
-    tabs.push(COMPARE_TAB)
+    const compareTab = {
+      text: "Comparer",
+      value: "Comparer",
+      disabled: tabs.length < 2,
+    }
+    tabs.push(compareTab)
     return {
       tabs,
-      tab: tabs[0],
+      tab: tabs[0].value,
     }
   },
   computed: {

--- a/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
@@ -143,7 +143,7 @@ export default {
       value: +d.year,
       disabled: false,
     }))
-    tabs.sort((a, b) => b - a)
+    tabs.sort((a, b) => b.value - a.value)
     const compareTab = {
       text: "Comparer",
       value: "Comparer",

--- a/frontend/src/components/DsfrSegmentedControl.vue
+++ b/frontend/src/components/DsfrSegmentedControl.vue
@@ -10,6 +10,7 @@
           :name="name"
           v-on:input="$emit('input', $event.target.value)"
           :checked="value === item.value"
+          :disabled="item.disabled"
         />
         <label class="fr-label" :for="`segmented-${item.value}`">{{ item.text }}</label>
       </div>
@@ -86,6 +87,11 @@ export default {
   position: absolute;
   width: 100%;
   z-index: -1;
+}
+.fr-segmented input:disabled + label {
+  --text-disabled-grey: rgb(146, 146, 146);
+  color: var(--text-disabled-grey);
+  cursor: not-allowed;
 }
 .fr-segmented input + label {
   align-items: center;


### PR DESCRIPTION
Closes #3892 
Lors qu'on a seulement un an de données :
![image](https://github.com/betagouv/ma-cantine/assets/1225929/e341ab03-7be8-477a-84ff-f5e397622a32)


Lors qu'on a au moins deux ans de données :
![image](https://github.com/betagouv/ma-cantine/assets/1225929/c1bee50e-205d-42a6-8cfd-959ef6da0186)
