### PR TITLE
API: Récupérer les WasteActions avec leur ResourceActions (si l'utilisateur est authentifié, filtré sur ses cantines)

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -52,4 +52,4 @@ from .communityevent import CommunityEventSerializer  # noqa: F401
 from .partner import PartnerSerializer, PartnerShortSerializer, PartnerContactSerializer  # noqa: F401
 from .videotutorial import VideoTutorialSerializer  # noqa: F401
 from .wasteaction import WasteActionSerializer, WasteActionWithActionsSerializer  # noqa: F401
-from .resourceaction import ResourceActionSerializer, ResourceActionWithCanteenSerializer  # noqa: F401
+from .resourceaction import ResourceActionSerializer, ResourceActionFullSerializer  # noqa: F401

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -51,5 +51,5 @@ from .review import ReviewSerializer  # noqa: F401
 from .communityevent import CommunityEventSerializer  # noqa: F401
 from .partner import PartnerSerializer, PartnerShortSerializer, PartnerContactSerializer  # noqa: F401
 from .videotutorial import VideoTutorialSerializer  # noqa: F401
-from .wasteaction import WasteActionSerializer  # noqa: F401
-from .resourceaction import ResourceActionSerializer  # noqa: F401
+from .wasteaction import WasteActionSerializer, WasteActionWithActionsSerializer  # noqa: F401
+from .resourceaction import ResourceActionSerializer, ResourceActionWithCanteenSerializer  # noqa: F401

--- a/api/serializers/resourceaction.py
+++ b/api/serializers/resourceaction.py
@@ -1,22 +1,38 @@
 from rest_framework import serializers
 
-from api.serializers.canteen import MinimalCanteenSerializer
 from data.models import ResourceAction
 
 
 class ResourceActionSerializer(serializers.ModelSerializer):
+    resource_id = serializers.IntegerField(read_only=True)
     canteen_id = serializers.IntegerField(required=True)
 
     class Meta:
         model = ResourceAction
         fields = (
+            # "id",
+            "resource_id",
             "canteen_id",
             "is_done",
         )
 
 
-class ResourceActionWithCanteenSerializer(ResourceActionSerializer):
-    canteen = MinimalCanteenSerializer(read_only=True)
+class ResourceActionFullSerializer(ResourceActionSerializer):
+    resource = serializers.SerializerMethodField(read_only=True)
+    canteen = serializers.SerializerMethodField(read_only=True)
 
     class Meta(ResourceActionSerializer.Meta):
-        fields = ResourceActionSerializer.Meta.fields + ("canteen",)
+        fields = ResourceActionSerializer.Meta.fields + (
+            "resource",
+            "canteen",
+        )
+
+    def get_resource(self, obj):
+        from .wasteaction import WasteActionSerializer
+
+        return WasteActionSerializer(obj.resource).data
+
+    def get_canteen(self, obj):
+        from .canteen import MinimalCanteenSerializer
+
+        return MinimalCanteenSerializer(obj.canteen).data

--- a/api/serializers/resourceaction.py
+++ b/api/serializers/resourceaction.py
@@ -10,7 +10,6 @@ class ResourceActionSerializer(serializers.ModelSerializer):
     class Meta:
         model = ResourceAction
         fields = (
-            # "id",
             "resource_id",
             "canteen_id",
             "is_done",

--- a/api/serializers/resourceaction.py
+++ b/api/serializers/resourceaction.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from api.serializers.canteen import MinimalCanteenSerializer
 from data.models import ResourceAction
 
 
@@ -12,3 +13,16 @@ class ResourceActionSerializer(serializers.ModelSerializer):
             "canteen_id",
             "is_done",
         )
+
+
+class ResourceActionWithCanteenSerializer(ResourceActionSerializer):
+    canteen = MinimalCanteenSerializer(read_only=True)
+
+    class Meta(ResourceActionSerializer.Meta):
+        fields = ResourceActionSerializer.Meta.fields + ("canteen",)
+
+    def get_queryset(self):
+        user = self.context["request"].user
+        if user:
+            return self.filter(canteen__in=user.canteens.all())
+        return self.none()

--- a/api/serializers/resourceaction.py
+++ b/api/serializers/resourceaction.py
@@ -20,9 +20,3 @@ class ResourceActionWithCanteenSerializer(ResourceActionSerializer):
 
     class Meta(ResourceActionSerializer.Meta):
         fields = ResourceActionSerializer.Meta.fields + ("canteen",)
-
-    def get_queryset(self):
-        user = self.context["request"].user
-        if user:
-            return self.filter(canteen__in=user.canteens.all())
-        return self.none()

--- a/api/serializers/wasteaction.py
+++ b/api/serializers/wasteaction.py
@@ -46,6 +46,6 @@ class WasteActionWithActionsSerializer(WasteActionSerializer):
         actions = ResourceAction.objects.none()
         user = self.context["request"].user
         if user.is_authenticated:
-            actions = ResourceAction.objects.filter(resource=obj).for_user(user)
+            actions = ResourceAction.objects.filter(resource=obj).for_user_canteens(user)
         serializer = ResourceActionWithCanteenSerializer(instance=actions, many=True)
         return serializer.data

--- a/api/serializers/wasteaction.py
+++ b/api/serializers/wasteaction.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from rest_framework.fields import Field
 
-from api.serializers.resourceaction import ResourceActionWithCanteenSerializer
+from api.serializers.resourceaction import ResourceActionFullSerializer
 from data.models import ResourceAction, WasteAction
 
 
@@ -47,5 +47,5 @@ class WasteActionWithActionsSerializer(WasteActionSerializer):
         user = self.context["request"].user
         if user.is_authenticated:
             actions = ResourceAction.objects.filter(resource=obj).for_user_canteens(user)
-        serializer = ResourceActionWithCanteenSerializer(instance=actions, many=True)
+        serializer = ResourceActionFullSerializer(instance=actions, many=True)
         return serializer.data

--- a/api/serializers/wasteaction.py
+++ b/api/serializers/wasteaction.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from rest_framework.fields import Field
 
 from api.serializers.resourceaction import ResourceActionWithCanteenSerializer
-from data.models import WasteAction
+from data.models import ResourceAction, WasteAction
 
 
 class WagtailImageSerializedField(Field):
@@ -40,3 +40,11 @@ class WasteActionWithActionsSerializer(WasteActionSerializer):
 
     class Meta(WasteActionSerializer.Meta):
         fields = WasteActionSerializer.Meta.fields + ("actions",)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        user = kwargs.pop("user", None)
+        if user:
+            self.fields["actions"].queryset = ResourceAction.objects.for_user(user)
+        else:
+            self.fields["actions"].queryset = ResourceAction.objects.none()

--- a/api/serializers/wasteaction.py
+++ b/api/serializers/wasteaction.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from rest_framework.fields import Field
 
+from api.serializers.resourceaction import ResourceActionWithCanteenSerializer
 from data.models import WasteAction
 
 
@@ -32,3 +33,10 @@ class WasteActionSerializer(serializers.ModelSerializer):
             "waste_origins",
             "lead_image",
         )
