### PR TITLE
Permet l'ajout des chiffres séparées par une virgule

### DIFF
--- a/api/tests/files/comma_separated_purchase_import.csv
+++ b/api/tests/files/comma_separated_purchase_import.csv
@@ -1,0 +1,2 @@
+canteen siret,description,fournisseur,date,prix HT,famille,caractéristiques,definition de local
+82399356058716,"Pommes, rouges",Le bon traiteur ,2022-05-02,"90,11", PRODUITS_LAITIERS ,"BIO, LOCAL", DEPARTMENT

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -47,6 +47,19 @@ class TestPurchaseImport(APITestCase):
         self.assertEqual(Purchase.objects.first().import_source, filehash_md5)
 
     @authenticate
+    def test_import_comma_separated_numbers(self):
+        """
+        Tests that can import a file with comma-separated numbers
+        """
+        CanteenFactory.create(siret="82399356058716", managers=[authenticate.user])
+        with open("./api/tests/files/comma_separated_purchase_import.csv") as purchase_file:
+            response = self.client.post(reverse("import_purchases"), {"file": purchase_file})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Purchase.objects.count(), 1)
+        purchase = Purchase.objects.filter(description="Pommes, rouges").first()
+        self.assertEqual(purchase.price_ht, Decimal("90.11"))
+
+    @authenticate
     def test_import_with_no_local_definition(self):
         """
         Tests that can import a file without local definition

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -177,7 +177,7 @@ class ImportPurchasesView(APIView):
         if date == "":
             raise ValidationError({"date": "La date ne peut pas être vide"})
 
-        price = row.pop(0).strip()
+        price = row.pop(0).strip().replace(",", ".")
         if price == "":
             raise ValidationError({"price_ht": "Le prix ne peut pas être vide"})
 


### PR DESCRIPTION
Ceci uniformise les chiffres entre l'import des bilans et celui des achats.