### PR TITLE
Possibilité de chercher des éléments avec ou sans accent

### DIFF
--- a/frontend/src/components/DsfrAutocomplete.vue
+++ b/frontend/src/components/DsfrAutocomplete.vue
@@ -17,6 +17,7 @@
       auto-select-first
       :search-input.sync="searchInput"
       @change="searchInput = ''"
+      :filter="unaccentedFilter"
     >
       <template v-slot:label><span></span></template>
 
@@ -29,6 +30,7 @@
 </template>
 
 <script>
+import { normaliseText } from "@/utils"
 export default {
   inheritAttrs: false,
   props: {
@@ -56,6 +58,11 @@ export default {
     },
     assignInputId() {
       this.inputId = this.$refs?.["autocomplete"]?.$refs?.["input"].id
+    },
+    unaccentedFilter(item, queryText, itemText) {
+      const normalizedQueryText = normaliseText(queryText).toLocaleLowerCase()
+      const normalizedItemText = normaliseText(itemText).toLocaleLowerCase()
+      return normalizedItemText.indexOf(normalizedQueryText) > -1
     },
   },
   mounted() {


### PR DESCRIPTION
La fonction par défaut de `filter` (de `v-autocomplete`) ne considère les match que si le string est identique. Avec une fonction custom on peut ignorer les accents.

Avant : 
![image](https://github.com/betagouv/ma-cantine/assets/1225929/0d55edac-2a49-4429-a5d6-852be5bb8119)

Après :
![image](https://github.com/betagouv/ma-cantine/assets/1225929/d4ec745e-7d43-4d79-b41d-096e89dc73ca)