+
+
+class WasteActionWithActionsSerializer(WasteActionSerializer):
+    actions = ResourceActionWithCanteenSerializer(many=True, read_only=True)
+
+    class Meta(WasteActionSerializer.Meta):
+        fields = WasteActionSerializer.Meta.fields + ("actions",)

--- a/api/tests/test_resource_actions.py
+++ b/api/tests/test_resource_actions.py
@@ -40,10 +40,13 @@ class TestResourceActionsApi(APITestCase):
         self.client.force_login(user=self.user_with_canteen)
         response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": True})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["resource_id"], self.waste_action.id)
+        self.assertEqual(response.data["canteen_id"], self.canteen.id)
+        self.assertTrue(response.data["is_done"])
         self.assertEqual(ResourceAction.objects.count(), 1)
         self.assertEqual(ResourceAction.objects.first().resource, self.waste_action)
         self.assertEqual(ResourceAction.objects.first().canteen, self.canteen)
-        self.assertEqual(ResourceAction.objects.first().is_done, True)
+        self.assertTrue(ResourceAction.objects.first().is_done)
 
     def test_update_resource_action(self):
         # create an existing ResourceAction
@@ -55,4 +58,4 @@ class TestResourceActionsApi(APITestCase):
         self.assertEqual(ResourceAction.objects.count(), 1)
         self.assertEqual(ResourceAction.objects.first().resource, self.waste_action)
         self.assertEqual(ResourceAction.objects.first().canteen, self.canteen)
