### PR TITLE
CI : pre-commit : ajout d'isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,11 @@ repos:
     hooks:
       - id: flake8
         args: [--config=.flake8]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
     rev: v1.1.3
     hooks:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,9 +16,13 @@
   "prettier.configPath": "./frontend/.prettierrc",
   "files.eol": "\n",
   "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter"
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    },
   },
   "black-formatter.args": ["--line-length=119"],
   "black-formatter.path": ["./venv/bin/black"],
-  "emmet.includeLanguages": {"django-html": "html"}
+  "emmet.includeLanguages": {"django-html": "html"},
+  "isort.args": ["--profile", "black", "--filter-files"],
 }

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,7 +1,8 @@
-from rest_framework import permissions
+from django.contrib.auth import get_user_model
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from oauth2_provider.contrib.rest_framework.permissions import TokenHasResourceScope
-from django.contrib.auth import get_user_model
+from rest_framework import permissions
+
 from data.models import Canteen, Diagnostic, Teledeclaration
 
 

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -1,56 +1,54 @@
-from .blogpost import BlogPostSerializer  # noqa: F401
+# isort: skip_file
+
+from .user import LoggedUserSerializer, UserInfoSerializer  # noqa: F401
 from .canteen import (  # noqa: F401
-    CanteenActionsSerializer,
-    CanteenPreviewSerializer,
-    CanteenStatusSerializer,
-    CanteenSummarySerializer,
-    CanteenTeledeclarationSerializer,
-    ElectedCanteenSerializer,
+    PublicCanteenSerializer,
+    PublicCanteenPreviewSerializer,
     FullCanteenSerializer,
     ManagingTeamSerializer,
-    MinimalCanteenSerializer,
-    PublicCanteenPreviewSerializer,
-    PublicCanteenSerializer,
+    CanteenPreviewSerializer,
     SatelliteCanteenSerializer,
+    CanteenActionsSerializer,
+    CanteenStatusSerializer,
+    CanteenTeledeclarationSerializer,
     SatelliteTeledeclarationSerializer,
+    ElectedCanteenSerializer,
+    MinimalCanteenSerializer,
+    CanteenSummarySerializer,
 )
-from .communityevent import CommunityEventSerializer  # noqa: F401
 from .diagnostic import (  # noqa: F401
-    ApproDeferredTeledeclarationDiagnosticSerializer,
+    ManagerDiagnosticSerializer,
+    PublicDiagnosticSerializer,
+    FullDiagnosticSerializer,
     ApproDiagnosticSerializer,
     CentralKitchenDiagnosticSerializer,
-    CompleteApproOnlyTeledeclarationDiagnosticSerializer,
-    CompleteTeledeclarationDiagnosticSerializer,
-    DiagnosticAndCanteenSerializer,
-    FullDiagnosticSerializer,
-    ManagerDiagnosticSerializer,
-    PublicApproDiagnosticSerializer,
-    PublicDiagnosticSerializer,
-    PublicServiceDiagnosticSerializer,
-    SimpleApproOnlyTeledeclarationDiagnosticSerializer,
     SimpleTeledeclarationDiagnosticSerializer,
+    CompleteTeledeclarationDiagnosticSerializer,
+    ApproDeferredTeledeclarationDiagnosticSerializer,
+    SimpleApproOnlyTeledeclarationDiagnosticSerializer,
+    CompleteApproOnlyTeledeclarationDiagnosticSerializer,
+    DiagnosticAndCanteenSerializer,
+    PublicApproDiagnosticSerializer,
+    PublicServiceDiagnosticSerializer,
 )
-from .managerinvitation import ManagerInvitationSerializer  # noqa: F401
-from .message import MessageSerializer  # noqa: F401
-from .partner import (  # noqa: F401
-    PartnerContactSerializer,
-    PartnerSerializer,
-    PartnerShortSerializer,
-)
+from .wastemeasurement import WasteMeasurementSerializer  # noqa: F401
+from .sector import SectorSerializer  # noqa: F401
 from .partnertype import PartnerTypeSerializer  # noqa: F401
+from .blogpost import BlogPostSerializer  # noqa: F401
 from .password import PasswordSerializer  # noqa: F401
+from .managerinvitation import ManagerInvitationSerializer  # noqa: F401
+from .teledeclaration import ShortTeledeclarationSerializer  # noqa: F401
 from .purchase import (  # noqa: F401
-    PurchaseExportSerializer,
-    PurchasePercentageSummarySerializer,
     PurchaseSerializer,
     PurchaseSummarySerializer,
+    PurchasePercentageSummarySerializer,
+    PurchaseExportSerializer,
 )
 from .reservationexpe import ReservationExpeSerializer  # noqa: F401
-from .review import ReviewSerializer  # noqa: F401
-from .sector import SectorSerializer  # noqa: F401
-from .teledeclaration import ShortTeledeclarationSerializer  # noqa: F401
-from .user import LoggedUserSerializer, UserInfoSerializer  # noqa: F401
 from .vegetarianexpe import VegetarianExpeSerializer  # noqa: F401
+from .message import MessageSerializer  # noqa: F401
+from .review import ReviewSerializer  # noqa: F401
+from .communityevent import CommunityEventSerializer  # noqa: F401
+from .partner import PartnerSerializer, PartnerShortSerializer, PartnerContactSerializer  # noqa: F401
 from .videotutorial import VideoTutorialSerializer  # noqa: F401
 from .wasteaction import WasteActionSerializer  # noqa: F401
-from .wastemeasurement import WasteMeasurementSerializer  # noqa: F401

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -1,52 +1,56 @@
-from .user import LoggedUserSerializer, UserInfoSerializer  # noqa: F401
+from .blogpost import BlogPostSerializer  # noqa: F401
 from .canteen import (  # noqa: F401
-    PublicCanteenSerializer,
-    PublicCanteenPreviewSerializer,
+    CanteenActionsSerializer,
+    CanteenPreviewSerializer,
+    CanteenStatusSerializer,
+    CanteenSummarySerializer,
+    CanteenTeledeclarationSerializer,
+    ElectedCanteenSerializer,
     FullCanteenSerializer,
     ManagingTeamSerializer,
-    CanteenPreviewSerializer,
-    SatelliteCanteenSerializer,
-    CanteenActionsSerializer,
-    CanteenStatusSerializer,
-    CanteenTeledeclarationSerializer,
-    SatelliteTeledeclarationSerializer,
-    ElectedCanteenSerializer,
     MinimalCanteenSerializer,
-    CanteenSummarySerializer,
+    PublicCanteenPreviewSerializer,
+    PublicCanteenSerializer,
+    SatelliteCanteenSerializer,
+    SatelliteTeledeclarationSerializer,
 )
+from .communityevent import CommunityEventSerializer  # noqa: F401
 from .diagnostic import (  # noqa: F401
-    ManagerDiagnosticSerializer,
-    PublicDiagnosticSerializer,
-    FullDiagnosticSerializer,
+    ApproDeferredTeledeclarationDiagnosticSerializer,
     ApproDiagnosticSerializer,
     CentralKitchenDiagnosticSerializer,
-    SimpleTeledeclarationDiagnosticSerializer,
-    CompleteTeledeclarationDiagnosticSerializer,
-    ApproDeferredTeledeclarationDiagnosticSerializer,
-    SimpleApproOnlyTeledeclarationDiagnosticSerializer,
     CompleteApproOnlyTeledeclarationDiagnosticSerializer,
+    CompleteTeledeclarationDiagnosticSerializer,
     DiagnosticAndCanteenSerializer,
+    FullDiagnosticSerializer,
+    ManagerDiagnosticSerializer,
     PublicApproDiagnosticSerializer,
+    PublicDiagnosticSerializer,
     PublicServiceDiagnosticSerializer,
+    SimpleApproOnlyTeledeclarationDiagnosticSerializer,
+    SimpleTeledeclarationDiagnosticSerializer,
 )
-from .wastemeasurement import WasteMeasurementSerializer  # noqa: F401
-from .sector import SectorSerializer  # noqa: F401
-from .partnertype import PartnerTypeSerializer  # noqa: F401
-from .blogpost import BlogPostSerializer  # noqa: F401
-from .password import PasswordSerializer  # noqa: F401
 from .managerinvitation import ManagerInvitationSerializer  # noqa: F401
-from .teledeclaration import ShortTeledeclarationSerializer  # noqa: F401
+from .message import MessageSerializer  # noqa: F401
+from .partner import (  # noqa: F401
+    PartnerContactSerializer,
+    PartnerSerializer,
+    PartnerShortSerializer,
+)
+from .partnertype import PartnerTypeSerializer  # noqa: F401
+from .password import PasswordSerializer  # noqa: F401
 from .purchase import (  # noqa: F401
+    PurchaseExportSerializer,
+    PurchasePercentageSummarySerializer,
     PurchaseSerializer,
     PurchaseSummarySerializer,
-    PurchasePercentageSummarySerializer,
-    PurchaseExportSerializer,
 )
 from .reservationexpe import ReservationExpeSerializer  # noqa: F401
-from .vegetarianexpe import VegetarianExpeSerializer  # noqa: F401
-from .message import MessageSerializer  # noqa: F401
 from .review import ReviewSerializer  # noqa: F401
-from .communityevent import CommunityEventSerializer  # noqa: F401
-from .partner import PartnerSerializer, PartnerShortSerializer, PartnerContactSerializer  # noqa: F401
+from .sector import SectorSerializer  # noqa: F401
+from .teledeclaration import ShortTeledeclarationSerializer  # noqa: F401
+from .user import LoggedUserSerializer, UserInfoSerializer  # noqa: F401
+from .vegetarianexpe import VegetarianExpeSerializer  # noqa: F401
 from .videotutorial import VideoTutorialSerializer  # noqa: F401
 from .wasteaction import WasteActionSerializer  # noqa: F401
+from .wastemeasurement import WasteMeasurementSerializer  # noqa: F401

--- a/api/serializers/blogpost.py
+++ b/api/serializers/blogpost.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
+
 from data.models import BlogPost
+
 from .user import BlogPostAuthor
 
 

--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -1,15 +1,22 @@
 import logging
-from rest_framework import serializers
-from drf_base64.fields import Base64ImageField
-from data.models import Canteen, Sector, CanteenImage, Diagnostic
+
 from django.conf import settings
-from .diagnostic import PublicDiagnosticSerializer, FullDiagnosticSerializer, CentralKitchenDiagnosticSerializer
-from .diagnostic import ApproDiagnosticSerializer
-from .diagnostic import PublicApproDiagnosticSerializer, PublicServiceDiagnosticSerializer
+from drf_base64.fields import Base64ImageField
+from rest_framework import serializers
+
+from data.models import Canteen, CanteenImage, Diagnostic, Sector
+
+from .diagnostic import (
+    ApproDiagnosticSerializer,
+    CentralKitchenDiagnosticSerializer,
+    FullDiagnosticSerializer,
+    PublicApproDiagnosticSerializer,
+    PublicDiagnosticSerializer,
+    PublicServiceDiagnosticSerializer,
+)
+from .managerinvitation import ManagerInvitationSerializer
 from .sector import SectorSerializer
 from .user import CanteenManagerSerializer
-from .managerinvitation import ManagerInvitationSerializer
-
 
 logger = logging.getLogger(__name__)
 

--- a/api/serializers/communityevent.py
+++ b/api/serializers/communityevent.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from data.models import CommunityEvent
 
 

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -1,9 +1,12 @@
 import logging
-from rest_framework import serializers
-from data.models import Diagnostic
 from decimal import Decimal, InvalidOperation
+
+from rest_framework import serializers
+
+from data.models import Diagnostic
+
 from .teledeclaration import ShortTeledeclarationSerializer
-from .utils import appro_to_percentages, COMPLETE_APPRO_FIELDS
+from .utils import COMPLETE_APPRO_FIELDS, appro_to_percentages
 
 logger = logging.getLogger(__name__)
 

--- a/api/serializers/managerinvitation.py
+++ b/api/serializers/managerinvitation.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from data.models import ManagerInvitation
 
 

--- a/api/serializers/message.py
+++ b/api/serializers/message.py
@@ -1,6 +1,7 @@
-from rest_framework import serializers
-from data.models import Message
 from django.core.validators import validate_email
+from rest_framework import serializers
+
+from data.models import Message
 
 
 class MessageSerializer(serializers.ModelSerializer):

--- a/api/serializers/partner.py
+++ b/api/serializers/partner.py
@@ -1,5 +1,6 @@
 from drf_base64.fields import Base64ImageField
 from rest_framework import serializers
+
 from data.models import Partner
 
 

--- a/api/serializers/partnertype.py
+++ b/api/serializers/partnertype.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from data.models import PartnerType
 
 

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -1,6 +1,8 @@
-from rest_framework import serializers
-from data.models import Purchase
 from drf_base64.fields import Base64FileField
+from rest_framework import serializers
+
+from data.models import Purchase
+
 from .utils import appro_to_percentages
 
 

--- a/api/serializers/reservationexpe.py
+++ b/api/serializers/reservationexpe.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from data.models import ReservationExpe
 
 

--- a/api/serializers/review.py
+++ b/api/serializers/review.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from data.models import Review
 
 

--- a/api/serializers/sector.py
+++ b/api/serializers/sector.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from data.models import Sector
 
 

--- a/api/serializers/teledeclaration.py
+++ b/api/serializers/teledeclaration.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from data.models import Teledeclaration
 
 

--- a/api/serializers/user.py
+++ b/api/serializers/user.py
@@ -1,6 +1,7 @@
-from rest_framework import serializers
 from django.contrib.auth import get_user_model
 from drf_base64.fields import Base64ImageField
