### PR TITLE
Correction de l'endpoint API SIrene

### DIFF
--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -514,7 +514,7 @@ class TestCanteenApi(APITestCase):
         city = "Paris 15e Arrondissement"
         postcode = "75015"
         insee_code = "75115"
-        sirene_api_url = f"https://api.insee.fr/entreprises/sirene/V3/siret/{siret}"
+        sirene_api_url = f"https://api.insee.fr/entreprises/sirene/siret/{siret}"
         sirene_mocked_response = {
             "etablissement": {
                 "uniteLegale": {"denominationUniteLegale": "Canteen Name"},

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.http import JsonResponse
 import requests
 from common.utils import send_mail
-from macantine.utils import complete_location_data, complete_canteen_data
+from macantine.utils import complete_location_data, get_city_from_siret
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError, BadRequest
 from django.contrib.auth import get_user_model
@@ -448,7 +448,7 @@ class CanteenStatusView(APIView):
         siret = request.parser_context.get("kwargs").get("siret")
         response = check_siret_response(siret, request) or {}
         if not response:
-            response = complete_canteen_data(siret, response)
+            response = get_city_from_siret(siret, response)
             city = response.get("city", None)
             postcode = response.get("postalCode", None)
             if city and postcode:

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -6,7 +6,7 @@ from django.apps import apps
 from django.conf import settings
 from django.http import JsonResponse
 import requests
-from common.utils import send_mail
+from common.utils import send_mail, get_token_sirene
 from macantine.utils import complete_location_data, get_city_from_siret
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError, BadRequest
@@ -448,7 +448,8 @@ class CanteenStatusView(APIView):
         siret = request.parser_context.get("kwargs").get("siret")
         response = check_siret_response(siret, request) or {}
         if not response:
-            response = get_city_from_siret(siret, response)
+            token = get_token_sirene()
+            response = get_city_from_siret(siret, response, token)
             city = response.get("city", None)
             postcode = response.get("postalCode", None)
             if city and postcode:

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.http import JsonResponse
 import requests
 from common.utils import send_mail, get_token_sirene
-from macantine.utils import complete_location_data, get_city_from_siret
+from macantine.utils import fetch_geo_data_from_api_entreprise_by_siret, fetch_geo_data_from_api_insee_sirene_by_siret
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError, BadRequest
 from django.contrib.auth import get_user_model
@@ -449,11 +449,11 @@ class CanteenStatusView(APIView):
         response = check_siret_response(siret, request) or {}
         if not response:
             token = get_token_sirene()
-            response = get_city_from_siret(siret, response, token)
+            response = fetch_geo_data_from_api_insee_sirene_by_siret(siret, response, token)
             city = response.get("city", None)
             postcode = response.get("postalCode", None)
             if city and postcode:
-                response = complete_location_data(response)
+                response = fetch_geo_data_from_api_entreprise_by_siret(response)
         return JsonResponse(response, status=status.HTTP_200_OK)
 
 

--- a/common/utils/__init__.py
+++ b/common/utils/__init__.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)
 
 
-def get_or_create_token_sirene():
+def get_token_sirene():
     if not settings.SIRET_API_KEY or not settings.SIRET_API_SECRET:
         logger.warning("skipping siret token fetching because key and secret env vars aren't set")
         return

--- a/common/utils/__init__.py
+++ b/common/utils/__init__.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)
 
 
-def get_siret_token():
+def get_or_create_token_sirene():
     if not settings.SIRET_API_KEY or not settings.SIRET_API_SECRET:
         logger.warning("skipping siret token fetching because key and secret env vars aren't set")
         return

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -13,7 +13,7 @@ from django.db.models.functions import Length
 from django.core.management import call_command
 from data.models import User, Canteen
 import redis as r
-from common.utils import get_or_create_token_sirene
+from common.utils import get_token_sirene
 from .celery import app
 from .utils import get_city_from_siret
 from .etl.analysis import ETL_ANALYSIS
@@ -359,7 +359,7 @@ def _update_canteen_geo_data(canteen, response):
 @app.task()
 def fill_missing_geolocation_data_using_siret():
     candidate_canteens = _get_candidate_canteens_for_siret_geobot()
-    token = get_or_create_token_sirene()
+    token = get_token_sirene()
 
     if len(candidate_canteens) == 0:
         logger.info("No candidate canteens have been found. Nothing to do here...")

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -365,9 +365,10 @@ def fill_missing_geolocation_data_using_siret():
         logger.info("No candidate canteens have been found. Nothing to do here...")
         return
     for canteen in candidate_canteens:
-        response = get_infos_from_siret(canteen.siret, token)
-        if response:
-            _update_canteen_geo_data(canteen, response)
+        if len(canteen.siret) == 14:
+            response = get_infos_from_siret(canteen.siret, token)
+            if response:
+                _update_canteen_geo_data(canteen, response)
 
     logger.info(f"Siret Geolocation Bot: Ended process for {candidate_canteens.count()} canteens")
 

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -15,11 +15,12 @@ from data.models import User, Canteen
 import redis as r
 from common.utils import get_token_sirene
 from .celery import app
