### PR TITLE
Affiche, appro : publier les données d'achats pour l'année en cours, avec l'option de dépublier

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -34,7 +34,12 @@ from .blogpost import BlogPostSerializer  # noqa: F401
 from .password import PasswordSerializer  # noqa: F401
 from .managerinvitation import ManagerInvitationSerializer  # noqa: F401
 from .teledeclaration import ShortTeledeclarationSerializer  # noqa: F401
-from .purchase import PurchaseSerializer, PurchaseSummarySerializer, PurchaseExportSerializer  # noqa: F401
+from .purchase import (  # noqa: F401
+    PurchaseSerializer,
+    PurchaseSummarySerializer,
+    PurchasePercentageSummarySerializer,
+    PurchaseExportSerializer,
+)
 from .reservationexpe import ReservationExpeSerializer  # noqa: F401
 from .vegetarianexpe import VegetarianExpeSerializer  # noqa: F401
 from .message import MessageSerializer  # noqa: F401

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from data.models import Diagnostic
 from decimal import Decimal, InvalidOperation
 from .teledeclaration import ShortTeledeclarationSerializer
+from .utils import appro_to_percentages, COMPLETE_APPRO_FIELDS
 
 logger = logging.getLogger(__name__)
 
@@ -17,124 +18,6 @@ SIMPLE_APPRO_FIELDS = (
     "value_meat_poultry_france_ht",
     "value_fish_ht",
     "value_fish_egalim_ht",
-)
-
-COMPLETE_APPRO_FIELDS = (
-    "value_total_ht",
-    "value_meat_poultry_ht",
-    "value_fish_ht",
-    "value_viandes_volailles_bio",
-    "value_produits_de_la_mer_bio",
-    "value_fruits_et_legumes_bio",
-    "value_charcuterie_bio",
-    "value_produits_laitiers_bio",
-    "value_boulangerie_bio",
-    "value_boissons_bio",
-    "value_autres_bio",
-    "value_viandes_volailles_label_rouge",
-    "value_produits_de_la_mer_label_rouge",
-    "value_fruits_et_legumes_label_rouge",
-    "value_charcuterie_label_rouge",
-    "value_produits_laitiers_label_rouge",
-    "value_boulangerie_label_rouge",
-    "value_boissons_label_rouge",
-    "value_autres_label_rouge",
-    "value_viandes_volailles_aocaop_igp_stg",
-    "value_produits_de_la_mer_aocaop_igp_stg",
-    "value_fruits_et_legumes_aocaop_igp_stg",
-    "value_charcuterie_aocaop_igp_stg",
-    "value_produits_laitiers_aocaop_igp_stg",
-    "value_boulangerie_aocaop_igp_stg",
-    "value_boissons_aocaop_igp_stg",
-    "value_autres_aocaop_igp_stg",
-    "value_viandes_volailles_hve",
-    "value_produits_de_la_mer_hve",
-    "value_fruits_et_legumes_hve",
-    "value_charcuterie_hve",
-    "value_produits_laitiers_hve",
-    "value_boulangerie_hve",
-    "value_boissons_hve",
-    "value_autres_hve",
-    "value_viandes_volailles_peche_durable",
-    "value_produits_de_la_mer_peche_durable",
-    "value_fruits_et_legumes_peche_durable",
-    "value_charcuterie_peche_durable",
-    "value_produits_laitiers_peche_durable",
-    "value_boulangerie_peche_durable",
-    "value_boissons_peche_durable",
-    "value_autres_peche_durable",
-    "value_viandes_volailles_rup",
-    "value_produits_de_la_mer_rup",
-    "value_fruits_et_legumes_rup",
-    "value_charcuterie_rup",
-    "value_produits_laitiers_rup",
-    "value_boulangerie_rup",
-    "value_boissons_rup",
-    "value_autres_rup",
-    "value_viandes_volailles_fermier",
-    "value_produits_de_la_mer_fermier",
-    "value_fruits_et_legumes_fermier",
-    "value_charcuterie_fermier",
-    "value_produits_laitiers_fermier",
-    "value_boulangerie_fermier",
-    "value_boissons_fermier",
-    "value_autres_fermier",
-    "value_viandes_volailles_externalites",
-    "value_produits_de_la_mer_externalites",
-    "value_fruits_et_legumes_externalites",
-    "value_charcuterie_externalites",
-    "value_produits_laitiers_externalites",
-    "value_boulangerie_externalites",
-    "value_boissons_externalites",
-    "value_autres_externalites",
-    "value_viandes_volailles_commerce_equitable",
-    "value_produits_de_la_mer_commerce_equitable",
-    "value_fruits_et_legumes_commerce_equitable",
-    "value_charcuterie_commerce_equitable",
-    "value_produits_laitiers_commerce_equitable",
-    "value_boulangerie_commerce_equitable",
-    "value_boissons_commerce_equitable",
-    "value_autres_commerce_equitable",
-    "value_viandes_volailles_performance",
-    "value_produits_de_la_mer_performance",
-    "value_fruits_et_legumes_performance",
-    "value_charcuterie_performance",
-    "value_produits_laitiers_performance",
-    "value_boulangerie_performance",
-    "value_boissons_performance",
-    "value_autres_performance",
-    "value_viandes_volailles_non_egalim",
-    "value_produits_de_la_mer_non_egalim",
-    "value_fruits_et_legumes_non_egalim",
-    "value_charcuterie_non_egalim",
-    "value_produits_laitiers_non_egalim",
-    "value_boulangerie_non_egalim",
-    "value_boissons_non_egalim",
-    "value_autres_non_egalim",
-    "value_viandes_volailles_france",
-    "value_produits_de_la_mer_france",
-    "value_fruits_et_legumes_france",
-    "value_charcuterie_france",
-    "value_produits_laitiers_france",
-    "value_boulangerie_france",
-    "value_boissons_france",
-    "value_autres_france",
-    "value_viandes_volailles_short_distribution",
-    "value_produits_de_la_mer_short_distribution",
-    "value_fruits_et_legumes_short_distribution",
-    "value_charcuterie_short_distribution",
-    "value_produits_laitiers_short_distribution",
-    "value_boulangerie_short_distribution",
-    "value_boissons_short_distribution",
-    "value_autres_short_distribution",
-    "value_viandes_volailles_local",
-    "value_produits_de_la_mer_local",
-    "value_fruits_et_legumes_local",
-    "value_charcuterie_local",
-    "value_produits_laitiers_local",
-    "value_boulangerie_local",
-    "value_boissons_local",
-    "value_autres_local",
 )
 
 NON_APPRO_FIELDS = (
@@ -195,51 +78,6 @@ TUNNEL_PROGRESS_FIELDS = (
 )
 
 FIELDS = META_FIELDS + SIMPLE_APPRO_FIELDS + COMPLETE_APPRO_FIELDS + NON_APPRO_FIELDS
-
-
-def appro_to_percentages(representation, instance):
-    # first do the percentages relative to meat and fish totals
-    # not removing these totals so that can then calculate the percent of those compared to global total
-    meat_total = representation.get("value_meat_poultry_ht")
-    if meat_total:
-        field = "value_meat_poultry_egalim_ht"
-        value = representation.get(field)
-        if value:
-            representation[f"percentage_{field}"] = value / meat_total
-        field = "value_meat_poultry_france_ht"
-        value = representation.get(field)
-        if value:
-            representation[f"percentage_{field}"] = value / meat_total
-
-    fish_total = representation.get("value_fish_ht")
-    if fish_total:
-        field = "value_fish_egalim_ht"
-        value = representation.get(field)
-        if value:
-            representation[f"percentage_{field}"] = value / fish_total
-
-    appro_field = (
-        "value_total_ht",
-        "value_bio_ht",
-        "value_sustainable_ht",
-        "value_externality_performance_ht",
-        "value_egalim_others_ht",
-    ) + COMPLETE_APPRO_FIELDS  # meat and fish totals included in COMPLETE
-    total = instance.value_total_ht
-
-    for field in appro_field:
-        new_field_name = f"percentage_{field}"
-        if representation.get(field):
-            representation[new_field_name] = representation[field] / total if total else None
-        representation.pop(field, None)
-
-    representation["percentage_value_total_ht"] = 1
-    representation.pop("value_total_ht", None)
-    representation.pop("value_meat_poultry_egalim_ht", None)
-    representation.pop("value_meat_poultry_france_ht", None)
-    representation.pop("value_fish_egalim_ht", None)
-
-    return representation
 
 
 class DiagnosticSerializer(serializers.ModelSerializer):

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -175,6 +175,8 @@ class PurchaseSummarySerializer(serializers.Serializer):
 
 
 class PurchasePercentageSummarySerializer(PurchaseSummarySerializer):
+    last_purchase_date = serializers.DateField()
+
     def to_representation(self, instance):
         representation = super().to_representation(instance)
         return appro_to_percentages(representation, instance)

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -47,8 +47,6 @@ class PurchaseField(serializers.DecimalField):
 
 # NB: these names reflect the names in the diagnostic model
 class PurchaseSummarySerializer(serializers.Serializer):
-    year = serializers.IntegerField()
-    modification_date = serializers.DateField(required=False)
     value_total_ht = PurchaseField()
     value_bio_ht = PurchaseField()
     value_sustainable_ht = PurchaseField()

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -47,6 +47,8 @@ class PurchaseField(serializers.DecimalField):
 
 # NB: these names reflect the names in the diagnostic model
 class PurchaseSummarySerializer(serializers.Serializer):
+    year = serializers.IntegerField()
+    modification_date = serializers.DateField(required=False)
     value_total_ht = PurchaseField()
     value_bio_ht = PurchaseField()
     value_sustainable_ht = PurchaseField()

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from data.models import Purchase
 from drf_base64.fields import Base64FileField
+from .utils import appro_to_percentages
 
 
 class PurchaseSerializer(serializers.ModelSerializer):
@@ -171,6 +172,12 @@ class PurchaseSummarySerializer(serializers.Serializer):
     value_boulangerie_non_egalim = PurchaseField()
     value_boissons_non_egalim = PurchaseField()
     value_autres_non_egalim = PurchaseField()
+
+
+class PurchasePercentageSummarySerializer(PurchaseSummarySerializer):
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        return appro_to_percentages(representation, instance)
 
 
 class PurchaseExportSerializer(serializers.ModelSerializer):

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -175,7 +175,7 @@ class PurchaseSummarySerializer(serializers.Serializer):
 
 
 class PurchasePercentageSummarySerializer(PurchaseSummarySerializer):
-    last_purchase_date = serializers.DateField()
+    last_purchase_date = serializers.DateField(required=False)
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)

