### PR TITLE
Reinstate frontend tests, but in separate job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Ma Cantine CI
 on: [push]
 
 jobs:
-  build:
+  backend:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -60,3 +60,23 @@ jobs:
           SIRET_API_SECRET: fake
         run: |
           python3 manage.py test
+
+  frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - name: Test Vue 3
+        working-directory: ./frontend
+        run: |
+          npm install
+          npm run build --if-present
+          npm run test
+      - name: Test Vue 3
+        working-directory: ./2024-frontend
+        run: |
+          npm install
+          npm run build --if-present


### PR DESCRIPTION
C'est utile d'avoir les tests du front pour les PRs dependabot - au moins pour le build. Alors je les reintroduit.

Je voulais lancer le job que pour main, staging, et les PRs dependabot en faisant:

```
    on:
      pull_request:
        branches:
          - staging
          - main
          - "dependabot/**"
```
Mais [selon les docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-branches)
> If a workflow is skipped due to branch filtering, [path filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), or a [commit message](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs), then checks associated with that workflow will remain in a "Pending" state. A pull request that requires those checks to be successful will be blocked from merging.

Qui ne resoudre le pb de base qui est que les tests de front sont lentes et c'est difficile d'avoir la visibilité sur quand les tests de back sont validés. Alors je propose qu'on : 
- decoupe les tests en deux, qui nous permets plus facilement de voir l'etat des deux et prendre la bonne decision avec
- ajoute le build de Vue 3, pour aider avec les PRs dependabot
