### PR TITLE
Page acteurs de l'eco-système : ajouter une barre de recherche par nom d'acteur

### DIFF
--- a/api/views/partner.py
+++ b/api/views/partner.py
@@ -8,6 +8,7 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 from api.serializers import PartnerSerializer, PartnerShortSerializer, PartnerContactSerializer
 from data.models import Partner
+from .utils import UnaccentSearchFilter
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,8 @@ class PartnersPagination(LimitOffsetPagination):
 class PartnersView(ListCreateAPIView):
     model = Partner
     pagination_class = PartnersPagination
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [DjangoFilterBackend, UnaccentSearchFilter]
+    search_fields = ["name"]
 
     def get_serializer_class(self):
         if self.request.method == "POST":

--- a/frontend/src/components/DsfrSearchField.vue
+++ b/frontend/src/components/DsfrSearchField.vue
@@ -7,7 +7,7 @@
     v-on="$listeners"
     @input="(v) => $emit('input', v)"
     @click:clear="clear"
-    @keyup.enter="searchAction"
+    @keyup.enter="search"
     ref="text-field"
   >
     <template v-slot:append>
@@ -18,7 +18,7 @@
         min-width="40px"
         max-width="40px"
         height="40px"
-        @click="searchAction"
+        @click="search"
         aria-label="Rechercher"
       >
         <v-icon>$search-line</v-icon>
