### PR TITLE
API : nouveau middleware pour gérer les ValidationErrors renvoyées par les modèles

### DIFF
--- a/api/middleware.py
+++ b/api/middleware.py
@@ -1,0 +1,20 @@
+from django.core import exceptions
+from django.views import View
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import exception_handler
+
+
+def custom_exception_handler(exc: Exception, context: View):
+    """
+    Custom exception handler for DRF
+    To better handle Django ValidationError
+    source: https://stackoverflow.com/a/61701513/4293684
+    """
+    response = exception_handler(exc, context)
+
+    if isinstance(exc, exceptions.ValidationError):
+        data = exc.message_dict
+        return Response(data=data, status=status.HTTP_400_BAD_REQUEST)
+
+    return response

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -247,6 +247,7 @@ REST_FRAMEWORK = {
         "djangorestframework_camel_case.parser.CamelCaseMultiPartParser",
         "djangorestframework_camel_case.parser.CamelCaseJSONParser",
     ),
+    "EXCEPTION_HANDLER": "api.middleware.custom_exception_handler",
     "JSON_UNDERSCOREIZE": {
         "no_underscore_before_number": True,
     },


### PR DESCRIPTION
### Quoi ?

Lié à l'issue https://github.com/betagouv/ma-cantine/issues/4273 (étape 1)

Dans l'idée de basculer certaines (toutes ?) les validations depuis l'API (serializers) vers les modèles (save / full_clean), il nous faut un moyen de renvoyer une erreur propre (avec son message) lorsque il y a une erreur de validation.

Sinon cela fera des erreurs 500.

### Suite ?

#4289