--- a/api/serializers/utils.py
+++ b/api/serializers/utils.py
@@ -1,0 +1,162 @@
+def appro_to_percentages(representation, instance):
+    # first do the percentages relative to meat and fish totals
+    # not removing these totals so that can then calculate the percent of those compared to global total
+    meat_total = representation.get("value_meat_poultry_ht")
+    if meat_total:
+        field = "value_meat_poultry_egalim_ht"
+        value = representation.get(field)
+        if value:
+            representation[f"percentage_{field}"] = value / meat_total
+        field = "value_meat_poultry_france_ht"
+        value = representation.get(field)
+        if value:
+            representation[f"percentage_{field}"] = value / meat_total
+
+    fish_total = representation.get("value_fish_ht")
+    if fish_total:
+        field = "value_fish_egalim_ht"
+        value = representation.get(field)
+        if value:
+            representation[f"percentage_{field}"] = value / fish_total
+
+    appro_field = (
+        "value_total_ht",
+        "value_bio_ht",
+        "value_sustainable_ht",
+        "value_externality_performance_ht",
+        "value_egalim_others_ht",
+    ) + COMPLETE_APPRO_FIELDS  # meat and fish totals included in COMPLETE
+    total = representation.get("value_total_ht")
+
+    for field in appro_field:
+        new_field_name = f"percentage_{field}"
+        if representation.get(field):
+            representation[new_field_name] = representation[field] / total if total else None
+        representation.pop(field, None)
+
+    representation["percentage_value_total_ht"] = 1
+    representation.pop("value_total_ht", None)
+    representation.pop("value_meat_poultry_egalim_ht", None)
+    representation.pop("value_meat_poultry_france_ht", None)
+    representation.pop("value_fish_egalim_ht", None)
+
+    return representation
+
+
+COMPLETE_APPRO_FIELDS = (
+    "value_total_ht",
+    "value_meat_poultry_ht",
+    "value_fish_ht",
+    "value_viandes_volailles_bio",
+    "value_produits_de_la_mer_bio",
+    "value_fruits_et_legumes_bio",
+    "value_charcuterie_bio",
+    "value_produits_laitiers_bio",
+    "value_boulangerie_bio",
+    "value_boissons_bio",
+    "value_autres_bio",
+    "value_viandes_volailles_label_rouge",
+    "value_produits_de_la_mer_label_rouge",
+    "value_fruits_et_legumes_label_rouge",
+    "value_charcuterie_label_rouge",
+    "value_produits_laitiers_label_rouge",
+    "value_boulangerie_label_rouge",
+    "value_boissons_label_rouge",
+    "value_autres_label_rouge",
+    "value_viandes_volailles_aocaop_igp_stg",
+    "value_produits_de_la_mer_aocaop_igp_stg",
+    "value_fruits_et_legumes_aocaop_igp_stg",
+    "value_charcuterie_aocaop_igp_stg",
+    "value_produits_laitiers_aocaop_igp_stg",
+    "value_boulangerie_aocaop_igp_stg",
+    "value_boissons_aocaop_igp_stg",
+    "value_autres_aocaop_igp_stg",
+    "value_viandes_volailles_hve",
+    "value_produits_de_la_mer_hve",
+    "value_fruits_et_legumes_hve",
+    "value_charcuterie_hve",
+    "value_produits_laitiers_hve",
+    "value_boulangerie_hve",
+    "value_boissons_hve",
+    "value_autres_hve",
+    "value_viandes_volailles_peche_durable",
+    "value_produits_de_la_mer_peche_durable",
+    "value_fruits_et_legumes_peche_durable",
+    "value_charcuterie_peche_durable",
+    "value_produits_laitiers_peche_durable",
+    "value_boulangerie_peche_durable",
+    "value_boissons_peche_durable",
+    "value_autres_peche_durable",
+    "value_viandes_volailles_rup",
+    "value_produits_de_la_mer_rup",
+    "value_fruits_et_legumes_rup",
+    "value_charcuterie_rup",
+    "value_produits_laitiers_rup",
+    "value_boulangerie_rup",
+    "value_boissons_rup",
+    "value_autres_rup",
+    "value_viandes_volailles_fermier",
+    "value_produits_de_la_mer_fermier",
+    "value_fruits_et_legumes_fermier",
+    "value_charcuterie_fermier",
+    "value_produits_laitiers_fermier",
+    "value_boulangerie_fermier",
+    "value_boissons_fermier",
+    "value_autres_fermier",
+    "value_viandes_volailles_externalites",
+    "value_produits_de_la_mer_externalites",
+    "value_fruits_et_legumes_externalites",
+    "value_charcuterie_externalites",
+    "value_produits_laitiers_externalites",
+    "value_boulangerie_externalites",
+    "value_boissons_externalites",
+    "value_autres_externalites",
+    "value_viandes_volailles_commerce_equitable",
+    "value_produits_de_la_mer_commerce_equitable",
+    "value_fruits_et_legumes_commerce_equitable",
+    "value_charcuterie_commerce_equitable",
+    "value_produits_laitiers_commerce_equitable",
+    "value_boulangerie_commerce_equitable",
+    "value_boissons_commerce_equitable",
+    "value_autres_commerce_equitable",
+    "value_viandes_volailles_performance",
+    "value_produits_de_la_mer_performance",
+    "value_fruits_et_legumes_performance",
+    "value_charcuterie_performance",
+    "value_produits_laitiers_performance",
+    "value_boulangerie_performance",
+    "value_boissons_performance",
+    "value_autres_performance",
+    "value_viandes_volailles_non_egalim",
+    "value_produits_de_la_mer_non_egalim",
+    "value_fruits_et_legumes_non_egalim",
+    "value_charcuterie_non_egalim",
+    "value_produits_laitiers_non_egalim",
+    "value_boulangerie_non_egalim",
+    "value_boissons_non_egalim",
+    "value_autres_non_egalim",
+    "value_viandes_volailles_france",
+    "value_produits_de_la_mer_france",
+    "value_fruits_et_legumes_france",
+    "value_charcuterie_france",
+    "value_produits_laitiers_france",
+    "value_boulangerie_france",
+    "value_boissons_france",
+    "value_autres_france",
+    "value_viandes_volailles_short_distribution",
+    "value_produits_de_la_mer_short_distribution",
+    "value_fruits_et_legumes_short_distribution",
+    "value_charcuterie_short_distribution",
+    "value_produits_laitiers_short_distribution",
+    "value_boulangerie_short_distribution",
+    "value_boissons_short_distribution",
+    "value_autres_short_distribution",
+    "value_viandes_volailles_local",
+    "value_produits_de_la_mer_local",
+    "value_fruits_et_legumes_local",
+    "value_charcuterie_local",
+    "value_produits_laitiers_local",
+    "value_boulangerie_local",
+    "value_boissons_local",
+    "value_autres_local",
+)

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -1175,9 +1175,23 @@ class TestPublicPurchasesSummaryApi(APITestCase):
         PurchaseFactory.create(canteen=canteen, date="2024-01-01")
         response = self.client.get(
             reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}),