+from rest_framework import serializers
+
 from .review import MiniReviewSerializer
 
 

--- a/api/serializers/vegetarianexpe.py
+++ b/api/serializers/vegetarianexpe.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from data.models import VegetarianExpe
 
 

--- a/api/serializers/videotutorial.py
+++ b/api/serializers/videotutorial.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from data.models import VideoTutorial
 
 

--- a/api/serializers/wasteaction.py
+++ b/api/serializers/wasteaction.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from rest_framework.fields import Field
+
 from data.models import WasteAction
 
 

--- a/api/serializers/wastemeasurement.py
+++ b/api/serializers/wastemeasurement.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from data.models import WasteMeasurement
 
 

--- a/api/templatetags/diagnostic_extras.py
+++ b/api/templatetags/diagnostic_extras.py
@@ -1,4 +1,5 @@
 from django.template.defaulttags import register
+
 from data.models import Diagnostic
 
 

--- a/api/tests/test_blog_posts.py
+++ b/api/tests/test_blog_posts.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories import BlogPostFactory, BlogTagFactory
 
 

--- a/api/tests/test_canteen_not_found.py
+++ b/api/tests/test_canteen_not_found.py
@@ -1,8 +1,8 @@
 from django.core import mail
 from django.test.utils import override_settings
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
+from rest_framework.test import APITestCase
 
 
 class TestCanteenNotFoundMessage(APITestCase):

--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -1,13 +1,13 @@
+import requests_mock
 from django.test.utils import override_settings
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
-import requests_mock
-from data.department_choices import Department
-from data.factories import CanteenFactory, SectorFactory
-from data.factories import DiagnosticFactory
-from data.models import Canteen, Diagnostic, Sector
+from rest_framework.test import APITestCase
+
 from api.views.canteen import badges_for_queryset
+from data.department_choices import Department
+from data.factories import CanteenFactory, DiagnosticFactory, SectorFactory
+from data.models import Canteen, Diagnostic, Sector
 from data.region_choices import Region
 
 

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -1,17 +1,25 @@
-import os
 import base64
+import os
+from unittest import mock
+
 import requests
 import requests_mock
-from unittest import mock
-from django.urls import reverse
 from django.test.utils import override_settings
-from rest_framework.test import APITestCase
-from rest_framework import status
-from data.factories import CanteenFactory, ManagerInvitationFactory, PurchaseFactory
-from data.factories import DiagnosticFactory, SectorFactory
-from data.models import Canteen, Teledeclaration, Diagnostic
-from .utils import authenticate, get_oauth2_token
+from django.urls import reverse
 from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from data.factories import (
+    CanteenFactory,
+    DiagnosticFactory,
+    ManagerInvitationFactory,
+    PurchaseFactory,
+    SectorFactory,
+)
+from data.models import Canteen, Diagnostic, Teledeclaration
+
+from .utils import authenticate, get_oauth2_token
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 

--- a/api/tests/test_communityevents.py
+++ b/api/tests/test_communityevents.py
@@ -1,8 +1,10 @@
 from datetime import timedelta
+
 from django.urls import reverse
 from django.utils import timezone
-from rest_framework.test import APITestCase
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories import CommunityEventFactory
 
 

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -1,12 +1,15 @@
 from decimal import Decimal
-from django.urls import reverse
+
+from django.core.exceptions import BadRequest
 from django.db import transaction
 from django.test.utils import override_settings
-from django.core.exceptions import BadRequest
-from rest_framework.test import APITestCase
+from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories import CanteenFactory, DiagnosticFactory, SectorFactory
-from data.models import Diagnostic, Teledeclaration, Canteen
+from data.models import Canteen, Diagnostic, Teledeclaration
+
 from .utils import authenticate, get_oauth2_token
 
 

--- a/api/tests/test_import_diagnostics.py
+++ b/api/tests/test_import_diagnostics.py
@@ -1,23 +1,26 @@
+import datetime
 import os
-from decimal import Decimal
 import unittest
-from django.urls import reverse
-from django.test.utils import override_settings
-from django.core import mail
-from rest_framework.test import APITestCase
-from rest_framework import status
-from data.models import Diagnostic, Canteen, ManagerInvitation
-from data.factories import SectorFactory, CanteenFactory, UserFactory, DiagnosticFactory
-from data.department_choices import Department
-from data.models.teledeclaration import Teledeclaration
-from data.region_choices import Region
+import zoneinfo
+from decimal import Decimal
+from unittest.mock import patch
+
 import requests
 import requests_mock
-from .utils import authenticate
-import datetime
-from unittest.mock import patch
+from django.core import mail
+from django.test.utils import override_settings
+from django.urls import reverse
 from django.utils import timezone
-import zoneinfo
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from data.department_choices import Department
+from data.factories import CanteenFactory, DiagnosticFactory, SectorFactory, UserFactory
+from data.models import Canteen, Diagnostic, ManagerInvitation
+from data.models.teledeclaration import Teledeclaration
+from data.region_choices import Region
+
+from .utils import authenticate
 
 NEXT_YEAR = datetime.date.today().year + 1
 

--- a/api/tests/test_import_failures.py
+++ b/api/tests/test_import_failures.py
@@ -1,10 +1,13 @@
-from django.urls import reverse
-from django.test.utils import override_settings
-from rest_framework.test import APITestCase
-from data.models import ImportFailure, ImportType
-from data.factories import CanteenFactory
-from .utils import authenticate
 import filecmp
+
+from django.test.utils import override_settings
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from data.factories import CanteenFactory
+from data.models import ImportFailure, ImportType
+
+from .utils import authenticate
 
 
 class TestImportDiagnosticsAPI(APITestCase):

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -1,14 +1,17 @@
 import hashlib
 from datetime import date
 from decimal import Decimal
-from django.urls import reverse
-from django.test.utils import override_settings
-from rest_framework.test import APITestCase
+from pathlib import Path
 from unittest.mock import patch
+
+from django.test.utils import override_settings
+from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories import CanteenFactory
 from data.models.purchase import Purchase
-from pathlib import Path
+
 from .utils import authenticate
 
 

--- a/api/tests/test_initial_data.py
+++ b/api/tests/test_initial_data.py
@@ -1,17 +1,20 @@
-import json
 import datetime
+import json
+
 from django.urls import reverse
 from django.utils import timezone
-from rest_framework.test import APITestCase
 from rest_framework import status
-from data.models import Canteen
+from rest_framework.test import APITestCase
+
 from data.factories import (
-    SectorFactory,
-    PartnerTypeFactory,
-    CommunityEventFactory,
-    VideoTutorialFactory,
     CanteenFactory,
+    CommunityEventFactory,
+    PartnerTypeFactory,
+    SectorFactory,
+    VideoTutorialFactory,
 )
+from data.models import Canteen
+
 from .utils import authenticate
 
 

--- a/api/tests/test_inquiry.py
+++ b/api/tests/test_inquiry.py
@@ -1,10 +1,12 @@
-from django.urls import reverse
-from django.test.utils import override_settings
-from rest_framework.test import APITestCase
-from rest_framework import status
 from django.core import mail
+from django.test.utils import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories.canteen import CanteenFactory
 from data.factories.user import UserFactory
+
 from .utils import authenticate
 
 

--- a/api/tests/test_manager_invitations.py
+++ b/api/tests/test_manager_invitations.py
@@ -1,11 +1,13 @@
-from data.factories.managerinvitation import ManagerInvitationFactory
 from django.core import mail
-from django.urls import reverse
 from django.test.utils import override_settings
-from rest_framework.test import APITestCase
+from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories import CanteenFactory, UserFactory
+from data.factories.managerinvitation import ManagerInvitationFactory
 from data.models import ManagerInvitation
+
 from .utils import authenticate
 
 

--- a/api/tests/test_messages.py
+++ b/api/tests/test_messages.py
@@ -1,9 +1,11 @@
-from django.urls import reverse
 from django.test.utils import override_settings
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
+
 from data.factories import CanteenFactory
 from data.models import Message
+
 from .utils import authenticate
 
 

--- a/api/tests/test_partners.py
+++ b/api/tests/test_partners.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories import PartnerFactory, PartnerTypeFactory, UserFactory
 from data.models import Partner, Sector
 

--- a/api/tests/test_partnertypes.py
+++ b/api/tests/test_partnertypes.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories import PartnerTypeFactory
 
 

--- a/api/tests/test_public_canteen_previews.py
+++ b/api/tests/test_public_canteen_previews.py
@@ -1,13 +1,14 @@
-import os
 import datetime
+import os
 from datetime import date
+
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
-from django.test.utils import override_settings
-from rest_framework.test import APITestCase
 from rest_framework import status
-from data.factories import CanteenFactory, SectorFactory
-from data.factories import DiagnosticFactory
+from rest_framework.test import APITestCase
+
+from data.factories import CanteenFactory, DiagnosticFactory, SectorFactory
 from data.models import Canteen
 from data.region_choices import Region
 

--- a/api/tests/test_publish_canteen.py
+++ b/api/tests/test_publish_canteen.py
@@ -1,9 +1,11 @@
-from data.models.canteen import Canteen
-from data.factories.canteen import CanteenFactory
 from django.test.utils import override_settings
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
+from rest_framework.test import APITestCase
+
+from data.factories.canteen import CanteenFactory
+from data.models.canteen import Canteen
+
 from .utils import authenticate
 
 

--- a/api/tests/test_published_canteens.py
+++ b/api/tests/test_published_canteens.py
@@ -1,12 +1,19 @@
 import os
-from django.urls import reverse
+
 from django.core.files import File
-from rest_framework.test import APITestCase
-from rest_framework import status
-from data.factories import CanteenFactory, UserFactory
-from data.factories import DiagnosticFactory, TeledeclarationFactory
-from data.models import Canteen, CanteenImage, Diagnostic, Teledeclaration
 from django.test import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from data.factories import (
+    CanteenFactory,
+    DiagnosticFactory,
+    TeledeclarationFactory,
+    UserFactory,
+)
+from data.models import Canteen, CanteenImage, Diagnostic, Teledeclaration
+
 from .utils import authenticate
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -2,8 +2,15 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
-from data.factories import UserFactory, PurchaseFactory, CanteenFactory, DiagnosticFactory
-from data.models import Purchase, Diagnostic, Canteen
+
+from data.factories import (
+    CanteenFactory,
+    DiagnosticFactory,
+    PurchaseFactory,
+    UserFactory,
+)
+from data.models import Canteen, Diagnostic, Purchase
+
 from .utils import authenticate
 
 

--- a/api/tests/test_relation_central_satellite.py
+++ b/api/tests/test_relation_central_satellite.py
@@ -1,8 +1,10 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories import CanteenFactory, SectorFactory, UserFactory
 from data.models import Canteen
+
 from .utils import authenticate
 
 

--- a/api/tests/test_reservation_expe.py
+++ b/api/tests/test_reservation_expe.py
@@ -1,9 +1,11 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
-from .utils import authenticate
+from rest_framework.test import APITestCase
+
 from data.factories import CanteenFactory, ReservationExpeFactory
 from data.models import ReservationExpe
+
+from .utils import authenticate
 
 
 class TestReservationExpeApi(APITestCase):

--- a/api/tests/test_reviews.py
+++ b/api/tests/test_reviews.py
@@ -1,8 +1,10 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
-from data.factories import CanteenFactory, ReviewFactory, DiagnosticFactory
-from data.models import Review
 from rest_framework import status
+from rest_framework.test import APITestCase
+
+from data.factories import CanteenFactory, DiagnosticFactory, ReviewFactory
+from data.models import Review
+
 from .utils import authenticate
 
 

--- a/api/tests/test_sectors.py
+++ b/api/tests/test_sectors.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories import SectorFactory
 
 

--- a/api/tests/test_signals.py
+++ b/api/tests/test_signals.py
@@ -1,10 +1,12 @@
+from django.test.utils import override_settings
 from django.urls import reverse
+from freezegun import freeze_time
 from rest_framework.test import APITestCase
+
 from data.factories import DiagnosticFactory
 from data.models import AuthenticationMethodHistoricalRecords
-from django.test.utils import override_settings
+
 from .utils import authenticate, get_oauth2_token
-from freezegun import freeze_time
 
 
 class TestSignals(APITestCase):

--- a/api/tests/test_subscription.py
+++ b/api/tests/test_subscription.py
@@ -1,10 +1,11 @@
 from unittest.mock import MagicMock
-from django.test.utils import override_settings
-from django.urls import reverse
-from rest_framework.test import APITestCase
-from rest_framework import status
+
 import requests_mock
 import sib_api_v3_sdk
+from django.test.utils import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
 
 
 @requests_mock.Mocker()

--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -1,16 +1,25 @@
-from django.urls import reverse
-from django.db.utils import IntegrityError
-from rest_framework.test import APITestCase
-from rest_framework import status
-from data.factories import CanteenFactory, DiagnosticFactory, UserFactory, TeledeclarationFactory, SectorFactory
-from data.models import Teledeclaration, Diagnostic, Canteen
-from django.test.utils import override_settings
-from .utils import authenticate
 import datetime
+import zoneinfo
 from unittest.mock import patch
+
+from django.db.utils import IntegrityError
+from django.test.utils import override_settings
+from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
-import zoneinfo
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from data.factories import (
+    CanteenFactory,
+    DiagnosticFactory,
+    SectorFactory,
+    TeledeclarationFactory,
+    UserFactory,
+)
+from data.models import Canteen, Diagnostic, Teledeclaration
+
+from .utils import authenticate
 
 LAST_YEAR = datetime.date.today().year - 1
 

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -1,8 +1,11 @@
 import json
