### PR TITLE
API: Renvoyer les ResourceAction de la cantine

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -119,7 +119,6 @@ class PublicCanteenPreviewSerializer(serializers.ModelSerializer):
     appro_diagnostic = PublicApproDiagnosticSerializer(read_only=True, source="latest_published_appro_diagnostic")
     lead_image = CanteenImageSerializer()
     badges = BadgesSerializer(read_only=True, source="*")
-    resource_actions = ResourceActionFullSerializer(many=True, read_only=True)
 
     class Meta:
         model = Canteen

--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -15,6 +15,7 @@ from .diagnostic import (
     PublicServiceDiagnosticSerializer,
 )
 from .managerinvitation import ManagerInvitationSerializer
+from .resourceaction import ResourceActionFullSerializer
 from .sector import SectorSerializer
 from .user import CanteenManagerSerializer
 
@@ -115,9 +116,10 @@ class BadgesSerializer(serializers.ModelSerializer):
 
 class PublicCanteenPreviewSerializer(serializers.ModelSerializer):
     sectors = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    badges = BadgesSerializer(read_only=True, source="*")
     appro_diagnostic = PublicApproDiagnosticSerializer(read_only=True, source="latest_published_appro_diagnostic")
     lead_image = CanteenImageSerializer()
+    badges = BadgesSerializer(read_only=True, source="*")
+    resource_actions = ResourceActionFullSerializer(many=True, read_only=True)
 
     class Meta:
         model = Canteen
@@ -134,11 +136,12 @@ class PublicCanteenPreviewSerializer(serializers.ModelSerializer):
             "satellite_canteens_count",
             "region",
             "department",
-            "badges",
             "appro_diagnostic",
             "lead_image",
             "is_central_cuisine",
             "is_satellite",
+            "badges",
+            "resource_actions",
         )
 
 
@@ -155,6 +158,7 @@ class PublicCanteenSerializer(serializers.ModelSerializer):
     images = MediaListSerializer(child=CanteenImageSerializer(), read_only=True)
     is_managed_by_user = serializers.SerializerMethodField(read_only=True)
     badges = BadgesSerializer(read_only=True, source="*")
+    resource_actions = ResourceActionFullSerializer(many=True, read_only=True)
 
     class Meta:
         model = Canteen
@@ -185,6 +189,7 @@ class PublicCanteenSerializer(serializers.ModelSerializer):
             "is_managed_by_user",
             "central_kitchen",
             "badges",
+            "resource_actions",
         )
 
     def get_is_managed_by_user(self, obj):
@@ -267,6 +272,7 @@ class FullCanteenSerializer(serializers.ModelSerializer, PublicationStatusMixin)
     central_kitchen = MinimalCanteenSerializer(read_only=True)
     satellites = MinimalCanteenSerializer(many=True, read_only=True)
     badges = BadgesSerializer(read_only=True, source="*")
+    resource_actions = ResourceActionFullSerializer(many=True, read_only=True)
     publication_status = PublicationStatusMixin.publication_status
 
     class Meta:
@@ -285,6 +291,7 @@ class FullCanteenSerializer(serializers.ModelSerializer, PublicationStatusMixin)
             "is_satellite",
             "modification_date",
             "badges",
+            "resource_actions",
         )
         fields = (
             "id",
@@ -330,6 +337,7 @@ class FullCanteenSerializer(serializers.ModelSerializer, PublicationStatusMixin)
             "is_satellite",
             "modification_date",
             "badges",
+            "resource_actions",
         )
 
         extra_kwargs = {"name": {"required": True}, "siret": {"required": True}}

--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -140,7 +140,6 @@ class PublicCanteenPreviewSerializer(serializers.ModelSerializer):
             "is_central_cuisine",
             "is_satellite",
             "badges",
-            "resource_actions",
         )
 
 

--- a/api/tests/test_resource_actions.py
+++ b/api/tests/test_resource_actions.py
@@ -8,7 +8,7 @@ from data.factories import (
     UserFactory,
     WasteActionFactory,
 )
-from data.models import ResourceAction
+from data.models import Canteen, ResourceAction
 
 
 class TestResourceActionsApi(APITestCase):
@@ -59,3 +59,55 @@ class TestResourceActionsApi(APITestCase):
         self.assertEqual(ResourceAction.objects.first().resource, self.waste_action)
         self.assertEqual(ResourceAction.objects.first().canteen, self.canteen)
         self.assertFalse(ResourceAction.objects.first().is_done)
