### PR TITLE
Refactoring : basuler les validation de Diagnostic depuis le serializer vers le modèle

### DIFF
--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -199,21 +199,6 @@ class ManagerDiagnosticSerializer(DiagnosticSerializer):
             self.fields.pop("creation_mtm_campaign")
             self.fields.pop("creation_mtm_medium")
 
-    def validate(self, data):
-        total = self.return_value(self, data, "value_total_ht")
-        if total is not None and isinstance(total, Decimal):
-            bio = self.return_value(self, data, "value_bio_ht")
-            sustainable = self.return_value(self, data, "value_sustainable_ht")
-            externality_performance = self.return_value(self, data, "value_externality_performance_ht")
-            egalim_others = self.return_value(self, data, "value_egalim_others_ht")
-            value_sum = (bio or 0) + (sustainable or 0) + (externality_performance or 0) + (egalim_others or 0)
-            if value_sum > total:
-                raise serializers.ValidationError(
-                    f"La somme des valeurs d'approvisionnement, {value_sum}, est plus que le total, {total}"
-                )
-            # TODO: test meat and fish too?
-        return data
-
     @staticmethod
     def return_value(serializer, data, field_name):
         if field_name in data:

--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -68,7 +68,7 @@ class TestCanteenStatsApi(APITestCase):
             value_externality_performance_ht=0,
             value_egalim_others_ht=0,
             has_waste_diagnostic=True,
-            waste_actions=["action1", "action2"],
+            waste_actions=[Diagnostic.WasteActions.AWARENESS, Diagnostic.WasteActions.DISTRIBUTION],
             has_donation_agreement=True,
             vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.LOW,
             cooking_plastic_substituted=True,
@@ -315,22 +315,29 @@ class TestCanteenStatsApi(APITestCase):
         """
         # --- Canteens which don't earn waste badge:
         waste_actions_only = CanteenFactory.create(daily_meal_count=2999)
-        DiagnosticFactory.create(canteen=waste_actions_only, has_waste_diagnostic=False, waste_actions=["action1"])
+        DiagnosticFactory.create(
+            canteen=waste_actions_only, has_waste_diagnostic=False, waste_actions=[Diagnostic.WasteActions.AWARENESS]
+        )
         waste_diagnostic_only = CanteenFactory.create(daily_meal_count=2999)
         DiagnosticFactory.create(canteen=waste_diagnostic_only, has_waste_diagnostic=True, waste_actions=[])
         large_canteen_no_badge = CanteenFactory.create(daily_meal_count=3000)
         DiagnosticFactory.create(
             canteen=large_canteen_no_badge,
             has_waste_diagnostic=True,
-            waste_actions=["action1"],
+            waste_actions=[Diagnostic.WasteActions.AWARENESS],
             has_donation_agreement=False,
         )
         # --- Canteens which earn waste badge:
         small_canteen = CanteenFactory.create(daily_meal_count=2999)
-        DiagnosticFactory.create(canteen=small_canteen, has_waste_diagnostic=True, waste_actions=["action1"])
+        DiagnosticFactory.create(
+            canteen=small_canteen, has_waste_diagnostic=True, waste_actions=[Diagnostic.WasteActions.AWARENESS]
+        )
         large_canteen = CanteenFactory.create(daily_meal_count=3000)
         DiagnosticFactory.create(
-            canteen=large_canteen, has_waste_diagnostic=True, waste_actions=["action1"], has_donation_agreement=True
+            canteen=large_canteen,
+            has_waste_diagnostic=True,
+            waste_actions=[Diagnostic.WasteActions.AWARENESS],
+            has_donation_agreement=True,
         )
 
         badges = badges_for_queryset(Diagnostic.objects.all())
@@ -352,12 +359,14 @@ class TestCanteenStatsApi(APITestCase):
         high_canteen.sectors.remove(primaire)
         high_canteen.sectors.remove(secondaire)
         DiagnosticFactory.create(
-            canteen=high_canteen, vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.HIGH.value
+            canteen=high_canteen, year=2019, vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.HIGH.value
         )
 
         low_canteen = CanteenFactory.create()
         low_canteen.sectors.add(primaire)
-        DiagnosticFactory.create(canteen=low_canteen, vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.LOW.value)
+        DiagnosticFactory.create(
+            canteen=low_canteen, year=2019, vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.LOW.value
+        )
 
         # --- canteens which earn diversification badge:
         daily_vege = CanteenFactory.create()

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -236,6 +236,7 @@ class TestDiagnosticsApi(APITestCase):
 
         diagnostic = Diagnostic.objects.get(canteen__id=canteen.id)
 
+        self.assertEqual(diagnostic.diagnostic_type, None)
         self.assertEqual(diagnostic.year, 2020)
         self.assertTrue(diagnostic.cooking_plastic_substituted)
         self.assertFalse(diagnostic.has_donation_agreement)
@@ -416,7 +417,13 @@ class TestDiagnosticsApi(APITestCase):
         """
         Do not save edits to a diagnostic which make the sum of the values > total
         """
-        diagnostic = DiagnosticFactory.create(year=2019, value_total_ht=10, value_bio_ht=5, value_sustainable_ht=2)
+        diagnostic = DiagnosticFactory.create(
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+            year=2019,
+            value_total_ht=10,
+            value_bio_ht=5,
+            value_sustainable_ht=2,
+        )
         diagnostic.canteen.managers.add(authenticate.user)
         payload = {"value_sustainable_ht": 999}
 
@@ -630,7 +637,7 @@ class TestDiagnosticsApi(APITestCase):
         """
         canteen = CanteenFactory.create()
         canteen.managers.add(authenticate.user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, total_leftovers=Decimal("1.23456"))