+
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories import UserFactory
+
 from .utils import authenticate, get_oauth2_token
 
 

--- a/api/tests/test_vegetarian_expe.py
+++ b/api/tests/test_vegetarian_expe.py
@@ -1,9 +1,11 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
-from .utils import authenticate
+from rest_framework.test import APITestCase
+
 from data.factories import CanteenFactory, VegetarianExpeFactory
 from data.models import VegetarianExpe
+
+from .utils import authenticate
 
 
 class TestVegetarianExpeApi(APITestCase):

--- a/api/tests/test_video_tutorial.py
+++ b/api/tests/test_video_tutorial.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from data.factories import VideoTutorialFactory
 
 

--- a/api/tests/test_waste_actions.py
+++ b/api/tests/test_waste_actions.py
@@ -1,5 +1,6 @@
-from rest_framework.test import APITestCase
 from django.urls import reverse
+from rest_framework.test import APITestCase
+
 from data.factories import WasteActionFactory
 from data.models import WasteAction
 

--- a/api/tests/test_waste_measurements.py
+++ b/api/tests/test_waste_measurements.py
@@ -1,12 +1,15 @@
 import datetime
 from decimal import Decimal
+
 from django.urls import reverse
-from rest_framework.test import APITestCase
-from rest_framework import status
-from data.factories import CanteenFactory, WasteMeasurementFactory
-from data.models import WasteMeasurement, Canteen
-from .utils import authenticate
 from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from data.factories import CanteenFactory, WasteMeasurementFactory
+from data.models import Canteen, WasteMeasurement
+
+from .utils import authenticate
 
 
 class TestWasteMeasurementsApi(APITestCase):

--- a/api/tests/unit/test_canteen_serializer.py
+++ b/api/tests/unit/test_canteen_serializer.py
@@ -1,8 +1,9 @@
+from django.test.utils import override_settings
 from rest_framework.test import APITestCase
+
 from api.serializers import MinimalCanteenSerializer
 from data.factories import CanteenFactory
 from data.models import Canteen
-from django.test.utils import override_settings
 
 
 class TestCanteenSerializer(APITestCase):

--- a/api/tests/utils.py
+++ b/api/tests/utils.py
@@ -1,5 +1,6 @@
 import functools
 from datetime import timedelta
+
 from django.utils import timezone
 
 from data.factories import UserFactory

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,47 +1,77 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
+
 from api.views import (
+    ActionableCanteenRetrieveView,
+    ActionableCanteensListView,
+    AddManagerView,
+    BlogPostsView,
+    BlogPostView,
+    CanteenLocationsView,
+    CanteenPurchasesPercentageSummaryView,
+    CanteenPurchasesSummaryView,
+    CanteenStatisticsView,
+    CanteenStatusView,
+    CanteenWasteMeasurementsView,
+    CanteenWasteMeasurementView,
+    ChangePasswordView,
+    ClaimCanteenView,
+    CommunityEventsView,
+    DiagnosticCreateView,
+    DiagnosticsFromPurchasesView,
+    DiagnosticsToTeledeclareListView,
+    DiagnosticUpdateView,
+    EmailDiagnosticImportFileView,
+    ImportCompleteCentralKitchenView,
+    ImportCompleteDiagnosticsView,
+    ImportPurchasesView,
+    ImportSimpleCentralKitchenView,
+    ImportSimpleDiagnosticsView,
+    InitialDataView,
     InquiryView,
     LoggedUserView,
-    UserInfoView,
-    SubscribeNewsletter,
+    MessageCreateView,
+    PartnersView,
+    PartnerTypeListView,
+    PartnerView,
+    PublicCanteenPreviewView,
+    PublishCanteenView,
+    PublishedCanteenSingleView,
+    PublishedCanteensView,
+    PublishManyCanteensView,
     PurchaseListCreateView,
+    PurchaseListExportView,
+    PurchaseOptionsView,
     PurchaseRetrieveUpdateDestroyView,
     PurchasesDeleteView,
     PurchasesRestoreView,
-    CanteenPurchasesSummaryView,
-    CanteenPurchasesPercentageSummaryView,
-    DiagnosticsFromPurchasesView,
-    UsernameSuggestionView,
-    ImportSimpleCentralKitchenView,
-    ImportCompleteCentralKitchenView,
+    RemoveManagerView,
+    ReservationExpeView,
+    RetrieveUpdateUserCanteenView,
+    ReviewView,
+    SatelliteListCreateView,
+    SectorListView,
+    SendCanteenNotFoundEmail,
+    SubscribeNewsletter,
+    TeamJoinRequestView,
+    TeledeclarationCancelView,
+    TeledeclarationCreateView,
+    TeledeclarationPdfView,
     TerritoryCanteensListView,
+    UndoClaimCanteenView,
+    UnlinkSatelliteView,
+    UnpublishCanteenView,
+    UpdateUserView,
+    UserCanteenPreviews,
+    UserCanteenSummaries,
+    UserCanteensView,
+    UserInfoView,
+    UsernameSuggestionView,
+    VegetarianExpeView,
+    VideoTutorialListView,
+    WasteActionsView,
+    WasteActionView,
 )
