### PR TITLE
RGAA 11.10 : améliorations création du compte

### DIFF
--- a/web/forms.py
+++ b/web/forms.py
@@ -37,11 +37,9 @@ class RegisterUserForm(UserCreationForm):
     def __init__(self, *args, **kwargs):
         super(RegisterUserForm, self).__init__(*args, **kwargs)
         self.label_suffix = ""
-        self.fields["first_name"].widget.attrs.update(
-            {"placeholder": "Agnès", "autocomplete": "given-name"}, autoFocus=True
-        )
+        self.fields["first_name"].widget.attrs.update({"placeholder": "Agnès", "autocomplete": "given-name"})
         self.fields["last_name"].widget.attrs.update({"placeholder": "Dufresne", "autocomplete": "family-name"})
-        self.fields["username"].widget.attrs.update({"placeholder": "agnes.dufresne"})
+        self.fields["username"].widget.attrs.update({"placeholder": "agnes.dufresne", "autofocus": False})
         self.fields["email"].label = "Adresse électronique"
         self.fields["email"].help_text = "Format attendu : nom@domaine.fr"
         self.fields["email"].widget.attrs.update({"placeholder": "agnes.d@example.com", "autocomplete": "email"})

--- a/web/static/css/auth.css
+++ b/web/static/css/auth.css
@@ -199,19 +199,12 @@ input[type="checkbox"]#id_cgu_approved {
 }
 
 .register-top-text {
-  margin-bottom: 30px;
-  margin-top: 0;
   text-align: left;
   line-height: 24px;
 }
 
 .register-top-text > p {
   font-size: 15px;
-}
-
-label[for="id_is_dev"] {
-  font-size: 15px;
-  margin-top: 15px;
 }
 
 #id_is_dev {
@@ -226,7 +219,7 @@ input.cantine-number-input {
 }
 
 .cgu-right-column > div {
-  margin-top: 40px;
+  margin-top: 20px;
 }
 
 @media (max-width: 1005px) {

--- a/web/templates/auth/register.html
+++ b/web/templates/auth/register.html
@@ -42,9 +42,7 @@
       Munissez-vous du <strong>numéro SIRET</strong> de votre ou de vos établissement(s) de restauration pour la prochaine étape :
       la création de votre ou de vos cantine(s).
     </p>
-    <p>
-      {{ form.is_dev }}<label for="{{form.is_dev.id_for_label}}">Je suis une développeuse ou un développeur logiciel et j'ai besoin d'accéder aux APIs</label>
-    </p>
+    <p>Les champs marqués d'un astérisque (*) sont obligatoires.</p>
   </div>
   <div>
 
@@ -72,6 +70,7 @@
       <div class="control-group">
         <label class="control-label" for="{{field.id_for_label}}">
           {{ field.label }}
+          {% if field.field.required %}*{% endif %}
           {% if field.help_text %}
           <span class="field-help-text">
             {{ field.help_text }}</span>
@@ -91,7 +90,9 @@
       {% for field in form.right_column_fields %}
       <div class="control-group">
         <label class="control-label" for="{{field.id_for_label}}">
-          {{ field.label }}</label>
+          {{ field.label }}
+          {% if field.field.required %}*{% endif %}
+        </label>
         {{ field }}
         {% for error in field.errors %}
         <p class="inline-error-container">
@@ -103,9 +104,14 @@
 
       <div class="control-group cgu-right-column">
         <div>
+          {{ form.is_dev }}<label for="{{form.is_dev.id_for_label}}">Je suis une développeuse ou un développeur logiciel et j'ai besoin d'accéder aux APIs</label>
+        </div>
+        <div>
           {{ form.cgu_approved }}
           <label class="control-label" for="{{form.cgu_approved.id_for_label}}">
-            {{ form.cgu_approved.label }}</label>
+            {{ form.cgu_approved.label }}
+            {% if form.cgu_approved.field.required %}*{% endif %}
+          </label>
           {% for error in form.cgu_approved.errors %}
           <p class="inline-error-container">
             {{ error | safe }}


### PR DESCRIPTION
Faut avoir une indication des champs obligatoires/optionnelles avec un texte pour expliquer comment les identifier.

Avec le texte, je trouvais que le cas à cocher pour les dévs a pris trop d'espace verticale, alors je l'ai déplacé. 

J'ai profité pour enlever l'autofocus (du champ nom, et l'autofocus par défaut de django https://github.com/django/django/blob/a6291394256aa758d74eec9ce0cfae8aea6475f2/django/contrib/auth/forms.py#L108) pour éviter les sautes de page en version mobile.

![Screenshot 2024-06-17 at 19-28-08 Créer mon compte - ma-cantine agriculture gouv fr](https://github.com/betagouv/ma-cantine/assets/9282816/a88031a0-31bb-48aa-81c2-2090b340cb61)
