### PR TITLE
:lady_beetle:  Ajout de la méthode `reset` aux champs des formulaires

### DIFF
--- a/frontend/src/components/DsfrCombobox.vue
+++ b/frontend/src/components/DsfrCombobox.vue
@@ -52,6 +52,9 @@ export default {
     errorMessageId() {
       return this.inputId && `${this.inputId}-error`
     },
+    reset() {
+      return this.$refs["combobox"].reset
+    },
   },
   methods: {
     removeInnerLabel() {

--- a/frontend/src/components/DsfrNativeSelect.vue
+++ b/frontend/src/components/DsfrNativeSelect.vue
@@ -85,6 +85,10 @@ export default {
       }
       return !this.hasError
     },
+    reset() {
+      this.$emit("input", null)
+      this.$nextTick(() => (this.errorMessage = null))
+    },
   },
   mounted() {
     this.assignInputId()

--- a/frontend/src/components/DsfrRadio.vue
+++ b/frontend/src/components/DsfrRadio.vue
@@ -69,6 +69,9 @@ export default {
     value() {
       return this.$refs["radiogroup"].value
     },
+    reset() {
+      return this.$refs["radiogroup"].reset
+    },
     items() {
       if (this.yesNo) {
         return [

--- a/frontend/src/components/DsfrSearchField.vue
+++ b/frontend/src/components/DsfrSearchField.vue
@@ -54,6 +54,9 @@ export default {
     value() {
       return this.$refs["text-field"].value
     },
+    reset() {
+      return this.$refs["text-field"].reset
+    },
     clear() {
       const noAction = () => {}
       return this.clearAction || noAction

--- a/frontend/src/components/DsfrSelect.vue
+++ b/frontend/src/components/DsfrSelect.vue
@@ -41,6 +41,9 @@ export default {
     value() {
       return this.$refs["select"].value
     },
+    reset() {
+      return this.$refs["select"].reset
+    },
     errorMessageId() {
       return this.inputId && `${this.inputId}-error`
     },

--- a/frontend/src/components/DsfrTextField.vue
+++ b/frontend/src/components/DsfrTextField.vue
@@ -63,6 +63,9 @@ export default {
     lazyValue() {
       return this.$refs["text-field"].lazyValue
     },
+    reset() {
+      return this.$refs["text-field"].reset
+    },
     value() {
       return this.$refs["text-field"].value
     },

--- a/frontend/src/components/DsfrTextarea.vue
+++ b/frontend/src/components/DsfrTextarea.vue
@@ -57,6 +57,9 @@ export default {
     value() {
       return this.$refs["textarea"].value
     },
+    reset() {
+      return this.$refs["textarea"].reset
+    },
     optional() {
       return !validators._includesRequiredValidator(this.$attrs.rules)
     },

--- a/frontend/src/components/GeneralContactForm.vue
+++ b/frontend/src/components/GeneralContactForm.vue
@@ -129,7 +129,10 @@ export default {
           this.$refs.form.reset()
           window.scrollTo(0, 0)
         })
-        .catch((e) => this.$store.dispatch("notifyServerError", e))
+        .catch((e) => {
+          console.log(e)
+          this.$store.dispatch("notifyServerError", e)
+        })
     },
   },
 }


### PR DESCRIPTION
L'erreur remontée concernant la forme de contact était en fait une erreur front-end, le backend ayant retourné un 200 OK :

![image](https://github.com/betagouv/ma-cantine/assets/1225929/833f6e3d-7d6d-4b98-8d54-040a3765450b)

Cela vient de la ligne `this.$refs.form.reset()` de _GeneralContactForm.vue_. Cette méthode enchaîne l'appel à la méthode `reset` de chaque champ présent dans le formulaire. Or, certains de nos champs n'avait pas cette méthode disponible.