### PR TITLE
:bug: Les cantines supprimées devrait pas être visible comme des cantines publiées

### DIFF
--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -60,11 +60,12 @@ class DeprecatedCanteenQuerySet(SoftDeletionQuerySet):
 
 
 class CanteenManager(SoftDeletionManager):
-    def get_queryset(self):
+    def get_queryset(self, *args, **kwargs):
         if settings.PUBLISH_BY_DEFAULT:
-            return CanteenQuerySet(self.model)
+            self.queryset_model = CanteenQuerySet
         else:
-            return DeprecatedCanteenQuerySet(self.model)
+            self.queryset_model = DeprecatedCanteenQuerySet
+        return super(CanteenManager, self).get_queryset(*args, **kwargs)
 
     def publicly_visible(self):
         return self.get_queryset().publicly_visible()
@@ -74,8 +75,8 @@ class CanteenManager(SoftDeletionManager):
 
 
 class Canteen(SoftDeletionModel):
-    objects = SoftDeletionManager()
-    all_objects = SoftDeletionManager(alive_only=False)
+    objects = CanteenManager()
+    all_objects = CanteenManager(alive_only=False)
 
     class Meta:
         verbose_name = "cantine"

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -74,8 +74,8 @@ class CanteenManager(SoftDeletionManager):
 
 
 class Canteen(SoftDeletionModel):
-    objects = CanteenManager()
-    all_objects = CanteenManager(alive_only=False)
+    objects = SoftDeletionManager()
+    all_objects = SoftDeletionManager(alive_only=False)
 
     class Meta:
         verbose_name = "cantine"

--- a/data/models/softdeletionmodel.py
+++ b/data/models/softdeletionmodel.py
@@ -12,14 +12,16 @@ class SoftDeletionQuerySet(QuerySet):
 
 
 class SoftDeletionManager(models.Manager):
+    queryset_model = SoftDeletionQuerySet
+
     def __init__(self, *args, **kwargs):
         self.alive_only = kwargs.pop("alive_only", True)
         super(SoftDeletionManager, self).__init__(*args, **kwargs)
 
     def get_queryset(self):
         if self.alive_only:
-            return SoftDeletionQuerySet(self.model).filter(deletion_date=None)
-        return SoftDeletionQuerySet(self.model)
+            return self.queryset_model(self.model).filter(deletion_date=None)
+        return self.queryset_model(self.model)
 
     def hard_delete(self):
         return self.get_queryset().hard_delete()

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -27,6 +27,6 @@ class TestCanteenModel(TestCase):
         canteen = CanteenFactory.create()
         canteen.delete()
         qs = Canteen.objects.all()
-        self.assertEqual(qs.count(), 0)
+        self.assertEqual(qs.count(), 0, "Soft deleted canteen is not visible in default queryset")
         qs = Canteen.all_objects.all()
-        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs.count(), 1, "Soft deleted canteens can be accessed in custom queryset")

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -19,8 +19,14 @@ class TestCanteenModel(TestCase):
         self.assertEqual(canteen.service_diagnostics.first().year, 2023)
         self.assertEqual(canteen.latest_published_year, 2023)
 
-    def test_user_deleted_canteens_not_in_custom_manager(self):
+    def test_soft_delete_canteen(self):
+        """
+        The delete method should "soft delete" a canteen and have it hidden by default
+        from querysets, unless specifically asked for
+        """
         canteen = CanteenFactory.create()
         canteen.delete()
         qs = Canteen.objects.all()
         self.assertEqual(qs.count(), 0)
+        qs = Canteen.all_objects.all()
+        self.assertEqual(qs.count(), 1)

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from data.models import Canteen
 from data.factories import CanteenFactory, DiagnosticFactory
 from freezegun import freeze_time
 
@@ -17,3 +18,9 @@ class TestCanteenModel(TestCase):
         self.assertEqual(canteen.service_diagnostics.count(), 2)
         self.assertEqual(canteen.service_diagnostics.first().year, 2023)
         self.assertEqual(canteen.latest_published_year, 2023)
+
+    def test_user_deleted_canteens_not_in_custom_manager(self):
+        canteen = CanteenFactory.create()
+        canteen.delete()
+        qs = Canteen.objects.all()
+        self.assertEqual(qs.count(), 0)


### PR DESCRIPTION
Pour tester, tu pourrais vérifier les chiffres en admin quand tu filtre par public/non visible et active/toutes (statut de suppression plus bas dans la liste de filtres pour les cantines). Le chiffre sur la page nos cantines publiées devrait reflechir public x actives