### PR TITLE
Actions anti-gaspi : pouvoir indiquer que sa/ses cantines ont mis en place cette action

### DIFF
--- a/frontend/src/components/ResourceActionDialog.vue
+++ b/frontend/src/components/ResourceActionDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="isOpen" id="resource-action-dialog">
+  <v-dialog v-model="isOpen" id="resource-action-dialog" width="500">
     <v-card class="pa-6">
       <div class="mt-n6 mx-n6 mb-4 pa-4 d-flex" style="background-color: #F5F5F5">
         <v-spacer></v-spacer>
@@ -51,9 +51,10 @@ export default {
       type: Array,
       required: true,
     },
-    actionsDone: {
+    actionCanteensDone: {
       type: Array,
       required: true,
+      example: [{ id: 1, name: "Cantine 1" }],
     },
   },
   data() {
@@ -62,9 +63,9 @@ export default {
     }
   },
   mounted() {
-    // Get the canteens that have already done the action
+    // Pre-select the canteens that have already done the action
     this.chosenCanteenIds = this.userCanteens
-      .filter((canteen) => this.actionsDone.find((actionCanteen) => actionCanteen.id === canteen.id))
+      .filter((canteen) => this.actionCanteensDone.find((actionCanteen) => actionCanteen.id === canteen.id))
       .map((canteen) => canteen.id)
   },
   computed: {
@@ -90,11 +91,11 @@ export default {
       const actionChanges = []
       // Compare the chosen canteens with the actions done (new & removed)
       this.chosenCanteenIds.forEach((canteenId) => {
-        if (!this.actionsDone.find((actionCanteen) => actionCanteen.id === canteenId)) {
+        if (!this.actionCanteensDone.find((actionCanteen) => actionCanteen.id === canteenId)) {
           actionChanges.push(this.createOrUpdateResourceAction(canteenId, true))
         }
       })
-      this.actionsDone.forEach((actionCanteen) => {
+      this.actionCanteensDone.forEach((actionCanteen) => {
         if (!this.chosenCanteenIds.includes(actionCanteen.id)) {
           actionChanges.push(this.createOrUpdateResourceAction(actionCanteen.id, false))
         }

--- a/frontend/src/components/ResourceActionDialog.vue
+++ b/frontend/src/components/ResourceActionDialog.vue
@@ -4,11 +4,11 @@
       <div class="mt-n6 mx-n6 mb-4 pa-4 d-flex" style="background-color: #F5F5F5">
         <v-spacer></v-spacer>
         <v-btn outlined color="primary" @click="$emit('close')">
-          Fermer
+          Annuler
         </v-btn>
       </div>
 
-      <h2 id="modal-title" class="mb-3" tabindex="-1">Mis en place ?</h2>
+      <h2 class="mb-3">Mis en place ?</h2>
 
       <v-form ref="form" @submit.prevent>
         <DsfrAutocomplete
@@ -18,7 +18,7 @@
           multiple
           hide-details
           id="select-canteen"
-          placeholder="Toutes mes cantines"
+          placeholder="Choissisez les établissements"
           class="mt-1"
           no-data-text="Pas de résultats"
           item-text="name"
@@ -54,7 +54,7 @@ export default {
     actionCanteensDone: {
       type: Array,
       required: true,
-      example: [{ id: 1, name: "Cantine 1" }],
+      // example: [{ id: 1, name: "Cantine 1" }],
     },
   },
   data() {
@@ -79,11 +79,11 @@ export default {
     },
   },
   methods: {
-    createOrUpdateResourceAction(canteenId, is_done = true) {
+    createOrUpdateResourceAction(canteenId, isDone) {
       return this.$store
         .dispatch("createOrUpdateResourceAction", {
           resourceId: this.resourceId,
-          payload: { canteenId, is_done },
+          payload: { canteenId, isDone },
         })
         .catch((e) => this.$store.dispatch("notifyServerError", e))
     },

--- a/frontend/src/components/ResourceActionDialog.vue
+++ b/frontend/src/components/ResourceActionDialog.vue
@@ -1,0 +1,113 @@
+<template>
+  <v-dialog v-model="isOpen" id="resource-action-dialog">
+    <v-card class="pa-6">
+      <div class="mt-n6 mx-n6 mb-4 pa-4 d-flex" style="background-color: #F5F5F5">
+        <v-spacer></v-spacer>
+        <v-btn outlined color="primary" @click="$emit('close')">
+          Fermer
+        </v-btn>
+      </div>
+
+      <h2 id="modal-title" class="mb-3" tabindex="-1">Mis en place ?</h2>
+
+      <v-form ref="form" @submit.prevent>
+        <DsfrAutocomplete
+          v-model="chosenCanteenIds"
+          :items="userCanteens"
+          clearable
+          multiple
+          hide-details
+          id="select-canteen"
+          placeholder="Toutes mes cantines"
+          class="mt-1"
+          no-data-text="Pas de résultats"
+          item-text="name"
+          item-value="id"
+        />
+        <v-row class="mt-2 pa-4">
+          <v-spacer></v-spacer>
+          <v-btn x-large color="primary" @click="saveActionChanges">Valider</v-btn>
+        </v-row>
+      </v-form>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import DsfrAutocomplete from "@/components/DsfrAutocomplete"
+
+export default {
+  name: "ResourceActionDialog",
+  components: { DsfrAutocomplete },
+  props: {
+    value: {
+      type: Boolean,
+      required: true,
+    },
+    resourceId: {
+      required: true,
+    },
+    userCanteens: {
+      type: Array,
+      required: true,
+    },
+    actionsDone: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      chosenCanteenIds: [],
+    }
+  },
+  mounted() {
+    // Get the canteens that have already done the action
+    this.chosenCanteenIds = this.userCanteens
+      .filter((canteen) => this.actionsDone.find((actionCanteen) => actionCanteen.id === canteen.id))
+      .map((canteen) => canteen.id)
+  },
+  computed: {
+    isOpen: {
+      get() {
+        return this.value
+      },
+      set(newValue) {
+        this.$emit("input", newValue)
+      },
+    },
+  },
+  methods: {
+    createOrUpdateResourceAction(canteenId, is_done = true) {
+      return this.$store
+        .dispatch("createOrUpdateResourceAction", {
+          resourceId: this.resourceId,
+          payload: { canteenId, is_done },
+        })
+        .catch((e) => this.$store.dispatch("notifyServerError", e))
+    },
+    saveActionChanges() {
+      const actionChanges = []
+      // Compare the chosen canteens with the actions done (new & removed)
+      this.chosenCanteenIds.forEach((canteenId) => {
+        if (!this.actionsDone.find((actionCanteen) => actionCanteen.id === canteenId)) {
+          actionChanges.push(this.createOrUpdateResourceAction(canteenId, true))
+        }
+      })
+      this.actionsDone.forEach((actionCanteen) => {
+        if (!this.chosenCanteenIds.includes(actionCanteen.id)) {
+          actionChanges.push(this.createOrUpdateResourceAction(actionCanteen.id, false))
+        }
+      })
+      // close dialog and refresh the wasteAction if needed
+      if (actionChanges.length) {
+        Promise.all(actionChanges).then(() => {
+          this.$emit("close", true)
+        })
+      } else {
+        this.$emit("close")
+      }
+    },
+  },
+}
+</script>

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -246,9 +246,7 @@ export default new Vuex.Store({
         })
     },
 
-    /**
-     * payload: { canteen_id: int, is_done: boolean }
-     */
+    // payload: { canteenId: int, isDone: boolean }
     createOrUpdateResourceAction(context, { resourceId, payload }) {
       return fetch(`/api/v1/wasteActions/${resourceId}/actions`, {
         method: "POST",

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -246,6 +246,17 @@ export default new Vuex.Store({
         })
     },
 
+    /**
+     * payload: { canteen_id: int, is_done: boolean }
+     */
+    createOrUpdateResourceAction(context, { resourceId, payload }) {
+      return fetch(`/api/v1/wasteActions/${resourceId}/actions`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+      }).then(verifyResponse)
+    },
+
     fetchInitialData(context) {
       context.commit("SET_USER_LOADING_STATUS", Constants.LoadingStatus.LOADING)
       context.commit("SET_CANTEENS_LOADING_STATUS", Constants.LoadingStatus.LOADING)

--- a/frontend/src/views/WasteActionsPage/ResourceActionDialog.vue
+++ b/frontend/src/views/WasteActionsPage/ResourceActionDialog.vue
@@ -51,7 +51,7 @@ export default {
       type: Array,
       required: true,
     },
-    canteensDoneAction: {
+    canteensActionDone: {
       type: Array,
       required: true,
       // example: [{ id: 1, name: "Cantine 1" }],
@@ -65,7 +65,7 @@ export default {
   mounted() {
     // Pre-select the canteens that have already done the action
     this.chosenCanteenIds = this.userCanteens
-      .filter((canteen) => this.canteensDoneAction.find((actionCanteen) => actionCanteen.id === canteen.id))
+      .filter((canteen) => this.canteensActionDone.find((canteenActionDone) => canteenActionDone.id === canteen.id))
       .map((canteen) => canteen.id)
   },
   computed: {
@@ -91,13 +91,13 @@ export default {
       const actionChanges = []
       // Compare the chosen canteens with the actions done (new & removed)
       this.chosenCanteenIds.forEach((canteenId) => {
-        if (!this.canteensDoneAction.find((actionCanteen) => actionCanteen.id === canteenId)) {
+        if (!this.canteensActionDone.find((canteenActionDone) => canteenActionDone.id === canteenId)) {
           actionChanges.push(this.createOrUpdateResourceAction(canteenId, true))
         }
       })
-      this.canteensDoneAction.forEach((actionCanteen) => {
-        if (!this.chosenCanteenIds.includes(actionCanteen.id)) {
-          actionChanges.push(this.createOrUpdateResourceAction(actionCanteen.id, false))
+      this.canteensActionDone.forEach((canteenActionDone) => {
+        if (!this.chosenCanteenIds.includes(canteenActionDone.id)) {
+          actionChanges.push(this.createOrUpdateResourceAction(canteenActionDone.id, false))
         }
       })
       // close dialog and refresh the wasteAction if needed

--- a/frontend/src/views/WasteActionsPage/ResourceActionDialog.vue
+++ b/frontend/src/views/WasteActionsPage/ResourceActionDialog.vue
@@ -18,7 +18,7 @@
           multiple
           hide-details
           id="select-canteen"
-          placeholder="Choissisez les établissements"
+          placeholder="Choisissez les établissements"
           class="mt-1"
           no-data-text="Pas de résultats"
           item-text="name"
@@ -51,7 +51,7 @@ export default {
       type: Array,
       required: true,
     },
-    actionCanteensDone: {
+    canteensDoneAction: {
       type: Array,
       required: true,
       // example: [{ id: 1, name: "Cantine 1" }],
@@ -65,7 +65,7 @@ export default {
   mounted() {
     // Pre-select the canteens that have already done the action
     this.chosenCanteenIds = this.userCanteens
-      .filter((canteen) => this.actionCanteensDone.find((actionCanteen) => actionCanteen.id === canteen.id))
+      .filter((canteen) => this.canteensDoneAction.find((actionCanteen) => actionCanteen.id === canteen.id))
       .map((canteen) => canteen.id)
   },
   computed: {
@@ -91,11 +91,11 @@ export default {
       const actionChanges = []
       // Compare the chosen canteens with the actions done (new & removed)
       this.chosenCanteenIds.forEach((canteenId) => {
-        if (!this.actionCanteensDone.find((actionCanteen) => actionCanteen.id === canteenId)) {
+        if (!this.canteensDoneAction.find((actionCanteen) => actionCanteen.id === canteenId)) {
           actionChanges.push(this.createOrUpdateResourceAction(canteenId, true))
         }
       })
-      this.actionCanteensDone.forEach((actionCanteen) => {
+      this.canteensDoneAction.forEach((actionCanteen) => {
         if (!this.chosenCanteenIds.includes(actionCanteen.id)) {
           actionChanges.push(this.createOrUpdateResourceAction(actionCanteen.id, false))
         }

--- a/frontend/src/views/WasteActionsPage/ResourceActionDialog.vue
+++ b/frontend/src/views/WasteActionsPage/ResourceActionDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="isOpen" id="resource-action-dialog" width="500">
+  <v-dialog v-model="isOpen" max-width="500px">
     <v-card class="pa-6">
       <div class="mt-n6 mx-n6 mb-4 pa-4 d-flex" style="background-color: #F5F5F5">
         <v-spacer></v-spacer>

--- a/frontend/src/views/WasteActionsPage/WasteActionPage.vue
+++ b/frontend/src/views/WasteActionsPage/WasteActionPage.vue
@@ -45,7 +45,7 @@
             <i>Aucune cantine</i>
           </p>
           <br />
-          <v-btn small color="primary" @click="showActionModal">
+          <v-btn small color="primary" @click="showActionDialog">
             <span class="mx-2">
               Modifier
             </span>
@@ -56,11 +56,11 @@
         <BackLink :to="backLink" text="Retour" :primary="true" />
       </v-row>
 
-      <v-dialog v-model="showModal">
+      <v-dialog v-model="actionDialog">
         <v-card class="pa-6">
           <div class="mt-n6 mx-n6 mb-4 pa-4 d-flex" style="background-color: #F5F5F5">
             <v-spacer></v-spacer>
-            <v-btn outlined color="primary" @click="showModal = false">
+            <v-btn outlined color="primary" @click="actionDialog = false">
               Fermer
             </v-btn>
           </div>
@@ -104,7 +104,7 @@ export default {
   data() {
     return {
       wasteAction: null,
-      actionModal: false,
+      actionDialog: false,
       actionFormIsValid: true,
       chosenCanteenIds: [],
       backLink: { name: "WasteActionsHome" },
@@ -147,12 +147,12 @@ export default {
         })
         .catch((e) => this.$store.dispatch("notifyServerError", e))
     },
-    showActionModal() {
+    showActionDialog() {
       // Get the canteens that have already done the action
       this.chosenCanteenIds = this.userCanteens
         .filter((canteen) => this.actionsDone.find((actionCanteen) => actionCanteen.id === canteen.id))
         .map((canteen) => canteen.id)
-      this.actionModal = true
+      this.actionDialog = true
     },
     saveActionChanges() {
       const actionChanges = []
@@ -167,14 +167,14 @@ export default {
           actionChanges.push(this.createOrUpdateResourceAction(actionCanteen.id, false))
         }
       })
-      // close modal and refresh the wasteAction if needed
+      // close dialog and refresh the wasteAction if needed
       if (actionChanges.length) {
         Promise.all(actionChanges).then(() => {
           this.fetchWasteAction()
-          this.actionModal = false
+          this.actionDialog = false
         })
       } else {
-        this.actionModal = false
+        this.actionDialog = false
       }
     },
   },
@@ -209,14 +209,6 @@ export default {
       return this.wasteAction?.canteenActions
         ?.filter((canteenAction) => canteenAction.isDone)
         .map((canteenAction) => ({ id: canteenAction.canteen.id, text: canteenAction.canteen.name }))
-    },
-    showModal: {
-      get() {
-        return !!this.actionModal
-      },
-      set(newValue) {
-        if (!newValue) this.actionModal = null
-      },
     },
   },
   mounted() {

--- a/frontend/src/views/WasteActionsPage/WasteActionPage.vue
+++ b/frontend/src/views/WasteActionsPage/WasteActionPage.vue
@@ -40,7 +40,7 @@
             :small="true"
             :clickable="false"
           />
-          <p v-else>
+          <p v-else class="mb-2">
             <i>Aucune cantine</i>
           </p>
           <br />

--- a/frontend/src/views/WasteActionsPage/WasteActionPage.vue
+++ b/frontend/src/views/WasteActionsPage/WasteActionPage.vue
@@ -32,7 +32,6 @@
           <p v-html="wasteAction.description" class="mt-9"></p>
         </v-col>
         <v-col v-if="loggedUser" cols="12" class="d-flex flex-column align-start mt-8" sm="2">
-          <!-- Implement action buttons -->
           <p class="mb-2">Mis en place</p>
           <DsfrTagGroup
             v-if="canteensDoneAction && canteensDoneAction.length"
@@ -55,58 +54,30 @@
       <v-row class="mt-9">
         <BackLink :to="backLink" text="Retour" :primary="true" />
       </v-row>
-
-      <v-dialog v-model="actionDialog">
-        <v-card class="pa-6">
-          <div class="mt-n6 mx-n6 mb-4 pa-4 d-flex" style="background-color: #F5F5F5">
-            <v-spacer></v-spacer>
-            <v-btn outlined color="primary" @click="actionDialog = false">
-              Fermer
-            </v-btn>
-          </div>
-
-          <h2 id="modal-title" class="mb-3" tabindex="-1">Mis en place ?</h2>
-
-          <v-form ref="form" v-model="actionFormIsValid" @submit.prevent>
-            <DsfrAutocomplete
-              v-model="chosenCanteenIds"
-              :items="userCanteens"
-              clearable
-              multiple
-              hide-details
-              id="select-canteen"
-              placeholder="Toutes mes cantines"
-              class="mt-1"
-              no-data-text="Pas de résultats"
-              item-text="name"
-              item-value="id"
-            />
-            <v-row class="mt-2 pa-4">
-              <v-spacer></v-spacer>
-              <v-btn x-large color="primary" @click="saveActionChanges">Valider</v-btn>
-            </v-row>
-          </v-form>
-        </v-card>
-      </v-dialog>
+      <ResourceActionDialog
+        v-model="actionDialog"
+        :resourceId="id"
+        :userCanteens="userCanteens"
+        :actionsDone="actionsDone"
+        @close="closeActionDialog($event)"
+      />
     </div>
   </div>
 </template>
 <script>
-import DsfrAutocomplete from "@/components/DsfrAutocomplete"
 import BreadcrumbsNav from "@/components/BreadcrumbsNav.vue"
 import BackLink from "@/components/BackLink"
 import DsfrTagGroup from "@/components/DsfrTagGroup"
 import DsfrTag from "@/components/DsfrTag"
+import ResourceActionDialog from "@/components/ResourceActionDialog"
 import Constants from "@/constants"
 
 export default {
-  components: { DsfrAutocomplete, BreadcrumbsNav, BackLink, DsfrTagGroup, DsfrTag },
+  components: { BreadcrumbsNav, BackLink, DsfrTagGroup, DsfrTag, ResourceActionDialog },
   data() {
     return {
       wasteAction: null,
       actionDialog: false,
-      actionFormIsValid: true,
-      chosenCanteenIds: [],
       backLink: { name: "WasteActionsHome" },
     }
   },
@@ -139,43 +110,12 @@ export default {
           })
         })
     },
-    createOrUpdateResourceAction(canteenId, is_done = true) {
-      return this.$store
-        .dispatch("createOrUpdateResourceAction", {
-          resourceId: this.id,
-          payload: { canteenId, is_done },
-        })
-        .catch((e) => this.$store.dispatch("notifyServerError", e))
-    },
     showActionDialog() {
-      // Get the canteens that have already done the action
-      this.chosenCanteenIds = this.userCanteens
-        .filter((canteen) => this.actionsDone.find((actionCanteen) => actionCanteen.id === canteen.id))
-        .map((canteen) => canteen.id)
       this.actionDialog = true
     },
-    saveActionChanges() {
-      const actionChanges = []
-      // Compare the chosen canteens with the actions done (new & removed)
-      this.chosenCanteenIds.forEach((canteenId) => {
-        if (!this.actionsDone.find((actionCanteen) => actionCanteen.id === canteenId)) {
-          actionChanges.push(this.createOrUpdateResourceAction(canteenId, true))
-        }
-      })
-      this.actionsDone.forEach((actionCanteen) => {
-        if (!this.chosenCanteenIds.includes(actionCanteen.id)) {
-          actionChanges.push(this.createOrUpdateResourceAction(actionCanteen.id, false))
-        }
-      })
-      // close dialog and refresh the wasteAction if needed
-      if (actionChanges.length) {
-        Promise.all(actionChanges).then(() => {
-          this.fetchWasteAction()
-          this.actionDialog = false
-        })
-      } else {
-        this.actionDialog = false
-      }
+    closeActionDialog(refresh) {
+      if (refresh) this.fetchWasteAction()
+      this.actionDialog = false
     },
   },
   computed: {

--- a/frontend/src/views/WasteActionsPage/WasteActionPage.vue
+++ b/frontend/src/views/WasteActionsPage/WasteActionPage.vue
@@ -44,15 +44,55 @@
           <p v-else>
             <i>Aucune cantine</i>
           </p>
+          <br />
+          <v-btn small color="primary" @click="showActionModal">
+            <span class="mx-2">
+              Modifier
+            </span>
+          </v-btn>
         </v-col>
       </v-row>
       <v-row class="mt-9">
         <BackLink :to="backLink" text="Retour" :primary="true" />
       </v-row>
+
+      <v-dialog v-model="showModal">
+        <v-card class="pa-6">
+          <div class="mt-n6 mx-n6 mb-4 pa-4 d-flex" style="background-color: #F5F5F5">
+            <v-spacer></v-spacer>
+            <v-btn outlined color="primary" @click="showModal = false">
+              Fermer
+            </v-btn>
+          </div>
+
+          <h2 id="modal-title" class="mb-3" tabindex="-1">Mis en place ?</h2>
+
+          <v-form ref="form" v-model="actionFormIsValid" @submit.prevent>
+            <DsfrAutocomplete
+              v-model="chosenCanteenIds"
+              :items="userCanteens"
+              clearable
+              multiple
+              hide-details
+              id="select-canteen"
+              placeholder="Toutes mes cantines"
+              class="mt-1"
+              no-data-text="Pas de résultats"
+              item-text="name"
+              item-value="id"
+            />
+            <v-row class="mt-2 pa-4">
+              <v-spacer></v-spacer>
+              <v-btn x-large color="primary" @click="saveActionChanges">Valider</v-btn>
+            </v-row>
+          </v-form>
+        </v-card>
+      </v-dialog>
     </div>
   </div>
 </template>
 <script>
+import DsfrAutocomplete from "@/components/DsfrAutocomplete"
 import BreadcrumbsNav from "@/components/BreadcrumbsNav.vue"
 import BackLink from "@/components/BackLink"
 import DsfrTagGroup from "@/components/DsfrTagGroup"
@@ -60,10 +100,13 @@ import DsfrTag from "@/components/DsfrTag"
 import Constants from "@/constants"
 
 export default {
-  components: { BreadcrumbsNav, BackLink, DsfrTagGroup, DsfrTag },
+  components: { DsfrAutocomplete, BreadcrumbsNav, BackLink, DsfrTagGroup, DsfrTag },
   data() {
     return {
       wasteAction: null,
+      actionModal: false,
+      actionFormIsValid: true,
+      chosenCanteenIds: [],
       backLink: { name: "WasteActionsHome" },
     }
   },
@@ -96,10 +139,52 @@ export default {
           })
         })
     },
+    createOrUpdateResourceAction(canteenId, is_done = true) {
+      return this.$store
+        .dispatch("createOrUpdateResourceAction", {
+          resourceId: this.id,
+          payload: { canteenId, is_done },
+        })
+        .catch((e) => this.$store.dispatch("notifyServerError", e))
+    },
+    showActionModal() {
+      // Get the canteens that have already done the action
+      this.chosenCanteenIds = this.userCanteens
+        .filter((canteen) => this.actionsDone.find((actionCanteen) => actionCanteen.id === canteen.id))
+        .map((canteen) => canteen.id)
+      this.actionModal = true
+    },
+    saveActionChanges() {
+      const actionChanges = []
+      // Compare the chosen canteens with the actions done (new & removed)
+      this.chosenCanteenIds.forEach((canteenId) => {
+        if (!this.actionsDone.find((actionCanteen) => actionCanteen.id === canteenId)) {
+          actionChanges.push(this.createOrUpdateResourceAction(canteenId, true))
+        }
+      })
+      this.actionsDone.forEach((actionCanteen) => {
+        if (!this.chosenCanteenIds.includes(actionCanteen.id)) {
+          actionChanges.push(this.createOrUpdateResourceAction(actionCanteen.id, false))
+        }
+      })
+      // close modal and refresh the wasteAction if needed
+      if (actionChanges.length) {
+        Promise.all(actionChanges).then(() => {
+          this.fetchWasteAction()
+          this.actionModal = false
+        })
+      } else {
+        this.actionModal = false
+      }
+    },
   },
   computed: {
     loggedUser() {
       return this.$store.state.loggedUser
+    },
+    userCanteens() {
+      if (!this.loggedUser) return []
+      return this.$store.state.userCanteenPreviews
     },
     effort() {
       return (
@@ -123,7 +208,15 @@ export default {
     canteensDoneAction() {
       return this.wasteAction?.canteenActions
         ?.filter((canteenAction) => canteenAction.isDone)
-        .map((canteenAction) => ({ text: canteenAction.canteen.name }))
+        .map((canteenAction) => ({ id: canteenAction.canteen.id, text: canteenAction.canteen.name }))
+    },
+    showModal: {
+      get() {
+        return !!this.actionModal
+      },
+      set(newValue) {
+        if (!newValue) this.actionModal = null
+      },
     },
   },
   mounted() {

--- a/frontend/src/views/WasteActionsPage/WasteActionPage.vue
+++ b/frontend/src/views/WasteActionsPage/WasteActionPage.vue
@@ -58,7 +58,7 @@
         v-model="actionDialog"
         :resourceId="id"
         :userCanteens="userCanteens"
-        :actionsDone="actionsDone"
+        :actionCanteensDone="actionCanteensDone"
         @close="closeActionDialog($event)"
       />
     </div>
@@ -71,6 +71,7 @@ import DsfrTagGroup from "@/components/DsfrTagGroup"
 import DsfrTag from "@/components/DsfrTag"
 import ResourceActionDialog from "@/components/ResourceActionDialog"
 import Constants from "@/constants"
+import { normaliseText } from "@/utils"
 
 export default {
   components: { BreadcrumbsNav, BackLink, DsfrTagGroup, DsfrTag, ResourceActionDialog },
@@ -124,7 +125,10 @@ export default {
     },
     userCanteens() {
       if (!this.loggedUser) return []
-      return this.$store.state.userCanteenPreviews
+      const canteens = this.$store.state.userCanteenPreviews
+      return canteens.sort((a, b) => {
+        return normaliseText(a.name) > normaliseText(b.name) ? 1 : 0
+      })
     },
     effort() {
       return (

--- a/frontend/src/views/WasteActionsPage/WasteActionPage.vue
+++ b/frontend/src/views/WasteActionsPage/WasteActionPage.vue
@@ -58,18 +58,19 @@
         v-model="actionDialog"
         :resourceId="id"
         :userCanteens="userCanteens"
-        :actionCanteensDone="actionCanteensDone"
+        :canteensDoneAction="canteensDoneAction"
         @close="closeActionDialog($event)"
       />
     </div>
   </div>
 </template>
+
 <script>
 import BreadcrumbsNav from "@/components/BreadcrumbsNav.vue"
 import BackLink from "@/components/BackLink"
 import DsfrTagGroup from "@/components/DsfrTagGroup"
 import DsfrTag from "@/components/DsfrTag"
-import ResourceActionDialog from "@/components/ResourceActionDialog"
+import ResourceActionDialog from "./ResourceActionDialog"
 import Constants from "@/constants"
 import { normaliseText } from "@/utils"
 
@@ -150,6 +151,7 @@ export default {
       })
     },
     canteensDoneAction() {
+      if (!this.wasteAction?.canteenActions) return []
       return this.wasteAction?.canteenActions
         ?.filter((canteenAction) => canteenAction.isDone)
         .map((canteenAction) => ({ id: canteenAction.canteen.id, text: canteenAction.canteen.name }))

--- a/frontend/src/views/WasteActionsPage/WasteActionPage.vue
+++ b/frontend/src/views/WasteActionsPage/WasteActionPage.vue
@@ -34,8 +34,8 @@
         <v-col v-if="loggedUser" cols="12" class="d-flex flex-column align-start mt-8" sm="2">
           <p class="mb-2">Mis en place</p>
           <DsfrTagGroup
-            v-if="canteensDoneAction && canteensDoneAction.length"
-            :tags="canteensDoneAction"
+            v-if="canteensActionDone && canteensActionDone.length"
+            :tags="canteensActionDone"
             :closeable="false"
             :small="true"
             :clickable="false"
@@ -58,7 +58,7 @@
         v-model="actionDialog"
         :resourceId="id"
         :userCanteens="userCanteens"
-        :canteensDoneAction="canteensDoneAction"
+        :canteensActionDone="canteensActionDone"
         @close="closeActionDialog($event)"
       />
     </div>
@@ -150,7 +150,7 @@ export default {
         }
       })
     },
-    canteensDoneAction() {
+    canteensActionDone() {
       if (!this.wasteAction?.canteenActions) return []
       return this.wasteAction?.canteenActions
         ?.filter((canteenAction) => canteenAction.isDone)


### PR DESCRIPTION
### Quoi ?

Issue #4478. Suite de #4552

Nouveau bouton "Modifier" pour permettre à l'utilisateur connecté d'indiquer la/lesquelles de ses cantines ont effectivement mis en place cette action.

J'ai créé un component `ResourceActionDialog` dédié (pas simple ces histoires de v-model avec les dialog :exploding_head: )

### Captures d'écran

||Image|
|---|---|
|Bouton "Modifier"|![image](https://github.com/user-attachments/assets/fed23da3-1d5d-4ecf-a10a-60abdcf98b1a)
|Modale de choix|![image](https://github.com/user-attachments/assets/998d9e45-cc2f-4411-8c99-2451289cceb8)|