### PR TITLE
Bug fix, actions anti-gaspi : MAJ la vue liste quand on change de page

### DIFF
--- a/frontend/src/views/WasteActionsPage/WasteActionsListView.vue
+++ b/frontend/src/views/WasteActionsPage/WasteActionsListView.vue
@@ -37,7 +37,17 @@ export default {
   components: { DsfrTag },
   data() {
     return {
-      actionsDisplay: this.wasteActions.map((a) => {
+      listHeaders: [
+        { text: "Action", value: "title" },
+        { text: "Description courte", value: "subtitle" },
+        { text: "Taille", value: "effort", width: "15%" },
+        { text: "Source", value: "wasteOrigins", width: "20%" },
+      ],
+    }
+  },
+  computed: {
+    actionsDisplay() {
+      return this.wasteActions.map((a) => {
         return {
           id: a.id,
           title: a.title,
@@ -47,14 +57,8 @@ export default {
             Constants.WasteActionOrigins.find((item) => item.value === origin)
           ),
         }
-      }),
-      listHeaders: [
-        { text: "Action", value: "title" },
-        { text: "Description courte", value: "subtitle" },
-        { text: "Taille", value: "effort", width: "15%" },
-        { text: "Source", value: "wasteOrigins", width: "20%" },
-      ],
-    }
+      })
+    },
   },
 }
 </script>


### PR DESCRIPTION
Avant, le mapping pour avoir un `actionsDisplay` s'est fait en `data`, qui fait que c'est lancé une fois quand le composant est monté. Pour MAJ la liste quand le prop change, faut utiliser `computed`

![Screenshot 2024-09-23 at 18-15-36 ma cantine](https://github.com/user-attachments/assets/d7f57e83-93f4-477e-928c-e924debcde90)