+        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2019, total_leftovers=Decimal("1.23456"))
 
         payload = {
             "total_leftovers": 6666.66,
@@ -656,7 +663,7 @@ class TestDiagnosticsApi(APITestCase):
         """
         canteen = CanteenFactory.create()
         canteen.managers.add(authenticate.user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, total_leftovers=Decimal("1.23456"))
+        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2019, total_leftovers=Decimal("1.23456"))
 
         payload = {
             "bread_leftovers": 100,
@@ -730,7 +737,7 @@ class TestDiagnosticsApi(APITestCase):
         """
         canteen = CanteenFactory.create()
         canteen.managers.add(authenticate.user)
-        DiagnosticFactory.create(canteen=canteen, total_leftovers=Decimal("1.23456"))
+        DiagnosticFactory.create(canteen=canteen, year=2019, total_leftovers=Decimal("1.23456"))
         response = self.client.get(reverse("single_canteen", kwargs={"pk": canteen.id}))
         body = response.json()
 

--- a/api/tests/test_import_diagnostics.py
+++ b/api/tests/test_import_diagnostics.py
@@ -1173,7 +1173,9 @@ class TestImportDiagnosticsAPI(APITestCase):
         """
         canteen = CanteenFactory.create(siret="21340172201787", name="Old name")
         canteen.managers.add(authenticate.user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, value_total_ht=1, value_bio_ht=0.2)
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2020, value_total_ht=1, value_bio_ht=Decimal("0.2")
+        )
 
         with open("./api/tests/files/diagnostics_different_canteens.csv") as diag_file:
             response = self.client.post(reverse("import_diagnostics"), {"file": diag_file})
@@ -1194,7 +1196,9 @@ class TestImportDiagnosticsAPI(APITestCase):
         """
         canteen = CanteenFactory.create(siret="21340172201787", name="Old name")
         canteen.managers.add(authenticate.user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, value_total_ht=1, value_bio_ht=0.2)
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2020, value_total_ht=1, value_bio_ht=Decimal("0.2")
+        )
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, authenticate.user)
 
         with open("./api/tests/files/diagnostics_different_canteens.csv") as diag_file:

--- a/api/tests/test_public_canteen_previews.py
+++ b/api/tests/test_public_canteen_previews.py
@@ -8,7 +8,7 @@ from rest_framework.test import APITestCase
 from rest_framework import status
 from data.factories import CanteenFactory, SectorFactory
 from data.factories import DiagnosticFactory