-            {"year": 2024, "ignoreRedaction": True},
+            {"year": 2024, "ignoreRedaction": "true"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @authenticate
+    def test_manager_can_optionally_not_get_redacted_purchases(self):
+        """
+        The manager of the canteen has an option to not get redacted data
+        """
+        canteen = CanteenFactory.create(redacted_appro_years=[2024])
+        canteen.managers.add(authenticate.user)
+        PurchaseFactory.create(canteen=canteen, date="2024-01-01")
+        response = self.client.get(
+            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}),
+            {"year": 2024, "ignoreRedaction": "false"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_non_manager_cannot_optionally_get_redacted_purchases(self):
@@ -1188,7 +1202,7 @@ class TestPublicPurchasesSummaryApi(APITestCase):
         PurchaseFactory.create(canteen=canteen, date="2024-01-01")
         response = self.client.get(
             reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}),
-            {"year": 2024, "ignoreRedaction": True},
+            {"year": 2024, "ignoreRedaction": "true"},
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -1200,6 +1214,6 @@ class TestPublicPurchasesSummaryApi(APITestCase):
         PurchaseFactory.create(canteen=canteen, date="2024-01-01")
         response = self.client.get(
             reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}),
-            {"year": 2024, "ignoreRedaction": True},
+            {"year": 2024, "ignoreRedaction": "true"},
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -676,7 +676,18 @@ class TestPurchaseApi(APITestCase):
         The purchases summary should return the last purchase date if the user
         is the manager of the canteen
         """
-        pass
+        canteen = CanteenFactory.create()
+        canteen.managers.add(authenticate.user)
+
+        PurchaseFactory.create(canteen=canteen, date="2024-12-01")
+        PurchaseFactory.create(canteen=canteen, date="2024-05-31")
+        PurchaseFactory.create(canteen=canteen, date="2025-01-01")
+
+        response = self.client.get(
+            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
+        )
+        body = response.json()
+        self.assertEqual(body["lastPurchaseDate"], "2024-12-01")
 
     @authenticate
     def test_dont_get_last_purchase_date_in_public_summary_if_not_manager(self):

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -695,7 +695,14 @@ class TestPurchaseApi(APITestCase):
         The purchases summary should not return the last purchase date if the user
         is not the manager of the canteen, even if authenticated
         """
-        pass
+        canteen = CanteenFactory.create()
+        PurchaseFactory.create(canteen=canteen, date="2024-05-31")
+
+        response = self.client.get(
+            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
+        )
+        body = response.json()
+        self.assertNotIn("lastPurchaseDate", body)
 
     @authenticate
     def test_delete_purchase(self):

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -649,9 +649,21 @@ class TestPurchaseApi(APITestCase):
 
     def test_cannot_get_redacted_purchases_summary(self):
         """
-        If the canteen has redacted the year return a 400
+        If the canteen has redacted the year return a 404
+        TODO: do we really want to use redacted_appro_years to control this?
         """