-        self.assertEqual(ResourceAction.objects.first().is_done, False)
+        self.assertFalse(ResourceAction.objects.first().is_done)

--- a/api/tests/test_waste_actions.py
+++ b/api/tests/test_waste_actions.py
@@ -64,8 +64,8 @@ class TestWasteActionsDetailApi(APITestCase):
         cls.user = UserFactory()
         cls.user_with_canteen = UserFactory()
         CanteenFactory()
-        cls.canteen = CanteenFactory()
-        cls.canteen.managers.add(cls.user_with_canteen)
+        cls.canteen = CanteenFactory(managers=[cls.user_with_canteen])
+        # cls.canteen.managers.add(cls.user_with_canteen)
         cls.resource_action = ResourceActionFactory.create(
             resource=cls.waste_action, canteen=cls.canteen, is_done=True
         )

--- a/api/tests/test_waste_actions.py
+++ b/api/tests/test_waste_actions.py
@@ -65,7 +65,6 @@ class TestWasteActionsDetailApi(APITestCase):
         cls.user_with_canteen = UserFactory()
         CanteenFactory()
         cls.canteen = CanteenFactory(managers=[cls.user_with_canteen])
-        # cls.canteen.managers.add(cls.user_with_canteen)
         cls.resource_action = ResourceActionFactory.create(
             resource=cls.waste_action, canteen=cls.canteen, is_done=True
         )

--- a/api/tests/test_waste_actions.py
+++ b/api/tests/test_waste_actions.py
@@ -1,11 +1,16 @@
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
-from data.factories import WasteActionFactory
+from data.factories import (
+    CanteenFactory,
+    ResourceActionFactory,
+    UserFactory,
+    WasteActionFactory,
+)
 from data.models import WasteAction
 
 
-class TestWasteActionsApi(APITestCase):
+class TestWasteActionsListApi(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.waste_action = WasteActionFactory.create()
@@ -15,13 +20,8 @@ class TestWasteActionsApi(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data["results"]), 1)
 
-    def test_get_waste_action_detail(self):
-        response = self.client.get(reverse("waste_action_detail", kwargs={"pk": self.waste_action.id}))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["id"], self.waste_action.id)
 
-
-class TestWasteActionsFiltersApi(APITestCase):
+class TestWasteActionsListFiltersApi(APITestCase):
     def test_effort_filter(self):
         WasteActionFactory.create(effort=WasteAction.Effort.LARGE)
         WasteActionFactory.create(effort=WasteAction.Effort.MEDIUM)
@@ -55,3 +55,41 @@ class TestWasteActionsFiltersApi(APITestCase):
         response = self.client.get(f"{reverse('waste_actions_list')}?search=evaluation")
         results = response.data["results"]
         self.assertEqual(len(results), 2)
+
+
+class TestWasteActionsDetailApi(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.waste_action = WasteActionFactory.create()
+        cls.user = UserFactory()
+        cls.user_canteen = UserFactory()
+        cls.canteen = CanteenFactory()
+        cls.canteen = CanteenFactory()
+        cls.canteen.managers.add(cls.user_canteen)
+        cls.resource_action = ResourceActionFactory.create(
+            resource=cls.waste_action, canteen=cls.canteen, is_done=True
+        )
+
+    def test_get_waste_action_detail(self):
+        # anonymous
+        response = self.client.get(reverse("waste_action_detail", kwargs={"pk": self.waste_action.id}))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["id"], self.waste_action.id)
+        self.assertTrue("actions" not in response.data)
+        # logged in user (without canteen)
+        self.client.force_login(user=self.user)
+        response = self.client.get(reverse("waste_action_detail", kwargs={"pk": self.waste_action.id}))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["id"], self.waste_action.id)
+        self.assertTrue("actions" in response.data)
+        # logged in user with canteen & resource action
+        self.client.force_login(user=self.user_canteen)
+        response = self.client.get(reverse("waste_action_detail", kwargs={"pk": self.waste_action.id}))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["id"], self.waste_action.id)
+        self.assertTrue("actions" in response.data)
+        self.assertEqual(len(response.data["actions"]), 1)
+        self.assertEqual(response.data["actions"][0]["canteen_id"], self.canteen.id)
+        self.assertEqual(response.data["actions"][0]["canteen"]["id"], self.canteen.id)
+        self.assertEqual(response.data["actions"][0]["canteen"]["name"], self.canteen.name)
+        self.assertTrue(response.data["actions"][0]["is_done"])