-from data.models import Canteen
+from data.models import Canteen, Diagnostic
 from data.region_choices import Region
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -114,8 +114,13 @@ class TestPublicCanteenPreviewsApi(APITestCase):
         """
         canteen = CanteenFactory.create(publication_status=Canteen.PublicationStatus.PUBLISHED)
         DiagnosticFactory.create(
-            canteen=canteen, year=timezone.now().date().year - 1
-        )  # year must be in the past, otherwise canteen.appro_diagnostics is empty
+            canteen=canteen,
+            year=timezone.now().date().year - 1,  # year must be in the past, otherwise canteen.appro_diagnostics is empty
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+            value_total_ht=10,
+            value_bio_ht=5,
+            value_sustainable_ht=2,
+        )
 
         response = self.client.get(reverse("single_public_canteen_preview", kwargs={"pk": canteen.id}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -2,7 +2,14 @@ from django.urls import reverse
 from django.db.utils import IntegrityError
 from rest_framework.test import APITestCase
 from rest_framework import status
-from data.factories import CanteenFactory, DiagnosticFactory, UserFactory, TeledeclarationFactory, SectorFactory
+from data.factories import (
+    CanteenFactory,
+    DiagnosticFactory,
+    UserFactory,
+    TeledeclarationFactory,
+    SectorFactory,
+    CompleteDiagnosticFactory,
+)
 from data.models import Teledeclaration, Diagnostic, Canteen
 from django.test.utils import override_settings
 from .utils import authenticate
@@ -499,9 +506,7 @@ class TestTeledeclarationApi(APITestCase):
         user = authenticate.user
         canteen = CanteenFactory.create()
         canteen.managers.add(user)
-        diagnostic = DiagnosticFactory.create(
-            canteen=canteen, year=LAST_YEAR, diagnostic_type=Diagnostic.DiagnosticType.COMPLETE, value_total_ht=100
-        )
+        diagnostic = CompleteDiagnosticFactory.create(canteen=canteen, year=LAST_YEAR, value_total_ht=100)
         payload = {"diagnosticId": diagnostic.id}
 
         response = self.client.post(reverse("teledeclaration_create"), payload)

--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -73,7 +73,9 @@ class TestTeledeclarationApi(APITestCase):
         manager = UserFactory.create()
         canteen = CanteenFactory.create()
         canteen.managers.add(manager)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2020, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
         payload = {"diagnosticId": diagnostic.id}
 
         with patch.object(
@@ -94,7 +96,9 @@ class TestTeledeclarationApi(APITestCase):
         manager = UserFactory.create()
         canteen = CanteenFactory.create()
         canteen.managers.add(manager)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2020, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, manager)
 
         response = self.client.post(reverse("teledeclaration_cancel", kwargs={"pk": teledeclaration.id}))
@@ -109,7 +113,9 @@ class TestTeledeclarationApi(APITestCase):
         manager = UserFactory.create()
         canteen = CanteenFactory.create()
         canteen.managers.add(manager)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2020, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, manager)
 
         response = self.client.get(reverse("teledeclaration_pdf", kwargs={"pk": teledeclaration.id}))
@@ -136,7 +142,7 @@ class TestTeledeclarationApi(APITestCase):
         canteen = CanteenFactory.create(central_producer_siret=None)
         canteen.managers.add(user)
         diagnostic = DiagnosticFactory.create(
-            canteen=canteen, year=2020, value_total_ht=None, diagnostic_type="SIMPLE"
+            canteen=canteen, year=2020, value_total_ht=None, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
         )
         payload = {"diagnosticId": diagnostic.id}
 
@@ -159,7 +165,9 @@ class TestTeledeclarationApi(APITestCase):
         user = authenticate.user
         canteen = CanteenFactory.create(central_producer_siret=None)
         canteen.managers.add(user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2019, value_total_ht=100, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2019, value_total_ht=100, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
         payload = {"diagnosticId": diagnostic.id}
         response = self.client.post(reverse("teledeclaration_create"), payload)
 
@@ -176,7 +184,11 @@ class TestTeledeclarationApi(APITestCase):
         canteen = CanteenFactory.create()
         canteen.managers.add(user)
         diagnostic = DiagnosticFactory.create(
-            value_externality_performance_ht=0, canteen=canteen, year=2020, diagnostic_type="SIMPLE"
+            value_externality_performance_ht=0,
+            canteen=canteen,
+            year=2020,
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+            value_total_ht=100,
         )
         payload = {"diagnosticId": diagnostic.id}
         response = self.client.post(reverse("teledeclaration_create"), payload)
@@ -274,7 +286,10 @@ class TestTeledeclarationApi(APITestCase):
         canteen = CanteenFactory.create()
         canteen.managers.add(user)
         diagnostic = DiagnosticFactory.create(
-            value_externality_performance_ht=0, canteen=canteen, year=2020, diagnostic_type="SIMPLE"
+            value_externality_performance_ht=0,
+            canteen=canteen,
+            year=2020,
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
         )
         payload = {"diagnosticId": diagnostic.id}
         response = self.client.post(reverse("teledeclaration_create"), payload)
@@ -291,7 +306,9 @@ class TestTeledeclarationApi(APITestCase):
         user = authenticate.user
         canteen = CanteenFactory.create()
         canteen.managers.add(user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2020, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, user)
 
         response = self.client.post(reverse("teledeclaration_cancel", kwargs={"pk": teledeclaration.id}))
@@ -313,7 +330,9 @@ class TestTeledeclarationApi(APITestCase):
         user = authenticate.user
         canteen = CanteenFactory.create()
         canteen.managers.add(user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2021, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2021, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, user)
 
         response = self.client.post(reverse("teledeclaration_cancel", kwargs={"pk": teledeclaration.id}))
@@ -332,7 +351,9 @@ class TestTeledeclarationApi(APITestCase):
         user = authenticate.user
         canteen = CanteenFactory.create()
         canteen.managers.add(user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2022, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2022, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, user)
 
         response = self.client.post(reverse("teledeclaration_cancel", kwargs={"pk": teledeclaration.id}))
@@ -350,7 +371,9 @@ class TestTeledeclarationApi(APITestCase):
         """
         canteen = CanteenFactory.create()
         canteen.managers.add(authenticate.user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2020, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, authenticate.user)
 
         diagnostic.delete()
