### PR TITLE
Améliorer le libellé du champ alt texte

### DIFF
--- a/frontend/src/components/DsfrTextarea.vue
+++ b/frontend/src/components/DsfrTextarea.vue
@@ -2,7 +2,8 @@
   <div>
     <label :for="inputId" :class="labelClasses" v-if="$attrs.label">
       {{ $attrs.label }}
-      <span v-if="optional" class="fr-hint-text">Optionnel</span>
+      <span v-if="hintText" class="fr-hint-text">{{ hintText }}</span>
+      <span v-else-if="optional" class="fr-hint-text">Optionnel</span>
     </label>
     <slot name="label"></slot>
     <v-textarea
@@ -40,6 +41,10 @@ export default {
       type: String,
       required: false,
       default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",
+    },
+    hintText: {
+      type: String,
+      required: false,
     },
   },
   data() {

--- a/frontend/src/views/CanteenEditor/PublicationForm/ImagesField.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/ImagesField.vue
@@ -119,9 +119,10 @@ export default {
       })
     },
     prepareAltEdit(image) {
-      image._oldAlt = image.altText || ""
+      image._oldAlt = image.altText
     },
     saveAlt(image) {
+      if (!image._oldAlt && !image.altText) return
       if (image._oldAlt !== image.altText) this.saveImages("alt")
     },
     saveImages(action) {

--- a/frontend/src/views/CanteenEditor/PublicationForm/ImagesField.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/ImagesField.vue
@@ -23,8 +23,8 @@
         </div>
         <DsfrTextarea
           v-model="image.altText"
-          label="Description de l'image"
-          hint="Si l'image contient de l'information pertinente, pensez à ajouter une description pour les personnes malvoyantes"
+          label="Description pour les personnes malvoyantes"
+          hintText="Optionnel - Si l'image contient du texte, pensez à le répéter ici. Ce ne sera pas visible en legende."
           class="mt-2"
           rows="3"
           labelClasses="body-2 mt-4 mb-2"

--- a/frontend/src/views/CanteenEditor/PublicationForm/ImagesField.vue
+++ b/frontend/src/views/CanteenEditor/PublicationForm/ImagesField.vue
@@ -24,7 +24,7 @@
         <DsfrTextarea
           v-model="image.altText"
           label="Description pour les personnes malvoyantes"
-          hintText="Optionnel - Si l'image contient du texte, pensez à le répéter ici. Ce ne sera pas visible en legende."
+          hintText="Optionnel - Si l'image contient du texte, pensez à le répéter ici. Ce ne sera pas visible en légende."
           class="mt-2"
           rows="3"
           labelClasses="body-2 mt-4 mb-2"


### PR DESCRIPTION
Aussi éviter un sauvegarde quand il y avait pas du texte, et il n'en a pas.

![Screenshot 2024-06-10 at 17-17-00 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/9c29fb23-248f-44fd-822b-e40a10f53078)
