### PR TITLE
CI : Github Action : ajouter automatiquement les reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,5 +1,18 @@
+# Configuration file for https://github.com/kentaro-m/auto-assign-action
+
 # Set to true to add reviewers to pull requests
-addReviewers: false
+addReviewers: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:  # gip-inclusion/admins-le-marche
+  - hfroot
+  - alemangui
+  - qloridant
+  - raphodn
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
 
 # Set to true to add assignees to pull requests
 # Set to 'author' to set the PR creator as the assignee

--- a/.github/workflows/pr-auto-reviewers-and-assignee.yml
+++ b/.github/workflows/pr-auto-reviewers-and-assignee.yml
@@ -1,4 +1,4 @@
-name: PR Auto Assignee (author)
+name: PR Auto Reviewers (team) & Assignee (author)
 
 on:
   pull_request:


### PR DESCRIPTION
### Quoi ?

Suite de #4327. Closes #4375

On réutilise notre Github Action existante - https://github.com/betagouv/ma-cantine/pull/4327 - et on y rajoute la config pour mettre en reviewer automatiquement l'équipe dev de ma-cantine

J'ai renommé la GA pour clarifier son action