### PR TITLE
Vue3 : configuration d'en-tête et pied de page

### DIFF
--- a/2024-frontend/src/App.vue
+++ b/2024-frontend/src/App.vue
@@ -1,9 +1,7 @@
 <script setup>
 import { RouterView, useRoute } from "vue-router"
 import { reactive, computed, watch } from "vue"
-
-const logoText = ["Ministère", "de l’Agriculture", "et de la Souveraineté", "Alimentaire"]
-const serviceTitle = "ma cantine"
+import AppHeader from "@/components/AppHeader.vue"
 
 const layout = reactive({ fullscreen: false })
 const routerViewClass = computed(() => (layout.fullscreen ? "" : "fr-container fr-pb-2w"))
@@ -19,7 +17,7 @@ watch(route, (to) => {
 
 <template>
   <div>
-    <DsfrHeader v-if="!layout.fullscreen" :logo-text :service-title />
+    <AppHeader v-if="!layout.fullscreen" />
 
     <main :class="routerViewClass">
       <RouterView />

--- a/2024-frontend/src/App.vue
+++ b/2024-frontend/src/App.vue
@@ -2,6 +2,7 @@
 import { RouterView, useRoute } from "vue-router"
 import { reactive, computed, watch } from "vue"
 import AppHeader from "@/components/AppHeader.vue"
+import AppFooter from "@/components/AppFooter.vue"
 
 const layout = reactive({ fullscreen: false })
 const routerViewClass = computed(() => (layout.fullscreen ? "" : "fr-container fr-pb-2w"))
@@ -23,7 +24,7 @@ watch(route, (to) => {
       <RouterView />
     </main>
 
-    <DsfrFooter v-if="!layout.fullscreen" />
+    <AppFooter v-if="!layout.fullscreen" />
   </div>
 </template>
 

--- a/2024-frontend/src/components/AppFooter.vue
+++ b/2024-frontend/src/components/AppFooter.vue
@@ -1,15 +1,20 @@
 <script setup>
+const logoText = ["Ministère", "de l’Agriculture", "et de la Souveraineté", "Alimentaire"]
+
 const descText =
   "« ma cantine » est un outil pour accompagner les acteurs de la restauration collective à proposer une alimentation de qualité, saine et durable."
 </script>
 
 <template>
   <DsfrFooter
+    :logo-text
     a11yCompliance="partiellement conforme"
     :a11yComplianceLink="{ name: 'AccessibilityDeclaration' }"
     :personalDataLink="{ name: 'PrivacyPolicy' }"
     :cookiesLink="{ name: 'Cookies' }"
     :afterMandatoryLinks="[{ text: 'Plan du site', to: { name: 'SiteMap' } }]"
     :desc-text
+    licenceTo="https://github.com/betagouv/ma-cantine/blob/staging/LICENSE"
+    licenceName="licence MIT"
   />
 </template>

--- a/2024-frontend/src/components/AppFooter.vue
+++ b/2024-frontend/src/components/AppFooter.vue
@@ -1,0 +1,15 @@
+<script setup>
+const descText =
+  "« ma cantine » est un outil pour accompagner les acteurs de la restauration collective à proposer une alimentation de qualité, saine et durable."
+</script>
+
+<template>
+  <DsfrFooter
+    a11yCompliance="partiellement conforme"
+    :a11yComplianceLink="{ name: 'AccessibilityDeclaration' }"
+    :personalDataLink="{ name: 'PrivacyPolicy' }"
+    :cookiesLink="{ name: 'Cookies' }"
+    :afterMandatoryLinks="[{ text: 'Plan du site', to: { name: 'SiteMap' } }]"
+    :desc-text
+  />
+</template>

--- a/2024-frontend/src/components/AppHeader.vue
+++ b/2024-frontend/src/components/AppHeader.vue
@@ -1,0 +1,12 @@
+<script setup>
+const logoText = ["Ministère", "de l’Agriculture", "et de la Souveraineté", "Alimentaire"]
+</script>
+
+<template>
+  <DsfrHeader
+    :logo-text
+    operatorImgSrc="/static/images/ma-cantine-logo-light.jpg"
+    operatorImgAlt="ma cantine"
+    operatorImgStyle="height: 65px;"
+  />
+</template>

--- a/2024-frontend/src/components/AppHeader.vue
+++ b/2024-frontend/src/components/AppHeader.vue
@@ -1,5 +1,25 @@
 <script setup>
+import { computed } from "vue"
+import { useRootStore } from "@/stores/root"
+
+const store = useRootStore()
+
 const logoText = ["Ministère", "de l’Agriculture", "et de la Souveraineté", "Alimentaire"]
+
+const quickLinks = computed(() => {
+  if (!store.loggedUser) {
+    const login = { to: "/s-identifier", label: "S'identifier" }
+    const signup = { to: "/creer-mon-compte", label: "Créer mon compte" }
+    return [login, signup]
+  }
+  // TODO: logout action
+  if (store.loggedUser.isDev) {
+    const apis = { to: { name: "DeveloperPage" }, label: "Développement et APIs" }
+    return [apis]
+  }
+  const mesCantines = { to: { name: "ManagementPage" }, label: "Mon tableau de bord" }
+  return [mesCantines]
+})
 </script>
 
 <template>
@@ -8,5 +28,6 @@ const logoText = ["Ministère", "de l’Agriculture", "et de la Souveraineté", 
     operatorImgSrc="/static/images/ma-cantine-logo-light.jpg"
     operatorImgAlt="ma cantine"
     operatorImgStyle="height: 65px;"
+    :quickLinks
   />
 </template>

--- a/2024-frontend/src/components/AppHeader.vue
+++ b/2024-frontend/src/components/AppHeader.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from "vue"
 import { useRootStore } from "@/stores/root"
+import keyMeasures from "@/data/key-measures.json"
 
 const store = useRootStore()
 
@@ -20,6 +21,133 @@ const quickLinks = computed(() => {
   const mesCantines = { to: { name: "ManagementPage" }, label: "Mon tableau de bord" }
   return [mesCantines]
 })
+
+const navItems = [
+  {
+    text: "Mon tableau de bord",
+    to: { name: "ManagementPage" },
+    authenticationState: true,
+  },
+  {
+    text: "Mes achats",
+    to: { name: "PurchasesHome" },
+    authenticationState: true,
+  },
+  {
+    text: "M'auto-évaluer",
+    to: { name: "DiagnosticPage" },
+    authenticationState: false,
+  },
+  {
+    title: "M'améliorer",
+    links: [
+      {
+        text: "Acteurs de l'éco-système",
+        to: { name: "PartnersHome" },
+      },
+      {
+        text: "Générer mon affiche",
+        to: { name: "GeneratePosterPage" },
+      },
+      {
+        text: "Webinaires",
+        to: { name: "CommunityPage" },
+      },
+      {
+        text: "Blog",
+        to: { name: "BlogsHome" },
+      },
+      {
+        text: "Pour aller plus loin",
+        to: "https://ma-cantine-1.gitbook.io/ma-cantine-egalim/",
+        target: "_blank",
+        rel: "noopener external",
+      },
+    ],
+  },
+  {
+    title: "Toutes les cantines",
+    links: [
+      {
+        text: "Dans mon territoire",
+        to: { name: "TerritoryCanteens" },
+        forElected: true,
+      },
+      {
+        text: "Trouver une cantine",
+        to: { name: "CanteenSearchLanding" },
+      },
+      {
+        text: "Dans ma collectivité",
+        to: { name: "PublicCanteenStatisticsPage" },
+      },
+      {
+        text: "Indicateurs clés",
+        to: "https://ma-cantine-metabase.cleverapps.io/public/dashboard/3dab8a21-c4b9-46e1-84fa-7ba485ddfbbb",
+        target: "_blank",
+        rel: "noopener external",
+      },
+    ],
+  },
+  {
+    title: "Comprendre mes obligations",
+    // TODO: get active()
+    links: [
+      ...keyMeasures.map((x) => ({
+        text: x.shortTitle,
+        to: { name: "KeyMeasurePage", params: { id: x.id } },
+      })),
+      ...[
+        {
+          text: "Pour aller plus loin",
+          to: "https://ma-cantine-1.gitbook.io/ma-cantine-egalim/",
+          target: "_blank",
+          rel: "noopener external",
+        },
+      ],
+    ],
+  },
+  {
+    title: "Aide",
+    links: [
+      {
+        text: "Foire aux questions",
+        to: { name: "FaqPage" },
+      },
+      {
+        text: "Contactez-nous",
+        to: { name: "ContactPage" },
+      },
+      {
+        text: "Documentation",
+        to: "https://ma-cantine-1.gitbook.io/ma-cantine-egalim/",
+        target: "_blank",
+        rel: "noopener external",
+      },
+    ],
+  },
+  {
+    text: "Mon compte",
+    to: { name: "AccountSummaryPage" },
+    authenticationState: true,
+  },
+]
+
+const navItemsForUser = computed(() => {
+  const userLinks = navItems.filter((parentItem) => {
+    if (parentItem.authenticationState) return !!store.loggedUser
+    else if (parentItem.authenticationState === false) return !store.loggedUser
+    return true
+  })
+  userLinks.forEach((parentGroup) => {
+    if (parentGroup.links && !store.loggedUser?.isElectedOfficial) {
+      parentGroup.links = parentGroup.links.filter((childLink) =>
+        childLink.forElected ? !!store.loggedUser?.isElectedOfficial : true
+      )
+    }
+  })
+  return userLinks
+})
 </script>
 
 <template>
@@ -29,5 +157,9 @@ const quickLinks = computed(() => {
     operatorImgAlt="ma cantine"
     operatorImgStyle="height: 65px;"
     :quickLinks
-  />
+  >
+    <template #mainnav>
+      <DsfrNavigation :nav-items="navItemsForUser" />
+    </template>
+  </DsfrHeader>
 </template>

--- a/2024-frontend/src/components/BreadcrumbsNav.vue
+++ b/2024-frontend/src/components/BreadcrumbsNav.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed } from "vue"
+import { routes } from "@/router"
+import { useRoute } from "vue-router"
+const route = useRoute()
+
+const props = defineProps(["links", "title"])
+
+const breadcrumbRoutes = JSON.parse(JSON.stringify(routes))
+// flatten routes for simplicity
+breadcrumbRoutes.forEach((r) => {
+  if (r.children) {
+    breadcrumbRoutes.push(...r.children)
+  }
+})
+
+const pageTitle = props.title || route.meta?.title
+
+const breadcrumbLinks = computed(() => {
+  const allLinks = [{ text: "Accueil", to: "/" }]
+  if (props.links) {
+    props.links.forEach((link) => {
+      if (!link.title && link.to?.name) {
+        link.title = breadcrumbRoutes.find((r) => r.name === link.to.name)?.meta?.title
+      }
+      link.text = link.title // DSFR component uses different key to our legacy code
+      allLinks.push(link)
+    })
+  }
+  allLinks.push({ text: pageTitle })
+  return allLinks
+})
+</script>
+
+<template>
+  <DsfrBreadcrumb breadcrumbId="ma-cantine-fil-dariane" :links="breadcrumbLinks" />
+</template>

--- a/2024-frontend/src/main.js
+++ b/2024-frontend/src/main.js
@@ -16,7 +16,7 @@ import LeafIcon from "mdi-icons/Leaf"
 import "mdi-icons/styles.css"
 
 import App from "./App.vue"
-import router from "./router"
+import { router } from "./router"
 
 const app = createApp(App)
 

--- a/2024-frontend/src/router/index.js
+++ b/2024-frontend/src/router/index.js
@@ -65,4 +65,4 @@ router.beforeEach((to, from, next) => {
   }
 })
 
-export default router
+export { router, routes }

--- a/2024-frontend/src/router/index.js
+++ b/2024-frontend/src/router/index.js
@@ -1,7 +1,7 @@
 import { createRouter, createWebHistory } from "vue-router"
 import DiagnosticTunnel from "@/views/DiagnosticTunnel"
 import ImportSelection from "@/views/ImportSelection"
-import { useRootStore } from "../stores/root"
+import { useRootStore } from "@/stores/root"
 
 const routes = [
   {
@@ -39,6 +39,14 @@ const vue2Routes = [
   {
     path: "/ma-progression/:canteenUrlComponent/:year/:measureId",
     name: "MyProgress",
+  },
+  {
+    path: "/gestion",
+    name: "ManagementPage",
+  },
+  {
+    path: "/developpement-et-apis",
+    name: "DeveloperPage",
   },
 ]
 routes.push(...vue2Routes)

--- a/2024-frontend/src/router/index.js
+++ b/2024-frontend/src/router/index.js
@@ -100,6 +100,22 @@ const vue2Routes = [
     path: "/mon-compte",
     name: "AccountSummaryPage",
   },
+  {
+    path: "/accessibilite",
+    name: "AccessibilityDeclaration",
+  },
+  {
+    path: "/plan-du-site/",
+    name: "SiteMap",
+  },
+  {
+    path: "/politique-de-confidentialite",
+    name: "PrivacyPolicy",
+  },
+  {
+    path: "/politique-de-confidentialite#cookies",
+    name: "Cookies",
+  },
 ]
 routes.push(...vue2Routes)
 

--- a/2024-frontend/src/router/index.js
+++ b/2024-frontend/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from "vue-router"
 import DiagnosticTunnel from "@/views/DiagnosticTunnel"
+import ImportSelection from "@/views/ImportSelection"
 import { useRootStore } from "../stores/root"
 
 const routes = [
@@ -12,6 +13,15 @@ const routes = [
       title: "Bilan",
       authenticationRequired: true,
       fullscreen: true,
+    },
+  },
+  {
+    path: "/importer-des-donnees",
+    name: "ImportSelection",
+    component: ImportSelection,
+    meta: {
+      title: "Importer des données",
+      authenticationRequired: true,
     },
   },
 ]

--- a/2024-frontend/src/router/index.js
+++ b/2024-frontend/src/router/index.js
@@ -48,6 +48,58 @@ const vue2Routes = [
     path: "/developpement-et-apis",
     name: "DeveloperPage",
   },
+  {
+    path: "/mes-achats",
+    name: "PurchasesHome",
+  },
+  {
+    path: "/diagnostic",
+    name: "DiagnosticPage",
+  },
+  {
+    path: "/mesures-phares/:id",
+    name: "KeyMeasurePage",
+  },
+  {
+    path: "/acteurs-de-l-eco-systeme",
+    name: "PartnersHome",
+  },
+  {
+    path: "/creation-affiche",
+    name: "GeneratePosterPage",
+  },
+  {
+    path: "/communaute",
+    name: "CommunityPage",
+  },
+  {
+    path: "/blog",
+    name: "BlogsHome",
+  },
+  {
+    path: "/les-cantines-de-mon-territoire",
+    name: "TerritoryCanteens",
+  },
+  {
+    path: "/trouver-une-cantine",
+    name: "CanteenSearchLanding",
+  },
+  {
+    path: "/statistiques-regionales",
+    name: "PublicCanteenStatisticsPage",
+  },
+  {
+    path: "/faq/",
+    name: "FaqPage",
+  },
+  {
+    path: "/contact",
+    name: "ContactPage",
+  },
+  {
+    path: "/mon-compte",
+    name: "AccountSummaryPage",
+  },
 ]
 routes.push(...vue2Routes)
 

--- a/2024-frontend/src/views/ImportSelection/index.vue
+++ b/2024-frontend/src/views/ImportSelection/index.vue
@@ -1,0 +1,5 @@
+<script setup></script>
+
+<template>
+  <h1>testing</h1>
+</template>

--- a/2024-frontend/src/views/ImportSelection/index.vue
+++ b/2024-frontend/src/views/ImportSelection/index.vue
@@ -1,5 +1,7 @@
-<script setup></script>
+<script setup>
+import BreadcrumbsNav from "@/components/BreadcrumbsNav.vue"
+</script>
 
 <template>
-  <h1>testing</h1>
+  <BreadcrumbsNav />
 </template>

--- a/frontend/src/views/PrivacyPolicy/index.vue
+++ b/frontend/src/views/PrivacyPolicy/index.vue
@@ -249,7 +249,7 @@
       </template>
     </v-simple-table>
 
-    <h2>X - Cookies</h2>
+    <h2 id="cookies">X - Cookies</h2>
     <p>
       Un cookie est un fichier déposé sur votre terminal lors de la visite d’un site. Il a pour but de collecter des
       informations relatives à votre navigation et de vous adresser des services adaptés à votre terminal (ordinateur,


### PR DESCRIPTION
En préparation pour #4184 (je pensais pourquoi pas le construire en vue 3), cette PR configure l'en-tête et pied de page du site.

Pour le voir, j'ai créé le début de la nouvelle page, qui est accessible sur le path : /v2/importer-des-donnees

![Screenshot 2024-08-14 at 14-42-09 ma cantine](https://github.com/user-attachments/assets/e8840616-e1e6-405b-abd2-4fb5788c4a44)

Version déconnecté :

![Screenshot 2024-08-14 at 14-44-12 ma cantine](https://github.com/user-attachments/assets/a24e12e0-c52d-4678-b935-10f078cd1e7b)

J'ai remarqué un bug et une limitation de vue dsfr qui impacte ce travail un peu :

https://github.com/dnum-mi/vue-dsfr/issues/889
https://github.com/dnum-mi/vue-dsfr/issues/892

En plus, la description du service dans le footer n'est pas la même que Vue 2, car DsfrFooter accept un `string` et non pas du HTML, alors je peux pas ajouter les liens originels. Après, je sais pas si c'est contre le DSFR d'avoir ces liens dans la description, alors j'ai laissé une question côté slack du DSFR pour voir le conseils pour les liens.