### PR TITLE
SIRET : améliorer les cas d'erreur

### DIFF
--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -1,6 +1,5 @@
 import logging
 import requests
-import time
 from data.region_choices import Region
 from django.conf import settings
 import redis as r
@@ -17,8 +16,8 @@ def fetch_geo_data_from_api_insee_sirene_by_siret(canteen_siret, response, token
         redis_key = f"{settings.REDIS_PREPEND_KEY}SIRET_API_CALLS_PER_MINUTE"
         redis.incr(redis_key) if redis.exists(redis_key) else redis.set(redis_key, 1, 60)
         if int(redis.get(redis_key)) > 30:
-            logger.warning("Siret lookup exceding API rate. Waiting 1 minute")
-            time.sleep(60)
+            logger.warning("Siret lookup exceding API rate. Skipping this attempt.")
+            return response
 
         siret_response = requests.get(
             f"https://api.insee.fr/entreprises/sirene/siret/{canteen_siret}",
@@ -87,3 +86,4 @@ def fetch_geo_data_from_api_entreprise_by_siret(response):
     except Exception as e:
         logger.exception(f"Error completing location data with SIRET for city: {response['city']}")
         logger.exception(e)
+    return response


### PR DESCRIPTION
J'ai vu plusieurs erreurs dans les logs kibana :

`WARNING Siret lookup exceding API rate. Waiting 1 minute` : je trouve 1 minute bcp très long pour l'utilisateur à attendre. J'ai décidé alors de simplement skipper le lookup de données, vu que l'utilisateur peut les renseigner sur la prochaine étape.

`api/views/canteen.py", line 457, in get#012    return JsonResponse(response, status=status.HTTP_200_OK)#012           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^#012  File "/home/bas/venv/lib/python3.11/site-packages/django/http/response.py", line 726, in __init__#012    raise TypeError(#012TypeError: In order to allow non-dict objects to be serialized set the safe parameter to False.` - je crois que si il y a une erreur avec `fetch_geo_data_from_api_entreprise_by_siret` on `return` rien, et alors quand on essaye de serializer la réponse `JsonResponse(response, status=status.HTTP_200_OK)` ça ne marche pas

l'erreur que je n'ai pas traité ici c'est : `WARNING features array for city 'PARIS' in location response format is non-existant or empty`