-from api.views import UpdateUserView, UserCanteensView, CanteenStatisticsView
-from api.views import (
-    PublishedCanteensView,
-    PublicCanteenPreviewView,
-    PublishManyCanteensView,
-    PublishedCanteenSingleView,
-)
-from api.views import DiagnosticCreateView, RetrieveUpdateUserCanteenView, DiagnosticUpdateView
-from api.views import CanteenWasteMeasurementsView, CanteenWasteMeasurementView
-from api.views import EmailDiagnosticImportFileView
-from api.views import BlogPostsView, SectorListView, ChangePasswordView, BlogPostView
-from api.views import AddManagerView, RemoveManagerView
-from api.views import ImportSimpleDiagnosticsView, ImportCompleteDiagnosticsView
-from api.views import TeledeclarationCreateView, TeledeclarationCancelView, TeledeclarationPdfView
-from api.views import PublishCanteenView, UnpublishCanteenView, SendCanteenNotFoundEmail
-from api.views import UserCanteenPreviews, UserCanteenSummaries, CanteenLocationsView
-from api.views import PartnerView, PartnersView, PartnerTypeListView
-from api.views import ReservationExpeView, PurchaseListExportView, PurchaseOptionsView, ImportPurchasesView
-from api.views import MessageCreateView, VegetarianExpeView, TeamJoinRequestView
-from api.views import ReviewView, CommunityEventsView, ClaimCanteenView, UndoClaimCanteenView, SatelliteListCreateView
-from api.views import ActionableCanteensListView, ActionableCanteenRetrieveView
-from api.views import CanteenStatusView, VideoTutorialListView, DiagnosticsToTeledeclareListView
-from api.views import InitialDataView, UnlinkSatelliteView
-from api.views import WasteActionsView, WasteActionView
-
 
 urlpatterns = {
     path("loggedUser/", LoggedUserView.as_view(), name="logged_user"),

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,81 +1,81 @@
-from .user import (  # noqa: F401
-    LoggedUserView,
-    UpdateUserView,
-    ChangePasswordView,
-    UsernameSuggestionView,
-    UserInfoView,
-)
+from .blog import BlogPostsView, BlogPostView  # noqa: F401
 from .canteen import (  # noqa: F401
-    PublishedCanteensView,
-    PublicCanteenPreviewView,
-    PublishedCanteenSingleView,
-    UserCanteensView,
-    RetrieveUpdateUserCanteenView,
-    AddManagerView,
-    RemoveManagerView,
-    PublishCanteenView,
-    UnpublishCanteenView,
-    PublishManyCanteensView,
-    SendCanteenNotFoundEmail,
-    UserCanteenPreviews,
-    CanteenStatisticsView,
-    CanteenLocationsView,
-    TeamJoinRequestView,
-    ClaimCanteenView,
-    UndoClaimCanteenView,
-    SatelliteListCreateView,
-    UnlinkSatelliteView,
-    ActionableCanteensListView,
     ActionableCanteenRetrieveView,
-    CanteenStatusView,
-    TerritoryCanteensListView,
-    UserCanteenSummaries,
+    ActionableCanteensListView,
+    AddManagerView,
+    CanteenLocationsView,
     CanteenMinistriesView,
+    CanteenStatisticsView,
+    CanteenStatusView,
+    ClaimCanteenView,
+    PublicCanteenPreviewView,
+    PublishCanteenView,
+    PublishedCanteenSingleView,
+    PublishedCanteensView,
+    PublishManyCanteensView,
+    RemoveManagerView,
+    RetrieveUpdateUserCanteenView,
+    SatelliteListCreateView,
+    SendCanteenNotFoundEmail,
+    TeamJoinRequestView,
+    TerritoryCanteensListView,
+    UndoClaimCanteenView,
+    UnlinkSatelliteView,
+    UnpublishCanteenView,
+    UserCanteenPreviews,
+    UserCanteenSummaries,
+    UserCanteensView,
 )
+from .communityevent import CommunityEventsView  # noqa: F401
 from .diagnostic import (  # noqa: F401
     DiagnosticCreateView,
+    DiagnosticsToTeledeclareListView,
     DiagnosticUpdateView,
     EmailDiagnosticImportFileView,
-    DiagnosticsToTeledeclareListView,
 )
+from .diagnosticimport import (  # noqa: F401
+    ImportCompleteCentralKitchenView,
+    ImportCompleteDiagnosticsView,
+    ImportSimpleCentralKitchenView,
+    ImportSimpleDiagnosticsView,
+)
+from .initial import InitialDataView  # noqa: F401
+from .inquiry import InquiryView  # noqa: F401
+from .message import MessageCreateView  # noqa: F401
+from .partner import PartnersView, PartnerView  # noqa: F401
+from .partnertype import PartnerTypeListView  # noqa: F401
+from .purchase import (  # noqa: F401
+    CanteenPurchasesPercentageSummaryView,
+    CanteenPurchasesSummaryView,
+    DiagnosticsFromPurchasesView,
+    PurchaseListCreateView,
+    PurchaseListExportView,
+    PurchaseOptionsView,
+    PurchaseRetrieveUpdateDestroyView,
+    PurchasesDeleteView,
+    PurchasesRestoreView,
+)
+from .purchaseimport import ImportPurchasesView  # noqa: F401
+from .reservationexpe import ReservationExpeView  # noqa: F401
+from .review import ReviewView  # noqa: F401
+from .sector import SectorListView  # noqa: F401
+from .subscription import SubscribeNewsletter  # noqa: F401
+from .teledeclaration import (  # noqa: F401
+    TeledeclarationCancelView,
+    TeledeclarationCreateView,
+    TeledeclarationPdfView,
+)
+from .user import (  # noqa: F401
+    ChangePasswordView,
+    LoggedUserView,
+    UpdateUserView,
+    UserInfoView,
+    UsernameSuggestionView,
+)
+from .vegetarianexpe import VegetarianExpeView  # noqa: F401
+from .videotutorial import VideoTutorialListView  # noqa: F401
+from .wasteaction import WasteActionsView, WasteActionView  # noqa: F401
 from .wastemeasurement import (  # noqa: F401
     CanteenWasteMeasurementsView,
     CanteenWasteMeasurementView,
 )
-from .diagnosticimport import (  # noqa: F401
-    ImportSimpleDiagnosticsView,
-    ImportCompleteDiagnosticsView,
-    ImportSimpleCentralKitchenView,
-    ImportCompleteCentralKitchenView,
-)
-from .sector import SectorListView  # noqa: F401
-from .partnertype import PartnerTypeListView  # noqa: F401
-from .blog import BlogPostsView, BlogPostView  # noqa: F401
-from .subscription import SubscribeNewsletter  # noqa: F401
-from .teledeclaration import (  # noqa: F401
-    TeledeclarationCreateView,
-    TeledeclarationCancelView,
-    TeledeclarationPdfView,
-)
-from .inquiry import InquiryView  # noqa: F401
-from .purchase import (  # noqa: F401
-    PurchaseListCreateView,
-    PurchaseRetrieveUpdateDestroyView,
-    CanteenPurchasesSummaryView,
-    CanteenPurchasesPercentageSummaryView,
-    PurchaseListExportView,
-    PurchaseOptionsView,
-    PurchasesDeleteView,
-    PurchasesRestoreView,
-    DiagnosticsFromPurchasesView,
-)
-from .purchaseimport import ImportPurchasesView  # noqa: F401
-from .reservationexpe import ReservationExpeView  # noqa: F401
-from .vegetarianexpe import VegetarianExpeView  # noqa: F401
-from .message import MessageCreateView  # noqa: F401
-from .review import ReviewView  # noqa: F401
-from .communityevent import CommunityEventsView  # noqa: F401
-from .partner import PartnersView, PartnerView  # noqa: F401
-from .videotutorial import VideoTutorialListView  # noqa: F401
-from .initial import InitialDataView  # noqa: F401
-from .wasteaction import WasteActionsView, WasteActionView  # noqa: F401

--- a/api/views/blog.py
+++ b/api/views/blog.py
@@ -1,11 +1,14 @@
-from collections import OrderedDict
 import logging
-from rest_framework.generics import RetrieveAPIView, ListAPIView
+from collections import OrderedDict
+
+from django_filters import rest_framework as django_filters
+from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
+
 from api.serializers import BlogPostSerializer
 from data.models import BlogPost
-from django_filters import rest_framework as django_filters
+
 from .utils import UnaccentSearchFilter
 
 logger = logging.getLogger(__name__)

--- a/api/views/communityevent.py
+++ b/api/views/communityevent.py
@@ -1,7 +1,8 @@
-from api.serializers import CommunityEventSerializer
-from data.models import CommunityEvent
 from django.utils import timezone
 from rest_framework.generics import ListAPIView
+
+from api.serializers import CommunityEventSerializer
+from data.models import CommunityEvent
 
 
 class CommunityEventsView(ListAPIView):

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -1,25 +1,32 @@
 import logging
-from common.utils import send_mail
-from data.models.diagnostic import Diagnostic
+
 from django.conf import settings
-from django.db import IntegrityError
-from django.http import JsonResponse, HttpResponse, HttpResponseBadRequest, HttpResponseServerError
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from drf_spectacular.utils import extend_schema_view, extend_schema
-from rest_framework.pagination import LimitOffsetPagination
-from rest_framework.generics import UpdateAPIView, CreateAPIView, ListAPIView
+from django.db import IntegrityError
+from django.http import (
+    HttpResponse,
+    HttpResponseBadRequest,
+    HttpResponseServerError,
+    JsonResponse,
+)
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.generics import CreateAPIView, ListAPIView, UpdateAPIView
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.views import APIView
-from api.serializers import ManagerDiagnosticSerializer, DiagnosticAndCanteenSerializer
-from api.views.utils import update_change_reason_with_auth
-from data.models import Canteen, Teledeclaration
+
+from api.exceptions import DuplicateException
 from api.permissions import (
-    IsCanteenManager,
     CanEditDiagnostic,
     IsAuthenticated,
     IsAuthenticatedOrTokenHasResourceScope,
+    IsCanteenManager,
 )
-from api.exceptions import DuplicateException
+from api.serializers import DiagnosticAndCanteenSerializer, ManagerDiagnosticSerializer
+from api.views.utils import update_change_reason_with_auth
+from common.utils import send_mail
+from data.models import Canteen, Teledeclaration
+from data.models.diagnostic import Diagnostic
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -20,8 +20,7 @@ from simple_history.utils import update_change_reason
 
 from api.permissions import IsAuthenticated
 from api.serializers import FullCanteenSerializer
-from data.factories import ImportFailureFactory
-from data.models import Canteen, ImportType, Sector
+from data.models import Canteen, ImportFailure, ImportType, Sector
 from data.models.diagnostic import Diagnostic
 from data.models.teledeclaration import Teledeclaration
 
@@ -85,7 +84,7 @@ class ImportDiagnosticsView(ABC, APIView):
     def _log_error(self, message, level="warning"):
         logger_function = getattr(logger, level)
         logger_function(message)
-        ImportFailureFactory.create(
+        ImportFailure.objects.create(
             user=self.request.user,
             file=self.file,
             details=message,

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -1,29 +1,32 @@
-from abc import ABC, abstractmethod
 import csv
-import time
-import re
 import logging
+import re
+import time
+from abc import ABC, abstractmethod
 from decimal import Decimal, InvalidOperation
-from data.models.diagnostic import Diagnostic
-from data.models.teledeclaration import Teledeclaration
+
+import requests
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.db import IntegrityError, transaction
 from django.db.models.functions import Lower
 from django.http import JsonResponse
-from django.core.exceptions import ValidationError
-from django.core.validators import validate_email
-from django.conf import settings
-from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.views import APIView
 from simple_history.utils import update_change_reason
-from api.serializers import FullCanteenSerializer
-from data.models import Canteen, Sector, ImportType
-from data.factories import ImportFailureFactory
+
 from api.permissions import IsAuthenticated
-from .utils import camelize, normalise_siret, decode_bytes
+from api.serializers import FullCanteenSerializer
+from data.factories import ImportFailureFactory
+from data.models import Canteen, ImportType, Sector
+from data.models.diagnostic import Diagnostic
+from data.models.teledeclaration import Teledeclaration
+
 from .canteen import AddManagerView
-import requests
+from .utils import camelize, decode_bytes, normalise_siret
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/initial.py
+++ b/api/views/initial.py
@@ -1,21 +1,23 @@
 import json
-from api.views import (
-    LoggedUserView,
-    SectorListView,
-    PartnerTypeListView,
-    CommunityEventsView,
-    VideoTutorialListView,
-    UserCanteenPreviews,
-    CanteenMinistriesView,
-)
-from rest_framework.views import APIView
-from djangorestframework_camel_case.render import CamelCaseJSONRenderer
+
 from django.http import JsonResponse
+from djangorestframework_camel_case.render import CamelCaseJSONRenderer
 from rest_framework import status
+from rest_framework.views import APIView
 
 
 class InitialDataView(APIView):
     def get(self, request, *args, **kwargs):
+        from api.views import (
+            CanteenMinistriesView,
+            CommunityEventsView,
+            LoggedUserView,
+            PartnerTypeListView,
+            SectorListView,
+            UserCanteenPreviews,
+            VideoTutorialListView,
+        )
+
         is_authenticated = request.user.is_authenticated
         json_content = {
             "logged_user": LoggedUserView.as_view()(request._request).data,

--- a/api/views/inquiry.py
+++ b/api/views/inquiry.py
@@ -1,9 +1,11 @@
-from django.http import JsonResponse
-from django.conf import settings
-from rest_framework import status
-from rest_framework.views import APIView
-from rest_framework.exceptions import ValidationError
 import logging
+
+from django.conf import settings
+from django.http import JsonResponse
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+from rest_framework.views import APIView
+
 import common.utils as utils
 
 logger = logging.getLogger(__name__)

--- a/api/views/message.py
+++ b/api/views/message.py
@@ -1,7 +1,9 @@
 import logging
-from data.models import Message
-from api.serializers import MessageSerializer
+
 from rest_framework.generics import CreateAPIView
+
+from api.serializers import MessageSerializer
+from data.models import Message
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/partner.py
+++ b/api/views/partner.py
@@ -1,13 +1,20 @@
-from collections import OrderedDict
 import logging
 import random
+from collections import OrderedDict
+
 from django.db import connection
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework.generics import RetrieveAPIView, ListCreateAPIView
+from rest_framework.generics import ListCreateAPIView, RetrieveAPIView
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
-from api.serializers import PartnerSerializer, PartnerShortSerializer, PartnerContactSerializer
+
+from api.serializers import (
+    PartnerContactSerializer,
+    PartnerSerializer,
+    PartnerShortSerializer,
+)
 from data.models import Partner
+
 from .utils import UnaccentSearchFilter
 
 logger = logging.getLogger(__name__)

--- a/api/views/partnertype.py
+++ b/api/views/partnertype.py
@@ -1,6 +1,8 @@
 import logging
+
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.generics import ListAPIView
-from drf_spectacular.utils import extend_schema_view, extend_schema
+
 from api.serializers import PartnerTypeSerializer
 from data.models import PartnerType
 

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -1,28 +1,30 @@
-from rest_framework.generics import RetrieveUpdateDestroyAPIView, ListCreateAPIView
-from rest_framework.exceptions import NotFound, PermissionDenied, MethodNotAllowed
-from rest_framework.pagination import LimitOffsetPagination
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework import status
-from drf_excel.renderers import XLSXRenderer
-from drf_excel.mixins import XLSXFileMixin
+import logging
+from collections import OrderedDict
+
 from django.core.exceptions import BadRequest, ObjectDoesNotExist, ValidationError
-from django.db.models import Sum, Q
+from django.db.models import Q, Sum
 from django.db.models.functions import ExtractYear
 from django.http import JsonResponse
 from django_filters import rest_framework as django_filters
-from api.permissions import IsLinkedCanteenManager, IsCanteenManager, IsAuthenticated
+from drf_excel.mixins import XLSXFileMixin
+from drf_excel.renderers import XLSXRenderer
+from rest_framework import status
+from rest_framework.exceptions import MethodNotAllowed, NotFound, PermissionDenied
+from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api.permissions import IsAuthenticated, IsCanteenManager, IsLinkedCanteenManager
 from api.serializers import (
+    PurchaseExportSerializer,
+    PurchasePercentageSummarySerializer,
     PurchaseSerializer,
     PurchaseSummarySerializer,
-    PurchasePercentageSummarySerializer,
-    PurchaseExportSerializer,
 )
-from data.models import Purchase, Canteen, Diagnostic
-from .utils import MaCantineOrderingFilter, UnaccentSearchFilter
-from collections import OrderedDict
-import logging
+from data.models import Canteen, Diagnostic, Purchase
 
+from .utils import MaCantineOrderingFilter, UnaccentSearchFilter
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -16,8 +16,7 @@ from rest_framework.views import APIView
 
 from api.permissions import IsAuthenticated
 from api.serializers import PurchaseSerializer
-from data.factories import ImportFailureFactory
-from data.models import Canteen, ImportType, Purchase
+from data.models import Canteen, ImportFailure, ImportType, Purchase
 
 from .utils import camelize, decode_bytes, normalise_siret
 
@@ -88,7 +87,7 @@ class ImportPurchasesView(APIView):
     def _log_error(self, message, level="warning"):
         logger_function = getattr(logger, level)
         logger_function(message)
-        ImportFailureFactory.create(
+        ImportFailure.objects.create(
             user=self.request.user,
             file=self.file,
             details=message,

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -1,22 +1,25 @@
 import csv
-import time
-import logging
 import hashlib
 import io
+import logging
+import time
 import uuid
-from decimal import Decimal, ROUND_HALF_DOWN, InvalidOperation
-from django.db import IntegrityError, transaction
+from decimal import ROUND_HALF_DOWN, Decimal, InvalidOperation
+
 from django.conf import settings
 from django.core.exceptions import BadRequest, ObjectDoesNotExist, ValidationError
+from django.db import IntegrityError, transaction
 from django.http import JsonResponse
 from rest_framework import status
-from rest_framework.views import APIView
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.views import APIView
+
 from api.permissions import IsAuthenticated
-from data.models import Purchase, Canteen, ImportType
-from data.factories import ImportFailureFactory
 from api.serializers import PurchaseSerializer
-from .utils import normalise_siret, camelize, decode_bytes
+from data.factories import ImportFailureFactory
+from data.models import Canteen, ImportType, Purchase
+
+from .utils import camelize, decode_bytes, normalise_siret
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/reservationexpe.py
+++ b/api/views/reservationexpe.py
@@ -1,16 +1,17 @@
-from django.http import HttpResponse
-from api.permissions import IsLinkedCanteenManager, IsAuthenticated
-from api.serializers import ReservationExpeSerializer
-from api.exceptions import DuplicateException
-from data.models import ReservationExpe, Canteen
-from django.core.exceptions import ObjectDoesNotExist
-from django.http.response import Http404
 import logging
-from rest_framework.response import Response
-from rest_framework.generics import get_object_or_404
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponse
+from django.http.response import Http404
 from rest_framework.exceptions import NotFound, PermissionDenied
-from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.generics import RetrieveUpdateAPIView, get_object_or_404
 from rest_framework.mixins import CreateModelMixin
+from rest_framework.response import Response
+
+from api.exceptions import DuplicateException
+from api.permissions import IsAuthenticated, IsLinkedCanteenManager
+from api.serializers import ReservationExpeSerializer
+from data.models import Canteen, ReservationExpe
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/review.py
+++ b/api/views/review.py
@@ -1,10 +1,12 @@
 import logging
-from api.exceptions import DuplicateException
-from api.serializers import ReviewSerializer
-from data.models import Review, Canteen, Diagnostic
+
 from django.db import IntegrityError
 from rest_framework import permissions
 from rest_framework.generics import CreateAPIView
+
+from api.exceptions import DuplicateException
+from api.serializers import ReviewSerializer
+from data.models import Canteen, Diagnostic, Review
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/sector.py
+++ b/api/views/sector.py
@@ -1,6 +1,8 @@
 import logging
+
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.generics import ListAPIView
-from drf_spectacular.utils import extend_schema_view, extend_schema
+
 from api.serializers import SectorSerializer
 from data.models import Sector
 

--- a/api/views/subscription.py
+++ b/api/views/subscription.py
@@ -1,12 +1,13 @@
-import logging
 import json
+import logging
+
+import sib_api_v3_sdk
 from django.conf import settings
-from django.http import JsonResponse
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from rest_framework.views import APIView
+from django.http import JsonResponse
 from rest_framework import status
-import sib_api_v3_sdk
+from rest_framework.views import APIView
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -1,20 +1,23 @@
 import logging
 import os
 from datetime import datetime
-from django.http import JsonResponse, HttpResponse
-from django.core.exceptions import ValidationError as DjangoValidationError
-from django.template.loader import get_template
-from django.contrib.staticfiles import finders
+
 from django.conf import settings
+from django.contrib.staticfiles import finders
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.http import HttpResponse, JsonResponse
+from django.template.loader import get_template
 from django.utils.text import slugify
-from drf_spectacular.utils import extend_schema_view, extend_schema, inline_serializer
-from rest_framework import status, serializers
+from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
+from rest_framework import serializers, status
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.views import APIView
-from rest_framework.exceptions import ValidationError, PermissionDenied
 from xhtml2pdf import pisa
-from data.models import Diagnostic, Teledeclaration, Canteen
-from api.serializers import FullDiagnosticSerializer
+
 from api.permissions import IsAuthenticatedOrTokenHasResourceScope
+from api.serializers import FullDiagnosticSerializer
+from data.models import Canteen, Diagnostic, Teledeclaration
+
 from .utils import camelize
 
 logger = logging.getLogger(__name__)

--- a/api/views/user.py
+++ b/api/views/user.py
@@ -1,23 +1,25 @@
 import logging
-import string
-import re
 import random
+import re
+import string
 import unicodedata
-from django.contrib.auth import get_user_model, tokens, update_session_auth_hash
+
 from django.conf import settings
+from django.contrib.auth import get_user_model, tokens, update_session_auth_hash
 from django.http import JsonResponse
-from common.utils import send_mail
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
-from drf_spectacular.utils import extend_schema_view, extend_schema
-from rest_framework.generics import RetrieveAPIView, UpdateAPIView
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from oauth2_provider.contrib.rest_framework import TokenHasResourceScope
+from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.generics import RetrieveAPIView, UpdateAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework import status
-from oauth2_provider.contrib.rest_framework import TokenHasResourceScope
+
+from api.permissions import IsAuthenticated, IsProfileOwner
 from api.serializers import LoggedUserSerializer, PasswordSerializer, UserInfoSerializer
-from api.permissions import IsProfileOwner, IsAuthenticated
+from common.utils import send_mail
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -1,12 +1,13 @@
-import logging
 import json
+import logging
+
 import chardet
-from django.db.models.constants import LOOKUP_SEP
 from django.db.models import F
-from rest_framework import filters
+from django.db.models.constants import LOOKUP_SEP
 from djangorestframework_camel_case.render import CamelCaseJSONRenderer
-from djangorestframework_camel_case.util import camel_to_underscore
 from djangorestframework_camel_case.settings import api_settings
+from djangorestframework_camel_case.util import camel_to_underscore
+from rest_framework import filters
 from simple_history.utils import update_change_reason
 
 logger = logging.getLogger(__name__)

--- a/api/views/vegetarianexpe.py
+++ b/api/views/vegetarianexpe.py
@@ -1,16 +1,17 @@
-from django.http import HttpResponse
-from api.permissions import IsLinkedCanteenManager, IsAuthenticated
-from api.serializers import VegetarianExpeSerializer
-from api.exceptions import DuplicateException
-from data.models import VegetarianExpe, Canteen
-from django.core.exceptions import ObjectDoesNotExist
-from django.http.response import Http404
 import logging
-from rest_framework.response import Response
-from rest_framework.generics import get_object_or_404
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponse
+from django.http.response import Http404
 from rest_framework.exceptions import NotFound, PermissionDenied
-from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.generics import RetrieveUpdateAPIView, get_object_or_404
 from rest_framework.mixins import CreateModelMixin
+from rest_framework.response import Response
+
+from api.exceptions import DuplicateException
+from api.permissions import IsAuthenticated, IsLinkedCanteenManager
+from api.serializers import VegetarianExpeSerializer
+from data.models import Canteen, VegetarianExpe
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/videotutorial.py
+++ b/api/views/videotutorial.py
@@ -1,6 +1,7 @@
 from rest_framework.generics import ListAPIView
-from data.models import VideoTutorial
+
 from api.serializers import VideoTutorialSerializer
+from data.models import VideoTutorial
 
 
 class VideoTutorialListView(ListAPIView):

--- a/api/views/wasteaction.py
+++ b/api/views/wasteaction.py
@@ -1,8 +1,9 @@
+from django_filters import rest_framework as django_filters
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.pagination import LimitOffsetPagination
-from data.models import WasteAction
+
 from api.serializers import WasteActionSerializer
-from django_filters import rest_framework as django_filters
+from data.models import WasteAction
 
 
 class WasteActionPagination(LimitOffsetPagination):

--- a/api/views/wastemeasurement.py
+++ b/api/views/wastemeasurement.py
@@ -1,17 +1,15 @@
 import logging
-from api.serializers import WasteMeasurementSerializer
-from api.permissions import (
-    IsAuthenticated,
-    IsCanteenManager,
-    IsLinkedCanteenManager,
-)
-from api.views.utils import update_change_reason_with_auth
-from data.models import WasteMeasurement, Canteen
+
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import JsonResponse
 from rest_framework import status
 from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView
+
+from api.permissions import IsAuthenticated, IsCanteenManager, IsLinkedCanteenManager
+from api.serializers import WasteMeasurementSerializer
+from api.views.utils import update_change_reason_with_auth
+from data.models import Canteen, WasteMeasurement
 
 logger = logging.getLogger(__name__)
 

--- a/cms/api.py
+++ b/cms/api.py
@@ -1,6 +1,6 @@
 from wagtail.api.v2.router import WagtailAPIRouter
-from wagtail.images.api.v2.views import ImagesAPIViewSet
 from wagtail.documents.api.v2.views import DocumentsAPIViewSet
+from wagtail.images.api.v2.views import ImagesAPIViewSet
 
 # Create the router. "wagtailapi" is the URL namespace
 api_router = WagtailAPIRouter("wagtailapi")

--- a/cms/filtersets/wasteaction.py
+++ b/cms/filtersets/wasteaction.py
@@ -1,6 +1,7 @@
 from django import forms
-from wagtail.admin.filters import WagtailFilterSet
 from django_filters import CharFilter, MultipleChoiceFilter
+from wagtail.admin.filters import WagtailFilterSet
+
 from data.models import WasteAction
 
 

--- a/cms/viewsets/wasteaction.py
+++ b/cms/viewsets/wasteaction.py
@@ -1,7 +1,8 @@
+from wagtail.admin.panels import FieldPanel, ObjectList, TabbedInterface
 from wagtail.snippets.views.snippets import SnippetViewSet
-from wagtail.admin.panels import TabbedInterface, ObjectList, FieldPanel
-from data.models import WasteAction
+
 from cms.filtersets.wasteaction import WasteActionFilterSet
+from data.models import WasteAction
 
 
 class WasteActionViewSet(SnippetViewSet):

--- a/cms/wagtail_hooks.py
+++ b/cms/wagtail_hooks.py
@@ -1,4 +1,5 @@
 from wagtail.snippets.models import register_snippet
+
 from cms.viewsets import WasteActionViewSet
 
 register_snippet(WasteActionViewSet)

--- a/common/utils/__init__.py
+++ b/common/utils/__init__.py
@@ -1,11 +1,12 @@
+import base64
+import logging
+
+import html2text
+import redis as r
+import requests
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
-import base64
-import html2text
-import redis as r
-import logging
-import requests
 
 logger = logging.getLogger(__name__)
 

--- a/data/admin/__init__.py
+++ b/data/admin/__init__.py
@@ -1,25 +1,27 @@
-from django.contrib import admin
-from django.contrib.auth.models import Group
+# isort: skip_file
 
+from .user import UserAdmin  # noqa
+from .canteen import CanteenAdmin  # noqa
+from .diagnostic import DiagnosticAdmin  # noqa
+from .wastemeasurement import WasteMeasurementAdmin  # noqa
+from .sector import Sector  # noqa
 from .blogpost import BlogPost  # noqa
 from .blogtag import BlogTag  # noqa
-from .canteen import CanteenAdmin  # noqa
-from .communityevent import CommunityEventAdmin  # noqa
-from .diagnostic import DiagnosticAdmin  # noqa
-from .importfailure import ImportFailureAdmin  # noqa: F401
 from .managerinvitation import ManagerInvitation  # noqa
+from .teledeclaration import TeledeclarationAdmin  # noqa
+from .reservationexpe import ReservationExpeAdmin  # noqa
+from .vegetarianexpe import VegetarianExpeAdmin  # noqa
 from .message import MessageAdmin  # noqa
+from .purchase import PurchaseAdmin  # noqa
+from .review import ReviewAdmin  # noqa
+from .communityevent import CommunityEventAdmin  # noqa
 from .partner import Partner  # noqa: F401
 from .partnertype import PartnerType  # noqa: F401
-from .purchase import PurchaseAdmin  # noqa
-from .reservationexpe import ReservationExpeAdmin  # noqa
-from .review import ReviewAdmin  # noqa
-from .sector import Sector  # noqa
-from .teledeclaration import TeledeclarationAdmin  # noqa
-from .user import UserAdmin  # noqa
-from .vegetarianexpe import VegetarianExpeAdmin  # noqa
 from .videotutorial import VideoTutorial  # noqa: F401
+from .importfailure import ImportFailureAdmin  # noqa: F401
 from .wasteaction import WasteActionAdmin  # noqa: F401
-from .wastemeasurement import WasteMeasurementAdmin  # noqa
+
+from django.contrib import admin
+from django.contrib.auth.models import Group
 
 admin.site.unregister(Group)

--- a/data/admin/__init__.py
+++ b/data/admin/__init__.py
@@ -1,25 +1,25 @@
-from .user import UserAdmin  # noqa
-from .canteen import CanteenAdmin  # noqa
-from .diagnostic import DiagnosticAdmin  # noqa
-from .wastemeasurement import WasteMeasurementAdmin  # noqa
-from .sector import Sector  # noqa
-from .blogpost import BlogPost  # noqa
-from .blogtag import BlogTag  # noqa
-from .managerinvitation import ManagerInvitation  # noqa
-from .teledeclaration import TeledeclarationAdmin  # noqa
-from .reservationexpe import ReservationExpeAdmin  # noqa
-from .vegetarianexpe import VegetarianExpeAdmin  # noqa
-from .message import MessageAdmin  # noqa
-from .purchase import PurchaseAdmin  # noqa
-from .review import ReviewAdmin  # noqa
-from .communityevent import CommunityEventAdmin  # noqa
-from .partner import Partner  # noqa: F401
-from .partnertype import PartnerType  # noqa: F401
-from .videotutorial import VideoTutorial  # noqa: F401
-from .importfailure import ImportFailureAdmin  # noqa: F401
-from .wasteaction import WasteActionAdmin  # noqa: F401
-
 from django.contrib import admin
 from django.contrib.auth.models import Group
+
+from .blogpost import BlogPost  # noqa
+from .blogtag import BlogTag  # noqa
+from .canteen import CanteenAdmin  # noqa
+from .communityevent import CommunityEventAdmin  # noqa
+from .diagnostic import DiagnosticAdmin  # noqa
+from .importfailure import ImportFailureAdmin  # noqa: F401
+from .managerinvitation import ManagerInvitation  # noqa
+from .message import MessageAdmin  # noqa
+from .partner import Partner  # noqa: F401
+from .partnertype import PartnerType  # noqa: F401
+from .purchase import PurchaseAdmin  # noqa
+from .reservationexpe import ReservationExpeAdmin  # noqa
+from .review import ReviewAdmin  # noqa
+from .sector import Sector  # noqa
+from .teledeclaration import TeledeclarationAdmin  # noqa
+from .user import UserAdmin  # noqa
+from .vegetarianexpe import VegetarianExpeAdmin  # noqa
+from .videotutorial import VideoTutorial  # noqa: F401
+from .wasteaction import WasteActionAdmin  # noqa: F401
+from .wastemeasurement import WasteMeasurementAdmin  # noqa
 
 admin.site.unregister(Group)

--- a/data/admin/blogpost.py
+++ b/data/admin/blogpost.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+
 from data.models import BlogPost
 
 

--- a/data/admin/blogtag.py
+++ b/data/admin/blogtag.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+
 from data.models import BlogTag
 
 

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -2,7 +2,9 @@ from django import forms
 from django.conf import settings
 from django.contrib import admin
 from django.utils import timezone
+
 from data.models import Canteen, Teledeclaration
+
 from .diagnostic import DiagnosticInline
 from .softdeletionadmin import SoftDeletionHistoryAdmin, SoftDeletionStatusFilter
 

--- a/data/admin/communityevent.py
+++ b/data/admin/communityevent.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib import admin
 from django.utils import timezone
+
 from data.models import CommunityEvent
 
 

--- a/data/admin/diagnostic.py
+++ b/data/admin/diagnostic.py
@@ -1,7 +1,9 @@
 from django import forms
 from django.contrib import admin
-from data.models import Diagnostic, Teledeclaration
 from simple_history.admin import SimpleHistoryAdmin
+
+from data.models import Diagnostic, Teledeclaration
+
 from .teledeclaration import TeledeclarationInline
 
 

--- a/data/admin/importfailure.py
+++ b/data/admin/importfailure.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
+
 from data.models import ImportFailure
+
 from .utils import ReadOnlyAdminMixin
 
 

--- a/data/admin/managerinvitation.py
+++ b/data/admin/managerinvitation.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from data.models import ManagerInvitation
 
 

--- a/data/admin/message.py
+++ b/data/admin/message.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
+
 from data.models import Message
+
 from .utils import ReadOnlyAdminMixin
 
 

--- a/data/admin/partner.py
+++ b/data/admin/partner.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+
 from data.models import Partner
 
 

--- a/data/admin/partnertype.py
+++ b/data/admin/partnertype.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+
 from data.models import PartnerType
 
 

--- a/data/admin/purchase.py
+++ b/data/admin/purchase.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
+
 from data.models import Purchase
-from .utils import get_arrayfield_list_filter
+
 from .softdeletionadmin import SoftDeletionAdmin, SoftDeletionStatusFilter
+from .utils import get_arrayfield_list_filter
 
 
 @admin.register(Purchase)

--- a/data/admin/reservationexpe.py
+++ b/data/admin/reservationexpe.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from data.models import ReservationExpe
 
 

--- a/data/admin/review.py
+++ b/data/admin/review.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from data.models import Review
 
 

--- a/data/admin/sector.py
+++ b/data/admin/sector.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+
 from data.models import Sector
 
 

--- a/data/admin/teledeclaration.py
+++ b/data/admin/teledeclaration.py
@@ -1,7 +1,9 @@
 from django import forms
 from django.contrib import admin
-from data.models import Teledeclaration
 from simple_history.admin import SimpleHistoryAdmin
+
+from data.models import Teledeclaration
+
 from .utils import ReadOnlyAdminMixin
 
 

--- a/data/admin/user.py
+++ b/data/admin/user.py
@@ -1,10 +1,11 @@
 from django import forms
 from django.contrib import admin
-from django.contrib.auth.forms import UserChangeForm
 from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.forms import UserChangeForm
 from django.utils.translation import gettext_lazy as _
 
 from data.models import User
+
 from .canteen import CanteenInline
 
 

--- a/data/admin/vegetarianexpe.py
+++ b/data/admin/vegetarianexpe.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from data.models import VegetarianExpe
 
 

--- a/data/admin/videotutorial.py
+++ b/data/admin/videotutorial.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+
 from data.models import VideoTutorial
 
 

--- a/data/admin/wasteaction.py
+++ b/data/admin/wasteaction.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
+
 from data.models import WasteAction
+
 from .utils import ReadOnlyAdminMixin
 
 

--- a/data/admin/wastemeasurement.py
+++ b/data/admin/wastemeasurement.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
-from data.models import WasteMeasurement
 from simple_history.admin import SimpleHistoryAdmin
+
+from data.models import WasteMeasurement
 
 
 @admin.register(WasteMeasurement)

--- a/data/factories/__init__.py
+++ b/data/factories/__init__.py
@@ -1,24 +1,26 @@
+# isort: skip_file
+
 import factory  # noqa
 
 factory.Faker._DEFAULT_LOCALE = "fr-fr"  # noqa
 
+from .user import UserFactory  # noqa
+from .canteen import CanteenFactory  # noqa
+from .diagnostic import CompleteDiagnosticFactory, DiagnosticFactory  # noqa
+from .wastemeasurement import WasteMeasurementFactory  # noqa
+from .sector import SectorFactory  # noqa
 from .blogpost import BlogPostFactory  # noqa
 from .blogtag import BlogTagFactory  # noqa
-from .canteen import CanteenFactory  # noqa
-from .communityevent import CommunityEventFactory  # noqa
-from .diagnostic import CompleteDiagnosticFactory, DiagnosticFactory  # noqa
-from .importfailure import ImportFailureFactory  # noqa
 from .managerinvitation import ManagerInvitationFactory  # noqa
-from .message import MessageFactory  # noqa
-from .partner import PartnerFactory  # noqa
-from .partnertype import PartnerTypeFactory  # noqa
+from .teledeclaration import TeledeclarationFactory  # noqa
 from .purchase import PurchaseFactory  # noqa
 from .reservationexpe import ReservationExpeFactory  # noqa
-from .review import ReviewFactory  # noqa
-from .sector import SectorFactory  # noqa
-from .teledeclaration import TeledeclarationFactory  # noqa
-from .user import UserFactory  # noqa
 from .vegetarianexpe import VegetarianExpeFactory  # noqa
+from .message import MessageFactory  # noqa
+from .review import ReviewFactory  # noqa
+from .communityevent import CommunityEventFactory  # noqa
+from .partner import PartnerFactory  # noqa
+from .partnertype import PartnerTypeFactory  # noqa
 from .videotutorial import VideoTutorialFactory  # noqa
+from .importfailure import ImportFailureFactory  # noqa
 from .wasteaction import WasteActionFactory  # noqa
-from .wastemeasurement import WasteMeasurementFactory  # noqa

--- a/data/factories/__init__.py
+++ b/data/factories/__init__.py
@@ -2,23 +2,23 @@ import factory  # noqa
 
 factory.Faker._DEFAULT_LOCALE = "fr-fr"  # noqa
 
-from .user import UserFactory  # noqa
-from .canteen import CanteenFactory  # noqa
-from .diagnostic import CompleteDiagnosticFactory, DiagnosticFactory  # noqa
-from .wastemeasurement import WasteMeasurementFactory  # noqa
-from .sector import SectorFactory  # noqa
 from .blogpost import BlogPostFactory  # noqa
 from .blogtag import BlogTagFactory  # noqa
-from .managerinvitation import ManagerInvitationFactory  # noqa
-from .teledeclaration import TeledeclarationFactory  # noqa
-from .purchase import PurchaseFactory  # noqa
-from .reservationexpe import ReservationExpeFactory  # noqa
-from .vegetarianexpe import VegetarianExpeFactory  # noqa
-from .message import MessageFactory  # noqa
-from .review import ReviewFactory  # noqa
+from .canteen import CanteenFactory  # noqa
 from .communityevent import CommunityEventFactory  # noqa
+from .diagnostic import CompleteDiagnosticFactory, DiagnosticFactory  # noqa
+from .importfailure import ImportFailureFactory  # noqa
+from .managerinvitation import ManagerInvitationFactory  # noqa
+from .message import MessageFactory  # noqa
 from .partner import PartnerFactory  # noqa
 from .partnertype import PartnerTypeFactory  # noqa
+from .purchase import PurchaseFactory  # noqa
+from .reservationexpe import ReservationExpeFactory  # noqa
+from .review import ReviewFactory  # noqa
+from .sector import SectorFactory  # noqa
+from .teledeclaration import TeledeclarationFactory  # noqa
+from .user import UserFactory  # noqa
+from .vegetarianexpe import VegetarianExpeFactory  # noqa
 from .videotutorial import VideoTutorialFactory  # noqa
-from .importfailure import ImportFailureFactory  # noqa
 from .wasteaction import WasteActionFactory  # noqa
+from .wastemeasurement import WasteMeasurementFactory  # noqa

--- a/data/factories/blogpost.py
+++ b/data/factories/blogpost.py
@@ -1,5 +1,7 @@
 import factory
+
 from data.models import BlogPost
+
 from .user import UserFactory
 
 

--- a/data/factories/blogtag.py
+++ b/data/factories/blogtag.py
@@ -1,4 +1,5 @@
 import factory
+
 from data.models import BlogTag
 
 

--- a/data/factories/canteen.py
+++ b/data/factories/canteen.py
@@ -1,6 +1,9 @@
 import random
+
 import factory
+
 from data.models import Canteen
+
 from .sector import SectorFactory
 from .user import UserFactory
 

--- a/data/factories/communityevent.py
+++ b/data/factories/communityevent.py
@@ -1,6 +1,8 @@
-import factory
-from data.models import CommunityEvent
 import zoneinfo
+
+import factory
+
+from data.models import CommunityEvent
 
 
 class CommunityEventFactory(factory.django.DjangoModelFactory):

--- a/data/factories/diagnostic.py
+++ b/data/factories/diagnostic.py
@@ -1,7 +1,10 @@
 import random
+
 import factory
 from factory import fuzzy
+
 from data.models import Diagnostic
+
 from .canteen import CanteenFactory
 
 

--- a/data/factories/importfailure.py
+++ b/data/factories/importfailure.py
@@ -1,5 +1,7 @@
 import factory
+
 from data.models import ImportFailure
+
 from .user import UserFactory
 
 

--- a/data/factories/managerinvitation.py
+++ b/data/factories/managerinvitation.py
@@ -1,5 +1,7 @@
 import factory
+
 from data.models import ManagerInvitation
+
 from .canteen import CanteenFactory
 
 

--- a/data/factories/message.py
+++ b/data/factories/message.py
@@ -1,5 +1,7 @@
 import factory
+
 from data.models import Message
+
 from .canteen import CanteenFactory
 
 

--- a/data/factories/partner.py
+++ b/data/factories/partner.py
@@ -1,4 +1,5 @@
 import factory
+
 from data.models import Partner
 
 

--- a/data/factories/partnertype.py
+++ b/data/factories/partnertype.py
@@ -1,4 +1,5 @@
 import factory
+
 from data.models import PartnerType
 
 

--- a/data/factories/purchase.py
+++ b/data/factories/purchase.py
@@ -1,7 +1,10 @@
-import factory
 import random
+
+import factory
 from factory.fuzzy import FuzzyChoice
+
 from data.models import Purchase
+
 from .canteen import CanteenFactory
 
 

--- a/data/factories/reservationexpe.py
+++ b/data/factories/reservationexpe.py
@@ -1,5 +1,7 @@
 import factory
+
 from data.models import ReservationExpe
+
 from .canteen import CanteenFactory
 
 

--- a/data/factories/review.py
+++ b/data/factories/review.py
@@ -1,6 +1,9 @@
-import factory
 import random
+
+import factory
+
 from data.models import Review
+
 from .user import UserFactory
 
 

--- a/data/factories/sector.py
+++ b/data/factories/sector.py
@@ -1,4 +1,5 @@
 import factory
+
 from data.models import Sector
 
 

--- a/data/factories/teledeclaration.py
+++ b/data/factories/teledeclaration.py
@@ -1,6 +1,7 @@
 import factory
-from data.models import Teledeclaration
+
 from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
+from data.models import Teledeclaration
 
 
 class TeledeclarationFactory(factory.django.DjangoModelFactory):

--- a/data/factories/vegetarianexpe.py
+++ b/data/factories/vegetarianexpe.py
@@ -1,5 +1,7 @@
 import factory
+
 from data.models import VegetarianExpe
+
 from .canteen import CanteenFactory
 
 

--- a/data/factories/videotutorial.py
+++ b/data/factories/videotutorial.py
@@ -1,4 +1,5 @@
 import factory
+
 from data.models import VideoTutorial
 
 

--- a/data/factories/wasteaction.py
+++ b/data/factories/wasteaction.py
@@ -1,6 +1,8 @@
 import random
+
 import factory
 from factory import fuzzy
+
 from data.models import WasteAction
 
 

--- a/data/factories/wastemeasurement.py
+++ b/data/factories/wastemeasurement.py
@@ -1,6 +1,9 @@
-import factory
 from datetime import datetime, timedelta
+
+import factory
+
 from data.models import WasteMeasurement
+
 from .canteen import CanteenFactory
 
 

--- a/data/models/__init__.py
+++ b/data/models/__init__.py
@@ -1,24 +1,24 @@
-from .user import User  # noqa: F401  # isort: skip
+# isort: skip_file
+
+from .user import User  # noqa: F401
+from .historyauthenticationmethod import AuthenticationMethodHistoricalRecords  # noqa: F401
+from .canteen import Canteen, CanteenImage  # noqa: F401
+from .diagnostic import Diagnostic  # noqa: F401
+from .wastemeasurement import WasteMeasurement  # noqa: F401
+from .sector import Sector  # noqa: F401
 from .blogpost import BlogPost  # noqa: F401
 from .blogtag import BlogTag  # noqa: F401
-from .canteen import Canteen, CanteenImage  # noqa: F401
-from .communityevent import CommunityEvent  # noqa: F401
-from .diagnostic import Diagnostic  # noqa: F401
-from .historyauthenticationmethod import (  # noqa: F401
-    AuthenticationMethodHistoricalRecords,
-)
-from .importfailure import ImportFailure  # noqa: F401
-from .importtype import ImportType  # noqa: F401
 from .managerinvitation import ManagerInvitation  # noqa: F401
-from .message import Message  # noqa: F401
-from .partner import Partner  # noqa: F401
-from .partnertype import PartnerType  # noqa: F401
+from .teledeclaration import Teledeclaration  # noqa: F401
 from .purchase import Purchase  # noqa: F401
 from .reservationexpe import ReservationExpe  # noqa: F401
-from .review import Review  # noqa: F401
-from .sector import Sector  # noqa: F401
-from .teledeclaration import Teledeclaration  # noqa: F401
 from .vegetarianexpe import VegetarianExpe  # noqa: F401
+from .message import Message  # noqa: F401
+from .review import Review  # noqa: F401
+from .communityevent import CommunityEvent  # noqa: F401
+from .partner import Partner  # noqa: F401
+from .partnertype import PartnerType  # noqa: F401
 from .videotutorial import VideoTutorial  # noqa: F401
+from .importtype import ImportType  # noqa: F401
+from .importfailure import ImportFailure  # noqa: F401
 from .wasteaction import WasteAction  # noqa: F401
-from .wastemeasurement import WasteMeasurement  # noqa: F401

--- a/data/models/__init__.py
+++ b/data/models/__init__.py
@@ -1,22 +1,24 @@
-from .user import User  # noqa: F401
-from .historyauthenticationmethod import AuthenticationMethodHistoricalRecords  # noqa: F401
-from .canteen import Canteen, CanteenImage  # noqa: F401
-from .diagnostic import Diagnostic  # noqa: F401
-from .wastemeasurement import WasteMeasurement  # noqa: F401
-from .sector import Sector  # noqa: F401
 from .blogpost import BlogPost  # noqa: F401
 from .blogtag import BlogTag  # noqa: F401
-from .managerinvitation import ManagerInvitation  # noqa: F401
-from .teledeclaration import Teledeclaration  # noqa: F401
-from .purchase import Purchase  # noqa: F401
-from .reservationexpe import ReservationExpe  # noqa: F401
-from .vegetarianexpe import VegetarianExpe  # noqa: F401
-from .message import Message  # noqa: F401
-from .review import Review  # noqa: F401
+from .canteen import Canteen, CanteenImage  # noqa: F401
 from .communityevent import CommunityEvent  # noqa: F401
+from .diagnostic import Diagnostic  # noqa: F401
+from .historyauthenticationmethod import (  # noqa: F401
+    AuthenticationMethodHistoricalRecords,
+)
+from .importfailure import ImportFailure  # noqa: F401
+from .importtype import ImportType  # noqa: F401
+from .managerinvitation import ManagerInvitation  # noqa: F401
+from .message import Message  # noqa: F401
 from .partner import Partner  # noqa: F401
 from .partnertype import PartnerType  # noqa: F401
+from .purchase import Purchase  # noqa: F401
+from .reservationexpe import ReservationExpe  # noqa: F401
+from .review import Review  # noqa: F401
+from .sector import Sector  # noqa: F401
+from .teledeclaration import Teledeclaration  # noqa: F401
+from .user import User  # noqa: F401
+from .vegetarianexpe import VegetarianExpe  # noqa: F401
 from .videotutorial import VideoTutorial  # noqa: F401
-from .importtype import ImportType  # noqa: F401
-from .importfailure import ImportFailure  # noqa: F401
 from .wasteaction import WasteAction  # noqa: F401
+from .wastemeasurement import WasteMeasurement  # noqa: F401

--- a/data/models/__init__.py
+++ b/data/models/__init__.py
@@ -1,3 +1,4 @@
+from .user import User  # noqa: F401  # isort: skip
 from .blogpost import BlogPost  # noqa: F401
 from .blogtag import BlogTag  # noqa: F401
 from .canteen import Canteen, CanteenImage  # noqa: F401
@@ -17,7 +18,6 @@ from .reservationexpe import ReservationExpe  # noqa: F401
 from .review import Review  # noqa: F401
 from .sector import Sector  # noqa: F401
 from .teledeclaration import Teledeclaration  # noqa: F401
-from .user import User  # noqa: F401
 from .vegetarianexpe import VegetarianExpe  # noqa: F401
 from .videotutorial import VideoTutorial  # noqa: F401
 from .wasteaction import WasteAction  # noqa: F401

--- a/data/models/blogpost.py
+++ b/data/models/blogpost.py
@@ -1,7 +1,8 @@
-from django.utils import timezone
-from django.db import models
-from django.contrib.auth import get_user_model
 from ckeditor_uploader.fields import RichTextUploadingField
+from django.contrib.auth import get_user_model
+from django.db import models
+from django.utils import timezone
+
 from .blogtag import BlogTag
 
 

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -1,18 +1,29 @@
 from urllib.parse import quote
-from django.db import models
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
+from django.db import models
 from django.utils import timezone
 from django.utils.functional import cached_property
 from simple_history.models import HistoricalRecords
+
 from data.department_choices import Department
-from data.region_choices import Region
 from data.fields import ChoiceArrayField
-from data.utils import get_region, optimize_image
-from data.utils import get_diagnostic_lower_limit_year, get_diagnostic_upper_limit_year
+from data.region_choices import Region
+from data.utils import (
+    get_diagnostic_lower_limit_year,
+    get_diagnostic_upper_limit_year,
+    get_region,
+    optimize_image,
+)
+
 from .sector import Sector
-from .softdeletionmodel import SoftDeletionModel, SoftDeletionManager, SoftDeletionQuerySet
+from .softdeletionmodel import (
+    SoftDeletionManager,
+    SoftDeletionModel,
+    SoftDeletionQuerySet,
+)
 
 
 def validate_siret(siret):

--- a/data/models/communityevent.py
+++ b/data/models/communityevent.py
@@ -1,5 +1,5 @@
-from django.db import models
 from django.core.exceptions import ValidationError
+from django.db import models
 
 
 class CommunityEvent(models.Model):

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1,13 +1,16 @@
 from decimal import Decimal
+
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator
 from django.db import models
 from simple_history.models import HistoricalRecords
-from data.fields import ChoiceArrayField
-from .canteen import Canteen
-from data.utils import get_diagnostic_lower_limit_year, get_diagnostic_upper_limit_year
+
 from data.department_choices import Department
+from data.fields import ChoiceArrayField
 from data.region_choices import Region
+from data.utils import get_diagnostic_lower_limit_year, get_diagnostic_upper_limit_year
+
+from .canteen import Canteen
 
 
 class Diagnostic(models.Model):

--- a/data/models/importfailure.py
+++ b/data/models/importfailure.py
@@ -1,5 +1,6 @@
-from django.db import models
 from django.contrib.auth import get_user_model
+from django.db import models
+
 from .importtype import ImportType
 
 

--- a/data/models/managerinvitation.py
+++ b/data/models/managerinvitation.py
@@ -1,5 +1,6 @@
-from django.utils.translation import gettext_lazy as _
 from django.db import models
+from django.utils.translation import gettext_lazy as _
+
 from .canteen import Canteen
 
 

--- a/data/models/message.py
+++ b/data/models/message.py
@@ -1,9 +1,11 @@
 import logging
-from django.db import models
-from data.models import Canteen
+
 from django.conf import settings
-from common.utils import send_mail
+from django.db import models
 from django.utils.timezone import now
+
+from common.utils import send_mail
+from data.models import Canteen
 
 logger = logging.getLogger(__name__)
 

--- a/data/models/partner.py
+++ b/data/models/partner.py
@@ -1,10 +1,13 @@
 from urllib.parse import quote
+
+from ckeditor_uploader.fields import RichTextUploadingField
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from ckeditor_uploader.fields import RichTextUploadingField
+
 from data.department_choices import Department
-from data.utils import optimize_image
 from data.fields import ChoiceArrayField
+from data.utils import optimize_image
+
 from .partnertype import PartnerType
 from .sector import Sector
 

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -1,6 +1,9 @@
 from datetime import date
+
 from django.db import models
+
 from data.fields import ChoiceArrayField
+
 from .canteen import Canteen
 from .softdeletionmodel import SoftDeletionModel
 

--- a/data/models/reservationexpe.py
+++ b/data/models/reservationexpe.py
@@ -1,5 +1,6 @@
-from django.core.validators import MinValueValidator, MaxValueValidator
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
+
 from .canteen import Canteen
 
 

--- a/data/models/review.py
+++ b/data/models/review.py
@@ -1,6 +1,6 @@
-from django.db import models
 from django.conf import settings
-from django.core.validators import MinValueValidator, MaxValueValidator
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
 
 
 class Review(models.Model):

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -1,15 +1,17 @@
 import logging
 from decimal import Decimal
-from django.db import models
-from django.db.models.signals import pre_delete
-from django.dispatch import receiver
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
+from django.db import models
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
 from django.utils import timezone
-from data.models import Canteen, Diagnostic, AuthenticationMethodHistoricalRecords
 from simple_history.models import HistoricalRecords
+
+from data.models import AuthenticationMethodHistoricalRecords, Canteen, Diagnostic
 
 logger = logging.getLogger(__name__)
 
@@ -230,11 +232,11 @@ class Teledeclaration(models.Model):
     @staticmethod
     def _get_diagnostic_serializer(diagnostic):
         from api.serializers import (
-            SimpleTeledeclarationDiagnosticSerializer,
-            CompleteTeledeclarationDiagnosticSerializer,
             ApproDeferredTeledeclarationDiagnosticSerializer,
-            SimpleApproOnlyTeledeclarationDiagnosticSerializer,
             CompleteApproOnlyTeledeclarationDiagnosticSerializer,
+            CompleteTeledeclarationDiagnosticSerializer,
+            SimpleApproOnlyTeledeclarationDiagnosticSerializer,
+            SimpleTeledeclarationDiagnosticSerializer,
         )
 
         uses_central_kitchen_appro = Teledeclaration.should_use_central_kitchen_appro(diagnostic)

--- a/data/models/user.py
+++ b/data/models/user.py
@@ -1,9 +1,10 @@
 from django.contrib.auth.models import AbstractUser
-from django.utils.translation import gettext_lazy as _
 from django.db import models
-from data.utils import optimize_image
-from data.fields import ChoiceArrayField
+from django.utils.translation import gettext_lazy as _
+
 from data.department_choices import Department
+from data.fields import ChoiceArrayField
+from data.utils import optimize_image
 
 
 class User(AbstractUser):

--- a/data/models/vegetarianexpe.py
+++ b/data/models/vegetarianexpe.py
@@ -1,6 +1,8 @@
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
-from django.core.validators import MinValueValidator, MaxValueValidator
+
 from data.fields import ChoiceArrayField
+
 from .canteen import Canteen
 
 

--- a/data/models/videotutorial.py
+++ b/data/models/videotutorial.py
@@ -1,6 +1,7 @@
-from django.db import models
-from data.fields import ChoiceArrayField
 from ckeditor_uploader.fields import RichTextUploadingField
+from django.db import models
+
+from data.fields import ChoiceArrayField
 
 
 class VideoTutorialCategory(models.TextChoices):

--- a/data/models/wasteaction.py
+++ b/data/models/wasteaction.py
@@ -1,8 +1,9 @@
-from django.db import models
-from data.fields import ChoiceArrayField
 from ckeditor.fields import RichTextField
-from wagtail.models import RevisionMixin
 from django.contrib.contenttypes.fields import GenericRelation
+from django.db import models
+from wagtail.models import RevisionMixin
+
+from data.fields import ChoiceArrayField
 
 
 class WasteAction(RevisionMixin, models.Model):

--- a/data/models/wastemeasurement.py
+++ b/data/models/wastemeasurement.py
@@ -1,8 +1,10 @@
+from datetime import datetime
+
+from django.core.exceptions import ValidationError
 from django.db import models
 from simple_history.models import HistoricalRecords
+
 from .canteen import Canteen
-from datetime import datetime
-from django.core.exceptions import ValidationError
 
 
 def validate_before_today(value):

--- a/data/signals.py
+++ b/data/signals.py
@@ -1,9 +1,11 @@
 import logging
+
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
-from simple_history.signals import pre_create_historical_record
 from simple_history.models import HistoricalRecords
-from .models import User, ManagerInvitation, Canteen
+from simple_history.signals import pre_create_historical_record
+
+from .models import Canteen, ManagerInvitation, User
 
 logger = logging.getLogger(__name__)
 

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
-from data.models import Canteen
-from data.factories import CanteenFactory, DiagnosticFactory
 from freezegun import freeze_time
+
+from data.factories import CanteenFactory, DiagnosticFactory
+from data.models import Canteen
 
 
 class TestCanteenModel(TestCase):

--- a/data/tests/test_history.py
+++ b/data/tests/test_history.py
@@ -1,8 +1,10 @@
 from datetime import timedelta
+
 from django.test import TestCase
+from django.test.utils import override_settings
+
 from data.factories import CanteenFactory, TeledeclarationFactory
 from data.models import AuthenticationMethodHistoricalRecords
-from django.test.utils import override_settings
 from macantine import tasks
 
 

--- a/data/tests/test_manager_invitation.py
+++ b/data/tests/test_manager_invitation.py
@@ -1,7 +1,8 @@
-from data.models import ManagerInvitation
-from data.factories.managerinvitation import ManagerInvitationFactory
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
+
+from data.factories.managerinvitation import ManagerInvitationFactory
+from data.models import ManagerInvitation
 
 
 class TestManagerInvitation(APITestCase):

--- a/data/tests/test_messages.py
+++ b/data/tests/test_messages.py
@@ -1,9 +1,10 @@
-from django.test import TestCase
 from django.core import mail
+from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.timezone import now
+
+from data.factories import CanteenFactory, MessageFactory, UserFactory
 from data.models import Message
-from data.factories import MessageFactory, CanteenFactory, UserFactory
 
 
 @override_settings(DEFAULT_FROM_EMAIL="no-reply@example.com")

--- a/data/tests/test_waste_action.py
+++ b/data/tests/test_waste_action.py
@@ -1,8 +1,8 @@
-from django.test import TransactionTestCase, TestCase
 from django.core.exceptions import ValidationError
-from data.models import WasteAction
-from data.factories import WasteActionFactory
+from django.test import TestCase, TransactionTestCase
 
+from data.factories import WasteActionFactory
+from data.models import WasteAction
 
 WASTE_ACTION = {
     "title": "Action 1",

--- a/data/utils.py
+++ b/data/utils.py
@@ -1,8 +1,9 @@
-from io import BytesIO
-from PIL import Image as Img
-from PIL import ExifTags
-from django.core.files.base import ContentFile
 import datetime
+from io import BytesIO
+
+from django.core.files.base import ContentFile
+from PIL import ExifTags
+from PIL import Image as Img
 
 
 def _needs_rotation(pillow_image):

--- a/macantine/backends.py
+++ b/macantine/backends.py
@@ -1,5 +1,5 @@
-from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import MultipleObjectsReturned
 from django.db.models import Q
 

--- a/macantine/celery.py
+++ b/macantine/celery.py
@@ -1,4 +1,5 @@
 import os
+
 import dotenv
 from celery import Celery
 from celery.schedules import crontab

--- a/macantine/etl/analysis.py
+++ b/macantine/etl/analysis.py
@@ -1,11 +1,12 @@
-import pandas as pd
-import logging
 import json
-import numpy as np
+import logging
 import re
 
-from macantine.etl.data_ware_house import DataWareHouse
+import numpy as np
+import pandas as pd
+
 from macantine.etl import etl, open_data, utils
+from macantine.etl.data_ware_house import DataWareHouse
 
 logger = logging.getLogger(__name__)
 

--- a/macantine/etl/data_ware_house.py
+++ b/macantine/etl/data_ware_house.py
@@ -1,6 +1,7 @@
-from sqlalchemy import create_engine, URL
-from dotenv import load_dotenv
 import os
+
+from dotenv import load_dotenv
+from sqlalchemy import URL, create_engine
 
 
 class DataWareHouse:

--- a/macantine/etl/etl.py
+++ b/macantine/etl/etl.py
@@ -1,5 +1,4 @@
 import logging
-
 from abc import ABC, abstractmethod
 
 from data.department_choices import Department

--- a/macantine/etl/open_data.py
+++ b/macantine/etl/open_data.py
@@ -1,18 +1,18 @@
+import csv
 import json
 import os
 import time
-import csv
-import requests
-import pandas as pd
-
-from data.models import Canteen
-from macantine.etl import etl
-from django.core.files.storage import default_storage
-from django.db.models import Q
 from io import BytesIO
 
-from macantine.etl.etl import logger
+import pandas as pd
+import requests
+from django.core.files.storage import default_storage
+from django.db.models import Q
+
 import macantine.etl.utils
+from data.models import Canteen
+from macantine.etl import etl
+from macantine.etl.etl import logger
 from macantine.etl.utils import fetch_teledeclarations
 
 

--- a/macantine/etl/utils.py
+++ b/macantine/etl/utils.py
@@ -1,13 +1,15 @@
+import logging
+import os
+import zoneinfo
+from datetime import date, datetime
 from typing import Dict
+
+import numpy as np
 import pandas as pd
+import requests
+
 from api.serializers import SectorSerializer
 from data.models import Sector, Teledeclaration
-import requests
-import os
-from datetime import datetime, date
-import logging
-import numpy as np
-import zoneinfo
 
 logger = logging.getLogger(__name__)
 

--- a/macantine/management/commands/buildnpm.py
+++ b/macantine/management/commands/buildnpm.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+
 from django.core.management.base import BaseCommand
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))

--- a/macantine/management/commands/buildnpmvue3.py
+++ b/macantine/management/commands/buildnpmvue3.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+
 from django.core.management.base import BaseCommand
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))

--- a/macantine/management/commands/export_dataset.py
+++ b/macantine/management/commands/export_dataset.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+
 from macantine.tasks import export_datasets
 
 

--- a/macantine/management/commands/fill_missing_geolocation_data_using_siret.py
+++ b/macantine/management/commands/fill_missing_geolocation_data_using_siret.py
@@ -1,5 +1,7 @@
 import logging
+
 from django.core.management.base import BaseCommand
+
 from macantine.tasks import fill_missing_geolocation_data_using_siret
 
 logger = logging.getLogger(__name__)

--- a/macantine/management/commands/importcsv.py
+++ b/macantine/management/commands/importcsv.py
@@ -1,8 +1,10 @@
 import csv
-import requests
 import logging
+
+import requests
 from django.core.management.base import BaseCommand
-from django.db import transaction, IntegrityError
+from django.db import IntegrityError, transaction
+
 from data.models import Canteen, Diagnostic, ManagerInvitation
 
 logger = logging.getLogger(__name__)

--- a/macantine/sentry.py
+++ b/macantine/sentry.py
@@ -1,5 +1,5 @@
-from rest_framework.exceptions import PermissionDenied
 from django.core.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied
 
 
 def before_send(event, hint):
@@ -25,8 +25,8 @@ def before_send(event, hint):
         # the app registry is not ready yet.
         # django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
 
-        from data.models import Sector
         from api.views.diagnosticimport import FileFormatError
+        from data.models import Sector
 
         exceptions.append(Sector.DoesNotExist)
         exceptions.append(FileFormatError)

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -10,16 +10,17 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
+import logging
 import os
 import sys
-import logging
 from pathlib import Path
-from macantine.sentry import before_send
-import dotenv  # noqa
 
+import dotenv  # noqa
 import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.django import DjangoIntegration
+
+from macantine.sentry import before_send
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -1,26 +1,27 @@
-import logging
-import datetime
-import requests
 import csv
+import datetime
+import logging
 import time
-from api.views.utils import update_change_reason
-from django.utils import timezone
-from django.conf import settings
-from django.db.models import Q
-from django.core.paginator import Paginator
-from django.db.models import F
-from django.db.models.functions import Length
-from django.core.management import call_command
-from data.models import User, Canteen
+
 import redis as r
-from common.utils import get_token_sirene
-from .celery import app
-from .utils import fetch_geo_data_from_api_insee_sirene_by_siret
-from .etl.analysis import ETL_ANALYSIS
-from .etl.open_data import ETL_TD, ETL_CANTEEN
+import requests
 import sib_api_v3_sdk
+from django.conf import settings
+from django.core.management import call_command
+from django.core.paginator import Paginator
+from django.db.models import F, Q
+from django.db.models.functions import Length
+from django.utils import timezone
 from sib_api_v3_sdk.rest import ApiException
 
+from api.views.utils import update_change_reason
+from common.utils import get_token_sirene
+from data.models import Canteen, User
+
+from .celery import app
+from .etl.analysis import ETL_ANALYSIS
+from .etl.open_data import ETL_CANTEEN, ETL_TD
+from .utils import fetch_geo_data_from_api_insee_sirene_by_siret
 
 logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)

--- a/macantine/testrunner.py
+++ b/macantine/testrunner.py
@@ -1,5 +1,6 @@
-import factory.random
 from random import randint
+
+import factory.random
 from django.conf import settings
 from django.test.runner import DiscoverRunner
 

--- a/macantine/tests/test_automatic_emails.py
+++ b/macantine/tests/test_automatic_emails.py
@@ -1,9 +1,11 @@
-from unittest import mock
 from datetime import timedelta
-from django.utils import timezone
+from unittest import mock
+
 from django.test import TestCase
 from django.test.utils import override_settings
-from data.factories import CanteenFactory, UserFactory, DiagnosticFactory
+from django.utils import timezone
+
+from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 from data.models import Canteen
 from macantine import tasks
 

--- a/macantine/tests/test_brevo_user_data.py
+++ b/macantine/tests/test_brevo_user_data.py
@@ -2,10 +2,16 @@ from unittest import mock
 
 # import sib_api_v3_sdk
 from django.test import TestCase
-from macantine import tasks
 from freezegun import freeze_time
-from data.factories import UserFactory, CanteenFactory, DiagnosticFactory, TeledeclarationFactory
-from data.models import Teledeclaration, Canteen, Diagnostic
+
+from data.factories import (
+    CanteenFactory,
+    DiagnosticFactory,
+    TeledeclarationFactory,
+    UserFactory,
+)
+from data.models import Canteen, Diagnostic, Teledeclaration
+from macantine import tasks
 
 
 class TestBrevoUserData(TestCase):

--- a/macantine/tests/test_etl.py
+++ b/macantine/tests/test_etl.py
@@ -1,18 +1,22 @@
-import pandas as pd
-import requests_mock
-from macantine.etl.utils import map_communes_infos
-from django.test import TestCase, override_settings
-from data.factories import DiagnosticFactory, CanteenFactory, UserFactory, SectorFactory
-from data.models import Teledeclaration
-from macantine.etl.analysis import ETL_ANALYSIS, aggregate_col, get_egalim_hors_bio, format_sector_column
-from macantine.etl.open_data import ETL_CANTEEN, ETL_TD
-from freezegun import freeze_time
 import json
-from django.core.files.storage import default_storage
-
 import os
 
-from macantine.etl.utils import update_datagouv_resources
+import pandas as pd
+import requests_mock
+from django.core.files.storage import default_storage
+from django.test import TestCase, override_settings
+from freezegun import freeze_time
+
+from data.factories import CanteenFactory, DiagnosticFactory, SectorFactory, UserFactory
+from data.models import Teledeclaration
+from macantine.etl.analysis import (
+    ETL_ANALYSIS,
+    aggregate_col,
+    format_sector_column,
+    get_egalim_hors_bio,
+)
+from macantine.etl.open_data import ETL_CANTEEN, ETL_TD
+from macantine.etl.utils import map_communes_infos, update_datagouv_resources
 
 
 class TestETLAnalysis(TestCase):

--- a/macantine/tests/test_geolocation_bot.py
+++ b/macantine/tests/test_geolocation_bot.py
@@ -1,9 +1,11 @@
+import json
+
 import requests_mock
 from django.test import TestCase
-from data.factories import CanteenFactory, UserFactory, SectorFactory
+
 from data.department_choices import Department
+from data.factories import CanteenFactory, SectorFactory, UserFactory
 from macantine import tasks, utils
-import json
 
 
 @requests_mock.Mocker()

--- a/macantine/urls.py
+++ b/macantine/urls.py
@@ -1,14 +1,15 @@
 from django.conf import settings
-from django.contrib import admin
 from django.conf.urls import include
 from django.conf.urls.static import static
+from django.contrib import admin
 from django.urls import path, re_path
 from magicauth.urls import urlpatterns as magicauth_urls
-from web.views import VueAppDisplayView, Vue3AppDisplayView
-from wagtail.admin import urls as wagtailadmin_urls
 from wagtail import urls as wagtail_urls
+from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
+
 from cms.api import api_router
+from web.views import Vue3AppDisplayView, VueAppDisplayView
 
 urlpatterns = [
     path("admin/", admin.site.urls),  # if the path of 'admin/' changes, update historical_record_add_auth_method

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -1,8 +1,10 @@
 import logging
 import requests
-from data.region_choices import Region
-from django.conf import settings
+
 import redis as r
+from django.conf import settings
+
+from data.region_choices import Region
 
 logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -1,7 +1,7 @@
 import logging
-import requests
 
 import redis as r
+import requests
 from django.conf import settings
 
 from data.region_choices import Region

--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,7 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
+
 import dotenv
 
 

--- a/web/forms.py
+++ b/web/forms.py
@@ -1,7 +1,8 @@
 import re
-from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
-from django.contrib.auth import get_user_model
+
 from django import forms
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 from django.utils.safestring import mark_safe
 
 

--- a/web/sitemaps.py
+++ b/web/sitemaps.py
@@ -1,5 +1,6 @@
 from django.contrib.sitemaps import Sitemap
-from data.models import Canteen, BlogPost, Partner
+
+from data.models import BlogPost, Canteen, Partner
 
 
 class CanteenSitemap(Sitemap):

--- a/web/tests/test_registration.py
+++ b/web/tests/test_registration.py
@@ -1,9 +1,11 @@
 import re
+
 from django.core import mail
-from django.urls import reverse
 from django.test.utils import override_settings
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
+
 from web.forms import RegisterUserForm
 
 

--- a/web/tests/test_sitemaps.py
+++ b/web/tests/test_sitemaps.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, Client
+from django.test import Client, TestCase
 from django.urls import reverse
 from rest_framework import status
 

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,24 +1,25 @@
-from django.contrib.auth import views as auth_views
-from django.views.generic import TemplateView
 from django.conf import settings
+from django.contrib.auth import views as auth_views
 from django.contrib.sitemaps.views import sitemap
-from django.views.decorators.cache import cache_page
-from django.views.generic.base import RedirectView
 from django.urls import path, re_path
-from drf_spectacular.views import SpectacularSwaggerView, SpectacularAPIView
-from web.sitemaps import CanteenSitemap, BlogPostSitemap, WebSitemap, PartnerSitemap
+from django.views.decorators.cache import cache_page
+from django.views.generic import TemplateView
+from django.views.generic.base import RedirectView
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+
+from web.sitemaps import BlogPostSitemap, CanteenSitemap, PartnerSitemap, WebSitemap
 from web.views import (
+    AccountActivationView,
+    ActivationTokenView,
+    LoginUserView,
+    OIDCAuthorizeView,
+    OIDCLoginView,
+    RegisterDoneView,
+    RegisterInvalidTokenView,
+    RegisterSendMailFailedView,
+    RegisterUserView,
     VueAppDisplayView,
     WidgetView,
-    LoginUserView,
-    RegisterUserView,
-    ActivationTokenView,
-    RegisterDoneView,
-    RegisterSendMailFailedView,
-    RegisterInvalidTokenView,
-    AccountActivationView,
-    OIDCLoginView,
-    OIDCAuthorizeView,
 )
 
 sitemaps = {

--- a/web/views.py
+++ b/web/views.py
@@ -1,20 +1,22 @@
 import logging
-from django.urls import reverse_lazy
-from django.shortcuts import redirect, render
-from django.conf import settings
-from django.contrib.auth import get_user_model, tokens, login
-from django.contrib.auth import views as auth_views
-from django.contrib import messages
-from django.http import HttpResponseRedirect
-from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
-from django.utils.encoding import force_bytes
-from common.utils import send_mail
-from django.core.exceptions import ObjectDoesNotExist
-from django.views.generic import TemplateView, FormView, View
-from web.forms import RegisterUserForm, LoginUserForm
-from data.factories import UserFactory
-from django.views.decorators.clickjacking import xframe_options_exempt
+
 from authlib.integrations.django_client import OAuth
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth import get_user_model, login, tokens
+from django.contrib.auth import views as auth_views
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponseRedirect
+from django.shortcuts import redirect, render
+from django.urls import reverse_lazy
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from django.views.decorators.clickjacking import xframe_options_exempt
+from django.views.generic import FormView, TemplateView, View
+
+from common.utils import send_mail
+from data.factories import UserFactory
+from web.forms import LoginUserForm, RegisterUserForm
 
 logger = logging.getLogger(__name__)
 

--- a/web/views.py
+++ b/web/views.py
@@ -15,7 +15,6 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import FormView, TemplateView, View
 
 from common.utils import send_mail
-from data.factories import UserFactory
 from web.forms import LoginUserForm, RegisterUserForm
 
 logger = logging.getLogger(__name__)
@@ -250,7 +249,7 @@ class OIDCAuthorizeView(View):
 
         # Create user
         logger.info(f"Creating new user from MonComptePro user {mcp_id} with email {mcp_email}.")
-        user = UserFactory.create(
+        user = get_user_model().objects.create(
             first_name=mcp_data.get("given_name"),
             last_name=mcp_data.get("family_name"),
             email=mcp_email,


### PR DESCRIPTION
### Quoi ?

Suite de #4389. Closes #4341

- [x] ajouter `isort` à la config `pre-commit` + configurer avec `black`
- [x] lancer sur tous les fichiers et réordonner les imports python
- [x] réparer quelques erreurs

### Pourquoi ?

Avoir des imports bien ordonnés / consistants / homogènes