+
+
+class TestCanteenResourceActionApi(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.waste_action = WasteActionFactory()
+        cls.user = UserFactory()
+        cls.user_with_canteen = UserFactory()
+        cls.canteen = CanteenFactory(publication_status=Canteen.PublicationStatus.PUBLISHED)
+        cls.canteen_with_resource_action = CanteenFactory(publication_status=Canteen.PublicationStatus.PUBLISHED)
+        cls.canteen_with_resource_action.managers.add(cls.user_with_canteen)
+        ResourceActionFactory(resource=cls.waste_action, canteen=cls.canteen_with_resource_action, is_done=True)
+
+    def test_get_published_canteen_with_resource_actions(self):
+        response = self.client.get(reverse("published_canteens"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_cateens = response.json()["results"]
+        self.assertEqual(len(returned_cateens), 2)
+        # canteen without resource_actions
+        self.assertEqual(returned_cateens[1]["id"], self.canteen.id)
+        self.assertTrue("resourceActions" in returned_cateens[1])
+        self.assertEqual(len(returned_cateens[1]["resourceActions"]), 0)
+        # canteen with resource_actions
+        self.assertEqual(returned_cateens[0]["id"], self.canteen_with_resource_action.id)
+        self.assertTrue("resourceActions" in returned_cateens[0])
+        self.assertEqual(len(returned_cateens[0]["resourceActions"]), 1)
+        self.assertTrue(returned_cateens[0]["resourceActions"][0]["isDone"])
+        self.assertEqual(returned_cateens[0]["resourceActions"][0]["resource"]["id"], self.waste_action.id)
+        self.assertEqual(
+            returned_cateens[0]["resourceActions"][0]["canteen"]["id"], self.canteen_with_resource_action.id
+        )
+
+    def test_get_single_published_canteen_with_resource_actions(self):
+        # canteen without resource_actions
+        response = self.client.get(reverse("single_published_canteen", kwargs={"pk": self.canteen.id}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["id"], self.canteen.id)
+        self.assertTrue("resourceActions" in body)
+        self.assertEqual(len(body["resourceActions"]), 0)
+        # canteen with resource_actions
+        response = self.client.get(
+            reverse("single_published_canteen", kwargs={"pk": self.canteen_with_resource_action.id})
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["id"], self.canteen_with_resource_action.id)
+        self.assertTrue("resourceActions" in body)
+        self.assertEqual(len(body["resourceActions"]), 1)
+        self.assertTrue(body["resourceActions"][0]["isDone"])
+        self.assertEqual(body["resourceActions"][0]["resource"]["id"], self.waste_action.id)
+        self.assertEqual(body["resourceActions"][0]["canteen"]["id"], self.canteen_with_resource_action.id)

--- a/api/tests/test_resource_actions.py
+++ b/api/tests/test_resource_actions.py
@@ -72,24 +72,18 @@ class TestCanteenResourceActionApi(APITestCase):
         cls.canteen_with_resource_action.managers.add(cls.user_with_canteen)
         ResourceActionFactory(resource=cls.waste_action, canteen=cls.canteen_with_resource_action, is_done=True)
 
-    def test_get_published_canteen_with_resource_actions(self):
-        response = self.client.get(reverse("published_canteens"))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        returned_cateens = response.json()["results"]
-        self.assertEqual(len(returned_cateens), 2)
-        # canteen without resource_actions
-        self.assertEqual(returned_cateens[1]["id"], self.canteen.id)
-        self.assertTrue("resourceActions" in returned_cateens[1])
-        self.assertEqual(len(returned_cateens[1]["resourceActions"]), 0)
+    def test_get_single_user_canteen_with_resource_actions(self):
+        self.client.force_login(user=self.user_with_canteen)
         # canteen with resource_actions
-        self.assertEqual(returned_cateens[0]["id"], self.canteen_with_resource_action.id)
-        self.assertTrue("resourceActions" in returned_cateens[0])
-        self.assertEqual(len(returned_cateens[0]["resourceActions"]), 1)
-        self.assertTrue(returned_cateens[0]["resourceActions"][0]["isDone"])
-        self.assertEqual(returned_cateens[0]["resourceActions"][0]["resource"]["id"], self.waste_action.id)
-        self.assertEqual(
-            returned_cateens[0]["resourceActions"][0]["canteen"]["id"], self.canteen_with_resource_action.id
-        )
+        response = self.client.get(reverse("single_canteen", kwargs={"pk": self.canteen_with_resource_action.id}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["id"], self.canteen_with_resource_action.id)
+        self.assertTrue("resourceActions" in body)
+        self.assertEqual(len(body["resourceActions"]), 1)
+        self.assertTrue(body["resourceActions"][0]["isDone"])
+        self.assertEqual(body["resourceActions"][0]["resource"]["id"], self.waste_action.id)
+        self.assertEqual(body["resourceActions"][0]["canteen"]["id"], self.canteen_with_resource_action.id)
 
     def test_get_single_published_canteen_with_resource_actions(self):
         # canteen without resource_actions


### PR DESCRIPTION
Issue #4423. Suite de #4544

### Quoi

Nouveau champ `Canteen.resource_actions` renvoyé

Serializers modifiés : 
- ~PublicCanteenPreviewSerializer : utilisé par PublishedCanteensView (list) & PublicCanteenPreviewView (retrieve)~
- PublicCanteenSerializer : utilisé par PublishedCanteenSingleView (retrieve)
- FullCanteenSerializer : utilisé par plusieurs vues (utilisateur connecté)

### Pourquoi

Pour pouvoir afficher les actions effectuées par la cantine sur son affiche