### PR TITLE
Automatiser le build (faut ajouter CC_PRE_BUILD_HOOK)

### DIFF
--- a/2024-frontend/src/router/index.js
+++ b/2024-frontend/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from "vue-router"
 import HomeView from "../views/HomeView.vue"
+import AboutView from "../views/AboutView.vue"
 
 const routes = [
   {
@@ -10,10 +11,7 @@ const routes = [
   {
     path: "/about",
     name: "AboutView",
-    // route level code-splitting
-    // this generates a separate chunk (About.[hash].js) for this route
-    // which is lazy-loaded when the route is visited.
-    component: () => import("../views/AboutView.vue"),
+    component: AboutView,
   },
 ]
 

--- a/2024-frontend/vite.config.js
+++ b/2024-frontend/vite.config.js
@@ -21,7 +21,4 @@ export default defineConfig({
       vue: fileURLToPath(new URL("./node_modules/vue/index.js", import.meta.url)),
     },
   },
-  build: {
-    manifest: true,
-  },
 })

--- a/clevercloud/manifest.json
+++ b/clevercloud/manifest.json
@@ -1,0 +1,3 @@
+{
+  "dummy": "manifest file. This is a hack to work around a django-vite-plugin bug."
+}

--- a/clevercloud/pre-build-hook.sh
+++ b/clevercloud/pre-build-hook.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mkdir build
+mkdir build/.vite
+cp ./clevercloud/manifest.json build/.vite/
+mkdir 2024-frontend/build
+mkdir 2024-frontend/build/.vite
+cp ./clevercloud/manifest.json 2024-frontend/build/.vite/

--- a/clevercloud/python.json
+++ b/clevercloud/python.json
@@ -4,10 +4,12 @@
   },
   "deploy": {
     "managetasks": [
-      "migrate --noinput",
       "buildnpm",
-      "compilemessages",
-      "collectstatic --noinput"
+      "collectstatic --noinput",
+      "buildnpmvue3",
+      "collectstatic --noinput",
+      "migrate --noinput",
+      "compilemessages"
     ]
   }
 }

--- a/clevercloud/test-build.sh
+++ b/clevercloud/test-build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+rm -rf static/
+rm -rf build/
+rm -rf 2024-frontend/build/
+bash ./clevercloud/pre-build-hook.sh
+# the following should mirror the hooks in clevercloud/python.json["deploy"]["managetasks"]
+python manage.py buildnpm
+python manage.py collectstatic --noinput
+python manage.py buildnpmvue3
+python manage.py collectstatic --noinput
+python manage.py migrate --noinput
+python manage.py compilemessages
+# use the following command to run the server when testing locally. Need --insecure flag to serve local static assets
+# python manage.py runserver --insecure

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -248,14 +248,17 @@ Des extensions qu'on trouve utile :
 
 ## Test déploiement en locale
 
+Les commandes lancées sur CleverCloud sont listées dans `clevercloud/python.json`.
+
 .env :
 
 ```
-DEBUG=True
+DEBUG=False
 DEBUG_FRONT=False
 ```
 
-`frontend/ > export DEBUG=False; npm run build`
-`2024-frontend/ > npm run build`
-`/ > python manage.py collectstatic`
-`/ > python manage.py runserver --insecure`
+Dans le dossier principal, lancez :
+`bash ./clevercloud/test-build.sh`
+`python manage.py runserver --insecure`
+
+En prod, faut ajouter `CC_PRE_BUILD_HOOK=./clevercloud/pre-build-hook.sh`

--- a/macantine/management/commands/buildnpmvue3.py
+++ b/macantine/management/commands/buildnpmvue3.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+from django.core.management.base import BaseCommand
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+
+class Command(BaseCommand):
+    help = "Fetches npm dependencies and makes a prod build of the frontend application"
+
+    def handle(self, *args, **options):
+        print(BASE_DIR)
+
+        os.chdir(os.path.join(BASE_DIR, "2024-frontend"))
+        subprocess.run(["npm", "install"])
+        subprocess.run(["npm", "run", "build"])
+        os.chdir(os.path.join(BASE_DIR))


### PR DESCRIPTION
Faut avoir un manifest dans deux locations malheureusement. Il me paraît que quand les commandes sont lancées depuis le project root le fichier est cherché dans `ma-cantine/build/.vite/manifest.json` mais quand on fait `npm run build` dans `2024-frontend/` le fichier est cherché dans `ma-cantine/2024-frontend/build/.vite/manifest.json`.

Le code en question qui nous donne des pbs c'est dans `django_vite_plugin/utils.py` :

```
if not CONFIG['DEV_MODE']:
    manifest_path = CONFIG['MANIFEST']
    if not path.isfile(manifest_path):
        raise RuntimeError(
            f"The Vite manifest file does not exist at: {manifest_path}"
        )
    try:
        manifest_file = open(manifest_path, "r")
        manifest_content = manifest_file.read()
        manifest_file.close()
        VITE_MANIFEST = json.loads(manifest_content)
    except Exception as error:
        raise RuntimeError(
            f"Cannot read Vite manifest file at "
            f"{manifest_path} : {str(error)}"
        )
```

Alors le contenu de `ma-cantine/clevercloud/manifest.json` n'est pas important, mais il ne peut pas être vide. (`path.isfile(...)` demande qu'il existe et `manifest_file.read()` demande qu'il n'est pas vide)