### PR TITLE
Bug fix test : s'assurer que la date du diagnostic est dans le passé

### DIFF
--- a/api/tests/test_public_canteen_previews.py
+++ b/api/tests/test_public_canteen_previews.py
@@ -113,7 +113,9 @@ class TestPublicCanteenPreviewsApi(APITestCase):
         Should get summary data in a public preview
         """
         canteen = CanteenFactory.create(publication_status=Canteen.PublicationStatus.PUBLISHED)
-        DiagnosticFactory.create(canteen=canteen)
+        DiagnosticFactory.create(
+            canteen=canteen, year=2020
+        )  # year must be in the past, otherwise canteen.appro_diagnostics is empty
 
         response = self.client.get(reverse("single_public_canteen_preview", kwargs={"pk": canteen.id}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -129,7 +131,6 @@ class TestPublicCanteenPreviewsApi(APITestCase):
         self.assertIn("info", body["badges"])
         self.assertIn("approDiagnostic", body)
         self.assertIn("percentageValueBioHt", body["approDiagnostic"])
-        # self.assertIn("combinedSustainablePercent", body["approDiagnostic"])
 
     # TODO: test satellites: CC APPRO, CC ALL, own diag
 

--- a/api/tests/test_public_canteen_previews.py
+++ b/api/tests/test_public_canteen_previews.py
@@ -114,7 +114,7 @@ class TestPublicCanteenPreviewsApi(APITestCase):
         """
         canteen = CanteenFactory.create(publication_status=Canteen.PublicationStatus.PUBLISHED)
         DiagnosticFactory.create(
-            canteen=canteen, year=2020
+            canteen=canteen, year=timezone.now().date().year - 1
         )  # year must be in the past, otherwise canteen.appro_diagnostics is empty
 
         response = self.client.get(reverse("single_public_canteen_preview", kwargs={"pk": canteen.id}))


### PR DESCRIPTION
Je crois que le test fail car le factory génére n'import quelle année, mais pour `appro_diagnostics` on filtre sur les années dans le passé. Et alors si le diagnostic généré est dans l'avenir, notre réponse est `body['approDiagnostics']: None`.

J'ai "testé" ça en mettant l'année dans l'avenir et voir si l'erreur est la même que l'erreur vu dans GitHub workflow