### PR TITLE
CMS : Actions anti-gaspi : améliorer la navigation dans Wagtail

### DIFF
--- a/cms/filtersets/wasteaction.py
+++ b/cms/filtersets/wasteaction.py
@@ -1,11 +1,19 @@
+from django import forms
 from wagtail.admin.filters import WagtailFilterSet
-from django_filters import CharFilter
+from django_filters import CharFilter, MultipleChoiceFilter
 from cms.models import WasteAction
 
 
 class WasteActionFilterSet(WagtailFilterSet):
     title = CharFilter(lookup_expr="icontains")
+    effort = MultipleChoiceFilter(choices=WasteAction.Effort.choices, widget=forms.CheckboxSelectMultiple)
+    waste_origins = MultipleChoiceFilter(
+        label=WasteAction._meta.get_field("waste_origins").verbose_name,
+        choices=WasteAction.WasteOrigin.choices,
+        widget=forms.CheckboxSelectMultiple,
+        lookup_expr="icontains",
+    )
 
     class Meta:
         model = WasteAction
-        fields = ["effort"]
+        fields = ["title", "effort", "waste_origins"]

--- a/cms/filtersets/wasteaction.py
+++ b/cms/filtersets/wasteaction.py
@@ -5,7 +5,7 @@ from cms.models import WasteAction
 
 
 class WasteActionFilterSet(WagtailFilterSet):
-    title = CharFilter(lookup_expr="icontains")
+    title = CharFilter(label="Titre contient", lookup_expr="unaccent__icontains")
     effort = MultipleChoiceFilter(choices=WasteAction.Effort.choices, widget=forms.CheckboxSelectMultiple)
     waste_origins = MultipleChoiceFilter(
         label=WasteAction._meta.get_field("waste_origins").verbose_name,

--- a/cms/filtersets/wasteaction.py
+++ b/cms/filtersets/wasteaction.py
@@ -1,8 +1,11 @@
 from wagtail.admin.filters import WagtailFilterSet
+from django_filters import CharFilter
 from cms.models import WasteAction
 
 
 class WasteActionFilterSet(WagtailFilterSet):
+    title = CharFilter(lookup_expr="icontains")
+
     class Meta:
         model = WasteAction
         fields = ["effort"]

--- a/cms/filtersets/wasteaction.py
+++ b/cms/filtersets/wasteaction.py
@@ -1,0 +1,8 @@
+from wagtail.admin.filters import WagtailFilterSet
+from cms.models import WasteAction
+
+
+class WasteActionFilterSet(WagtailFilterSet):
+    class Meta:
+        model = WasteAction
+        fields = ["effort"]

--- a/cms/viewsets/wasteaction.py
+++ b/cms/viewsets/wasteaction.py
@@ -1,8 +1,9 @@
 from wagtail.snippets.views.snippets import SnippetViewSet
 from wagtail.admin.panels import TabbedInterface, ObjectList, FieldPanel
-from cms.models.wasteaction import WasteAction
 from wagtail.images.api.v2.views import BaseAPIViewSet
 from djangorestframework_camel_case.render import CamelCaseJSONRenderer, CamelCaseBrowsableAPIRenderer
+from cms.models.wasteaction import WasteAction
+from cms.filtersets.wasteaction import WasteActionFilterSet
 
 
 class WasteActionViewSet(SnippetViewSet):
@@ -16,6 +17,8 @@ class WasteActionViewSet(SnippetViewSet):
     menu_name = "wasteactions"
     menu_order = 90
     add_to_admin_menu = True
+    filterset_class = WasteActionFilterSet
+    list_display = ["title", "modification_date"]
     edit_handler = TabbedInterface(
         [
             ObjectList(
@@ -31,7 +34,6 @@ class WasteActionViewSet(SnippetViewSet):
             ObjectList([FieldPanel("lead_image")], heading="Illustration"),
         ]
     )
-    list_display = ["title", "modification_date"]
 
 
 class WasteActionAPIViewSet(BaseAPIViewSet):


### PR DESCRIPTION
Voire issue #4313

### Quoi ?

Aider à la navigation dans les (futures) nombreuses fiches "Action anti-gaspi"
- [x] filtre par "title" (recherche)
- [x] filtre par "effort" (multi-select)
- [x] filtre par "waste_origins (mult-select)

### Comment ?

Grâce à un FilterSet (similaire à DRF !)
https://docs.wagtail.org/en/stable/reference/viewsets.html#wagtail.admin.viewsets.model.ModelViewSet.filterset_class

### Screenshot

![image](https://github.com/user-attachments/assets/0aaceb63-1e0c-4dd4-9204-8cc9ba1c9023)

### Todo après (dans une autre PR, et après la migration vers `/data`)

- RevisionMixin
- DraftStateMixin