### PR TITLE
Fix export open_data

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore=E501,W503,E704
+ignore=E501,W503,E704,E203
 exclude = .git,__pycache__,docs/source/conf.py,build,dist,migrations,media,fixtures,requirements,static,assets
 max-complexity = 10

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ static/*
 # except the .keep to keep it in git
 media/*
 !media/.keep
+!media/open_data/.keep
 
 # Flask stuff:
 instance/

--- a/macantine/etl.py
+++ b/macantine/etl.py
@@ -383,37 +383,33 @@ class ETL_OPEN_DATA(ETL):
             self.df.to_parquet(parquet_file)
 
     def _load_data_xlsx(self, filename):
-        try:
-            chunk_size = 1000
-            start_row = 0
+        chunk_size = 1000
+        start_row = 0
 
-            # Convert datetime to string
-            df = datetimes_to_str(self.df.copy())  # Assuming it converts datetimes to strings
+        # Convert datetime to string
+        df = datetimes_to_str(self.df.copy())  # Assuming it converts datetimes to strings
 
-            # Create an in-memory bytes buffer
-            output = BytesIO()
+        # Create an in-memory bytes buffer
+        output = BytesIO()
 
-            # Create ExcelWriter with the actual file path
-            with pd.ExcelWriter(output, engine="openpyxl") as writer:
-                for chunk in [df[i : i + chunk_size] for i in range(0, len(df.copy()), chunk_size)]:
-                    # Write chunk to the sheet, accumulating data
-                    chunk.to_excel(
-                        writer,
-                        startrow=start_row,
-                        index=False,
-                        header=True if start_row == 0 else False,
-                    )
-                    start_row += len(chunk)  # Update starting row for next chunk
+        # Create ExcelWriter with the actual file path
+        with pd.ExcelWriter(output, engine="openpyxl") as writer:
+            for chunk in [df[i : i + chunk_size] for i in range(0, len(df.copy()), chunk_size)]:
+                # Write chunk to the sheet, accumulating data
+                chunk.to_excel(
+                    writer,
+                    startrow=start_row,
+                    index=False,
+                    header=True if start_row == 0 else False,
+                )
+                start_row += len(chunk)  # Update starting row for next chunk
 
-            # Ensure the buffer is ready for reading
-            output.seek(0)
+        # Ensure the buffer is ready for reading
+        output.seek(0)
 
-            # Save the in-memory bytes buffer to the storage backend
-            with default_storage.open(filename + ".xlsx", "wb") as f:
-                f.write(output.getvalue())
-
-        except Exception as e:
-            logger.error(e)
+        # Save the in-memory bytes buffer to the storage backend
+        with default_storage.open(filename + ".xlsx", "wb") as f:
+            f.write(output.getvalue())
 
     def load_dataset(self):
         filepath = f"open_data/{self.dataset_name}"

--- a/macantine/etl.py
+++ b/macantine/etl.py
@@ -386,16 +386,16 @@ class ETL_OPEN_DATA(ETL):
         chunk_size = 1000
         start_row = 0
 
-        # Convert datetime to string
-        df = datetimes_to_str(self.df.copy())  # Assuming it converts datetimes to strings
-
         # Create an in-memory bytes buffer
         output = BytesIO()
 
         # Create ExcelWriter with the actual file path
         with pd.ExcelWriter(output, engine="openpyxl") as writer:
-            dataframe_chunks = [df[i : i + chunk_size] for i in range(0, len(df), chunk_size)]
+            dataframe_chunks = [self.df[i : i + chunk_size] for i in range(0, len(self.df), chunk_size)]
             for chunk in dataframe_chunks:
+                # Convert datetime to string and create copy to avoid modifications on the original dataframe
+                chunk = datetimes_to_str(chunk.copy())
+
                 # Write chunk to the sheet, accumulating data
                 chunk.to_excel(
                     writer,

--- a/macantine/etl.py
+++ b/macantine/etl.py
@@ -373,8 +373,17 @@ class ETL_OPEN_DATA(ETL):
             return 1
 
     def _load_data_csv(self, filename):
+        df_csv = self.df.copy()
         with default_storage.open(filename + ".csv", "w") as csv_file:
-            self.df.to_csv(csv_file, sep=";", index=False, na_rep="", encoding="utf_8_sig", quoting=csv.QUOTE_NONE)
+            df_csv.to_csv(
+                csv_file,
+                sep=";",
+                index=False,
+                na_rep="",
+                encoding="utf_8_sig",
+                quoting=csv.QUOTE_NONE,
+                escapechar="\\",
+            )
 
     def _load_data_parquet(self, filename):
         with default_storage.open(filename + ".parquet", "wb") as parquet_file:

--- a/macantine/etl.py
+++ b/macantine/etl.py
@@ -394,7 +394,8 @@ class ETL_OPEN_DATA(ETL):
 
         # Create ExcelWriter with the actual file path
         with pd.ExcelWriter(output, engine="openpyxl") as writer:
-            for chunk in [df[i : i + chunk_size] for i in range(0, len(df.copy()), chunk_size)]:
+            dataframe_chunks = [df[i : i + chunk_size] for i in range(0, len(df), chunk_size)]
+            for chunk in dataframe_chunks:
                 # Write chunk to the sheet, accumulating data
                 chunk.to_excel(
                     writer,

--- a/macantine/etl.py
+++ b/macantine/etl.py
@@ -395,7 +395,7 @@ class ETL_OPEN_DATA(ETL):
 
             # Create ExcelWriter with the actual file path
             with pd.ExcelWriter(output, engine="openpyxl") as writer:
-                for chunk in [df[i: i + chunk_size] for i in range(0, len(df.copy()), chunk_size)]:
+                for chunk in [df[i : i + chunk_size] for i in range(0, len(df.copy()), chunk_size)]:
                     # Write chunk to the sheet, accumulating data
                     chunk.to_excel(
                         writer,
@@ -414,7 +414,6 @@ class ETL_OPEN_DATA(ETL):
 
         except Exception as e:
             logger.error(e)
-            return
 
     def load_dataset(self):
         filepath = f"open_data/{self.dataset_name}"

--- a/macantine/etl.py
+++ b/macantine/etl.py
@@ -344,8 +344,20 @@ class ETL_OPEN_DATA(ETL):
         else:
             return 0
 
-    def is_valid(self) -> bool:
-        dataset_to_validate_url = f"{os.environ['CELLAR_HOST']}/{os.environ['CELLAR_BUCKET_NAME']}/media/open_data/{self.dataset_name}_to_validate.csv"
+    def is_valid(self, filepath) -> bool:
+        # Saving file online
+        with default_storage.open(filepath + "_to_validate.csv", "w") as file:
+            self.df.to_csv(
+                file,
+                sep=";",
+                index=False,
+                na_rep="",
+                encoding="utf_8_sig",
+                quoting=csv.QUOTE_NONE,
+            )
+        dataset_to_validate_url = (
+            f"{os.environ['CELLAR_HOST']}/{os.environ['CELLAR_BUCKET_NAME']}/media/{filepath}_to_validate.csv"
+        )
 
         res = requests.get(
             f"https://api.validata.etalab.studio/validate?schema={self.schema_url}&url={dataset_to_validate_url}&header_case=true"
@@ -359,22 +371,6 @@ class ETL_OPEN_DATA(ETL):
         else:
             return 1
 
-    def build_filename(self, stage):
-        if stage == "to_validate":
-            return f"open_data/{self.dataset_name}_to_validate.csv"
-        elif stage == "validated":
-            return f"open_data/{self.dataset_name}.csv"
-        else:
-            raise ValueError(f"Invalid stage: {stage}")
-
-    def _read_dataframe(self, filename):
-        try:
-            with default_storage.open(filename, "r") as file:
-                self.df = pd.read_csv(file, sep=";")
-        except FileNotFoundError:
-            logger.warning(f"File {filename} not found. Dataset assumed empty.")
-            self.df = pd.DataFrame()
-
     def _load_data_csv(self, filename):
         with default_storage.open(filename + ".csv", "w") as csv_file:
             self.df.to_csv(csv_file, sep=";", index=False, na_rep="", encoding="utf_8_sig", quoting=csv.QUOTE_NONE)
@@ -386,25 +382,51 @@ class ETL_OPEN_DATA(ETL):
             self.df.to_parquet(parquet_file)
 
     def _load_data_xlsx(self, filename):
-        with default_storage.open(filename + ".xlsx", "wb") as excel_file:
-            df_export = self.df.copy()
-            df_export = datetimes_to_str(df_export)
-            df_export.to_excel(excel_file, index=False)
+        try:
+            chunk_size = 1000
+            start_row = 0
+
+            # Convert datetime to string
+            df = datetimes_to_str(self.df.copy())  # Assuming it converts datetimes to strings
+            
+            # Create an in-memory bytes buffer
+            output = BytesIO()
+
+            # Create ExcelWriter with the actual file path
+            with pd.ExcelWriter(output, engine='openpyxl') as writer:
+                for chunk in [df[i:i + chunk_size] for i in range(0, len(df.copy()), chunk_size)]:
+                    # Write chunk to the sheet, accumulating data
+                    chunk.to_excel(writer, sheet_name='Sheet1', startrow=start_row, index=False, header=True if start_row == 0 else False)
+                    start_row += len(chunk)  # Update starting row for next chunk
+                
+            # Ensure the buffer is ready for reading
+            output.seek(0)
+
+            # Save the in-memory bytes buffer to the storage backend
+            with default_storage.open(filename + ".xlsx", "wb") as f:
+                f.write(output.getvalue())
+
+        except Exception as e:
+            logger.error(e)
+            return
 
     def load_dataset(self):
-        self._read_dataframe(self.build_filename(self, stage="to_validate"))
-        if self.is_valid():
-            validated_filename = self.build_filename(self, stage="validated")
-            try:
-                self._load_data_csv(validated_filename)
-                self._load_data_parquet(validated_filename)
-                self._load_data_xlsx(validated_filename)
+        filepath = f"open_data/{self.dataset_name}"
+        if (
+            os.environ.get("STATICFILES_STORAGE") == "dstorages.backends.s3boto3.S3StaticStorage"
+            and os.environ.get("DEFAULT_FILE_STORAGE") == "storages.backends.s3boto3.S3Boto3Storage"
+        ):
+            if not self.is_valid():
+                logger.error(f"The dataset {self.name} is invalid and therefore will not be exported to s3")
+                return
+        try:
+            self._load_data_csv(filepath)
+            self._load_data_parquet(filepath)
+            self._load_data_xlsx(filepath)
 
-                update_datagouv_resources()
-            except Exception as e:
-                logger.error(f"Error saving validated data: {e}")
-        else:
-            logger.error(f"The dataset {self.name} is invalid and therefore will not be exported to s3")
+            update_datagouv_resources()
+        except Exception as e:
+            logger.error(f"Error saving validated data: {e}")
 
 
 class ETL_CANTEEN(ETL_OPEN_DATA):

--- a/macantine/etl.py
+++ b/macantine/etl.py
@@ -17,6 +17,7 @@ from api.serializers import SectorSerializer
 from api.views.utils import camelize
 from django.core.files.storage import default_storage
 from django.db.models import Q
+from io import BytesIO
 
 logger = logging.getLogger(__name__)
 
@@ -388,17 +389,22 @@ class ETL_OPEN_DATA(ETL):
 
             # Convert datetime to string
             df = datetimes_to_str(self.df.copy())  # Assuming it converts datetimes to strings
-            
+
             # Create an in-memory bytes buffer
             output = BytesIO()
 
             # Create ExcelWriter with the actual file path
-            with pd.ExcelWriter(output, engine='openpyxl') as writer:
-                for chunk in [df[i:i + chunk_size] for i in range(0, len(df.copy()), chunk_size)]:
+            with pd.ExcelWriter(output, engine="openpyxl") as writer:
+                for chunk in [df[i: i + chunk_size] for i in range(0, len(df.copy()), chunk_size)]:
                     # Write chunk to the sheet, accumulating data
-                    chunk.to_excel(writer, sheet_name='Sheet1', startrow=start_row, index=False, header=True if start_row == 0 else False)
+                    chunk.to_excel(
+                        writer,
+                        startrow=start_row,
+                        index=False,
+                        header=True if start_row == 0 else False,
+                    )
                     start_row += len(chunk)  # Update starting row for next chunk
-                
+
             # Ensure the buffer is ready for reading
             output.seek(0)
 

--- a/macantine/tests/test_extract_open_data.py
+++ b/macantine/tests/test_extract_open_data.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import requests_mock
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from macantine.etl import map_communes_infos, update_datagouv_resources
 from data.factories import DiagnosticFactory, CanteenFactory, UserFactory, SectorFactory
 from data.models import Teledeclaration
@@ -447,9 +447,9 @@ class TestETLOpenData(TestCase):
         number_of_updated_resources = update_datagouv_resources()
         self.assertEqual(number_of_updated_resources, 1, "Only the csv resource should be updated")
 
+    @override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
     def test_load_dataset_canteen(self, mock):
         # Making sure the code will not enter online dataset validation by forcing local filesystem management
-        os.environ["STATICFILES_STORAGE"] = "django.contrib.staticfiles.storage.StaticFilesStorage"
         test_cases = [
             {
                 "name": " Load valid dataset",

--- a/macantine/tests/test_extract_open_data.py
+++ b/macantine/tests/test_extract_open_data.py
@@ -456,6 +456,11 @@ class TestETLOpenData(TestCase):
                 "data": pd.DataFrame({"index": [0], "name": ["a valid name"]}),
                 "expected_length": 1,
             },
+            {
+                "name": " Load valid dataset with special characters",
+                "data": pd.DataFrame({"index": [0], "name": ["a valid name with our csv sep ;"]}),
+                "expected_length": 1,
+            },
         ]
         etl = ETL_CANTEEN()
         etl.dataset_name += "_test"  # Avoid interferring with other files


### PR DESCRIPTION
Il y avait deux problèmes : 
* un bug inséré lors de mon dernier refacto : les filenames n"étaient pas bon
* un bug beaucoup plus complexe : lorsque le dataset devient trop gros, lesexport en Excel affichaient un tableau vide (alors que le fichier n'était pas vide). Pour solutionner ce problème , un découpe en chunk a été mus en place, en travaillant sur un buffer.