@@ -366,7 +389,9 @@ class TestTeledeclarationApi(APITestCase):
         """
         canteen = CanteenFactory.create()
         canteen.managers.add(authenticate.user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2020, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, authenticate.user)
 
         response = self.client.get(reverse("teledeclaration_pdf", kwargs={"pk": teledeclaration.id}))
@@ -410,7 +435,9 @@ class TestTeledeclarationApi(APITestCase):
         """
         canteen = CanteenFactory.create(production_type=Canteen.ProductionType.CENTRAL, daily_meal_count=345)
         canteen.managers.add(authenticate.user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=2020, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, authenticate.user)
         self.assertIsNone(teledeclaration.declared_data["canteen"]["daily_meal_count"])
 
@@ -426,7 +453,9 @@ class TestTeledeclarationApi(APITestCase):
         user = authenticate.user
         canteen = CanteenFactory.create(siret="12345678912345")
         canteen.managers.add(user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=LAST_YEAR, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=LAST_YEAR, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
         Teledeclaration.create_from_diagnostic(diagnostic, user)
 
         payload = {"diagnosticId": diagnostic.id}
@@ -443,7 +472,9 @@ class TestTeledeclarationApi(APITestCase):
         user = authenticate.user
         canteen = CanteenFactory.create(siret="")
         canteen.managers.add(user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=LAST_YEAR, diagnostic_type="SIMPLE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=LAST_YEAR, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE, value_total_ht=100
+        )
         Teledeclaration.create_from_diagnostic(diagnostic, user)
 
         payload = {"diagnosticId": diagnostic.id}
@@ -452,7 +483,7 @@ class TestTeledeclarationApi(APITestCase):
 
         canteen2 = CanteenFactory.create(siret="")
         canteen2.managers.add(user)
-        diagnostic2 = DiagnosticFactory.create(canteen=canteen2, year=LAST_YEAR)
+        diagnostic2 = DiagnosticFactory.create(canteen=canteen2, year=LAST_YEAR, value_total_ht=100)
 
         payload = {"diagnosticId": diagnostic2.id}
         response = self.client.post(reverse("teledeclaration_create"), payload)
@@ -468,7 +499,9 @@ class TestTeledeclarationApi(APITestCase):
         user = authenticate.user
         canteen = CanteenFactory.create()
         canteen.managers.add(user)
-        diagnostic = DiagnosticFactory.create(canteen=canteen, year=LAST_YEAR, diagnostic_type="COMPLETE")
+        diagnostic = DiagnosticFactory.create(
+            canteen=canteen, year=LAST_YEAR, diagnostic_type=Diagnostic.DiagnosticType.COMPLETE, value_total_ht=100
+        )
         payload = {"diagnosticId": diagnostic.id}
 
         response = self.client.post(reverse("teledeclaration_create"), payload)

--- a/data/factories/diagnostic.py
+++ b/data/factories/diagnostic.py
@@ -32,10 +32,10 @@ class CompleteDiagnosticFactory(factory.django.DjangoModelFactory):
     value_boissons_bio = factory.Faker("random_int", min=0, max=20)
 
     value_egalim_others_ht = factory.Faker("random_int", min=0, max=20)
-    value_meat_poultry_ht = factory.Faker("random_int", min=0, max=20)
+    value_meat_poultry_ht = factory.Faker("random_int", min=100, max=150)
     value_meat_poultry_egalim_ht = factory.Faker("random_int", min=0, max=20)
     value_meat_poultry_france_ht = factory.Faker("random_int", min=0, max=20)
-    value_fish_ht = factory.Faker("random_int", min=0, max=20)
+    value_fish_ht = factory.Faker("random_int", min=50, max=100)
     value_fish_egalim_ht = factory.Faker("random_int", min=0, max=20)
 
     has_waste_diagnostic = factory.Faker("boolean")

--- a/data/factories/diagnostic.py
+++ b/data/factories/diagnostic.py
@@ -10,38 +10,8 @@ class DiagnosticFactory(factory.django.DjangoModelFactory):
         model = Diagnostic
 
     canteen = factory.SubFactory(CanteenFactory)
-    year = factory.Faker("year")
-    diagnostic_type = fuzzy.FuzzyChoice(list(Diagnostic.DiagnosticType))
-
-    value_bio_ht = factory.Faker("random_int", min=0, max=2000)
-    value_sustainable_ht = factory.Faker("random_int", min=0, max=2000)
-    value_total_ht = factory.Faker("random_int", min=6000, max=10000)
-
-    value_externality_performance_ht = factory.Faker("random_int", min=0, max=20)
-    value_egalim_others_ht = factory.Faker("random_int", min=0, max=20)
-    value_meat_poultry_ht = factory.Faker("random_int", min=0, max=20)
-    value_meat_poultry_egalim_ht = factory.Faker("random_int", min=0, max=20)
-    value_meat_poultry_france_ht = factory.Faker("random_int", min=0, max=20)
-    value_fish_ht = factory.Faker("random_int", min=0, max=20)
-    value_fish_egalim_ht = factory.Faker("random_int", min=0, max=20)
-
-    has_waste_diagnostic = factory.Faker("boolean")
-    has_waste_plan = factory.Faker("boolean")
-    waste_actions = factory.List(random.sample(list(Diagnostic.WasteActions), random.randint(0, 2)))
-    has_donation_agreement = factory.Faker("boolean")
-
-    has_diversification_plan = factory.Faker("boolean")
-    vegetarian_weekly_recurrence = fuzzy.FuzzyChoice(list(Diagnostic.MenuFrequency))
-    vegetarian_menu_type = fuzzy.FuzzyChoice(list(Diagnostic.MenuType))
-
-    cooking_plastic_substituted = factory.Faker("boolean")
-    serving_plastic_substituted = factory.Faker("boolean")
-    plastic_bottles_substituted = factory.Faker("boolean")
-    plastic_tableware_substituted = factory.Faker("boolean")
-
-    communication_supports = factory.List(random.sample(list(Diagnostic.CommunicationType), random.randint(0, 2)))
-    communication_support_url = factory.Faker("uri")
-    communicates_on_food_plan = factory.Faker("boolean")
+    year = 2019
+    diagnostic_type = Diagnostic.DiagnosticType.SIMPLE
 
 
 class CompleteDiagnosticFactory(factory.django.DjangoModelFactory):

--- a/data/factories/diagnostic.py
+++ b/data/factories/diagnostic.py
@@ -2,6 +2,7 @@ import random
 import factory
 from factory import fuzzy
 from data.models import Diagnostic
+from data.utils import get_diagnostic_lower_limit_year, get_diagnostic_upper_limit_year
 from .canteen import CanteenFactory
 
 
@@ -10,7 +11,9 @@ class DiagnosticFactory(factory.django.DjangoModelFactory):
         model = Diagnostic
 
     canteen = factory.SubFactory(CanteenFactory)
-    year = 2019
+    year = factory.Faker(
+        "random_int", min=get_diagnostic_lower_limit_year(), max=get_diagnostic_upper_limit_year()
+    )  # "year"
     diagnostic_type = Diagnostic.DiagnosticType.SIMPLE
 
 
@@ -19,7 +22,9 @@ class CompleteDiagnosticFactory(factory.django.DjangoModelFactory):
         model = Diagnostic
 
     canteen = factory.SubFactory(CanteenFactory)
-    year = factory.Faker("year")
+    year = factory.Faker(
+        "random_int", min=get_diagnostic_lower_limit_year(), max=get_diagnostic_upper_limit_year()
+    )  # "year"
     diagnostic_type = Diagnostic.DiagnosticType.COMPLETE
 
     value_total_ht = factory.Faker("random_int", min=6000, max=10000)

--- a/data/factories/diagnostic.py
+++ b/data/factories/diagnostic.py
@@ -11,9 +11,7 @@ class DiagnosticFactory(factory.django.DjangoModelFactory):
         model = Diagnostic
 
     canteen = factory.SubFactory(CanteenFactory)
-    year = factory.Faker(
-        "random_int", min=get_diagnostic_lower_limit_year(), max=get_diagnostic_upper_limit_year()
-    )  # "year"
+    year = factory.Faker("random_int", min=get_diagnostic_lower_limit_year(), max=get_diagnostic_upper_limit_year())
     diagnostic_type = Diagnostic.DiagnosticType.SIMPLE
 
 
@@ -22,9 +20,7 @@ class CompleteDiagnosticFactory(factory.django.DjangoModelFactory):
         model = Diagnostic
 
     canteen = factory.SubFactory(CanteenFactory)
-    year = factory.Faker(
-        "random_int", min=get_diagnostic_lower_limit_year(), max=get_diagnostic_upper_limit_year()
-    )  # "year"
+    year = factory.Faker("random_int", min=get_diagnostic_lower_limit_year(), max=get_diagnostic_upper_limit_year())
     diagnostic_type = Diagnostic.DiagnosticType.COMPLETE
 
     value_total_ht = factory.Faker("random_int", min=6000, max=10000)

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1386,18 +1386,6 @@ class Diagnostic(models.Model):
     def is_teledeclared(self):
         return self.latest_submitted_teledeclaration is not None
 
-    def clean(self):
-        self.validate_year()
-
-        if self.diagnostic_type == Diagnostic.DiagnosticType.COMPLETE:
-            self.populate_simplified_diagnostic_values()
-
-        self.validate_approvisionment_total()
-        self.validate_meat_total()
-        self.validate_fish_total()
-        self.validate_meat_fish_egalim()
-        return super().clean()
-
     def populate_simplified_diagnostic_values(self):
         self.value_bio_ht = self.total_label_bio
         self.value_sustainable_ht = self.total_label_label_rouge + self.total_label_aocaop_igp_stg
@@ -1519,6 +1507,22 @@ class Diagnostic(models.Model):
                     "value_sustainable_ht": f"La somme des valeurs viandes et poissons EGAlim, {meat_fish_egalim_sum}, est plus que la somme des valeurs bio, SIQO, environnementales et autres EGAlim, {egalim_sum}"
                 }
             )
