### PR TITLE
Bug fix : quand on filtre les cantines publiées, inclure les satellites qui ont un CC diagnostic quand on filtre sur les données appro

### DIFF
--- a/api/tests/test_published_canteens.py
+++ b/api/tests/test_published_canteens.py
@@ -379,13 +379,8 @@ class TestPublishedCanteenApi(APITestCase):
         guadeloupe_canteen = CanteenFactory.create(
             publication_status=Canteen.PublicationStatus.PUBLISHED, region=Region.guadeloupe, name="Guadeloupe"
         )
+
         publication_year = date.today().year - 1
-        # redacted_good_canteen = CanteenFactory.create(
-        #     publication_status=Canteen.PublicationStatus.PUBLISHED,
-        #     name="Redacted",
-        #     region=Region.auvergne_rhone_alpes,
-        #     redacted_appro_years=[publication_year],
-        # )
 
         DiagnosticFactory.create(
             canteen=good_canteen,
@@ -414,15 +409,6 @@ class TestPublishedCanteenApi(APITestCase):
             value_externality_performance_ht=0,
             value_egalim_others_ht=0,
         )
-        # DiagnosticFactory.create(
-        #     canteen=redacted_good_canteen,
-        #     year=publication_year,
-        #     value_total_ht=100,
-        #     value_bio_ht=30,
-        #     value_sustainable_ht=30,
-        #     value_externality_performance_ht=0,
-        #     value_egalim_others_ht=0,
-        # )
         DiagnosticFactory.create(
             canteen=medium_canteen,
             year=publication_year,

--- a/api/tests/test_published_canteens.py
+++ b/api/tests/test_published_canteens.py
@@ -345,9 +345,24 @@ class TestPublishedCanteenApi(APITestCase):
     def test_filter_appro_values(self):
         """
         Should be able to filter by bio %, sustainable %, combined % based on last year's diagnostic
+        and based on the rules for their region
         """
         good_canteen = CanteenFactory.create(
             publication_status="published", name="Shiso", region=Region.auvergne_rhone_alpes
+        )
+        central = CanteenFactory.create(
+            publication_status="draft",
+            name="Central",
+            region=Region.auvergne_rhone_alpes,
+            production_type=Canteen.ProductionType.CENTRAL,
+            siret="22730656663081",
+        )
+        CanteenFactory.create(
+            publication_status="published",
+            name="Satellite",
+            region=Region.auvergne_rhone_alpes,
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+            central_producer_siret="22730656663081",
         )
         medium_canteen = CanteenFactory.create(
             publication_status="published", name="Wasabi", region=Region.auvergne_rhone_alpes
@@ -364,10 +379,25 @@ class TestPublishedCanteenApi(APITestCase):
         guadeloupe_canteen = CanteenFactory.create(
             publication_status=Canteen.PublicationStatus.PUBLISHED, region=Region.guadeloupe, name="Guadeloupe"
         )
-
         publication_year = date.today().year - 1
+        # redacted_good_canteen = CanteenFactory.create(
+        #     publication_status=Canteen.PublicationStatus.PUBLISHED,
+        #     name="Redacted",
+        #     region=Region.auvergne_rhone_alpes,
+        #     redacted_appro_years=[publication_year],
+        # )
+
         DiagnosticFactory.create(
             canteen=good_canteen,
+            year=publication_year,
+            value_total_ht=100,
+            value_bio_ht=30,
+            value_sustainable_ht=10,
+            value_externality_performance_ht=10,
+            value_egalim_others_ht=10,
+        )
+        DiagnosticFactory.create(
+            canteen=central,
             year=publication_year,
             value_total_ht=100,
             value_bio_ht=30,
@@ -384,6 +414,15 @@ class TestPublishedCanteenApi(APITestCase):
             value_externality_performance_ht=0,
             value_egalim_others_ht=0,
         )
+        # DiagnosticFactory.create(
+        #     canteen=redacted_good_canteen,
+        #     year=publication_year,
+        #     value_total_ht=100,
+        #     value_bio_ht=30,
+        #     value_sustainable_ht=30,
+        #     value_externality_performance_ht=0,
+        #     value_egalim_others_ht=0,
+        # )
         DiagnosticFactory.create(
             canteen=medium_canteen,
             year=publication_year,
@@ -432,50 +471,56 @@ class TestPublishedCanteenApi(APITestCase):
         url = f"{reverse('published_canteens')}?min_portion_bio={0.2}"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
+        self.assertIn("Satellite", result_names)
 
         url = f"{reverse('published_canteens')}?min_portion_combined={0.5}"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 4)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
+        self.assertIn("Satellite", result_names)
         self.assertIn("Wasabi", result_names)
         self.assertIn("Umami", result_names)
 
         url = f"{reverse('published_canteens')}?min_portion_bio={0.1}&min_portion_combined={0.5}"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
+        self.assertIn("Satellite", result_names)
         self.assertIn("Wasabi", result_names)
 
         url = f"{reverse('published_canteens')}?badge=appro"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
+        self.assertIn("Satellite", result_names)
         self.assertIn("Guadeloupe", result_names)
 
         # if both badge and thresholds specified, return the results that match the most strict threshold
         url = f"{reverse('published_canteens')}?badge=appro&min_portion_combined={0.01}"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
+        self.assertIn("Satellite", result_names)
         self.assertIn("Guadeloupe", result_names)
 
         url = f"{reverse('published_canteens')}?badge=appro&min_portion_combined={0.5}"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
+        self.assertIn("Satellite", result_names)
 
     def test_pagination_departments(self):
         CanteenFactory.create(publication_status="published", department="75", name="Shiso")

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -238,7 +238,8 @@ def filter_by_diagnostic_params(queryset, query_params):
                 )
             ).distinct()
         canteen_ids = qs_diag.values_list("canteen", flat=True)
-        return queryset.filter(id__in=canteen_ids)
+        canteen_sirets = qs_diag.values_list("canteen__siret", flat=True)
+        return queryset.filter(Q(id__in=canteen_ids) | Q(central_producer_siret__in=canteen_sirets))
     return queryset
 
 


### PR DESCRIPTION
Avant:
![Screenshot 2024-05-16 at 15-39-44 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/1e898656-f66e-4105-b2e7-8516591911aa)


Après ("Callisto" est un satellite):

![Screenshot 2024-05-16 at 15-39-20 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/a696b584-0399-466c-acd3-20c298a9ee01)

