### PR TITLE
:lady_beetle: Fix de la comparaison pou le badge waste

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1686,7 +1686,7 @@ class Diagnostic(models.Model):
     @property
     def waste_badge(self):
         if self.has_waste_diagnostic and self.waste_actions and len(self.waste_actions) > 0:
-            if self.canteen.daily_meal_count and (self.canteen.daily_meal_count < 3000 or self.has_donation_agreement):
+            if self.has_donation_agreement or (self.canteen.daily_meal_count and self.canteen.daily_meal_count < 3000):
                 return True
 
     @property

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1686,7 +1686,7 @@ class Diagnostic(models.Model):
     @property
     def waste_badge(self):
         if self.has_waste_diagnostic and self.waste_actions and len(self.waste_actions) > 0:
-            if self.canteen.daily_meal_count < 3000 or self.has_donation_agreement:
+            if self.canteen.daily_meal_count and (self.canteen.daily_meal_count < 3000 or self.has_donation_agreement):
                 return True
 
     @property


### PR DESCRIPTION
La ligne de la comparaison du badge waste 

```python
if self.canteen.daily_meal_count < 3000 or self.has_donation_agreement:
```

pouvait échouer si `daily_meal_count` n'était pas renseigné (çad à `None`). Fut un temps c'était une possibilité, donc on a des cantines dans la base de données dans ce cas de figure. 

Dans les logs on a :

```python
 if self.canteen.daily_meal_count < 3000 or self.has_donation_agreement:#012       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^#012TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

Ce petit fix s'assure que la valeur existe avant de faire la comparaison. Testé localement.