-        pass
+        canteen = CanteenFactory.create(redacted_appro_years=[2024])
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-01-01",
+            characteristics=[Purchase.Characteristic.BIO],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=100,
+        )
+        response = self.client.get(
+            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_no_purchases_for_public_summary(self):
         """

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -559,6 +559,122 @@ class TestPurchaseApi(APITestCase):
         self.assertEquals(body["results"][1]["year"], 2021)
         self.assertEquals(body["results"][1]["valueTotalHt"], 450)
 
+    def test_get_public_purchases_summary(self):
+        """
+        Return percentages from purchase data for the given year and canteen
+        """
+        canteen = CanteenFactory.create()
+        year = 2024
+
+        # bio percent, ignore lesser labels
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-01-01",
+            characteristics=[Purchase.Characteristic.BIO, Purchase.Characteristic.LABEL_ROUGE],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=10,
+        )
+        # sustainable percent, meat egalim
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-01-01",
+            characteristics=[Purchase.Characteristic.LABEL_ROUGE],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=10,
+        )
+        # externalities percent, meat egalim, meat france
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-01-01",
+            characteristics=[Purchase.Characteristic.EXTERNALITES, Purchase.Characteristic.FRANCE],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=10,
+        )
+        # egalim others, fish egalim
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-01-01",
+            characteristics=[Purchase.Characteristic.PECHE_DURABLE],
+            family=Purchase.Family.PRODUITS_DE_LA_MER,
+            price_ht=10,
+        )
+        # meat france (local and short_distribution not included?)
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-12-31",
+            characteristics=[Purchase.Characteristic.FRANCE],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=10,
+        )
+        # fish non egalim
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-12-31",
+            characteristics=[Purchase.Characteristic.FRANCE],
+            family=Purchase.Family.PRODUITS_DE_LA_MER,
+            price_ht=10,
+        )
+        # add misc purchase to have nice round total of 100 HT
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-12-31",
+            characteristics=[],
+            family=Purchase.Family.AUTRES,
+            price_ht=40,
+        )
+
+        # create purchase outside of requested year to check filtering
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2023-12-31",
+            characteristics=[Purchase.Characteristic.BIO],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=999999,
+        )
+
+        response = self.client.get(
+            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": year}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+
+        self.assertEqual(body["percentageValueBioHt"], 0.1)
+        self.assertEqual(body["percentageValueSustainableHt"], 0.1)
+        self.assertEqual(body["percentageValueExternalityPerformanceHt"], 0.1)
+        self.assertEqual(body["percentageValueEgalimOthersHt"], 0.1)
+        # 30 HT, meat total is 40.
+        self.assertEqual(body["percentageValueMeatPoultryEgalimHt"], 0.75)
+        self.assertEqual(body["percentageValueMeatPoultryFranceHt"], 0.5)
+        self.assertEqual(body["percentageValueFishEgalimHt"], 0.5)
+
+    def test_cannot_get_redacted_purchases_summary(self):
+        """
+        If the canteen has redacted the year return a 400
+        """
+        pass
+
+    def test_no_purchases_for_public_summary(self):
+        """
+        If the canteen doesn't have purchases for the year requested return a 400
+        """
+        pass
+
+    @authenticate
+    def test_get_last_purchase_date_in_public_summary_if_manager(self):
+        """
+        The purchases summary should return the last purchase date if the user
+        is the manager of the canteen
+        """
+        pass
+
+    @authenticate
+    def test_dont_get_last_purchase_date_in_public_summary_if_not_manager(self):
+        """
+        The purchases summary should not return the last purchase date if the user
+        is not the manager of the canteen, even if authenticated
+        """
+        pass
+
     @authenticate
     def test_delete_purchase(self):
         """
@@ -924,6 +1040,7 @@ class TestPurchaseApi(APITestCase):
             family=Purchase.Family.BOISSONS,
             characteristics=[Purchase.Characteristic.AOCAOP],
         )
