### PR TITLE
Bug fix affichage : badge devrait avoir largeur du contenu

### DIFF
--- a/frontend/src/components/DsfrBadge.vue
+++ b/frontend/src/components/DsfrBadge.vue
@@ -3,7 +3,7 @@
     v-bind="$attrs"
     v-on="$listeners"
     :color="modes[mode].backgroundColor"
-    :style="`border-radius: 4px !important; color: ${modes[mode].color}`"
+    :style="`border-radius: 4px !important; color: ${modes[mode].color}; width: fit-content;`"
     small
     label
   >


### PR DESCRIPTION
Avant
![Screenshot 2024-06-03 at 17-23-27 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/6e7eac8b-3b93-4eca-95f5-082b430b041d)


Après
![Screenshot 2024-06-03 at 17-22-43 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/946eeaeb-2a69-463e-956e-7feaa44a00bd)
