### PR TITLE
Bug fix, affiche : pour la vue public, montrer les infos de la CC

### DIFF
--- a/frontend/src/components/CanteenPublication/ResultsComponents/CentralKitchenInfo.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/CentralKitchenInfo.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- TODO: use DsfrCallout instead -->
-  <v-card outlined elevation="0" color="primary lighten-5" class="d-flex mb-6" v-if="usesCentralKitchenDiagnostics">
+  <v-card outlined elevation="0" color="primary lighten-5" class="d-flex mb-6">
     <v-icon class="ml-4" color="primary">$information-fill</v-icon>
 
     <v-card-text>
@@ -33,11 +33,6 @@ export default {
   computed: {
     centralKitchen() {
       return this.canteen.centralKitchen
-    },
-    usesCentralKitchenDiagnostics() {
-      return (
-        this.canteen.productionType === "site_cooked_elsewhere" && this.canteen.centralKitchenDiagnostics?.length > 0
-      )
     },
   },
 }

--- a/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <CentralKitchenInfo :canteen="canteen" />
+    <CentralKitchenInfo :canteen="canteen" v-if="usesCentralKitchenDiagnostics" />
 
     <p>
       La loi EGAlim impose {{ applicableRules.qualityThreshold }} % de produits durables et de qualité et durable, dont
@@ -240,6 +240,11 @@ export default {
     },
     hasFamilyDetail() {
       return this.meatEgalimPercentage || this.meatFrancePercentage || this.fishEgalimPercentage
+    },
+    usesCentralKitchenDiagnostics() {
+      if (!this.canteen.centralKitchen) return
+      const hasCentralDiagnostic = this.approData.some((diagnostic) => diagnostic.canteenId !== this.canteen.id)
+      return hasCentralDiagnostic
     },
   },
   methods: {


### PR DESCRIPTION
I aim to reinstate the previous behaviour with this PR.

The previous behaviour is imperfect, since the central kitchen can change, and since a satellite might have provided their own data for the current year. Not sure what the best approach is, do you think we can wait to see if there is user feedback?

![Screenshot 2024-06-04 at 17-06-41 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/6feb72f4-028e-4fc6-93e3-9b0172beadd6)