+
+    def clean(self):
+        self.validate_year()
+
+        if self.diagnostic_type == Diagnostic.DiagnosticType.COMPLETE:
+            self.populate_simplified_diagnostic_values()
+
+        self.validate_approvisionment_total()
+        self.validate_meat_total()
+        self.validate_fish_total()
+        self.validate_meat_fish_egalim()
+        return super().clean()
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
 
     def __str__(self):
         return f"Diagnostic pour {self.canteen.name} ({self.year})"

--- a/macantine/tests/test_etl.py
+++ b/macantine/tests/test_etl.py
@@ -22,8 +22,8 @@ class TestETLAnalysis(TestCase):
         canteen = CanteenFactory.create()
         applicant = UserFactory.create()
         with freeze_time("2020-01-14"):
-            diagnostic_1990 = DiagnosticFactory.create(canteen=canteen, year=2019, diagnostic_type=None)
-            Teledeclaration.create_from_diagnostic(diagnostic_1990, applicant)
+            diagnostic_2019 = DiagnosticFactory.create(canteen=canteen, year=2019, diagnostic_type=None)
+            Teledeclaration.create_from_diagnostic(diagnostic_2019, applicant)
         with freeze_time("2023-05-14"):
             diagnostic_2022 = DiagnosticFactory.create(canteen=canteen, year=2022, diagnostic_type=None)
             td_2022 = Teledeclaration.create_from_diagnostic(diagnostic_2022, applicant)


### PR DESCRIPTION
### Quoi ?

Lié à l'issue #4273

En validant les diagnostiques à la sauvegarde, cela provoque pas mal d'erreurs de tests car les données générées par la factory sont rarement "valides" (année, sommes...)

J'ai du mettre à jours quelques tests pour que les validations passent (`Diagnostic`, mais aussi `Teledeclaration`)