### PR TITLE
Hot fix : améliorer la perf de la page "mes cantines"

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -12,6 +12,7 @@ from .canteen import (  # noqa: F401
     SatelliteTeledeclarationSerializer,
     ElectedCanteenSerializer,
     MinimalCanteenSerializer,
+    CanteenSummarySerializer,
 )
 from .diagnostic import (  # noqa: F401
     ManagerDiagnosticSerializer,

--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -365,6 +365,62 @@ class FullCanteenSerializer(serializers.ModelSerializer):
             return None
 
 
+class CanteenSummarySerializer(serializers.ModelSerializer):
+    images = MediaListSerializer(child=CanteenImageSerializer(), required=False)
+    diagnostics = FullDiagnosticSerializer(many=True, read_only=True, source="diagnostic_set")
+    central_kitchen_diagnostics = serializers.SerializerMethodField(read_only=True)
+
+    class Meta:
+        model = Canteen
+        my_fields = (
+            "id",
+            "name",
+            "city",
+            "city_insee_code",
+            "postal_code",
+            "sectors",
+            "daily_meal_count",
+            "yearly_meal_count",
+            "siret",
+            "management_type",
+            "production_type",
+            "department",
+            "region",
+            "publication_status",
+            "economic_model",
+            "is_central_cuisine",
+            "modification_date",
+            # the following can still be improved
+            "images",  # can return the first image only
+            "diagnostics",
+            "central_kitchen_diagnostics",  # can return a TD status instead of diagnostics
+        )
+        fields = my_fields
+        read_only_fields = my_fields
+
+    def get_central_kitchen_diagnostics(self, obj):
+        # Ideally we would also check the status of the satellite canteen and
+        # the central cuisine, for now we omit this check. For now it is the
+        # responsibility of the frontend to use this information.
+        if not obj.central_producer_siret or not obj.production_type == Canteen.ProductionType.ON_SITE_CENTRAL:
+            return None
+        try:
+            diagnostics = Diagnostic.objects.filter(
+                canteen__siret=obj.central_producer_siret,
+                central_kitchen_diagnostic_mode__in=[
+                    Diagnostic.CentralKitchenDiagnosticMode.ALL,
+                    Diagnostic.CentralKitchenDiagnosticMode.APPRO,
+                ],
+            )
+
+            return CentralKitchenDiagnosticSerializer(diagnostics, many=True).data
+        except Canteen.DoesNotExist:
+            return None
+        except Canteen.MultipleObjectsReturned as e:
+            logger.exception(f"Multiple canteens returned when obtaining the central_producer_siret field {e}")
+            return None
+
+
 class CanteenPreviewSerializer(serializers.ModelSerializer):
     class Meta:
         model = Canteen

--- a/api/urls.py
+++ b/api/urls.py
@@ -31,7 +31,7 @@ from api.views import AddManagerView, RemoveManagerView
 from api.views import ImportSimpleDiagnosticsView, ImportCompleteDiagnosticsView
 from api.views import TeledeclarationCreateView, TeledeclarationCancelView, TeledeclarationPdfView
 from api.views import PublishCanteenView, UnpublishCanteenView, SendCanteenNotFoundEmail
-from api.views import UserCanteenPreviews, CanteenLocationsView
+from api.views import UserCanteenPreviews, UserCanteenSummaries, CanteenLocationsView
 from api.views import PartnerView, PartnersView, PartnerTypeListView
 from api.views import ReservationExpeView, PurchaseListExportView, PurchaseOptionsView, ImportPurchasesView
 from api.views import MessageCreateView, VegetarianExpeView, TeamJoinRequestView
@@ -58,6 +58,7 @@ urlpatterns = {
     ),
     path("publish/", PublishManyCanteensView.as_view(), name="publish_canteens"),
     path("canteenPreviews/", UserCanteenPreviews.as_view(), name="user_canteen_previews"),
+    path("canteenSummaries/", UserCanteenSummaries.as_view(), name="user_canteens_summaries"),
     path("canteens/", UserCanteensView.as_view(), name="user_canteens"),
     path("canteens/<int:pk>", RetrieveUpdateUserCanteenView.as_view(), name="single_canteen"),
     path(

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -29,6 +29,7 @@ from .canteen import (  # noqa: F401
     ActionableCanteenRetrieveView,
     CanteenStatusView,
     TerritoryCanteensListView,
+    UserCanteenSummaries,
 )
 from .diagnostic import (  # noqa: F401
     DiagnosticCreateView,

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -36,6 +36,7 @@ from api.serializers import (
     CanteenStatusSerializer,
     ElectedCanteenSerializer,
     MinimalCanteenSerializer,
+    CanteenSummarySerializer,
 )
 from data.models import Canteen, ManagerInvitation, Sector, Diagnostic, Teledeclaration, Purchase
 from data.region_choices import Region
@@ -372,6 +373,25 @@ class UserCanteenPreviews(ListAPIView):
     serializer_class = CanteenPreviewSerializer
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope]
     required_scopes = ["canteen"]
+
+    def get_queryset(self):
+        return self.request.user.canteens.all()
+
+
+class UserCanteenSummaries(ListAPIView):
+    model = Canteen
+    serializer_class = CanteenSummarySerializer
+    permission_classes = [IsAuthenticatedOrTokenHasResourceScope]
+    required_scopes = ["canteen"]
+    pagination_class = UserCanteensPagination
+    filter_backends = [
+        django_filters.DjangoFilterBackend,
+        UnaccentSearchFilter,
+        MaCantineOrderingFilter,
+    ]
+    filterset_class = UserCanteensFilterSet
+    search_fields = ["name", "siret"]
+    ordering_fields = ["name", "creation_date", "modification_date", "daily_meal_count"]
 
     def get_queryset(self):
         return self.request.user.canteens.all()

--- a/frontend/src/views/ManagementPage/CanteensPagination.vue
+++ b/frontend/src/views/ManagementPage/CanteensPagination.vue
@@ -133,7 +133,7 @@ export default {
       if (this.filterProductionType !== "all") queryParam += `&production_type=${this.filterProductionType}`
       this.inProgress = true
 
-      return fetch(`/api/v1/canteens/?${queryParam}`)
+      return fetch(`/api/v1/canteenSummaries/?${queryParam}`)
         .then((response) => {
           if (response.status < 200 || response.status >= 400) throw new Error(`Error encountered : ${response}`)
           return response.json()


### PR DESCRIPTION
Suite à une PR qui a ajouté quelques champs complèxes sur le `FullCanteenSerializer`, il y a un interêt d'avoir un nouveau endpoint pour la pagination des cantines. Sur staging je c'est bcp trop lente.

Avant : 1.68s; après : 138 ms

![Screenshot 2024-05-27 at 15 14 31](https://github.com/betagouv/ma-cantine/assets/9282816/13c04110-7d95-413d-869c-048f00591260)
![Screenshot 2024-05-27 at 15 45 29](https://github.com/betagouv/ma-cantine/assets/9282816/b501bdc8-4124-483d-b8bc-1502e58dd8d2)

idéalement on fera en deuxième temps une refacto des serializers et endpoints pour voir lesquels on pourrait merger, quoi on a qui est maintenant redondant https://github.com/betagouv/ma-cantine/issues/3956