-from .utils import get_city_from_siret
+from .utils import fetch_geo_data_from_api_insee_sirene_by_siret
 from .etl.analysis import ETL_ANALYSIS
 from .etl.open_data import ETL_TD, ETL_CANTEEN
 import sib_api_v3_sdk
 from sib_api_v3_sdk.rest import ApiException
+
 
 logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)
@@ -367,7 +368,7 @@ def fill_missing_geolocation_data_using_siret():
     for canteen in candidate_canteens:
         if len(canteen.siret) == 14:
             response = {}
-            response = get_city_from_siret(canteen.siret, response, token)
+            response = fetch_geo_data_from_api_insee_sirene_by_siret(canteen.siret, response, token)
             if response:
                 _update_canteen_geo_data(canteen, response)
 

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -344,9 +344,9 @@ def _fill_from_api_response(response, canteens):
 
 def _update_canteen_geo_data(canteen, response):
     try:
-        if "city_insee_code" in response.keys():
-            canteen.city_insee_code = response["city_insee_code"]
-            canteen.postal_code = response["postal_code"]
+        if "cityInseeCode" in response.keys():
+            canteen.city_insee_code = response["cityInseeCode"]
+            canteen.postal_code = response["postalCode"]
             canteen.city = response["city"]
             canteen.save()
             update_change_reason(canteen, "Données de localisation MAJ par bot, via SIRET")

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -15,7 +15,7 @@ from data.models import User, Canteen
 import redis as r
 from common.utils import get_siret_token
 from .celery import app
-from .utils import get_infos_from_siret
+from .utils import get_city_from_siret
 from .etl.analysis import ETL_ANALYSIS
 from .etl.open_data import ETL_TD, ETL_CANTEEN
 import sib_api_v3_sdk
@@ -366,7 +366,7 @@ def fill_missing_geolocation_data_using_siret():
         return
     for canteen in candidate_canteens:
         if len(canteen.siret) == 14:
-            response = get_infos_from_siret(canteen.siret, token)
+            response = get_city_from_siret(canteen.siret, token)
             if response:
                 _update_canteen_geo_data(canteen, response)
 

--- a/macantine/tests/test_geolocation_bot.py
+++ b/macantine/tests/test_geolocation_bot.py
@@ -147,7 +147,7 @@ class TestGeolocationWithSiretBot(TestCase):
         # Call the service to hit the mocked API.
         mock.post(
             "https://api.insee.fr/token",
-            json={"token_type": "bearer", "access_token": "token"},
+            json={"token_type": "bearer", "access_token": token},
         )
         city_insee_code = "29352"
 

--- a/macantine/tests/test_geolocation_bot.py
+++ b/macantine/tests/test_geolocation_bot.py
@@ -168,7 +168,7 @@ class TestGeolocationWithSiretBot(TestCase):
             ),
             status_code=200,
         )
-        response = utils.get_city_from_siret(candidate_canteen.siret, token)
+        response = utils.get_city_from_siret(candidate_canteen.siret, {}, token)
         self.assertEquals(response["cityInseeCode"], city_insee_code)
 
     def test_geolocation_with_siret_data_filled(self, mock):
@@ -181,7 +181,7 @@ class TestGeolocationWithSiretBot(TestCase):
         canteen = CanteenFactory.create(city_insee_code=None, siret=siret_canteen)
         mock.post(
             "https://api.insee.fr/token",
-            json={"token_type": "bearer", "access_token": "token"},
+            json={"token_type": "bearer", "access_token": token},
         )
 
         city_insee_code = "29352"

--- a/macantine/tests/test_geolocation_bot.py
+++ b/macantine/tests/test_geolocation_bot.py
@@ -122,7 +122,7 @@ class TestGeolocationBot(TestCase):
 
 @requests_mock.Mocker()
 class TestGeolocationWithSiretBot(TestCase):
-    api_url = "https://api.insee.fr/entreprises/sirene/V3/siret/"
+    api_url = "https://api.insee.fr/entreprises/sirene/siret/"
 
     def test_candidate_canteens(self, _):
         """
@@ -159,7 +159,7 @@ class TestGeolocationWithSiretBot(TestCase):
                     "etablissement": {
                         "uniteLegale": {"denominationUniteLegale": "cantine test"},
                         "adresseEtablissement": {
-                            "codeCommuneEtablissement": "29352",
+                            "codeCommuneEtablissement": city_insee_code,
                             "codePostalEtablissement": "29890",
                             "libelleCommuneEtablissement": "Ville test",
                         },
@@ -168,28 +168,8 @@ class TestGeolocationWithSiretBot(TestCase):
             ),
             status_code=200,
         )
-        mock.get(
-            f"https://api-adresse.data.gouv.fr/search/?q={city_insee_code}&citycode={city_insee_code}&type=municipality&autocomplete=1",
-            headers={"Authorization": f"Bearer {token}"},
-            text=json.dumps(
-                {
-                    "features": [
-                        {
-                            "properties": {
-                                "label": "Ville test",
-                                "citycode": city_insee_code,
-                                "postcode": "29890",
-                                "context": "38, Isère, Auvergne-Rhône-Alpes",
-                            }
-                        }
-                    ]
-                }
-            ),
-            status_code=200,
-        )
         response = utils.get_city_from_siret(candidate_canteen.siret, token)
-        self.assertEquals(response["city_insee_code"], "29352")
-        self.assertEquals(response["postal_code"], "29890")
+        self.assertEquals(response["cityInseeCode"], city_insee_code)
 
     def test_geolocation_with_siret_data_filled(self, mock):
         """
