### PR TITLE
API : Rendre le champ Diagnostic.year obligatoire à la création

### DIFF
--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -79,6 +79,8 @@ TUNNEL_PROGRESS_FIELDS = (
 
 FIELDS = META_FIELDS + SIMPLE_APPRO_FIELDS + COMPLETE_APPRO_FIELDS + NON_APPRO_FIELDS
 
+REQUIRED_FIELDS = ("year",)
+
 
 class DiagnosticSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
@@ -189,7 +191,10 @@ class ManagerDiagnosticSerializer(DiagnosticSerializer):
     def __init__(self, *args, **kwargs):
         action = kwargs.pop("action", None)
         super().__init__(*args, **kwargs)
-        if action != "create":
+        if action == "create":
+            for field in REQUIRED_FIELDS:
+                self.fields[field].required = True
+        else:
             self.fields.pop("creation_mtm_source")
             self.fields.pop("creation_mtm_campaign")
             self.fields.pop("creation_mtm_medium")

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -287,9 +287,10 @@ class TestDiagnosticsApi(APITestCase):
 
         try:
             with transaction.atomic():
+                payload = {"year": 2020, "value_bio_ht": 1000}
                 response = self.client.post(
                     reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}),
-                    {**payload, "value_bio_ht": 1000},
+                    payload,
                 )
         except BadRequest:
             pass


### PR DESCRIPTION
closes #4152

### Quoi ?

Actuellement il est possible de créer des diagnostics sans préciser l'année.
On a ~80 diagnostic de la sorte en DB

### Comment ?

En modifiant le serializer. Et en ajoutant/modifiant les tests.

~~Une alternative aurait pu être d'enlever le `null=True` au niveau du modèle, mais quid des diagnostics existants ?~~