--- a/api/tests/test_waste_actions.py
+++ b/api/tests/test_waste_actions.py
@@ -62,10 +62,10 @@ class TestWasteActionsDetailApi(APITestCase):
     def setUpTestData(cls):
         cls.waste_action = WasteActionFactory.create()
         cls.user = UserFactory()
-        cls.user_canteen = UserFactory()
+        cls.user_with_canteen = UserFactory()
+        CanteenFactory()
         cls.canteen = CanteenFactory()
-        cls.canteen = CanteenFactory()
-        cls.canteen.managers.add(cls.user_canteen)
+        cls.canteen.managers.add(cls.user_with_canteen)
         cls.resource_action = ResourceActionFactory.create(
             resource=cls.waste_action, canteen=cls.canteen, is_done=True
         )
@@ -82,8 +82,9 @@ class TestWasteActionsDetailApi(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["id"], self.waste_action.id)
         self.assertTrue("actions" in response.data)
+        self.assertEqual(len(response.data["actions"]), 0)
         # logged in user with canteen & resource action
-        self.client.force_login(user=self.user_canteen)
+        self.client.force_login(user=self.user_with_canteen)
         response = self.client.get(reverse("waste_action_detail", kwargs={"pk": self.waste_action.id}))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["id"], self.waste_action.id)

--- a/api/views/wasteaction.py
+++ b/api/views/wasteaction.py
@@ -40,7 +40,9 @@ class WasteActionView(RetrieveAPIView):
     queryset = WasteAction.objects.all()
     serializer_class = WasteActionSerializer
 
-    def get_serializer_class(self):
+    def get_serializer(self, *args, **kwargs):
         if self.request.user.is_authenticated:
-            return WasteActionWithActionsSerializer
-        return super().get_serializer_class()
+            kwargs["context"] = self.get_serializer_context()
+            kwargs["context"]["user"] = self.request.user
+            return WasteActionWithActionsSerializer(*args, **kwargs)
+        return super().get_serializer(*args, **kwargs)

--- a/api/views/wasteaction.py
+++ b/api/views/wasteaction.py
@@ -2,7 +2,7 @@ from django_filters import rest_framework as django_filters
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.pagination import LimitOffsetPagination
 
-from api.serializers import WasteActionSerializer
+from api.serializers import WasteActionSerializer, WasteActionWithActionsSerializer
 from data.models import WasteAction
 
 from .utils import UnaccentSearchFilter
@@ -39,3 +39,8 @@ class WasteActionView(RetrieveAPIView):
     model = WasteAction
     queryset = WasteAction.objects.all()
     serializer_class = WasteActionSerializer
+
+    def get_serializer_class(self):
+        if self.request.user.is_authenticated:
+            return WasteActionWithActionsSerializer
+        return super().get_serializer_class()

--- a/api/views/wasteaction.py
+++ b/api/views/wasteaction.py
@@ -41,8 +41,7 @@ class WasteActionView(RetrieveAPIView):
     serializer_class = WasteActionSerializer
 
     def get_serializer(self, *args, **kwargs):
+        kwargs.setdefault("context", self.get_serializer_context())
         if self.request.user.is_authenticated:
-            kwargs["context"] = self.get_serializer_context()
-            kwargs["context"]["user"] = self.request.user
             return WasteActionWithActionsSerializer(*args, **kwargs)
         return super().get_serializer(*args, **kwargs)

--- a/data/models/resourceaction.py
+++ b/data/models/resourceaction.py
@@ -5,11 +5,18 @@ from .canteen import Canteen
 from .wasteaction import WasteAction
 
 
+class ResourceActionQuerySet(models.QuerySet):
+    def for_user(self, user):
+        return self.filter(canteen__in=user.canteens.all())
+
+
 class ResourceAction(models.Model):
     class Meta:
         unique_together = ("resource", "canteen")
         verbose_name = "ressource : action (cantine)"
         verbose_name_plural = "ressources : actions (cantines)"
