### PR TITLE
API: Stats cantines: supprimer le published count

### DIFF
--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -112,7 +112,6 @@ class TestCanteenStatsApi(APITestCase):
 
         body = response.json()
         self.assertEqual(body["canteenCount"], 3)
-        self.assertEqual(body["publishedCanteenCount"], 2)
         self.assertEqual(body["diagnosticsCount"], 2)
         self.assertEqual(body["bioPercent"], 30)
         self.assertEqual(body["sustainablePercent"], 40)
@@ -152,7 +151,6 @@ class TestCanteenStatsApi(APITestCase):
 
         body = response.json()
         self.assertEqual(body["canteenCount"], 2)
-        self.assertEqual(body["publishedCanteenCount"], 1)
 
     def test_canteen_stats_by_departments(self):
         department = "01"
@@ -548,4 +546,3 @@ class TestCanteenStatsApi(APITestCase):
 
         body = response.json()
         self.assertEqual(body["canteenCount"], 3)
-        self.assertEqual(body["publishedCanteenCount"], 2)

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -878,7 +878,6 @@ class CanteenStatisticsView(APIView):
 
         canteens = CanteenStatisticsView._filter_canteens(regions, departments, city_insee_codes, sector_categories)
         data["canteen_count"] = canteens.count()
-        data["published_canteen_count"] = canteens.publicly_visible().count()
 
         diagnostics = CanteenStatisticsView._filter_diagnostics(
             year, regions, departments, city_insee_codes, sector_categories


### PR DESCRIPTION
### Quoi ?

Suite de #4536, en lien avec #4367
On n'a plus besoin de published_canteen_count
- supprimé de la réponse API
- ajouté des tests sur les queryset visible/hidden
