### PR TITLE
RGAA 10.7 : améliorer la visibilité du focus sur le lien-logo dans l'en-tête

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -182,10 +182,12 @@ button:focus,
 .v-radio:focus-within,
 .v-card:focus,
 .drag-and-drop:focus-within,
-div[role="tab"]:focus {
+div[role="tab"]:focus,
+.outline-focus-within:focus-within {
   outline: rgb(0, 0, 145) !important;
   outline-width: 1px !important;
   outline-style: auto !important;
+  outline-offset: 2px;
 }
 
 .v-btn.primary:hover {

--- a/frontend/src/components/AppHeader/index.vue
+++ b/frontend/src/components/AppHeader/index.vue
@@ -13,8 +13,8 @@
       hide-on-scroll
       role="banner"
     >
-      <v-toolbar-title class="align-self-center">
-        <v-card
+      <v-toolbar-title class="align-self-center outline-focus-within">
+        <router-link
           :to="{ name: 'LandingPage' }"
           class="text-decoration-none d-flex align-center pl-4"
           aria-label="ma cantine (aller à l'accueil) - Ministère de l'Agriculture et de la Souveraineté Alimentaire"
@@ -25,7 +25,7 @@
           <v-chip v-if="chipInfo" label outlined :color="chipInfo.color" class="font-weight-bold ml-3" small>
             {{ chipInfo.text }}
           </v-chip>
-        </v-card>
+        </router-link>
       </v-toolbar-title>
 
       <v-spacer></v-spacer>


### PR DESCRIPTION
Avant, on a utilisé le hover de v-card qui gris l'image. Or, le gris n'avait pas suffisament de contraste (3:1) pour être utile. Je change le lien logo pour utiliser router-link. Je ne sais pas pourquoi, mais l'outline n'a pas été visible avec `a:focus`, alors j'ai créé un nouveau class `outline-focus-within` et je l'ai mis sur le parent.

J'ajoute `outline-offset: 2px` que parce que c'est utilisé par le DSFR.