### PR TITLE
CMS : Action anti-gaspi : ajout d'une factory et de validations

### DIFF
--- a/cms/factories.py
+++ b/cms/factories.py
@@ -1,0 +1,14 @@
+import random
+import factory
+from factory import fuzzy
+from .models import WasteAction
+
+
+class WasteActionFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = WasteAction
+
+    title = factory.Faker("text", max_nb_chars=20)
+    description = factory.Faker("text")
+    effort = fuzzy.FuzzyChoice(list(WasteAction.Effort))
+    waste_origins = factory.List(random.sample(list(WasteAction.WasteOrigin), random.randint(0, 2)))

--- a/cms/models/wasteaction.py
+++ b/cms/models/wasteaction.py
@@ -40,3 +40,7 @@ class WasteAction(models.Model):
 
     def __str__(self):
         return f'Action anti-gaspi "{self.title}"'
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)

--- a/cms/tests.py
+++ b/cms/tests.py
@@ -1,6 +1,15 @@
 from django.test import TransactionTestCase
-from django.db.utils import IntegrityError
+from django.core.exceptions import ValidationError
 from .models import WasteAction
+from .factories import WasteActionFactory
+
+
+WASTE_ACTION = {
+    "title": "Action 1",
+    "description": "Description",
+    "effort": WasteAction.Effort.SMALL,
+    "waste_origins": [WasteAction.WasteOrigin.PREP],
+}
 
 
 class WasteActionModelSaveTest(TransactionTestCase):
@@ -9,7 +18,12 @@ class WasteActionModelSaveTest(TransactionTestCase):
         pass
 
     def test_waste_action_validation(self):
-        # NOT OK : waste_origins is required
-        self.assertRaises(IntegrityError, WasteAction.objects.create, title="Action 1")
-        # OK
-        WasteAction.objects.create(title="Action 1", subtitle=None, waste_origins=[WasteAction.WasteOrigin.PREP])
+        # NOT OK: missing required field
+        for REQUIRED_FIELD in ["title", "description", "effort", "waste_origins"]:
+            WASTE_ACTION_WITHOUT_REQUIRED_FIELD = WASTE_ACTION | {REQUIRED_FIELD: None}
+            self.assertRaises(ValidationError, WasteActionFactory, **WASTE_ACTION_WITHOUT_REQUIRED_FIELD)
+        # OK: all required fields passed
+        WasteActionFactory(**WASTE_ACTION)
+        # OK: subtitle can be empty
+        WASTE_ACTION_WITHOUT_SUBTITLE = WASTE_ACTION | {"subtitle": None}
+        WasteActionFactory(**WASTE_ACTION_WITHOUT_SUBTITLE)

--- a/cms/tests.py
+++ b/cms/tests.py
@@ -11,6 +11,8 @@ WASTE_ACTION = {
     "waste_origins": [WasteAction.WasteOrigin.PREP],
 }
 
+WASTE_ACTION_REQUIRED_FIELDS = ["title", "description", "effort", "waste_origins"]
+
 
 class WasteActionModelSaveTest(TransactionTestCase):
     @classmethod
@@ -19,11 +21,8 @@ class WasteActionModelSaveTest(TransactionTestCase):
 
     def test_waste_action_validation(self):
         # NOT OK: missing required field
-        for REQUIRED_FIELD in ["title", "description", "effort", "waste_origins"]:
-            WASTE_ACTION_WITHOUT_REQUIRED_FIELD = WASTE_ACTION | {REQUIRED_FIELD: None}
+        for required_field in WASTE_ACTION_REQUIRED_FIELDS:
+            WASTE_ACTION_WITHOUT_REQUIRED_FIELD = WASTE_ACTION | {required_field: None}
             self.assertRaises(ValidationError, WasteActionFactory, **WASTE_ACTION_WITHOUT_REQUIRED_FIELD)
-        # OK: all required fields passed
+        # OK: all required fields passed (subtitle can be empty)
         WasteActionFactory(**WASTE_ACTION)
-        # OK: subtitle can be empty
-        WASTE_ACTION_WITHOUT_SUBTITLE = WASTE_ACTION | {"subtitle": None}
-        WasteActionFactory(**WASTE_ACTION_WITHOUT_SUBTITLE)


### PR DESCRIPTION
Suite à #4370, et en lien avec #4289

Modifications apportées
- j'ai crée une `WasteActionFactory` pour aider à la création de tests
- la validation se fait au moment du save (pour refléter le formulaire Wagtail actuel), et amélioré les tests pour expliciter les 4 champs obligatoires : "title", "description", "effort", "waste_origins"