### PR TITLE
Tunnel gaspi : utiliser les couverts par jour de la cantine

### DIFF
--- a/2024-frontend/src/stores/root.js
+++ b/2024-frontend/src/stores/root.js
@@ -44,6 +44,11 @@ export const useRootStore = defineStore("root", () => {
       })
   }
 
+  const fetchCanteen = (id) => {
+    return fetch(`/api/v1/canteens/${id}`)
+      .then(verifyResponse)
+  }
+
   const notify = (notification) => {
     // a notification consists of: message, title, status, undoAction, undoMessage
     notification.id = Math.floor(Math.random() * 10000) // generate random 5 digit id
@@ -94,6 +99,7 @@ export const useRootStore = defineStore("root", () => {
 
     // actions
     fetchInitialData,
+    fetchCanteen,
     createWasteMeasurement,
     updateWasteMeasurement,
     notify,

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/MeasurementPeriod.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/MeasurementPeriod.vue
@@ -41,7 +41,7 @@ const daysInPeriod = computed(() => {
 })
 
 const calculateMealCountMaybe = () => {
-  if (datesEntered.value) {
+  if (datesEntered.value && canteen.value.dailyMealCount) {
     payload.mealCount = canteen.value.dailyMealCount * daysInPeriod.value
   }
 }
@@ -117,7 +117,7 @@ onMounted(() => {
         </HelpText>
       </div>
     </div>
-    <div class="fr-grid-row fr-grid-row--middle fr-mt-2w">
+    <div class="fr-grid-row fr-grid-row--middle fr-mt-2w" v-if="canteen.dailyMealCount">
       <div class="fr-col-md-6">
         <div class="fr-grid-row fr-grid-row--bottom">
           <div class="fr-mr-2w">
@@ -151,6 +151,31 @@ onMounted(() => {
           </p>
           <p class="fr-mb-0">
             <b>{{ canteen.dailyMealCount }}</b>
+          </p>
+        </HelpText>
+      </div>
+    </div>
+    <div class="fr-grid-row fr-grid-row--middle fr-mt-2w" v-else>
+      <div class="fr-col-md-6">
+        <div class="fr-grid-row fr-grid-row--bottom">
+          <div class="fr-mr-2w">
+            <DsfrInputGroup
+              v-model.number="payload.mealCount"
+              type="number"
+              label="Nombre de couverts sur la période"
+              :hint="`${daysInPeriod || '?'} jours`"
+              label-visible
+              :error-message="formatError(v$.mealCount)"
+            />
+          </div>
+        </div>
+      </div>
+      <div class="fr-col-md-6">
+        <HelpText v-if="datesEntered && canteen.yearlyMealCount">
+          <p class="fr-mb-1w">
+            Pour rappel, votre établissement sert
+            <b>{{ canteen.yearlyMealCount }}</b>
+            repas par an.
           </p>
         </HelpText>
       </div>

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/MeasurementPeriod.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/MeasurementPeriod.vue
@@ -11,6 +11,7 @@ const { required, integer, minValue } = useValidators()
 const emit = defineEmits(["provide-vuelidate", "update-payload"])
 
 const originalPayload = inject("originalPayload")
+const canteen = inject("canteen")
 
 const state = reactive({
   editMealCount: false,
@@ -41,13 +42,9 @@ const daysInPeriod = computed(() => {
 
 const calculateMealCountMaybe = () => {
   if (datesEntered.value) {
-    payload.mealCount = canteen.dailyMealCount * daysInPeriod.value
+    payload.mealCount = canteen.value.dailyMealCount * daysInPeriod.value
   }
 }
-
-const canteen = reactive({
-  dailyMealCount: 200,
-})
 
 const payload = reactive({})
 

--- a/2024-frontend/src/views/WasteMeasurementTunnel/index.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/index.vue
@@ -12,8 +12,10 @@ const props = defineProps(["canteenUrlComponent", "id", "étape"])
 const canteenId = props.canteenUrlComponent.split("--")[0] // more globalised way of doing this?
 
 const originalPayload = reactive({})
+let canteen = ref({})
 const dataIsReady = ref(!props.id)
 provide("originalPayload", originalPayload)
+provide("canteen", canteen)
 
 onMounted(() => {
   if (props.id) {
@@ -24,6 +26,7 @@ onMounted(() => {
         dataIsReady.value = true
       })
   }
+  store.fetchCanteen(canteenId).then((response) => (canteen.value = response))
 })
 
 let steps = ref([])


### PR DESCRIPTION
![Screenshot 2024-09-19 at 17-24-36 ma cantine](https://github.com/user-attachments/assets/77cbceca-5f40-4057-b884-e5d33b5e23c2)

les cuisines centrales sans site n'ont pas un nombre de couverts par jour, que par an. Dans ce cas je propose:

![Screenshot 2024-09-23 at 10-48-35 ma cantine](https://github.com/user-attachments/assets/54ee2353-b8ba-4003-be77-1452a398e10d)

il y a pas de calcul automatique pour ce cas