### PR TITLE
Création de cantine : afficher le champ SIRET de la CC comme obligatoire

### DIFF
--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -254,7 +254,6 @@
             labelClasses="body-2 mb-2"
             :items="sectorCategories"
             v-model="sectorCategory"
-            :rules="[validators.required]"
           />
         </v-col>
         <v-col cols="12" md="6">

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -203,6 +203,7 @@
                 validators.length(14),
                 validators.luhn,
                 validators.isDifferent(canteen.siret, satelliteSiretMessage),
+                validators.required,
               ]"
               @blur="getCentralKitchen"
             />
@@ -253,6 +254,7 @@
             labelClasses="body-2 mb-2"
             :items="sectorCategories"
             v-model="sectorCategory"
+            :rules="[validators.required]"
           />
         </v-col>
         <v-col cols="12" md="6">


### PR DESCRIPTION
closes #4239

Ajout d'un `validators.required` au champ "SIRET de la cuisine centrale".

J'en ai profité pour faire de même pour le champ "Catégorie de secteur".