@@ -33,12 +33,6 @@ import DsfrTextField from "@/components/DsfrTextField"
 export default {
   inheritAttrs: false,
   components: { DsfrTextField },
-  props: {
-    searchAction: {
-      type: Function,
-      required: true,
-    },
-  },
   computed: {
     lazyValue() {
       return this.$refs["text-field"].lazyValue
@@ -59,6 +53,9 @@ export default {
     },
     clear() {
       this.$emit("clear")
+    },
+    search() {
+      this.$emit("search")
     },
   },
 }

--- a/frontend/src/components/DsfrSearchField.vue
+++ b/frontend/src/components/DsfrSearchField.vue
@@ -6,7 +6,6 @@
     v-bind="$attrs"
     v-on="$listeners"
     @input="(v) => $emit('input', v)"
-    :clearable="clearable"
     @click:clear="clear"
     @keyup.enter="searchAction"
     ref="text-field"
@@ -39,15 +38,8 @@ export default {
       type: Function,
       required: true,
     },
-    clearAction: {
-      type: Function,
-      required: false,
-    },
   },
   computed: {
-    clearable() {
-      return !!this.clearAction
-    },
     lazyValue() {
       return this.$refs["text-field"].lazyValue
     },
@@ -57,10 +49,6 @@ export default {
     reset() {
       return this.$refs["text-field"].reset
     },
-    clear() {
-      const noAction = () => {}
-      return this.clearAction || noAction
-    },
   },
   methods: {
     validate() {
@@ -68,6 +56,9 @@ export default {
     },
     resetValidation() {
       return this.$refs["text-field"].resetValidation()
+    },
+    clear() {
+      this.$emit("clear")
     },
   },
 }

--- a/frontend/src/views/BlogsPage/BlogsHome.vue
+++ b/frontend/src/views/BlogsPage/BlogsHome.vue
@@ -29,7 +29,7 @@
           hide-details
           clearable
           @clear="clearSearch"
-          :searchAction="search"
+          @search="search"
         />
       </v-col>
 

--- a/frontend/src/views/BlogsPage/BlogsHome.vue
+++ b/frontend/src/views/BlogsPage/BlogsHome.vue
@@ -21,16 +21,15 @@
       </v-row>
     </v-card>
 
-    <v-row>
+    <v-row class="align-end">
       <v-col cols="12" sm="6" md="8">
         <DsfrSearchField
           v-model="searchTerm"
           placeholder="Rechercher par titre ou contenu"
           hide-details
           clearable
-          :clearAction="clearSearch"
+          @clear="clearSearch"
           :searchAction="search"
-          label="Rechercher"
         />
       </v-col>
 

--- a/frontend/src/views/CanteenSearchLanding.vue
+++ b/frontend/src/views/CanteenSearchLanding.vue
@@ -26,7 +26,7 @@
           v-model="searchTerm"
           placeholder="Recherche par nom ou SIRET de l'établissement"
           hide-details
-          :searchAction="search"
+          @search="search"
         />
         <p class="my-4">
           <router-link :to="{ name: 'CanteensHome' }" class="d-flex align-center">

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -12,7 +12,7 @@
               ref="search"
               v-model="searchTerm"
               placeholder="Recherche par nom ou SIRET"
-              :searchAction="search"
+              @search="search"
               clearable
               @clear="clearSearch"
             />

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -13,7 +13,8 @@
               v-model="searchTerm"
               placeholder="Recherche par nom ou SIRET"
               :searchAction="search"
-              :clearAction="clearSearch"
+              clearable
+              @clear="clearSearch"
             />
           </form>
         </v-col>

--- a/frontend/src/views/ManagementPage/CanteensPagination.vue
+++ b/frontend/src/views/ManagementPage/CanteensPagination.vue
@@ -10,7 +10,7 @@
               v-model="searchTerm"
               placeholder="Recherche par nom ou SIRET de l'établissement"
               clearable
-              :clearAction="clearSearch"
+              @clear="clearSearch"
               :searchAction="search"
               class="mb-2 flex-grow-1"
             />

--- a/frontend/src/views/ManagementPage/CanteensPagination.vue
+++ b/frontend/src/views/ManagementPage/CanteensPagination.vue
@@ -11,7 +11,7 @@
               placeholder="Recherche par nom ou SIRET de l'établissement"
               clearable
               @clear="clearSearch"
-              :searchAction="search"
+              @search="search"
               class="mb-2 flex-grow-1"
             />
           </form>

--- a/frontend/src/views/PartnersPage/PartnersHome.vue
+++ b/frontend/src/views/PartnersPage/PartnersHome.vue
@@ -59,7 +59,7 @@
           <v-col cols="12" md="6">
             <DsfrSearchField
               v-model="filters.search.provisionalValue"
-              :searchAction="applyProvisionalValue(filters.search)"
+              @search="applyProvisionalValue(filters.search)"
               clearable
               @clear="clearFilterField(filters.search)"
               placeholder="Rechercher par nom"
@@ -486,7 +486,7 @@ export default {
       this.sectorCategories = [...enabledCategories, divider, header, ...disabledCategories]
     },
     applyProvisionalValue(filterTerm) {
-      return () => (filterTerm.value = filterTerm.provisionalValue)
+      filterTerm.value = filterTerm.provisionalValue
     },
     clearFilterField(filterTerm) {
       filterTerm.provisionalValue = filterTerm.default

--- a/frontend/src/views/PartnersPage/PartnersHome.vue
+++ b/frontend/src/views/PartnersPage/PartnersHome.vue
@@ -418,6 +418,7 @@ export default {
         })
     },
     populateParameters() {
+      // TODO: fix bug where search isn't populated
       Object.values(this.filters).forEach((f) => {
         f.value = this.$route.query[f.param]
         if (f.transformToFrontend) f.value = f.transformToFrontend(f.value)
@@ -437,9 +438,7 @@ export default {
       }
     },
     applyFilter() {
-      console.log("apply filter")
       const changedKeys = Object.keys(getObjectDiff(this.query, this.$route.query))
-      console.log(changedKeys)
       const shouldNavigate = changedKeys.length > 0
       if (shouldNavigate) {
         this.page = 1

--- a/frontend/src/views/PartnersPage/PartnersHome.vue
+++ b/frontend/src/views/PartnersPage/PartnersHome.vue
@@ -56,6 +56,17 @@
     <v-expand-transition>
       <v-sheet class="pa-6 text-left mt-2 ma-0" v-show="showFilters" rounded :outlined="showFilters">
         <v-row>
+          <v-col cols="12" md="6">
+            <DsfrSearchField
+              v-model="search"
+              :searchAction="applySearchTerm"
+              :clearAction="clearSearch"
+              placeholder="Rechercher par nom"
+              hide-details="auto"
+            />
+          </v-col>
+        </v-row>
+        <v-row>
           <v-col cols="12" sm="6" v-if="$vuetify.breakpoint.smAndDown">
             <label
               for="select-category"
@@ -222,6 +233,7 @@
 <script>
 import Constants from "@/constants"
 import BreadcrumbsNav from "@/components/BreadcrumbsNav"
+import DsfrSearchField from "@/components/DsfrSearchField"
 import DsfrPagination from "@/components/DsfrPagination"
 import DsfrSelect from "@/components/DsfrSelect"
 import DsfrCombobox from "@/components/DsfrCombobox"
@@ -235,6 +247,7 @@ export default {
   name: "PartnersHome",
   components: {
     BreadcrumbsNav,
+    DsfrSearchField,
     DsfrPagination,
     DsfrSelect,
     DsfrCombobox,
@@ -250,7 +263,13 @@ export default {
       types: [],
       visiblePartners: null,
       partnerCount: null,
+      search: null,
       filters: {
+        search: {
+          param: "recherche",
+          value: null,
+          default: null,
+        },
         gratuityOption: {
           param: "gratuit",
           value: [],
@@ -418,7 +437,9 @@ export default {
       }
     },
     applyFilter() {
+      console.log("apply filter")
       const changedKeys = Object.keys(getObjectDiff(this.query, this.$route.query))
+      console.log(changedKeys)
       const shouldNavigate = changedKeys.length > 0
       if (shouldNavigate) {
         this.page = 1
@@ -463,6 +484,13 @@ export default {
         }
       })
       this.sectorCategories = [...enabledCategories, divider, header, ...disabledCategories]
+    },
+    applySearchTerm() {
+      this.filters.search.value = this.search
+    },
+    clearSearch() {
+      this.search = this.filters.search.default
+      this.applySearchTerm()
     },
   },
   watch: {

--- a/frontend/src/views/PartnersPage/PartnersHome.vue
+++ b/frontend/src/views/PartnersPage/PartnersHome.vue
@@ -58,9 +58,10 @@
         <v-row>
           <v-col cols="12" md="6">
             <DsfrSearchField
-              v-model="search"
-              :searchAction="applySearchTerm"
-              :clearAction="clearSearch"
+              v-model="filters.search.provisionalValue"
+              :searchAction="applyProvisionalValue(filters.search)"
+              clearable
+              @clear="clearFilterField(filters.search)"
               placeholder="Rechercher par nom"
               hide-details="auto"
             />
@@ -263,11 +264,11 @@ export default {
       types: [],
       visiblePartners: null,
       partnerCount: null,
-      search: null,
       filters: {
         search: {
           param: "recherche",
           value: null,
+          provisionalValue: null,
           default: null,
         },
         gratuityOption: {
@@ -418,10 +419,10 @@ export default {
         })
     },
     populateParameters() {
-      // TODO: fix bug where search isn't populated
       Object.values(this.filters).forEach((f) => {
         f.value = this.$route.query[f.param]
         if (f.transformToFrontend) f.value = f.transformToFrontend(f.value)
+        if (Object.hasOwn(f, "provisionalValue")) f.provisionalValue = f.value
       })
       this.page = this.$route.query.page ? parseInt(this.$route.query.page) : 1
       this.fetchCurrentPage()
@@ -484,12 +485,12 @@ export default {
       })
       this.sectorCategories = [...enabledCategories, divider, header, ...disabledCategories]
     },
-    applySearchTerm() {
-      this.filters.search.value = this.search
+    applyProvisionalValue(filterTerm) {
+      return () => (filterTerm.value = filterTerm.provisionalValue)
     },
-    clearSearch() {
-      this.search = this.filters.search.default
-      this.applySearchTerm()
+    clearFilterField(filterTerm) {
+      filterTerm.provisionalValue = filterTerm.default
+      filterTerm.value = filterTerm.provisionalValue
     },
   },
   watch: {

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -78,7 +78,7 @@
             hide-details
             clearable
             @clear="clearSearch"
-            :searchAction="search"
+            @search="search"
           />
         </v-col>
         <v-spacer v-if="$vuetify.breakpoint.smAndUp"></v-spacer>

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -77,7 +77,7 @@
             placeholder="Chercher par produit ou fournisseur"
             hide-details
             clearable
-            :clearAction="clearSearch"
+            @clear="clearSearch"
             :searchAction="search"
           />
         </v-col>


### PR DESCRIPTION
Ça fait partie des améliorations demandées

Cette PR ajoute la barre de recherche DSFR dans la partie filtres et aussi repare l'API du composant pour utiliser les events, un interface plus conforme avec notre code et Vue/Vuetify.

![Screenshot 2024-06-24 at 17-50-52 ma cantine](https://github.com/betagouv/ma-cantine/assets/9282816/bc47e093-045a-4f9b-9fc8-95a78bc683e0)