@@ -219,25 +199,6 @@ class TestGeolocationWithSiretBot(TestCase):
                             "libelleCommuneEtablissement": "Ville test",
                         },
                     },
-                }
-            ),
-            status_code=200,
-        )
-        mock.get(
-            f"https://api-adresse.data.gouv.fr/search/?q={city_insee_code}&citycode={city_insee_code}&type=municipality&autocomplete=1",
-            headers={"Authorization": f"Bearer {token}"},
-            text=json.dumps(
-                {
-                    "features": [
-                        {
-                            "properties": {
-                                "label": "Ville test",
-                                "citycode": city_insee_code,
-                                "postcode": "29890",
-                                "context": "38, Isère, Auvergne-Rhône-Alpes",
-                            }
-                        }
-                    ]
                 }
             ),
             status_code=200,

--- a/macantine/tests/test_geolocation_bot.py
+++ b/macantine/tests/test_geolocation_bot.py
@@ -168,7 +168,7 @@ class TestGeolocationWithSiretBot(TestCase):
             ),
             status_code=200,
         )
-        response = utils.get_city_from_siret(candidate_canteen.siret, {}, token)
+        response = utils.fetch_geo_data_from_api_insee_sirene_by_siret(candidate_canteen.siret, {}, token)
         self.assertEquals(response["cityInseeCode"], city_insee_code)
 
     def test_geolocation_with_siret_data_filled(self, mock):

--- a/macantine/tests/test_geolocation_bot.py
+++ b/macantine/tests/test_geolocation_bot.py
@@ -187,7 +187,7 @@ class TestGeolocationWithSiretBot(TestCase):
             ),
             status_code=200,
         )
-        response = utils.get_infos_from_siret(candidate_canteen.siret, token)
+        response = utils.get_city_from_siret(candidate_canteen.siret, token)
         self.assertEquals(response["city_insee_code"], "29352")
         self.assertEquals(response["postal_code"], "29890")
 

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -11,7 +11,7 @@ redis = r.from_url(settings.REDIS_URL, decode_responses=True)
 REGIONS_LIB = {i.label.split(" - ")[1]: i.value for i in Region}
 
 
-def get_city_from_siret(canteen_siret, response, token):
+def fetch_geo_data_from_api_insee_sirene_by_siret(canteen_siret, response, token):
     response["siret"] = canteen_siret
     try:
         redis_key = f"{settings.REDIS_PREPEND_KEY}SIRET_API_CALLS_PER_MINUTE"
@@ -54,7 +54,7 @@ def get_city_from_siret(canteen_siret, response, token):
     return response
 
 
-def complete_location_data(response):
+def fetch_geo_data_from_api_entreprise_by_siret(response):
     try:
         location_response = requests.get(
             f"https://api-adresse.data.gouv.fr/search/?q={response['cityInseeCode']}&citycode={response['cityInseeCode']}&type=municipality&autocomplete=1"

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -22,7 +22,7 @@ def complete_canteen_data(canteen_siret, token):
             time.sleep(60)
 
         siret_response = requests.get(
-            f"https://api.insee.fr/entreprises/sirene/V3/siret/{canteen_siret}",
+            f"https://api.insee.fr/entreprises/sirene/siret/{canteen_siret}",
             headers={"Authorization": f"Bearer {token}"},
         )
         siret_response.raise_for_status()

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -11,7 +11,7 @@ redis = r.from_url(settings.REDIS_URL, decode_responses=True)
 REGIONS_LIB = {i.label.split(" - ")[1]: i.value for i in Region}
 
 
-def complete_canteen_data(canteen_siret, token):
+def get_city_from_siret(canteen_siret, token):
     canteen = {}
     canteen["siret"] = canteen_siret
     try:
@@ -88,9 +88,3 @@ def complete_location_data(response):
     except Exception as e:
         logger.exception(f"Error completing location data with SIRET for city: {response['city']}")
         logger.exception(e)
-
-
-def get_city_from_siret(siret: str, token: str):
-    response = complete_canteen_data(siret, token)
-    response = complete_location_data(response)
-    return response

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -90,7 +90,7 @@ def complete_location_data(response):
         logger.exception(e)
 
 
-def get_infos_from_siret(siret: str, token: str):
+def get_city_from_siret(siret: str, token: str):
     response = complete_canteen_data(siret, token)
     response = complete_location_data(response)
     return response


### PR DESCRIPTION
closes #3931 

Correction de l'endpoint de l'API Sirene qui a évolué

Réduction du scop du geo bot par SIRET -> on récupère uniquement le city insee code.
Tout le reste des informations géographiques sera généré par le premier geo bot 