+
+    objects = models.Manager.from_queryset(ResourceActionQuerySet)()
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)

--- a/data/models/resourceaction.py
+++ b/data/models/resourceaction.py
@@ -6,7 +6,7 @@ from .wasteaction import WasteAction
 
 
 class ResourceActionQuerySet(models.QuerySet):
-    def for_user(self, user):
+    def for_user_canteens(self, user):
         return self.filter(canteen__in=user.canteens.all())
 
 

--- a/data/tests/test_resource_action.py
+++ b/data/tests/test_resource_action.py
@@ -16,24 +16,22 @@ class ResourceActionQuerySetTest(TestCase):
         cls.user = UserFactory()
         cls.user_with_canteen = UserFactory()
         cls.canteen = CanteenFactory()
-        cls.canteen_with_manager = CanteenFactory()
-        cls.canteen_with_manager.managers.add(cls.user_with_canteen)
+        cls.canteen_with_manager = CanteenFactory(managers=[cls.user_with_canteen])
         cls.waste_action = WasteActionFactory()
         ResourceActionFactory(resource=cls.waste_action, canteen=cls.canteen, is_done=True)
         ResourceActionFactory(resource=cls.waste_action, canteen=cls.canteen_with_manager, is_done=True)
 
-    def test_for_user(self):
+    def test_for_user_canteens(self):
         self.assertEqual(ResourceAction.objects.count(), 2)
-        self.assertEqual(ResourceAction.objects.for_user(self.user).count(), 0)
-        self.assertEqual(ResourceAction.objects.for_user(self.user_with_canteen).count(), 1)
+        self.assertEqual(ResourceAction.objects.for_user_canteens(self.user).count(), 0)
+        self.assertEqual(ResourceAction.objects.for_user_canteens(self.user_with_canteen).count(), 1)
 
 
 class ResourceActionModelSaveTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
-        cls.canteen = CanteenFactory()
-        cls.canteen.managers.add(cls.user)
+        cls.canteen = CanteenFactory(managers=[cls.user])
         cls.waste_action = WasteActionFactory()
 
     def test_resource_action_validation(self):

--- a/data/tests/test_resource_action.py
+++ b/data/tests/test_resource_action.py
@@ -7,15 +7,34 @@ from data.factories import (
     UserFactory,
     WasteActionFactory,
 )
+from data.models import ResourceAction
+
+
+class ResourceActionQuerySetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.user_with_canteen = UserFactory()
+        cls.canteen = CanteenFactory()
+        cls.canteen_with_manager = CanteenFactory()
+        cls.canteen_with_manager.managers.add(cls.user_with_canteen)
+        cls.waste_action = WasteActionFactory()
+        ResourceActionFactory(resource=cls.waste_action, canteen=cls.canteen, is_done=True)
+        ResourceActionFactory(resource=cls.waste_action, canteen=cls.canteen_with_manager, is_done=True)
+
+    def test_for_user(self):
+        self.assertEqual(ResourceAction.objects.count(), 2)
+        self.assertEqual(ResourceAction.objects.for_user(self.user).count(), 0)
+        self.assertEqual(ResourceAction.objects.for_user(self.user_with_canteen).count(), 1)
 
 
 class ResourceActionModelSaveTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.waste_action = WasteActionFactory()
         cls.user = UserFactory()
         cls.canteen = CanteenFactory()
         cls.canteen.managers.add(cls.user)
+        cls.waste_action = WasteActionFactory()
 
     def test_resource_action_validation(self):
         # NOT OK: missing required field


### PR DESCRIPTION
### Quoi ?

Suite de #4500
On améliore l'endpoint API existant `wasteActions/<int:pk>`, en rajoutant un champ `actions` si l'utilisateur est connecté.
Ce champ contient une liste des ResourceAction existantes pour les cantines auxquelles l'utilisateur appartient.

Pour cela 
- on créé 2 nouveaux serializers : WasteActionWithActionsSerializer & ResourceActionWithCanteenSerializer
- on a besoin de passer le user au serializer pour changer la queryset dynamiquement
- nouveau Model queryset `ResourceAction.for_user_canteens(user)` pour simplifier un peu