### PR TITLE
Affiche, appro : gérer le cas où il y a pas assez de données pour le volet appro pour une année

### DIFF
--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -246,6 +246,10 @@ class ApproDiagnosticSerializer(DiagnosticSerializer):
         fields = META_FIELDS + SIMPLE_APPRO_FIELDS + COMPLETE_APPRO_FIELDS
         read_ony_fields = META_FIELDS + SIMPLE_APPRO_FIELDS + COMPLETE_APPRO_FIELDS
 
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        return appro_to_percentages(representation, instance, remove_values=False)
+
 
 class ApproDeferredTeledeclarationDiagnosticSerializer(DiagnosticSerializer):
     class Meta:

--- a/api/serializers/utils.py
+++ b/api/serializers/utils.py
@@ -1,4 +1,4 @@
-def appro_to_percentages(representation, instance):
+def appro_to_percentages(representation, instance, remove_values=True):
     # first do the percentages relative to meat and fish totals
     # not removing these totals so that can then calculate the percent of those compared to global total
     meat_total = representation.get("value_meat_poultry_ht")
@@ -32,13 +32,15 @@ def appro_to_percentages(representation, instance):
         new_field_name = f"percentage_{field}"
         if representation.get(field):
             representation[new_field_name] = representation[field] / total if total else None
-        representation.pop(field, None)
+        if remove_values:
+            representation.pop(field, None)
 
     representation["percentage_value_total_ht"] = 1
-    representation.pop("value_total_ht", None)
-    representation.pop("value_meat_poultry_egalim_ht", None)
-    representation.pop("value_meat_poultry_france_ht", None)
-    representation.pop("value_fish_egalim_ht", None)
+    if remove_values:
+        representation.pop("value_total_ht", None)
+        representation.pop("value_meat_poultry_egalim_ht", None)
+        representation.pop("value_meat_poultry_france_ht", None)
+        representation.pop("value_fish_egalim_ht", None)
 
     return representation
 

--- a/frontend/src/components/ApproGraph.vue
+++ b/frontend/src/components/ApproGraph.vue
@@ -1,19 +1,23 @@
 <template>
-  <VueApexCharts
-    :options="chartOptions"
-    :series="series"
-    role="figure"
-    aria-label="Approvisionnement bio et durable"
-    :aria-description="description"
-    height="100px"
-    width="100%"
-    class="my-4"
-  />
+  <div>
+    <p v-if="!hasEnoughData && fallbackText">{{ fallbackText }}</p>
+    <VueApexCharts
+      v-else
+      :options="chartOptions"
+      :series="series"
+      role="figure"
+      aria-label="Approvisionnement bio et durable"
+      :aria-description="description"
+      height="100px"
+      width="100%"
+      class="my-4"
+    />
+  </div>
 </template>
 
 <script>
 import VueApexCharts from "vue-apexcharts"
-import { applicableDiagnosticRules, getSustainableTotal, getPercentage } from "@/utils"
+import { applicableDiagnosticRules, getSustainableTotal, getPercentage, hasApproGraphData } from "@/utils"
 
 export default {
   name: "ApproGraph",
@@ -26,6 +30,10 @@ export default {
       type: Object,
     },
     colorTheme: {
+      type: String,
+      optional: true,
+    },
+    fallbackText: {
       type: String,
       optional: true,
     },
@@ -156,6 +164,9 @@ export default {
     },
     description() {
       return `Bio : ${this.bioPercentage} %. Durable et de qualité (hors bio) : ${this.sustainablePercentage} %. Rappel objectif EGAlim : ${this.applicableRules.qualityThreshold} % des achats de qualité et durable, dont ${this.applicableRules.bioThreshold} % bio.`
+    },
+    hasEnoughData() {
+      return hasApproGraphData(this.diagnostic)
     },
   },
 }

--- a/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
@@ -78,7 +78,13 @@
           </DsfrToggle>
         </DsfrCallout>
 
-        <ApproGraph v-if="diagnosticForYear" :diagnostic="diagnosticForYear" :canteen="canteen" class="my-8" />
+        <ApproGraph
+          v-if="diagnosticForYear"
+          :diagnostic="diagnosticForYear"
+          :canteen="canteen"
+          fallbackText="Pas de données disponibles"
+          class="my-8"
+        />
 
         <div v-if="hasFamilyDetail">
           <DsfrAccordion :items="[{ title: 'Détail par famille de produit' }]" class="mb-2">

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -234,6 +234,16 @@ export const getPercentage = (partialValue, totalValue, round = true) => {
   }
 }
 
+export const hasApproGraphData = (diagnostic) => {
+  const graphDataKeys = [
+    "percentageValueBioHt",
+    "percentageValueSustainableHt",
+    "percentageValueExternalityPerformanceHt",
+    "percentageValueEgalimOthersHt",
+  ]
+  return graphDataKeys.some((k) => Object.hasOwn(diagnostic, k))
+}
+
 export const getSustainableTotal = (diagnostic) => {
   const sustainableSum =
     (diagnostic.valueSustainableHt || 0) +


### PR DESCRIPTION
closes #3970 

![Screenshot 2024-06-03 at 13-16-45 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/5801d6b0-628a-4cbc-bfcf-faac60d98471)
![Screenshot 2024-06-03 at 13-10-17 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/aafef42e-d369-464a-b6d0-0a9a90f5c2d3)
![Screenshot 2024-06-03 at 13-10-03 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/af01685c-bbc4-4939-982f-d3665420fe34)
![Screenshot 2024-06-03 at 13-09-52 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/3c5c2b71-1ea3-4576-98cd-88211cb5aac4)
![Screenshot 2024-06-03 at 12-33-15 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/379a15fd-f914-4591-92d6-a186c60deee3)
![Screenshot 2024-06-03 at 12-33-03 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/4b322e9c-88ec-468d-98a6-8798955241e7)
