### PR TITLE
Bug fix fichiers media : Django 5.1 -> 5.0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ defusedxml==0.7.1
 Deprecated==1.2.14
 dill==0.3.8
 distlib==0.3.8
-Django==5.1
+Django==5.0.8
 django-anymail==10.3
 django-ckeditor==6.7.1
 django-debug-toolbar==4.4.6


### PR DESCRIPTION
Cette MAJ rendre les URLs faux pour les medias https://github.com/betagouv/ma-cantine/pull/4325

Ils doivent être comme https://cellar-c2.services.clever-cloud.com/ma-cantine-egalim/media/7c3ae2fb-6559-41fc-ab08-53e92500e7fb.png

Maintenant comme <HOSTNAME>/media/7c3ae2fb-6559-41fc-ab08-53e92500e7fb.png