### PR TITLE
API: pouvoir créer (et modifier) une ResourceAction

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -52,3 +52,4 @@ from .communityevent import CommunityEventSerializer  # noqa: F401
 from .partner import PartnerSerializer, PartnerShortSerializer, PartnerContactSerializer  # noqa: F401
 from .videotutorial import VideoTutorialSerializer  # noqa: F401
 from .wasteaction import WasteActionSerializer  # noqa: F401
+from .resourceaction import ResourceActionSerializer  # noqa: F401

--- a/api/serializers/resourceaction.py
+++ b/api/serializers/resourceaction.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+
+from data.models import ResourceAction
+
+
+class ResourceActionSerializer(serializers.ModelSerializer):
+    canteen_id = serializers.IntegerField(required=True)
+
+    class Meta:
+        model = ResourceAction
+        fields = (
+            "canteen_id",
+            "is_done",
+            "is_not_interested",
+            "is_favorite",
+        )

--- a/api/serializers/resourceaction.py
+++ b/api/serializers/resourceaction.py
@@ -11,6 +11,4 @@ class ResourceActionSerializer(serializers.ModelSerializer):
         fields = (
             "canteen_id",
             "is_done",
-            "is_not_interested",
-            "is_favorite",
         )

--- a/api/tests/test_resource_actions.py
+++ b/api/tests/test_resource_actions.py
@@ -1,0 +1,42 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from data.factories import CanteenFactory, UserFactory, WasteActionFactory
+from data.models import ResourceAction
+
+
+class TestReviews(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.waste_action = WasteActionFactory()
+        cls.user = UserFactory()
+        cls.user_canteen = UserFactory()
+        cls.canteen = CanteenFactory()
+        cls.canteen.managers.add(cls.user_canteen)
+        cls.url = reverse("resource_action_create", kwargs={"resource_pk": cls.waste_action.id})
+
+    def test_create_resource_action(self):
+        # user is not authenticated
+        response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": True})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        # user does not belong to the canteen
+        self.client.force_login(user=self.user)
+        response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": True})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        # user is authenticated and belongs to the canteen, but canteen_id missing
+        self.client.force_login(user=self.user_canteen)
+        response = self.client.post(self.url, data={"is_done": True})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # user is authenticated and belongs to the canteen, but canteen_id is wrong
+        response = self.client.post(self.url, data={"canteen_id": 999, "is_done": True})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # user is authenticated and belongs to the canteen
+        self.client.force_login(user=self.user_canteen)
+        response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": True})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(ResourceAction.objects.count(), 1)
+        self.assertEqual(ResourceAction.objects.first().resource, self.waste_action)
+        self.assertEqual(ResourceAction.objects.first().user, self.user_canteen)
+        self.assertEqual(ResourceAction.objects.first().canteen, self.canteen)
+        self.assertEqual(ResourceAction.objects.first().is_done, True)

--- a/api/tests/test_resource_actions.py
+++ b/api/tests/test_resource_actions.py
@@ -37,6 +37,5 @@ class TestReviews(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(ResourceAction.objects.count(), 1)
         self.assertEqual(ResourceAction.objects.first().resource, self.waste_action)
-        self.assertEqual(ResourceAction.objects.first().user, self.user_canteen)
         self.assertEqual(ResourceAction.objects.first().canteen, self.canteen)
         self.assertEqual(ResourceAction.objects.first().is_done, True)

--- a/api/tests/test_resource_actions.py
+++ b/api/tests/test_resource_actions.py
@@ -16,9 +16,9 @@ class TestResourceActionsApi(APITestCase):
     def setUpTestData(cls):
         cls.waste_action = WasteActionFactory()
         cls.user = UserFactory()
-        cls.user_canteen = UserFactory()
+        cls.user_with_canteen = UserFactory()
         cls.canteen = CanteenFactory()
-        cls.canteen.managers.add(cls.user_canteen)
+        cls.canteen.managers.add(cls.user_with_canteen)
         cls.url = reverse("resource_action_create_or_update", kwargs={"resource_pk": cls.waste_action.id})
 
     def test_create_resource_action(self):
@@ -30,14 +30,14 @@ class TestResourceActionsApi(APITestCase):
         response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": True})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         # user is authenticated and belongs to the canteen, but canteen_id missing
-        self.client.force_login(user=self.user_canteen)
+        self.client.force_login(user=self.user_with_canteen)
         response = self.client.post(self.url, data={"is_done": True})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         # user is authenticated and belongs to the canteen, but canteen_id is wrong
         response = self.client.post(self.url, data={"canteen_id": 999, "is_done": True})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         # user is authenticated and belongs to the canteen
-        self.client.force_login(user=self.user_canteen)
+        self.client.force_login(user=self.user_with_canteen)
         response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": True})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(ResourceAction.objects.count(), 1)
@@ -49,7 +49,7 @@ class TestResourceActionsApi(APITestCase):
         # create an existing ResourceAction
         ResourceActionFactory(resource=self.waste_action, canteen=self.canteen, is_done=True)
         # user is authenticated and belongs to the canteen
-        self.client.force_login(user=self.user_canteen)
+        self.client.force_login(user=self.user_with_canteen)
         response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": False})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(ResourceAction.objects.count(), 1)

--- a/api/urls.py
+++ b/api/urls.py
@@ -256,7 +256,9 @@ urlpatterns = {
     path("territoryCanteens/", TerritoryCanteensListView.as_view(), name="territory_canteens"),
     path("wasteActions/", WasteActionsView.as_view(), name="waste_actions_list"),
     path("wasteActions/<int:pk>", WasteActionView.as_view(), name="waste_action_detail"),
-    path("wasteActions/<int:resource_pk>/actions", ResourceActionView.as_view(), name="resource_action_create"),
+    path(
+        "wasteActions/<int:resource_pk>/actions", ResourceActionView.as_view(), name="resource_action_create_or_update"
+    ),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/urls.py
+++ b/api/urls.py
@@ -47,6 +47,7 @@ from api.views import (
     PurchasesRestoreView,
     RemoveManagerView,
     ReservationExpeView,
+    ResourceActionView,
     RetrieveUpdateUserCanteenView,
     ReviewView,
     SatelliteListCreateView,
@@ -255,6 +256,7 @@ urlpatterns = {
     path("territoryCanteens/", TerritoryCanteensListView.as_view(), name="territory_canteens"),
     path("wasteActions/", WasteActionsView.as_view(), name="waste_actions_list"),
     path("wasteActions/<int:pk>", WasteActionView.as_view(), name="waste_action_detail"),
+    path("wasteActions/<int:resource_pk>/actions", ResourceActionView.as_view(), name="resource_action_create"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -57,6 +57,7 @@ from .purchase import (  # noqa: F401
 )
 from .purchaseimport import ImportPurchasesView  # noqa: F401
 from .reservationexpe import ReservationExpeView  # noqa: F401
+from .resourceaction import ResourceActionView  # noqa: F401
 from .review import ReviewView  # noqa: F401
 from .sector import SectorListView  # noqa: F401
 from .subscription import SubscribeNewsletter  # noqa: F401

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -522,7 +522,7 @@ class PublishCanteenView(APIView):
             return JsonResponse(camelize(serialized_canteen), status=status.HTTP_200_OK)
 
         except Canteen.DoesNotExist:
-            raise ValidationError("Le cantine specifié n'existe pas")
+            raise ValidationError("La cantine spécifiée n'existe pas")
 
 
 class UnpublishCanteenView(APIView):
@@ -551,7 +551,7 @@ class UnpublishCanteenView(APIView):
             return JsonResponse(camelize(serialized_canteen), status=status.HTTP_200_OK)
 
         except Canteen.DoesNotExist:
-            raise ValidationError("Le cantine specifié n'existe pas")
+            raise ValidationError("La cantine spécifiée n'existe pas")
 
 
 def _respond_with_team(canteen):

--- a/api/views/resourceaction.py
+++ b/api/views/resourceaction.py
@@ -16,12 +16,11 @@ class ResourceActionView(CreateAPIView):
 
     def perform_create(self, serializer):
         resource = get_object_or_404(WasteAction, pk=self.request.parser_context.get("kwargs").get("resource_pk"))
-        user = self.request.user
         canteen_id = self.request.data.get("canteen_id")
         try:
             canteen = Canteen.objects.get(pk=canteen_id)
         except Canteen.DoesNotExist:
-            raise ValidationError({"canteen_id": "Le cantine specifié n'existe pas"})
+            raise ValidationError({"canteen_id": "La cantine spécifiée n'existe pas"})
         if not IsCanteenManager().has_object_permission(self.request, self, canteen):
             raise PermissionDenied()
-        serializer.save(resource=resource, canteen=canteen, user=user)
+        serializer.save(resource=resource, canteen=canteen)

--- a/api/views/resourceaction.py
+++ b/api/views/resourceaction.py
@@ -1,7 +1,8 @@
 from django.core.exceptions import ValidationError
-from rest_framework import permissions
+from rest_framework import permissions, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import CreateAPIView, get_object_or_404
+from rest_framework.response import Response
 
 from api.permissions import IsCanteenManager
 from api.serializers import ResourceActionSerializer
@@ -14,13 +15,25 @@ class ResourceActionView(CreateAPIView):
     queryset = ResourceAction.objects.all()
     serializer_class = ResourceActionSerializer
 
-    def perform_create(self, serializer):
-        resource = get_object_or_404(WasteAction, pk=self.request.parser_context.get("kwargs").get("resource_pk"))
-        canteen_id = self.request.data.get("canteen_id")
+    def create(self, request, *args, **kwargs):
+        # get resource
+        self.resource = get_object_or_404(WasteAction, pk=kwargs.get("resource_pk"))
+        # get canteen and check permissions
+        canteen_id = request.data.get("canteen_id")
         try:
-            canteen = Canteen.objects.get(pk=canteen_id)
+            self.canteen = Canteen.objects.get(pk=canteen_id)
         except Canteen.DoesNotExist:
             raise ValidationError({"canteen_id": "La cantine spécifiée n'existe pas"})
-        if not IsCanteenManager().has_object_permission(self.request, self, canteen):
+        if not IsCanteenManager().has_object_permission(request, self, self.canteen):
             raise PermissionDenied()
-        serializer.save(resource=resource, canteen=canteen)
+        # update or create resource action
+        try:
+            resource_action = ResourceAction.objects.get(resource=self.resource, canteen=self.canteen)
+            serializer = self.get_serializer(resource_action)
+            serializer.update(resource_action, request.data)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except ResourceAction.DoesNotExist:
+            return super().create(request, *args, **kwargs)
+
+    def perform_create(self, serializer):
+        serializer.save(resource=self.resource)

--- a/api/views/resourceaction.py
+++ b/api/views/resourceaction.py
@@ -1,0 +1,27 @@
+from django.core.exceptions import ValidationError
+from rest_framework import permissions
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.generics import CreateAPIView, get_object_or_404
+
+from api.permissions import IsCanteenManager
+from api.serializers import ResourceActionSerializer
+from data.models import Canteen, ResourceAction, WasteAction
+
+
+class ResourceActionView(CreateAPIView):
+    permission_classes = [permissions.IsAuthenticated]
+    model = ResourceAction
+    queryset = ResourceAction.objects.all()
+    serializer_class = ResourceActionSerializer
+
+    def perform_create(self, serializer):
+        resource = get_object_or_404(WasteAction, pk=self.request.parser_context.get("kwargs").get("resource_pk"))
+        user = self.request.user
+        canteen_id = self.request.data.get("canteen_id")
+        try:
+            canteen = Canteen.objects.get(pk=canteen_id)
+        except Canteen.DoesNotExist:
+            raise ValidationError({"canteen_id": "Le cantine specifié n'existe pas"})
+        if not IsCanteenManager().has_object_permission(self.request, self, canteen):
+            raise PermissionDenied()
+        serializer.save(resource=resource, canteen=canteen, user=user)


### PR DESCRIPTION
### Quoi ?

Suite de #4497

Nouvel endpoint `/wasteActions/<int:resource_pk>/actions` pour pouvoir créer un ResourceAction.
- il faut que l'utilisateur soit authentifié
- il faut qu'un canteen_id soit fourni, que la Canteen existe, et que le User fasse parti de cette cantine
- l'endpoint gère à la fois le create et l'update (renvoi un 201 si create ; un 200 si update)