### PR TITLE
Fix : Replacement de l'utilisation du message broker redis par une var gloable pour le suivi de l'api rate

### DIFF
--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -575,3 +575,7 @@ MAX_DAYS_HISTORICAL_RECORDS = (
 WAGTAIL_SITE_NAME = "ma-cantine"
 # WAGTAILADMIN_BASE_URL # Declare if null URL in notification emails
 WAGTAILDOCS_EXTENSIONS = ["csv", "docx", "key", "odt", "pdf", "pptx", "rtf", "txt", "xlsx", "zip"]
+
+
+# Define a counter to verify we are not exceeding API rate limit
+SIRET_API_CALLS_CMPT = 0


### PR DESCRIPTION
Fix : attente inutile d'une minute à chaque appel API Sirene car compteur jamais réinitialisé + refacto techno plus simple

Je ne sais pas tester cela pertinament sans test E2E