### PR TITLE
Enlever les tests front de github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,10 +60,3 @@ jobs:
           SIRET_API_SECRET: fake
         run: |
           python3 manage.py test
-
-      - name: Test Vue
-        working-directory: ./frontend
-        run: |
-          npm install
-          npm run build --if-present
-          npm run test


### PR DESCRIPTION
Le build de Vue 2 est lente, alors ça prend plus de 2 minutes de faire ces tests, mais on ecrit pas trop de tests alors le tradeoff ne vaut pas le coup ama. Je laisse le dossier tests quand-même si jamais on veut lancer les tests en local