+        # TODO: would be nice to double check the AOCAOP IGP STG aggregation vs other labels
         PurchaseFactory.create(
             canteen=canteen_site,
             date="2021-12-31",
@@ -954,6 +1071,7 @@ class TestPurchaseApi(APITestCase):
         diag_site = Diagnostic.objects.get(year=year, canteen=canteen_site)
         self.assertIn(diag_site.id, results)
         self.assertEqual(diag_site.value_total_ht, 200)
+        # TODO: would be nice to test the aggregation for a simple value (e.g. value_sustainable_ht)
         self.assertEqual(diag_site.value_boissons_aocaop_igp_stg, 50)
         self.assertEqual(diag_site.value_boulangerie_non_egalim, 150)
         self.assertEqual(diag_site.value_autres_aocaop_igp_stg, 0)

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -655,9 +655,20 @@ class TestPurchaseApi(APITestCase):
 
     def test_no_purchases_for_public_summary(self):
         """
-        If the canteen doesn't have purchases for the year requested return a 400
+        If the canteen doesn't have purchases for the year requested return a 404
         """
-        pass
+        canteen = CanteenFactory.create()
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2023-12-31",
+            characteristics=[Purchase.Characteristic.BIO],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=999999,
+        )
+        response = self.client.get(
+            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_get_last_purchase_date_in_public_summary_if_manager(self):

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -559,151 +559,6 @@ class TestPurchaseApi(APITestCase):
         self.assertEquals(body["results"][1]["year"], 2021)
         self.assertEquals(body["results"][1]["valueTotalHt"], 450)
 
-    def test_get_public_purchases_summary(self):
-        """
-        Return percentages from purchase data for the given year and canteen
-        """
-        canteen = CanteenFactory.create()
-        year = 2024
-
-        # bio percent, ignore lesser labels
-        PurchaseFactory.create(
-            canteen=canteen,
-            date="2024-01-01",
-            characteristics=[Purchase.Characteristic.BIO, Purchase.Characteristic.LABEL_ROUGE],
-            family=Purchase.Family.VIANDES_VOLAILLES,
-            price_ht=10,
-        )
-        # sustainable percent, meat egalim
-        PurchaseFactory.create(
-            canteen=canteen,
-            date="2024-01-01",
-            characteristics=[Purchase.Characteristic.LABEL_ROUGE],
-            family=Purchase.Family.VIANDES_VOLAILLES,
-            price_ht=10,
-        )
-        # externalities percent, meat egalim, meat france
-        PurchaseFactory.create(
-            canteen=canteen,
-            date="2024-01-01",
-            characteristics=[Purchase.Characteristic.EXTERNALITES, Purchase.Characteristic.FRANCE],
-            family=Purchase.Family.VIANDES_VOLAILLES,
-            price_ht=10,
-        )
-        # egalim others, fish egalim
-        PurchaseFactory.create(
-            canteen=canteen,
-            date="2024-01-01",
-            characteristics=[Purchase.Characteristic.PECHE_DURABLE],
-            family=Purchase.Family.PRODUITS_DE_LA_MER,
-            price_ht=10,
-        )
-        # meat france (local and short_distribution not included?)
-        PurchaseFactory.create(
-            canteen=canteen,
-            date="2024-12-31",
-            characteristics=[Purchase.Characteristic.FRANCE],
-            family=Purchase.Family.VIANDES_VOLAILLES,
-            price_ht=10,
-        )
-        # fish non egalim
-        PurchaseFactory.create(
-            canteen=canteen,
-            date="2024-12-31",
-            characteristics=[Purchase.Characteristic.FRANCE],
-            family=Purchase.Family.PRODUITS_DE_LA_MER,
-            price_ht=10,
-        )
-        # add misc purchase to have nice round total of 100 HT
-        PurchaseFactory.create(
-            canteen=canteen,
-            date="2024-12-31",
-            characteristics=[],
-            family=Purchase.Family.AUTRES,
-            price_ht=40,
-        )
-
-        # create purchase outside of requested year to check filtering
-        PurchaseFactory.create(
-            canteen=canteen,
-            date="2023-12-31",
-            characteristics=[Purchase.Characteristic.BIO],
-            family=Purchase.Family.VIANDES_VOLAILLES,
-            price_ht=999999,
-        )
-
-        response = self.client.get(
-            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": year}
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-
-        self.assertEqual(body["percentageValueBioHt"], 0.1)
-        self.assertEqual(body["percentageValueSustainableHt"], 0.1)
-        self.assertEqual(body["percentageValueExternalityPerformanceHt"], 0.1)
-        self.assertEqual(body["percentageValueEgalimOthersHt"], 0.1)
-        # 30 HT, meat total is 40.
-        self.assertEqual(body["percentageValueMeatPoultryEgalimHt"], 0.75)
-        self.assertEqual(body["percentageValueMeatPoultryFranceHt"], 0.5)
-        self.assertEqual(body["percentageValueFishEgalimHt"], 0.5)
-
-    def test_cannot_get_redacted_purchases_summary(self):
-        """
-        If the canteen has redacted the year return a 404
-        TODO: do we really want to use redacted_appro_years to control this?
-        """
-        canteen = CanteenFactory.create(redacted_appro_years=[2024])
-        PurchaseFactory.create(canteen=canteen, date="2024-01-01")
-        response = self.client.get(
-            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
-        )
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_no_purchases_for_public_summary(self):
-        """
-        If the canteen doesn't have purchases for the year requested return a 404
-        """
-        canteen = CanteenFactory.create()
-        PurchaseFactory.create(canteen=canteen, date="2023-12-31")
-        response = self.client.get(
-            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
-        )
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    @authenticate
-    def test_get_last_purchase_date_in_public_summary_if_manager(self):
-        """
-        The purchases summary should return the last purchase date if the user
-        is the manager of the canteen
-        """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
-
-        PurchaseFactory.create(canteen=canteen, date="2024-12-01")
-        PurchaseFactory.create(canteen=canteen, date="2024-05-31")
-        PurchaseFactory.create(canteen=canteen, date="2025-01-01")
-
-        response = self.client.get(
-            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
-        )
-        body = response.json()
-        self.assertEqual(body["lastPurchaseDate"], "2024-12-01")
-
-    @authenticate
-    def test_dont_get_last_purchase_date_in_public_summary_if_not_manager(self):
-        """
-        The purchases summary should not return the last purchase date if the user
-        is not the manager of the canteen, even if authenticated
-        """
-        canteen = CanteenFactory.create()
-        PurchaseFactory.create(canteen=canteen, date="2024-05-31")
-
-        response = self.client.get(
-            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
-        )
-        body = response.json()
-        self.assertNotIn("lastPurchaseDate", body)
-
     @authenticate
     def test_delete_purchase(self):
         """
@@ -1162,3 +1017,152 @@ class TestPurchaseApi(APITestCase):
         )
         self.assertEqual(errors[3], f"Aucun achat trouvé pour la cantine : {canteen_without_purchases.id}")
         self.assertEqual(len(errors), 4)
+
+
+class TestPublicPurchasesSummaryApi(APITestCase):
+    def test_get_public_purchases_summary(self):
+        """
+        Return percentages from purchase data for the given year and canteen
+        """
+        canteen = CanteenFactory.create()
+        year = 2024
+
+        # bio percent, ignore lesser labels
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-01-01",
+            characteristics=[Purchase.Characteristic.BIO, Purchase.Characteristic.LABEL_ROUGE],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=10,
+        )
+        # sustainable percent, meat egalim
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-01-01",
+            characteristics=[Purchase.Characteristic.LABEL_ROUGE],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=10,
+        )
+        # externalities percent, meat egalim, meat france
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-01-01",
+            characteristics=[Purchase.Characteristic.EXTERNALITES, Purchase.Characteristic.FRANCE],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=10,
+        )
+        # egalim others, fish egalim
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-01-01",
+            characteristics=[Purchase.Characteristic.PECHE_DURABLE],
+            family=Purchase.Family.PRODUITS_DE_LA_MER,
+            price_ht=10,
+        )
+        # meat france (local and short_distribution not included?)
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-12-31",
+            characteristics=[Purchase.Characteristic.FRANCE],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=10,
+        )
+        # fish non egalim
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-12-31",
+            characteristics=[Purchase.Characteristic.FRANCE],
+            family=Purchase.Family.PRODUITS_DE_LA_MER,
+            price_ht=10,
+        )
+        # add misc purchase to have nice round total of 100 HT
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2024-12-31",
+            characteristics=[],
+            family=Purchase.Family.AUTRES,
+            price_ht=40,
+        )
+
+        # create purchase outside of requested year to check filtering
+        PurchaseFactory.create(
+            canteen=canteen,
+            date="2023-12-31",
+            characteristics=[Purchase.Characteristic.BIO],
+            family=Purchase.Family.VIANDES_VOLAILLES,
+            price_ht=999999,
+        )
+
+        response = self.client.get(
+            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": year}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+
+        self.assertEqual(body["percentageValueBioHt"], 0.1)
+        self.assertEqual(body["percentageValueSustainableHt"], 0.1)
+        self.assertEqual(body["percentageValueExternalityPerformanceHt"], 0.1)
+        self.assertEqual(body["percentageValueEgalimOthersHt"], 0.1)
+        # 30 HT, meat total is 40.
+        self.assertEqual(body["percentageValueMeatPoultryEgalimHt"], 0.75)
+        self.assertEqual(body["percentageValueMeatPoultryFranceHt"], 0.5)
+        self.assertEqual(body["percentageValueFishEgalimHt"], 0.5)
+
+    def test_cannot_get_redacted_purchases_summary(self):
+        """
+        If the canteen has redacted the year return a 404
+        TODO: do we really want to use redacted_appro_years to control this?
+        """
+        canteen = CanteenFactory.create(redacted_appro_years=[2024])
+        PurchaseFactory.create(canteen=canteen, date="2024-01-01")
+        response = self.client.get(
+            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_no_purchases_for_public_summary(self):
+        """
+        If the canteen doesn't have purchases for the year requested return a 404
+        """
+        canteen = CanteenFactory.create()
+        PurchaseFactory.create(canteen=canteen, date="2023-12-31")
+        response = self.client.get(
+            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_get_last_purchase_date_in_public_summary_if_manager(self):
+        """
+        The purchases summary should return the last purchase date if the user
+        is the manager of the canteen
+        """
+        canteen = CanteenFactory.create()
+        canteen.managers.add(authenticate.user)
+
+        PurchaseFactory.create(canteen=canteen, date="2024-12-01")
+        PurchaseFactory.create(canteen=canteen, date="2024-05-31")
+        PurchaseFactory.create(canteen=canteen, date="2025-01-01")
+
+        response = self.client.get(
+            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
+        )
+        body = response.json()
+        self.assertEqual(body["lastPurchaseDate"], "2024-12-01")
+
+    @authenticate
+    def test_dont_get_last_purchase_date_in_public_summary_if_not_manager(self):
+        """
+        The purchases summary should not return the last purchase date if the user
+        is not the manager of the canteen, even if authenticated
+        """
+        canteen = CanteenFactory.create()
+        PurchaseFactory.create(canteen=canteen, date="2024-05-31")
+
+        response = self.client.get(
+            reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
+        )
+        body = response.json()
+        self.assertNotIn("lastPurchaseDate", body)
+
+    # TODO: option to ignore redaction for canteen managers

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -653,13 +653,7 @@ class TestPurchaseApi(APITestCase):
         TODO: do we really want to use redacted_appro_years to control this?
         """
         canteen = CanteenFactory.create(redacted_appro_years=[2024])
-        PurchaseFactory.create(
-            canteen=canteen,
-            date="2024-01-01",
-            characteristics=[Purchase.Characteristic.BIO],
-            family=Purchase.Family.VIANDES_VOLAILLES,
-            price_ht=100,
-        )
+        PurchaseFactory.create(canteen=canteen, date="2024-01-01")
         response = self.client.get(
             reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
         )
@@ -670,13 +664,7 @@ class TestPurchaseApi(APITestCase):
         If the canteen doesn't have purchases for the year requested return a 404
         """
         canteen = CanteenFactory.create()
-        PurchaseFactory.create(
-            canteen=canteen,
-            date="2023-12-31",
-            characteristics=[Purchase.Characteristic.BIO],
-            family=Purchase.Family.VIANDES_VOLAILLES,
-            price_ht=999999,
-        )
+        PurchaseFactory.create(canteen=canteen, date="2023-12-31")
         response = self.client.get(
             reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2024}
         )

--- a/api/urls.py
+++ b/api/urls.py
@@ -10,6 +10,7 @@ from api.views import (
     PurchasesDeleteView,
     PurchasesRestoreView,
     CanteenPurchasesSummaryView,
+    CanteenPurchasesPercentageSummaryView,
     DiagnosticsFromPurchasesView,
     UsernameSuggestionView,
     ImportSimpleCentralKitchenView,
@@ -171,6 +172,11 @@ urlpatterns = {
         "canteenPurchasesSummary/<int:canteen_pk>",
         CanteenPurchasesSummaryView.as_view(),
         name="canteen_purchases_summary",
+    ),
+    path(
+        "canteenPurchasesPercentageSummary/<int:canteen_pk>",
+        CanteenPurchasesPercentageSummaryView.as_view(),
+        name="canteen_purchases_percentage_summary",
     ),
     path(
         "createDiagnosticsFromPurchases/<int:year>",

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -56,6 +56,7 @@ from .purchase import (  # noqa: F401
     PurchaseListCreateView,
     PurchaseRetrieveUpdateDestroyView,
     CanteenPurchasesSummaryView,
+    CanteenPurchasesPercentageSummaryView,
     PurchaseListExportView,
     PurchaseOptionsView,
     PurchasesDeleteView,

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -204,6 +204,8 @@ class CanteenPurchasesPercentageSummaryView(APIView):
         if not year:
             raise BadRequest("year is required")
         data = canteen_summary_for_year(canteen, year)
+        if data["value_total_ht"] == 0:
+            raise NotFound()
         return Response(PurchasePercentageSummarySerializer(data).data)
 
     def _get_canteen(self, canteen_id, request):

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -212,6 +212,9 @@ class CanteenPurchasesPercentageSummaryView(APIView):
         data = canteen_summary_for_year(canteen, year)
         if data["value_total_ht"] == 0:
             raise NotFound()
+        data["last_purchase_date"] = (
+            Purchase.objects.only("date").filter(canteen=canteen, date__year=year).latest("date").date
+        )
         return Response(PurchasePercentageSummarySerializer(data).data)
 
     def _get_canteen(self, canteen_id, request):

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -194,7 +194,7 @@ def canteen_summary_for_year(canteen, year):
     purchases = Purchase.objects.only("id", "family", "characteristics", "price_ht").filter(
         canteen=canteen, date__year=year
     )
-    data = meta_data(purchases, year)
+    data = {}
     simple_diag_data(purchases, data)
     complete_diag_data(purchases, data)
     misc_totals(purchases, data)
@@ -209,23 +209,13 @@ def canteen_summary(canteen):
     )
     years = [y["year"] for y in years.values()]
     for year in years:
+        year_data = {"year": year}
         purchases = Purchase.objects.only("id", "family", "characteristics", "price_ht").filter(
             canteen=canteen, date__year=year
         )
-        year_data = meta_data(purchases, year)
         simple_diag_data(purchases, year_data)
         data["results"].append(year_data)
 
-    return data
-
-
-def meta_data(purchases, year):
-    data = {"year": year}
-    try:
-        last_purchase = purchases.latest("date")
-        data["modification_date"] = last_purchase.date
-    except Purchase.DoesNotExist:
-        pass
     return data
 
 

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -194,7 +194,7 @@ def canteen_summary_for_year(canteen, year):
     purchases = Purchase.objects.only("id", "family", "characteristics", "price_ht").filter(
         canteen=canteen, date__year=year
     )
-    data = {}
+    data = meta_data(purchases, year)
     simple_diag_data(purchases, data)
     complete_diag_data(purchases, data)
     misc_totals(purchases, data)
@@ -209,13 +209,23 @@ def canteen_summary(canteen):
     )
     years = [y["year"] for y in years.values()]
     for year in years:
-        year_data = {"year": year}
         purchases = Purchase.objects.only("id", "family", "characteristics", "price_ht").filter(
             canteen=canteen, date__year=year
         )
+        year_data = meta_data(purchases, year)
         simple_diag_data(purchases, year_data)
         data["results"].append(year_data)
 
+    return data
+
+
+def meta_data(purchases, year):
+    data = {"year": year}
+    try:
+        last_purchase = purchases.latest("date")
+        data["modification_date"] = last_purchase.date
+    except Purchase.DoesNotExist:
+        pass
     return data
 
 

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -209,7 +209,7 @@ class CanteenPurchasesPercentageSummaryView(APIView):
             raise BadRequest("the year query parameter is required")
 
         is_canteen_manager = IsCanteenManager().has_object_permission(request, self, canteen)
-        ignore_redaction = is_canteen_manager and request.query_params.get("ignoreRedaction")
+        ignore_redaction = is_canteen_manager and request.query_params.get("ignoreRedaction") == "true"
         if not ignore_redaction and year in canteen.redacted_appro_years:
             raise NotFound()
 

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -201,8 +201,14 @@ class CanteenPurchasesPercentageSummaryView(APIView):
         canteen_id = kwargs.get("canteen_pk")
         canteen = self._get_canteen(canteen_id, self.request)
         year = request.query_params.get("year")
-        if not year:
-            raise BadRequest("year is required")
+        try:
+            year = int(year)
+        except ValueError:
+            raise BadRequest("an integer is required for the year query parameter")
+        except TypeError:
+            raise BadRequest("the year query parameter is required")
+        if year in canteen.redacted_appro_years:
+            raise NotFound()
         data = canteen_summary_for_year(canteen, year)
         if data["value_total_ht"] == 0:
             raise NotFound()

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -212,9 +212,10 @@ class CanteenPurchasesPercentageSummaryView(APIView):
         data = canteen_summary_for_year(canteen, year)
         if data["value_total_ht"] == 0:
             raise NotFound()
-        data["last_purchase_date"] = (
-            Purchase.objects.only("date").filter(canteen=canteen, date__year=year).latest("date").date
-        )
+        if IsCanteenManager().has_object_permission(request, self, canteen):
+            data["last_purchase_date"] = (
+                Purchase.objects.only("date").filter(canteen=canteen, date__year=year).latest("date").date
+            )
         return Response(PurchasePercentageSummarySerializer(data).data)
 
     def _get_canteen(self, canteen_id, request):

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -12,7 +12,12 @@ from django.db.models.functions import ExtractYear
 from django.http import JsonResponse
 from django_filters import rest_framework as django_filters
 from api.permissions import IsLinkedCanteenManager, IsCanteenManager, IsAuthenticated
-from api.serializers import PurchaseSerializer, PurchaseSummarySerializer, PurchaseExportSerializer
+from api.serializers import (
+    PurchaseSerializer,
+    PurchaseSummarySerializer,
+    PurchasePercentageSummarySerializer,
+    PurchaseExportSerializer,
+)
 from data.models import Purchase, Canteen, Diagnostic
 from .utils import MaCantineOrderingFilter, UnaccentSearchFilter
 from collections import OrderedDict
@@ -178,13 +183,32 @@ class CanteenPurchasesSummaryView(APIView):
         canteen_id = kwargs.get("canteen_pk")
         canteen = self._get_canteen(canteen_id, self.request)
         year = request.query_params.get("year")
-        return Response(canteen_summary_for_year(canteen, year) if year else canteen_summary(canteen))
+        data = canteen_summary_for_year(canteen, year) if year else canteen_summary(canteen)
+        return Response(PurchaseSummarySerializer(data).data if year else data)
 
     def _get_canteen(self, canteen_id, request):
         try:
             canteen = Canteen.objects.get(pk=canteen_id)
             if not IsCanteenManager().has_object_permission(request, self, canteen):
                 raise PermissionDenied()
+            return canteen
+        except Canteen.DoesNotExist as e:
+            raise NotFound() from e
+
+
+class CanteenPurchasesPercentageSummaryView(APIView):
+    def get(self, request, *args, **kwargs):
+        canteen_id = kwargs.get("canteen_pk")
+        canteen = self._get_canteen(canteen_id, self.request)
+        year = request.query_params.get("year")
+        if not year:
+            raise BadRequest("year is required")
+        data = canteen_summary_for_year(canteen, year)
+        return Response(PurchasePercentageSummarySerializer(data).data)
+
+    def _get_canteen(self, canteen_id, request):
+        try:
+            canteen = Canteen.objects.get(pk=canteen_id)
             return canteen
         except Canteen.DoesNotExist as e:
             raise NotFound() from e
@@ -199,7 +223,7 @@ def canteen_summary_for_year(canteen, year):
     complete_diag_data(purchases, data)
     misc_totals(purchases, data)
 
-    return PurchaseSummarySerializer(data).data
+    return data
 
 
 def canteen_summary(canteen):
@@ -220,10 +244,21 @@ def canteen_summary(canteen):
 
 
 # the order of EGALIM_LABELS is significant - determines which labels trump others when aggregating purchases
-EGALIM_LABELS = [
+DIAGNOSTIC_EGALIM_LABELS = [
     "BIO",
     "LABEL_ROUGE",
     "AOCAOP_IGP_STG",
+    "HVE",
+    "PECHE_DURABLE",
+    "RUP",
+    "COMMERCE_EQUITABLE",
+    "FERMIER",
+    "EXTERNALITES",
+    "PERFORMANCE",
+]
+PURCHASE_EGALIM_LABELS = [
+    "BIO",
+    "LABEL_ROUGE",
     "AOCAOP",
     "IGP",
     "STG",
@@ -239,6 +274,7 @@ EGALIM_LABELS = [
 
 
 def simple_diag_data(purchases, data):
+    # TODO: is CONVERSION_BIO used?
     bio_filter = Q(characteristics__contains=[Purchase.Characteristic.BIO]) | Q(
         characteristics__contains=[Purchase.Characteristic.CONVERSION_BIO]
     )
@@ -297,7 +333,7 @@ def complete_diag_data(purchases, data):
 
     for family in families:
         purchase_family = purchases.filter(family=family)
-        for label in EGALIM_LABELS:
+        for label in DIAGNOSTIC_EGALIM_LABELS:
             if label == "AOCAOP_IGP_STG":
                 fam_label = purchase_family.filter(
                     Q(characteristics__contains=[Purchase.Characteristic.AOCAOP])
@@ -341,7 +377,7 @@ def misc_totals(purchases, data):
     )
     data["value_meat_poultry_ht"] = meat_poultry_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
 
-    meat_poultry_egalim = meat_poultry_purchases.filter(characteristics__overlap=EGALIM_LABELS)
+    meat_poultry_egalim = meat_poultry_purchases.filter(characteristics__overlap=PURCHASE_EGALIM_LABELS)
     data["value_meat_poultry_egalim_ht"] = meat_poultry_egalim.aggregate(total=Sum("price_ht"))["total"] or 0
 
     meat_poultry_france = meat_poultry_purchases.filter(
@@ -356,7 +392,7 @@ def misc_totals(purchases, data):
     )
     data["value_fish_ht"] = fish_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
 
-    fish_egalim = fish_purchases.filter(characteristics__overlap=EGALIM_LABELS)
+    fish_egalim = fish_purchases.filter(characteristics__overlap=PURCHASE_EGALIM_LABELS)
     data["value_fish_egalim_ht"] = fish_egalim.aggregate(total=Sum("price_ht"))["total"] or 0
 
 

--- a/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
@@ -50,13 +50,6 @@
             rapport annuel public remis au Parlement. Vos données sont publiées par défaut sur votre vitrine en ligne.
           </p>
         </div>
-        <div v-else-if="provisional" class="py-4">
-          <p class="mb-0">
-            <b>Total des achats au {{ lastPurchaseDate }}</b>
-            : le bilan provisoire ci-dessous est réalisé à partir des données d’achat au {{ lastPurchaseDate }}. Vos
-            données sont visibles par défaut sur votre affiche et en ligne.
-          </p>
-        </div>
         <DsfrToggle
           v-else
           v-model="publishedToggleState"
@@ -66,10 +59,17 @@
           uncheckedLabel="Caché"
         >
           <template v-slot:label>
-            <!-- TODO: DSFR recommends labels be <= 3 words long -->
-            <b>Données non télédéclarées</b>
-            : le bilan des achats de l'année {{ tab }} n'a pas été officiellement télédéclaré à l'administration. Il est
-            visible par défaut sur votre affiche et en ligne, mais vous pouvez le retirer.
+            <span v-if="provisional" class="mb-0">
+              <b>Total des achats au {{ lastPurchaseDate }}</b>
+              : le bilan provisoire ci-dessous est réalisé à partir des données d’achat au {{ lastPurchaseDate }}. Vos
+              données sont visibles par défaut sur votre affiche et en ligne.
+            </span>
+            <span v-else>
+              <!-- TODO: DSFR recommends labels be <= 3 words long -->
+              <b>Données non télédéclarées</b>
+              : le bilan des achats de l'année {{ tab }} n'a pas été officiellement télédéclaré à l'administration. Il
+              est visible par défaut sur votre affiche et en ligne, mais vous pouvez le retirer.
+            </span>
           </template>
         </DsfrToggle>
       </DsfrCallout>

--- a/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
@@ -9,7 +9,7 @@
     </p>
     <p v-else>Cet établissement ne respecte pas encore la loi EGAlim pour cette mesure.</p>
 
-    <v-row v-if="tabs" class="align-end flex-wrap mb-4">
+    <v-row class="align-end flex-wrap mb-4">
       <v-col>
         <DsfrSegmentedControl v-model="tab" legend="Bilan par période" :noLegend="editable" :items="tabs" />
       </v-col>
@@ -159,12 +159,14 @@ export default {
     DsfrToggle,
   },
   data() {
+    const tabs = this.approDiagnostics.map((d) => +d.year)
+    tabs.sort((a, b) => b - a)
+    tabs.push(COMPARE_TAB)
+    const tab = tabs[0]
     return {
-      tabs: undefined,
-      tab: undefined,
-      thisYear: new Date().getFullYear(),
-      purchasesSummary: undefined,
       redactedYears: this.canteen.redactedApproYears || [],
+      tabs,
+      tab,
       // it is published if it is not redacted
       publishedToggleState: undefined,
     }
@@ -175,14 +177,13 @@ export default {
       return latestCreatedDiagnostic(this.approDiagnostics)
     },
     diagnosticForYear() {
-      if (+this.tab === this.thisYear) return this.purchasesSummary
       return this.canteen.approDiagnostics.find((d) => d.year === +this.tab)
     },
     teledeclared() {
       return !!this.diagnosticForYear?.isTeledeclared
     },
     provisional() {
-      return this.diagnosticForYear?.year >= this.thisYear
+      return !!this.diagnosticForYear?.year >= new Date().getFullYear()
     },
     color() {
       // these are the same as the colours for "bio" in ApproGraph
@@ -192,6 +193,8 @@ export default {
     },
     lastPurchaseDate() {
       if (!this.provisional) return
+      if (!this.diagnosticForYear) return
+      // TODO: make this the date of the most recent purchase
       const date = new Date(this.diagnosticForYear.modificationDate)
       return date.toLocaleString("fr-FR", {
         day: "numeric",
@@ -281,24 +284,9 @@ export default {
     getPublicationState(year) {
       return this.redactedYears.indexOf(year) === -1
     },
-    fetchPurchasesSummary() {
-      this.purchasesSummary = null
-      // TODO: create an endpoint that just returns the percentages and conditionally the last purchase date for public view
-      return fetch(`/api/v1/canteenPurchasesSummary/${this.canteen.id}?year=${this.thisYear}`)
-        .then((response) => (response.ok ? response.json() : {}))
-        .then((response) => (this.purchasesSummary = response))
-    },
   },
   mounted() {
     this.publishedToggleState = this.getPublicationState(this.tab)
-    this.fetchPurchasesSummary().finally(() => {
-      const tabs = this.approDiagnostics.map((d) => +d.year)
-      if (this.purchasesSummary.modificationDate) tabs.push(this.thisYear)
-      tabs.sort((a, b) => b - a)
-      tabs.push(COMPARE_TAB)
-      this.tabs = tabs
-      this.tab = this.tabs[0]
-    })
   },
   watch: {
     tab(newValue) {

--- a/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
@@ -157,24 +157,11 @@ export default {
     DsfrToggle,
   },
   data() {
-    const approData = this.approDiagnostics
-    const tabs = approData.map((d) => ({
-      text: +d.year,
-      value: +d.year,
-      disabled: false,
-    }))
-    tabs.sort((a, b) => b.value - a.value)
-    const compareTab = {
-      text: "Comparer",
-      value: "Comparer",
-      disabled: tabs.length < 2,
-    }
-    tabs.push(compareTab)
     return {
-      approData,
+      approData: this.approDiagnostics,
       redactedYears: this.canteen.redactedApproYears || [],
-      tabs,
-      tab: tabs[0].value,
+      tabs: [],
+      tab: undefined,
       // it is published if it is not redacted
       publishedToggleState: undefined,
       thisYear: new Date().getFullYear(),
@@ -299,15 +286,29 @@ export default {
           if (response) {
             response.year = this.thisYear
             this.approData.push(response)
-            this.tabs.unshift({ value: this.thisYear, text: this.thisYear, disabled: false })
-            if (this.tab === this.tabs[1].value) this.tab = this.tabs[0].value
           }
         })
+    },
+    makeTabs() {
+      const tabs = this.approData.map((d) => ({
+        text: +d.year,
+        value: +d.year,
+        disabled: false,
+      }))
+      tabs.sort((a, b) => b.value - a.value)
+      const compareTab = {
+        text: "Comparer",
+        value: "Comparer",
+        disabled: tabs.length < 2,
+      }
+      tabs.push(compareTab)
+      this.tabs = tabs
+      this.tab = tabs[0].value
     },
   },
   mounted() {
     this.publishedToggleState = this.getPublicationState(this.tab)
-    return this.getPurchasesSummary()
+    return this.getPurchasesSummary().finally(() => this.makeTabs())
   },
   watch: {
     tab(newValue) {

--- a/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
@@ -280,7 +280,9 @@ export default {
       return this.redactedYears.indexOf(year) === -1
     },
     getPurchasesSummary() {
-      return fetch(`/api/v1/canteenPurchasesPercentageSummary/${this.canteen.id}?year=${this.thisYear}`)
+      return fetch(
+        `/api/v1/canteenPurchasesPercentageSummary/${this.canteen.id}?year=${this.thisYear}&ignoreRedaction=${this.editable}`
+      )
         .then((response) => (response.ok ? response.json() : undefined))
         .then((response) => {
           if (response) {
@@ -307,8 +309,10 @@ export default {
     },
   },
   mounted() {
-    this.publishedToggleState = this.getPublicationState(this.tab)
-    return this.getPurchasesSummary().finally(() => this.makeTabs())
+    return this.getPurchasesSummary().finally(() => {
+      this.makeTabs()
+      this.publishedToggleState = this.getPublicationState(this.tab)
+    })
   },
   watch: {
     tab(newValue) {

--- a/frontend/tests/unit/PublishedCanteenCard.spec.js
+++ b/frontend/tests/unit/PublishedCanteenCard.spec.js
@@ -14,6 +14,7 @@ describe("PublishedCanteenCard.vue", () => {
     name: "Wasabi",
     city: "Lyon",
     dailyMealCount: 100,
+    badges: {},
   }
 
   let store = new Vuex.Store({


### PR DESCRIPTION
Closes #3910 

Je suis pas convaincu.e que le champ `redacted_appro_years` est le mieux, car je pense que c'est pas "je veux dépublier les données de 2024" mais plutôt que "je veux dépublier les données en cours". Avec la solution actuelle dans cette PR, en 2025 les données en cours seront visibles à nouveau.

Je propose en deuxième temps alors un nouveau champ `redact_current_year` ou qqch. Tu penses quoi ?