### PR TITLE
RGAA 11.10 : message d'erreur doit reflechir champ

### DIFF
--- a/web/forms.py
+++ b/web/forms.py
@@ -1,5 +1,5 @@
 import re
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
 from django.contrib.auth import get_user_model
 from django import forms
 from django.utils.safestring import mark_safe
@@ -107,3 +107,11 @@ def _clean_username(form):
         raise forms.ValidationError("Vous ne pouvez pas utiliser une adresse email comme nom d'utilisateur.")
 
     return username
+
+
+class LoginUserForm(AuthenticationForm):
+    def __init__(self, *args, **kwargs):
+        super(LoginUserForm, self).__init__(*args, **kwargs)
+        self.error_messages["invalid_login"] = (
+            "Saisissez un nom d'utilisateur ou adresse électronique et un mot de passe valides. Remarquez que chacun de ces champs est sensible à la casse (différenciation des majuscules/minuscules)."
+        )

--- a/web/urls.py
+++ b/web/urls.py
@@ -10,6 +10,7 @@ from web.sitemaps import CanteenSitemap, BlogPostSitemap, WebSitemap, PartnerSit
 from web.views import (
     VueAppDisplayView,
     WidgetView,
+    LoginUserView,
     RegisterUserView,
     ActivationTokenView,
     RegisterDoneView,
@@ -33,7 +34,7 @@ urlpatterns = [
     # https://docs.djangoproject.com/en/3.1/topics/auth/default/#django.contrib.auth.views.LoginView
     path(
         "s-identifier",
-        auth_views.LoginView.as_view(
+        LoginUserView.as_view(
             template_name="auth/login.html",
             redirect_authenticated_user=True,
         ),

--- a/web/views.py
+++ b/web/views.py
@@ -3,6 +3,7 @@ from django.urls import reverse_lazy
 from django.shortcuts import redirect, render
 from django.conf import settings
 from django.contrib.auth import get_user_model, tokens, login
+from django.contrib.auth import views as auth_views
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
@@ -10,7 +11,7 @@ from django.utils.encoding import force_bytes
 from common.utils import send_mail
 from django.core.exceptions import ObjectDoesNotExist
 from django.views.generic import TemplateView, FormView, View
-from web.forms import RegisterUserForm
+from web.forms import RegisterUserForm, LoginUserForm
 from data.factories import UserFactory
 from django.views.decorators.clickjacking import xframe_options_exempt
 from authlib.integrations.django_client import OAuth
@@ -45,6 +46,10 @@ class VueAppDisplayView(TemplateView):
     """
 
     template_name = "vue-app.html"
+
+
+class LoginUserView(auth_views.LoginView):
+    form_class = LoginUserForm
 
 
 class RegisterUserView(FormView):


### PR DESCRIPTION
Avant, c'etait que "un nom d'utilisateur et un mot de passe", sans la phrase "ou adresse électronique"
![Screenshot 2024-06-17 at 19-47-19 S'identifier - ma-cantine agriculture gouv fr](https://github.com/betagouv/ma-cantine/assets/9282816/02250165-476d-49ad-9f24-2b5ce4f2604e)
