### PR TITLE
Bug fix : erreur de validation tunnel en prod (bump vue-i18n à v10)

### DIFF
--- a/2024-frontend/package-lock.json
+++ b/2024-frontend/package-lock.json
@@ -17,7 +17,7 @@
         "django-vite-plugin": "^4.0.2",
         "pinia": "^2.2.2",
         "vue": "^3.5.8",
-        "vue-i18n": "^9.13.1",
+        "vue-i18n": "^10.0.0",
         "vue-material-design-icons": "^5.3.0",
         "vue-router": "^4.4.3"
       },
@@ -940,12 +940,12 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.0.tgz",
-      "integrity": "sha512-zJn0imh9HIsZZUtt9v8T16PeVstPv6bP2YzlrYJwoF8F30gs4brZBwW2KK6EI5WYKFi3NeqX6+UU4gniz5TkGg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.3.tgz",
+      "integrity": "sha512-ysJnTGDtuXPa6R2Ii4JIvfMVvDahUUny3aY8+P4r6/0TYHkblgzIMjV6cAn60em67AB0M7OWNAdcAVfWWeN8Qg==",
       "dependencies": {
-        "@intlify/message-compiler": "9.14.0",
-        "@intlify/shared": "9.14.0"
+        "@intlify/message-compiler": "10.0.3",
+        "@intlify/shared": "10.0.3"
       },
       "engines": {
         "node": ">= 16"
@@ -955,11 +955,11 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.0.tgz",
-      "integrity": "sha512-sXNsoMI0YsipSXW8SR75drmVK56tnJHoYbPXUv2Cf9lz6FzvwsosFm6JtC1oQZI/kU+n7qx0qRrEWkeYFTgETA==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.3.tgz",
+      "integrity": "sha512-KC2fG8nCzSYmXjHptEt6i/xM3k6S2szsPaHDCRgWKEYAbeHe6JFm6X4KRw3Csy112A8CxpavMi1dh3h7khwV5w==",
       "dependencies": {
-        "@intlify/shared": "9.14.0",
+        "@intlify/shared": "10.0.3",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -970,9 +970,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.0.tgz",
-      "integrity": "sha512-r+N8KRQL7LgN1TMTs1A2svfuAU0J94Wu9wWdJVJqYsoMMLIeJxrPjazihfHpmJqfgZq0ah3Y9Q4pgWV2O90Fyg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.3.tgz",
+      "integrity": "sha512-PWxrCb6fDlnoGLnXLlWu6d7o/HdWACB9TjRnpLro+9uyfqgWA9hvqg5vekcPRyraTieV5srCbTk/ldYw9V3LHw==",
       "engines": {
         "node": ">= 16"
       },
@@ -6085,12 +6085,12 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.0.tgz",
-      "integrity": "sha512-LxmpRuCt2rI8gqU+kxeflRZMQn4D5+4M3oP3PWZdowW/ePJraHqhF7p4CuaME52mUxdw3Mmy2yAUKgfZYgCRjA==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.3.tgz",
+      "integrity": "sha512-8ul2S4Hy9orKs7eOlkw/zqnVu98GttUdyIMRyjoMpv6hFPxnybgBLdep/UCmdan5kUHyxqMnr2cGHTBuPBYJaw==",
       "dependencies": {
-        "@intlify/core-base": "9.14.0",
-        "@intlify/shared": "9.14.0",
+        "@intlify/core-base": "10.0.3",
+        "@intlify/shared": "10.0.3",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {
@@ -7090,27 +7090,27 @@
       "dev": true
     },
     "@intlify/core-base": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.0.tgz",
-      "integrity": "sha512-zJn0imh9HIsZZUtt9v8T16PeVstPv6bP2YzlrYJwoF8F30gs4brZBwW2KK6EI5WYKFi3NeqX6+UU4gniz5TkGg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.3.tgz",
+      "integrity": "sha512-ysJnTGDtuXPa6R2Ii4JIvfMVvDahUUny3aY8+P4r6/0TYHkblgzIMjV6cAn60em67AB0M7OWNAdcAVfWWeN8Qg==",
       "requires": {
-        "@intlify/message-compiler": "9.14.0",
-        "@intlify/shared": "9.14.0"
+        "@intlify/message-compiler": "10.0.3",
+        "@intlify/shared": "10.0.3"
       }
     },
     "@intlify/message-compiler": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.0.tgz",
-      "integrity": "sha512-sXNsoMI0YsipSXW8SR75drmVK56tnJHoYbPXUv2Cf9lz6FzvwsosFm6JtC1oQZI/kU+n7qx0qRrEWkeYFTgETA==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.3.tgz",
+      "integrity": "sha512-KC2fG8nCzSYmXjHptEt6i/xM3k6S2szsPaHDCRgWKEYAbeHe6JFm6X4KRw3Csy112A8CxpavMi1dh3h7khwV5w==",
       "requires": {
-        "@intlify/shared": "9.14.0",
+        "@intlify/shared": "10.0.3",
         "source-map-js": "^1.0.2"
       }
     },
     "@intlify/shared": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.0.tgz",
-      "integrity": "sha512-r+N8KRQL7LgN1TMTs1A2svfuAU0J94Wu9wWdJVJqYsoMMLIeJxrPjazihfHpmJqfgZq0ah3Y9Q4pgWV2O90Fyg=="
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.3.tgz",
+      "integrity": "sha512-PWxrCb6fDlnoGLnXLlWu6d7o/HdWACB9TjRnpLro+9uyfqgWA9hvqg5vekcPRyraTieV5srCbTk/ldYw9V3LHw=="
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -10729,12 +10729,12 @@
       }
     },
     "vue-i18n": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.0.tgz",
