### PR TITLE
Bug fix : ne pas supprimer le SIRET si il est pas changé

### DIFF
--- a/frontend/src/views/CanteenEditor/SiretCheck.vue
+++ b/frontend/src/views/CanteenEditor/SiretCheck.vue
@@ -146,7 +146,7 @@ export default {
       }
 
       if (this.canteen?.siret && this.siret === this.canteen?.siret) {
-        this.$emit("siretIsValid", this.siret)
+        this.$emit("siretIsValid", { siret: this.siret })
         return
       }
 


### PR DESCRIPTION
Closes #4176 et #4164

Pour reproduire le bug:
- checkout staging
- aller modifier les infos de n'importe quelle cantine avec un siret
- aller modifier le siret
- sauvegarder sans modifier le siret
- on voit que le siret est maintenant vide, si tu sauvegardes la page encore, avec ou sans autres modifications, le siret est supprimé

Il y a 27 cantines qui ont été touchées par ce bug : https://ma-cantine-metabase.cleverapps.io/question/1975-combien-de-cantines-a-efface-leur-siret

En deuxième temps :
- corriger ces 27 cantines (décider comment on veut faire ça)
- MAJ le back pour ne pas accepter la suppression d'un SIRET : https://github.com/betagouv/ma-cantine/pull/4204