### PR TITLE
Réparer flaky test : token invalide

### DIFF
--- a/web/tests/test_registration.py
+++ b/web/tests/test_registration.py
@@ -55,12 +55,14 @@ class TestRegistration(APITestCase):
 
         # Check that the email contains the token
         content = mail.outbox[0].body
-        matches = re.findall(r"compte\/(?P<uidb64>.*)\/(?P<token>.*)", content)
+        # the link sometimes gets broken in the middle of the token that has a hyphen, avoid this by replacing the line break
+        no_line_break = content.replace("-\n", "-")
+        matches = re.findall(r"compte\/(?P<uidb64>.*)\/(?P<token>.*)", no_line_break)
         self.assertEqual(len(matches), 1)
         uidb64, token = matches[0]
         activation_response = self.client.get(reverse("activate", kwargs={"uidb64": uidb64, "token": token}))
 
-        redirect_error_message = f"\nEmail body:\n{content}" + f"\n\nUIDB64: {uidb64}\n\nTOKEN: {token}"
+        redirect_error_message = f"\nEmail body:\n{no_line_break}" + f"\n\nUIDB64: {uidb64}\n\nTOKEN: {token}"
         self.assertRedirects(
             activation_response,
             reverse("app"),


### PR DESCRIPTION
closes #3587 