-      "integrity": "sha512-LxmpRuCt2rI8gqU+kxeflRZMQn4D5+4M3oP3PWZdowW/ePJraHqhF7p4CuaME52mUxdw3Mmy2yAUKgfZYgCRjA==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.3.tgz",
+      "integrity": "sha512-8ul2S4Hy9orKs7eOlkw/zqnVu98GttUdyIMRyjoMpv6hFPxnybgBLdep/UCmdan5kUHyxqMnr2cGHTBuPBYJaw==",
       "requires": {
-        "@intlify/core-base": "9.14.0",
-        "@intlify/shared": "9.14.0",
+        "@intlify/core-base": "10.0.3",
+        "@intlify/shared": "10.0.3",
         "@vue/devtools-api": "^6.5.0"
       }
     },

--- a/2024-frontend/package.json
+++ b/2024-frontend/package.json
@@ -20,7 +20,7 @@
     "django-vite-plugin": "^4.0.2",
     "pinia": "^2.2.2",
     "vue": "^3.5.8",
-    "vue-i18n": "^9.13.1",
+    "vue-i18n": "^10.0.0",
     "vue-material-design-icons": "^5.3.0",
     "vue-router": "^4.4.3"
   },


### PR DESCRIPTION
## Description du bug

Sur staging, si il y a une erreur de validation du formulaire, l'étape devient vide.

![Screenshot 2024-09-23 at 16-43-03 ma cantine](https://github.com/user-attachments/assets/cb397a93-3c2f-451b-8051-141ffea6b03f)

Dans le console, on voit le message (sur Firefox) `EvalError: call to Function() blocked by CSP`

Le problème vient de vue-i18n (j'ai confirmé ça en essayant le `test-build-with-vue3.sh` sur le commit juste avant le merge [de la PR](https://github.com/betagouv/ma-cantine/commit/71cc7c639511a5e42fa8315071f1dd2212adf8d4).)

Pour lire plus de l'issu, il y a [la discussion dans le repo i18n](https://github.com/intlify/vue-i18n/issues/1059)

J'ai vu que en [v10, sortie il y a deux semaines,](https://github.com/intlify/vue-i18n/releases/tag/v10.0.0) la configuration qu'ils suggèrent dans la discussion est ajoutée par défaut. Alors je préfère de MAJ la version plutôt que m'embrouiller avec la config.

Maintenant ça marche, c'est testable en suivant [les docs de local build dans ONBOARDING](https://github.com/betagouv/ma-cantine/blob/staging/docs/ONBOARDING.md#test-d%C3%A9ploiement-en-locale).