### PR TITLE
CMS : ignorer la migration des données WasteAction si il y a une erreur

### DIFF
--- a/cms/migrations/0005_delete_wasteaction.py
+++ b/cms/migrations/0005_delete_wasteaction.py
@@ -5,10 +5,13 @@ from django.core.serializers import serialize
 
 
 def backup_waste_action_data(apps, schema_editor):
-    WasteAction = apps.get_model("cms", "WasteAction")
-    data = serialize("json", WasteAction.objects.all())
-    with open("waste_action_backup.json", "w") as f:
-        f.write(data)
+    try:
+        WasteAction = apps.get_model("cms", "WasteAction")
+        data = serialize("json", WasteAction.objects.all())
+        with open("waste_action_backup.json", "w") as f:
+            f.write(data)
+    except:
+        pass
 
 
 class Migration(migrations.Migration):

--- a/data/migrations/0152_wasteaction.py
+++ b/data/migrations/0152_wasteaction.py
@@ -9,12 +9,15 @@ from django.core.serializers import deserialize
 
 
 def restore_waste_action_data(apps, schema_editor):
-    with open("waste_action_backup.json", "r") as f:
-        data = f.read()
-    data = data.replace("cms.wasteaction", "data.wasteaction")
-    for obj in deserialize("json", data):
-        obj.save()
-    os.remove("waste_action_backup.json")
+    try:
+        with open("waste_action_backup.json", "r") as f:
+            data = f.read()
+        data = data.replace("cms.wasteaction", "data.wasteaction")
+        for obj in deserialize("json", data):
+            obj.save()
+        os.remove("waste_action_backup.json")
+    except:  # noqa
+        pass
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
La migration du modèle `WasteAction` de `cms` vers `data` (#4431) provoque des erreurs en déploiement.

Rajouter un try/except pour éviter que le déploiement fail