### PR TITLE
CI : pre-commit : refactorer un peu la configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,17 @@
+# https://pre-commit.com/
+
 exclude: ^(.*\/migrations|.*package.json|.*package-lock.json|Pipfile*|.vscode|.*.spec.js|.*jsconfig.json|.*\/tests/files/.*.tsv)
 repos:
   # GENERAL
-  - hooks:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
       - id: forbid-new-submodules
-    repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
-  - hooks:
+    hooks:
       - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-executables-have-shebangs
@@ -16,26 +20,26 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: trailing-whitespace
-    repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
-  - hooks:
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.9
+    hooks:
       - id: forbid-crlf
       - id: remove-crlf
       - id: forbid-tabs
       - id: remove-tabs
-    repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
-  - hooks:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
       - id: check-json
       - args:
           - --autofix
           - --no-ensure-ascii
         id: pretty-format-json
-    repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
 
   # PYTHON
-  - hooks:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
       - id: check-ast
       - id: check-builtin-literals
       - id: check-docstring-first
@@ -44,62 +48,62 @@ repos:
           - --remove
         id: fix-encoding-pragma
       - id: requirements-txt-fixer
-    repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
-  - hooks:
-      - id: pyupgrade
-    repo: https://github.com/asottile/pyupgrade
+  - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.2
-  - hooks:
+    hooks:
+      - id: pyupgrade
+  - repo: https://github.com/ambv/black
+    rev: 24.4.2
+    hooks:
       - id: black
         args: [--line-length=119]
         exclude: ^migrations/
-    repo: https://github.com/ambv/black
-    rev: 24.4.2
-  - hooks:
+  - repo: https://github.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
       - args:
           - --config=.flake8
         id: flake8
-    repo: https://github.com/pycqa/flake8
-    rev: 3.8.3
-  - hooks:
-      - id: python-safety-dependencies-check
-    repo: https://github.com/Lucas-C/pre-commit-hooks-safety
+  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
     rev: v1.1.3
+    hooks:
+      - id: python-safety-dependencies-check
 
   # BASH
-  - hooks:
-      - id: beautysh
-    repo: https://github.com/bemeurer/beautysh.git
+  - repo: https://github.com/bemeurer/beautysh.git
     rev: 6.0.1
-  - hooks:
-      - id: script-must-have-extension
-    repo: https://github.com/jumanjihouse/pre-commit-hooks
+    hooks:
+      - id: beautysh
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.4
+    hooks:
+      - id: script-must-have-extension
 
   # XML / YAML
-  - hooks:
-      - id: check-xml
-    repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
-  - hooks:
+    hooks:
+      - id: check-xml
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.24.2
+    hooks:
       - args:
           - "-d {rules: {line-length: {max: 999}}}"
         id: yamllint
-    repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.24.2
-  - hooks:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
       - id: check-yaml
       - id: sort-simple-yaml
-    repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
-  - hooks:
-      - id: gitlab-ci-linter
-    repo: https://gitlab.com/devopshq/gitlab-ci-linter
+  - repo: https://gitlab.com/devopshq/gitlab-ci-linter
     rev: v1.0.1
+    hooks:
+      - id: gitlab-ci-linter
 
   # JS (Vue 2 app)
-  - hooks:
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v7.32.0
+    hooks:
       - id: eslint
         name: vue2-eslint
         additional_dependencies:
@@ -118,9 +122,9 @@ repos:
         types:
           - vue
         files: ^frontend/
-    repo: https://github.com/pre-commit/mirrors-eslint
+  - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v7.32.0
-  - hooks:
+    hooks:
       - additional_dependencies:
           - eslint@latest
           - vue-eslint-parser@latest
@@ -137,10 +141,10 @@ repos:
         files: ^frontend/
         id: eslint
         name: js-eslint-v2
-    repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v7.32.0
   # JS (Vue 3 app)
-  - hooks:
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v7.32.0
+    hooks:
       - id: eslint
         name: vue3-eslint
         additional_dependencies:
@@ -159,9 +163,9 @@ repos:
         types:
           - vue
         files: ^2024-frontend/
-    repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v7.32.0
-  - hooks:
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.55.0
+    hooks:
       - additional_dependencies:
           - eslint@8.55.0
           - vue-eslint-parser@latest
@@ -178,5 +182,3 @@ repos:
         files: ^2024-frontend/
         id: eslint
         name: js-eslint-v3
-    repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.55.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,9 +31,7 @@ repos:
     rev: v3.2.0
     hooks:
       - id: check-json
-      - args:
-          - --autofix
-          - --no-ensure-ascii
+      - args: [--autofix, --no-ensure-ascii]
         id: pretty-format-json
 
   # PYTHON
@@ -44,8 +42,7 @@ repos:
       - id: check-builtin-literals
       - id: check-docstring-first
       - id: debug-statements
-      - args:
-          - --remove
+      - args: [--remove]
         id: fix-encoding-pragma
       - id: requirements-txt-fixer
   - repo: https://github.com/asottile/pyupgrade
@@ -61,8 +58,7 @@ repos:
   - repo: https://github.com/pycqa/flake8
     rev: 3.8.3
     hooks:
-      - args:
-          - --config=.flake8
+      - args: [--config=.flake8]
         id: flake8
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
     rev: v1.1.3
@@ -87,8 +83,7 @@ repos:
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.24.2
     hooks:
-      - args:
-          - "-d {rules: {line-length: {max: 999}}}"
+      - args: ["-d {rules: {line-length: {max: 999}}}"]
         id: yamllint
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
@@ -116,9 +111,7 @@ repos:
           - eslint-config-prettier@latest
           - eslint-plugin-prettier@latest
           - babel-eslint
-        args:
-          - -c=frontend/.eslintrc.js
-          - --fix
+        args: [-c=frontend/.eslintrc.js, --fix]
         types:
           - vue
         files: ^frontend/
@@ -135,9 +128,7 @@ repos:
           - eslint-config-prettier@latest
           - eslint-plugin-prettier@latest
           - babel-eslint
-        args:
-          - -c=frontend/.eslintrc.js
-          - --fix
+        args: [-c=frontend/.eslintrc.js, --fix]
         files: ^frontend/
         id: eslint
         name: js-eslint-v2
@@ -157,9 +148,7 @@ repos:
           - eslint-config-prettier@latest
           - eslint-plugin-prettier@latest
           - babel-eslint
-        args:
-          - -c=2024-frontend/.eslintrc.cjs
-          - --fix
+        args: [-c=2024-frontend/.eslintrc.cjs, --fix]
         types:
           - vue
         files: ^2024-frontend/
@@ -176,9 +165,7 @@ repos:
           - eslint-config-prettier@latest
           - eslint-plugin-prettier@latest
           - babel-eslint
-        args:
-          - -c=2024-frontend/.eslintrc.cjs
-          - --fix
+        args: [-c=2024-frontend/.eslintrc.cjs, --fix]
         files: ^2024-frontend/
         id: eslint
         name: js-eslint-v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,8 @@ repos:
     rev: v3.2.0
     hooks:
       - id: check-json
-      - args: [--autofix, --no-ensure-ascii]
-        id: pretty-format-json
+      - id: pretty-format-json
+        args: [--autofix, --no-ensure-ascii]
 
   # PYTHON
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -42,8 +42,8 @@ repos:
       - id: check-builtin-literals
       - id: check-docstring-first
       - id: debug-statements
-      - args: [--remove]
-        id: fix-encoding-pragma
+      - id: fix-encoding-pragma
+        args: [--remove]
       - id: requirements-txt-fixer
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.2
@@ -58,8 +58,8 @@ repos:
   - repo: https://github.com/pycqa/flake8
     rev: 3.8.3
     hooks:
-      - args: [--config=.flake8]
-        id: flake8
+      - id: flake8
+        args: [--config=.flake8]
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
     rev: v1.1.3
     hooks:
@@ -83,8 +83,8 @@ repos:
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.24.2
     hooks:
-      - args: ["-d {rules: {line-length: {max: 999}}}"]
-        id: yamllint
+      - id: yamllint
+        args: ["-d {rules: {line-length: {max: 999}}}"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
@@ -102,7 +102,7 @@ repos:
       - id: eslint
         name: vue2-eslint
         additional_dependencies:
-          - eslint@latest
+          - eslint@7.32.0
           - vue-eslint-parser@latest
           - eslint-plugin-vue@latest
           - eslint-plugin-jquery@latest
@@ -118,8 +118,10 @@ repos:
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v7.32.0
     hooks:
-      - additional_dependencies:
-          - eslint@latest
+      - id: eslint
+        name: js-eslint-v2
+        additional_dependencies:
+          - eslint@7.32.0
           - vue-eslint-parser@latest
           - eslint-plugin-vue@latest
           - eslint-plugin-jquery@latest
@@ -130,8 +132,6 @@ repos:
           - babel-eslint
         args: [-c=frontend/.eslintrc.js, --fix]
         files: ^frontend/
-        id: eslint
-        name: js-eslint-v2
   # JS (Vue 3 app)
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v7.32.0
@@ -155,7 +155,9 @@ repos:
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.55.0
     hooks:
-      - additional_dependencies:
+      - id: eslint
+        name: js-eslint-v3
+        additional_dependencies:
           - eslint@8.55.0
           - vue-eslint-parser@latest
           - eslint-plugin-vue@latest
@@ -167,5 +169,3 @@ repos:
           - babel-eslint
         args: [-c=2024-frontend/.eslintrc.cjs, --fix]
         files: ^2024-frontend/
-        id: eslint
-        name: js-eslint-v3

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -199,6 +199,8 @@ l'environnement virtuel) : `pip install pre-commit`.
 
 Puis l'activer : `pre-commit install`.
 
+Note : commande pour lancer les règles du pre-commit sur tous les fichiers : `pre-commit run --all-files`
+
 Les vérifications seront ensuite effectuées avant chaque commit. Attention, lorsqu'une vérification `fail`,
 le commit est annulé. Il faut donc que toutes les vérifications passent pour que le commit soit pris en
 compte. Si exceptionnellement vous voulez commiter malgré qu'une vérification ne passe pas, c'est possible


### PR DESCRIPTION
### Quoi ?

Avant d'ajouter `isort` (issue #4341), j'ai mis le nez dans notre pre-commit et j'ai fait quelques petites modifications cosmétiques : 
- [x] mettre `repo` & `rev` avant `hooks` (et `id` et `name` avant `args`)
- [x] mettre les `args` au format liste
- [x] ajouter une ligne de doc sur comment lancer la config pre-commit sur tous les fichiers
- [ ] réparé les versions d'eslint (il y avait des erreurs) voir #4435
