### PR TITLE
Ajouter lien vers actions anti-gaspi dans l'en-tête

### DIFF
--- a/2024-frontend/src/components/AppHeader.vue
+++ b/2024-frontend/src/components/AppHeader.vue
@@ -46,6 +46,10 @@ const navItems = [
         to: { name: "PartnersHome" },
       },
       {
+        text: "Actions anti-gaspi",
+        to: { name: "WasteActionsHome" },
+      },
+      {
         text: "Générer mon affiche",
         to: { name: "GeneratePosterPage" },
       },

--- a/frontend/src/components/AppHeader/index.vue
+++ b/frontend/src/components/AppHeader/index.vue
@@ -235,6 +235,10 @@ export default {
               to: { name: "PartnersHome" },
             },
             {
+              text: "Actions anti-gaspi",
+              to: { name: "WasteActionsHome" },
+            },
+            {
               text: "Générer mon affiche",
               to: { name: "GeneratePosterPage" },
             },


### PR DESCRIPTION
à merger que après la finalisation de la migration actions demo -> prod

![Screenshot 2024-09-30 at 10-24-01 ma cantine](https://github.com/user-attachments/assets/c132fe83-e4be-4151-9477-7ccdfee5b772)
