### PR TITLE
Brevo update contacts : Commencer par la création des nouveaux contacts et ensuite MAJ des contacts existants

### DIFF
--- a/macantine/brevo.py
+++ b/macantine/brevo.py
@@ -75,7 +75,7 @@ def update_existing_brevo_contacts(users_tu_update, today):
         time.sleep(0.1)  # API rate limit is 10 req per second
 
 
-def create_new_brevo_users(users_to_create, today):
+def create_new_brevo_contacts(users_to_create, today):
     for user in users_to_create:
         try:
             contact = user_to_brevo_payload(user, bulk=False)

--- a/macantine/brevo.py
+++ b/macantine/brevo.py
@@ -60,7 +60,7 @@ def user_to_brevo_payload(user, bulk=True):
 
 
 def update_existing_brevo_contacts(users_to_update, today):
-    for chunk in users_tu_update:
+    for chunk in users_to_update:
         contacts = [user_to_brevo_payload(user) for user in chunk]
         update_object = sib_api_v3_sdk.UpdateBatchContacts(contacts)
         try:

--- a/macantine/brevo.py
+++ b/macantine/brevo.py
@@ -1,0 +1,87 @@
+import logging
+import time
+
+import requests
+import sib_api_v3_sdk
+from django.conf import settings
+
+from data.models import Canteen
+
+logger = logging.getLogger(__name__)
+
+configuration = sib_api_v3_sdk.Configuration()
+configuration.api_key["api-key"] = settings.ANYMAIL.get("SENDINBLUE_API_KEY")
+api_client = sib_api_v3_sdk.ApiClient(configuration)
+email_api_instance = sib_api_v3_sdk.TransactionalEmailsApi(api_client)
+contacts_api_instance = sib_api_v3_sdk.ContactsApi(api_client)
+
+
+def send_sib_template(template_id, parameters, to_email, to_name):
+    send_smtp_email = sib_api_v3_sdk.SendSmtpEmail(
+        to=[{"email": to_email, "name": to_name}],
+        params=parameters,
+        sender={"email": settings.CONTACT_EMAIL, "name": "ma cantine"},
+        reply_to={"email": settings.CONTACT_EMAIL, "name": "ma cantine"},
+        template_id=template_id,
+    )
+    email_api_instance.send_transac_email(send_smtp_email)
+
+
+def user_to_brevo_payload(user, bulk=True):
+    has_canteens = user.canteens.exists()
+    date_joined = user.date_joined
+
+    def missing_diag_for_year(year, user):
+        return user.canteens.exists() and any(not x.has_diagnostic_for_year(year) for x in user.canteens.all())
+
+    def missing_td_for_year(year, user):
+        return user.canteens.exists() and any(not x.has_teledeclaration_for_year(year) for x in user.canteens.all())
+
+    missing_publications = (
+        has_canteens and user.canteens.filter(publication_status=Canteen.PublicationStatus.DRAFT).exists()
+    )
+
+    dict_attributes = {
+        "MA_CANTINE_DATE_INSCRIPTION": date_joined.strftime("%Y-%m-%d"),
+        "MA_CANTINE_COMPTE_DEV": user.is_dev,
+        "MA_CANTINE_COMPTE_ELU_E": user.is_elected_official,
+        "MA_CANTINE_GERE_UN_ETABLISSEMENT": has_canteens,
+        "MA_CANTINE_MANQUE_BILAN_DONNEES_2023": missing_diag_for_year(2023, user),
+        "MA_CANTINE_MANQUE_BILAN_DONNEES_2022": missing_diag_for_year(2022, user),
+        "MA_CANTINE_MANQUE_BILAN_DONNEES_2021": missing_diag_for_year(2021, user),
+        "MA_CANTINE_MANQUE_TD_DONNEES_2023": missing_td_for_year(2023, user),
+        "MA_CANTINE_MANQUE_TD_DONNEES_2022": missing_td_for_year(2022, user),
+        "MA_CANTINE_MANQUE_TD_DONNEES_2021": missing_td_for_year(2021, user),
+        "MA_CANTINE_MANQUE_PUBLICATION": missing_publications,
+    }
+    if bulk:
+        return sib_api_v3_sdk.UpdateBatchContactsContacts(email=user.email, attributes=dict_attributes)
+    return sib_api_v3_sdk.CreateContact(email=user.email, attributes=dict_attributes, update_enabled=True)
+
+
+def update_existing_brevo_contacts(users_tu_update, today):
+    for chunk in users_tu_update:
+        contacts = [user_to_brevo_payload(user) for user in chunk]
+        update_object = sib_api_v3_sdk.UpdateBatchContacts(contacts)
+        try:
+            contacts_api_instance.update_batch_contacts(update_object)
+            for user in chunk:
+                user.last_brevo_update = today
+                user.save()
+        except requests.exceptions.HTTPError as e:
+            logger.warning(f"Bulk updating Brevo users: One or more of the users don't exist. {e}")
+        except Exception as e:
+            logger.exception(f"Bulk updating Brevo users: Error updating Brevo users {e}", stack_info=True)
+        time.sleep(0.1)  # API rate limit is 10 req per second
+
+
+def create_new_brevo_users(users_to_create, today):
+    for user in users_to_create:
+        try:
+            contact = user_to_brevo_payload(user, bulk=False)
+            contacts_api_instance.create_contact(contact)
+            user.last_brevo_update = today
+            user.save()
+        except Exception as e:
+            logger.exception(f"Error creating/updating an individual Brevo user {e}", stack_info=True)
+        time.sleep(0.1)  # API rate limit is 10 req per second

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -132,13 +132,13 @@ def update_brevo_contacts():
     threshold = today - datetime.timedelta(days=1)
 
     logger.info("Create individually new Brevo users (allowing the update flag to be set)")
-    users_to_update = User.objects.filter(Q(last_brevo_update__isnull=True))
-    brevo.create_new_brevo_users(users_to_update, today)
+    users_to_create = User.objects.filter(Q(last_brevo_update__isnull=True))
+    brevo.create_new_brevo_contacts(users_to_create, today)
 
     logger.info("Update existing Brevo contacts by batch")
-    users_to_update = User.objects.filter(Q(last_brevo_update__lte=threshold))
+    users_to_create = User.objects.filter(Q(last_brevo_update__lte=threshold))
     bulk_update_size = 100
-    chunks = batched(users_to_update, bulk_update_size)
+    chunks = batched(users_to_create, bulk_update_size)
     brevo.update_existing_brevo_contacts(chunks, today)
 
     end = time.time()

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -5,7 +5,6 @@ import time
 
 import redis as r
 import requests
-import sib_api_v3_sdk
 from django.conf import settings
 from django.core.management import call_command
 from django.core.paginator import Paginator
@@ -18,6 +17,11 @@ from api.views.utils import update_change_reason
 from common.utils import get_token_sirene
 from data.models import Canteen, User
 
+from .brevo import (
+    create_new_brevo_users,
+    send_sib_template,
+    update_existing_brevo_contacts,
+)
 from .celery import app
 from .etl.analysis import ETL_ANALYSIS_CANTEEN, ETL_ANALYSIS_TD
 from .etl.open_data import ETL_OPEN_DATA_CANTEEN, ETL_OPEN_DATA_TD
@@ -25,22 +29,6 @@ from .utils import fetch_geo_data_from_api_insee_sirene_by_siret
 
 logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)
-configuration = sib_api_v3_sdk.Configuration()
-configuration.api_key["api-key"] = settings.ANYMAIL.get("SENDINBLUE_API_KEY")
-api_client = sib_api_v3_sdk.ApiClient(configuration)
-email_api_instance = sib_api_v3_sdk.TransactionalEmailsApi(api_client)
-contacts_api_instance = sib_api_v3_sdk.ContactsApi(api_client)
-
-
-def _send_sib_template(template_id, parameters, to_email, to_name):
-    send_smtp_email = sib_api_v3_sdk.SendSmtpEmail(
-        to=[{"email": to_email, "name": to_name}],
-        params=parameters,
-        sender={"email": settings.CONTACT_EMAIL, "name": "ma cantine"},
-        reply_to={"email": settings.CONTACT_EMAIL, "name": "ma cantine"},
-        template_id=template_id,
-    )
-    email_api_instance.send_transac_email(send_smtp_email)
 
 
 def _user_name(user):
@@ -70,7 +58,7 @@ def no_canteen_first_reminder():
         try:
             parameters = {"PRENOM": user.first_name}
             to_name = _user_name(user)
-            _send_sib_template(settings.TEMPLATE_ID_NO_CANTEEN_FIRST, parameters, user.email, to_name)
+            send_sib_template(settings.TEMPLATE_ID_NO_CANTEEN_FIRST, parameters, user.email, to_name)
             logger.info(f"First email sent to {user.get_full_name()} ({user.email})")
             user.email_no_canteen_first_reminder = today
             user.save()
@@ -105,7 +93,7 @@ def no_canteen_second_reminder():
         try:
             parameters = {"PRENOM": user.first_name}
             to_name = _user_name(user)
-            _send_sib_template(settings.TEMPLATE_ID_NO_CANTEEN_SECOND, parameters, user.email, to_name)
+            send_sib_template(settings.TEMPLATE_ID_NO_CANTEEN_SECOND, parameters, user.email, to_name)
             logger.info(f"Second email sent to {user.get_full_name()} ({user.email})")
             user.email_no_canteen_second_reminder = today
             user.save()
@@ -113,38 +101,6 @@ def no_canteen_second_reminder():
             logger.exception(f"SIB error when sending second no-cantine reminder email to {user.username}:\n{e}")
         except Exception as e:
             logger.exception(f"Unable to send second no-cantine reminder email to {user.username}:\n{e}")
-
-
-def user_to_brevo_payload(user, bulk=True):
-    has_canteens = user.canteens.exists()
-    date_joined = user.date_joined
-
-    def missing_diag_for_year(year, user):
-        return user.canteens.exists() and any(not x.has_diagnostic_for_year(year) for x in user.canteens.all())
-
-    def missing_td_for_year(year, user):
-        return user.canteens.exists() and any(not x.has_teledeclaration_for_year(year) for x in user.canteens.all())
-
-    missing_publications = (
-        has_canteens and user.canteens.filter(publication_status=Canteen.PublicationStatus.DRAFT).exists()
-    )
-
-    dict_attributes = {
-        "MA_CANTINE_DATE_INSCRIPTION": date_joined.strftime("%Y-%m-%d"),
-        "MA_CANTINE_COMPTE_DEV": user.is_dev,
-        "MA_CANTINE_COMPTE_ELU_E": user.is_elected_official,
-        "MA_CANTINE_GERE_UN_ETABLISSEMENT": has_canteens,
-        "MA_CANTINE_MANQUE_BILAN_DONNEES_2023": missing_diag_for_year(2023, user),
-        "MA_CANTINE_MANQUE_BILAN_DONNEES_2022": missing_diag_for_year(2022, user),
-        "MA_CANTINE_MANQUE_BILAN_DONNEES_2021": missing_diag_for_year(2021, user),
-        "MA_CANTINE_MANQUE_TD_DONNEES_2023": missing_td_for_year(2023, user),
-        "MA_CANTINE_MANQUE_TD_DONNEES_2022": missing_td_for_year(2022, user),
-        "MA_CANTINE_MANQUE_TD_DONNEES_2021": missing_td_for_year(2021, user),
-        "MA_CANTINE_MANQUE_PUBLICATION": missing_publications,
-    }
-    if bulk:
-        return sib_api_v3_sdk.UpdateBatchContactsContacts(email=user.email, attributes=dict_attributes)
-    return sib_api_v3_sdk.CreateContact(email=user.email, attributes=dict_attributes, update_enabled=True)
 
 
 ##########################################################################
@@ -185,34 +141,12 @@ def update_brevo_contacts():
     chunks = batched(users_to_update, bulk_update_size)
 
     logger.info("update_brevo_contacts batch updating started")
-
-    for chunk in chunks:
-        contacts = [user_to_brevo_payload(user) for user in chunk]
-        update_object = sib_api_v3_sdk.UpdateBatchContacts(contacts)
-        try:
-            contacts_api_instance.update_batch_contacts(update_object)
-            for user in chunk:
-                user.last_brevo_update = today
-                user.save()
-        except requests.exceptions.HTTPError as e:
-            logger.warning(f"Bulk updating Brevo users: One or more of the users don't exist. {e}")
-        except Exception as e:
-            logger.exception(f"Bulk updating Brevo users: Error updating Brevo users {e}", stack_info=True)
-        time.sleep(0.1)  # API rate limit is 10 req per second
+    update_existing_brevo_contacts(chunks, today)
 
     # Try creating those who didn't make it (allowing the update flag to be set)
     users_to_update = User.objects.filter(Q(last_brevo_update__lte=threshold) | Q(last_brevo_update__isnull=True))
     logger.info("update_brevo_contacts individual creating/updating started")
-
-    for user in users_to_update:
-        try:
-            contact = user_to_brevo_payload(user, bulk=False)
-            contacts_api_instance.create_contact(contact)
-            user.last_brevo_update = today
-            user.save()
-        except Exception as e:
-            logger.exception(f"Error creating/updating an individual Brevo user {e}", stack_info=True)
-        time.sleep(0.1)  # API rate limit is 10 req per second
+    create_new_brevo_users(chunks, today)
 
     end = time.time()
     logger.info(f"update_brevo_contacts task ended. Duration : { end - start } seconds")
@@ -244,7 +178,7 @@ def no_diagnostic_first_reminder():
             try:
                 parameters = {"PRENOM": manager.first_name, "NOM_CANTINE": canteen.name}
                 to_name = _user_name(manager)
-                _send_sib_template(
+                send_sib_template(
                     settings.TEMPLATE_ID_NO_DIAGNOSTIC_FIRST,
                     parameters,
                     manager.email,

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -194,8 +194,10 @@ def update_brevo_contacts():
             for user in chunk:
                 user.last_brevo_update = today
                 user.save()
+        except requests.exceptions.HTTPError as e:
+            logger.warning(f"Bulk updating Brevo users: One or more of the users don't exist. {e}")
         except Exception as e:
-            logger.exception(f"Error bulk updating Brevo users {e}", stack_info=True)
+            logger.exception(f"Bulk updating Brevo users: Error updating Brevo users {e}", stack_info=True)
         time.sleep(0.1)  # API rate limit is 10 req per second
 
     # Try creating those who didn't make it (allowing the update flag to be set)

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -138,7 +138,7 @@ def update_brevo_contacts():
     logger.info("Update existing Brevo contacts by batch")
     users_to_update = User.objects.filter(Q(last_brevo_update__lte=threshold))
     bulk_update_size = 100
-    chunks = batched(users_to_create, bulk_update_size)
+    chunks = batched(users_to_update, bulk_update_size)
     brevo.update_existing_brevo_contacts(chunks, today)
 
     end = time.time()

--- a/macantine/tests/test_automatic_emails.py
+++ b/macantine/tests/test_automatic_emails.py
@@ -59,7 +59,7 @@ class TestAutomaticEmails(TestCase):
         tasks.no_canteen_first_reminder()
 
         # Email is only sent once to Jean
-        tasks._send_sib_template.assert_called_once_with(
+        tasks.send_sib_template.assert_called_once_with(
             1, {"PRENOM": "Jean"}, "jean.serien@example.com", "Jean Sérien"
         )
 
@@ -94,7 +94,7 @@ class TestAutomaticEmails(TestCase):
         )
 
         tasks.no_canteen_first_reminder()
-        tasks._send_sib_template.assert_not_called()
+        tasks.send_sib_template.assert_not_called()
 
         jean.refresh_from_db()
         self.assertIsNone(jean.email_no_canteen_first_reminder)
@@ -161,7 +161,7 @@ class TestAutomaticEmails(TestCase):
         tasks.no_canteen_second_reminder()
 
         # Email is only sent once to Marie
-        tasks._send_sib_template.assert_called_once_with(2, {"PRENOM": ""}, "marie.olait@example.com", "marie.olait")
+        tasks.send_sib_template.assert_called_once_with(2, {"PRENOM": ""}, "marie.olait@example.com", "marie.olait")
 
         jean.refresh_from_db()
         anna.refresh_from_db()
@@ -193,7 +193,7 @@ class TestAutomaticEmails(TestCase):
             is_dev=True,
         )
         tasks.no_canteen_second_reminder()
-        tasks._send_sib_template.assert_not_called()
+        tasks.send_sib_template.assert_not_called()
 
         marie.refresh_from_db()
         self.assertIsNone(marie.email_no_canteen_second_reminder)
@@ -225,7 +225,7 @@ class TestAutomaticEmails(TestCase):
         tasks.no_canteen_first_reminder()
         tasks.no_canteen_second_reminder()
 
-        tasks._send_sib_template.assert_not_called()
+        tasks.send_sib_template.assert_not_called()
 
     @mock.patch("macantine.tasks._send_sib_template")
     @override_settings(TEMPLATE_ID_NO_CANTEEN_FIRST=1)
@@ -257,16 +257,16 @@ class TestAutomaticEmails(TestCase):
         tasks.no_canteen_first_reminder()
         tasks.no_canteen_first_reminder()
         tasks.no_canteen_first_reminder()
-        tasks._send_sib_template.assert_called_once_with(
+        tasks.send_sib_template.assert_called_once_with(
             1, {"PRENOM": "Jean"}, "jean.serien@example.com", "Jean Sérien"
         )
 
-        tasks._send_sib_template.reset_mock()
+        tasks.send_sib_template.reset_mock()
 
         tasks.no_canteen_second_reminder()
         tasks.no_canteen_second_reminder()
         tasks.no_canteen_second_reminder()
-        tasks._send_sib_template.assert_called_once_with(
+        tasks.send_sib_template.assert_called_once_with(
             2, {"PRENOM": "Marie"}, "marie.olait@example.com", "Marie Olait"
         )
 
@@ -356,9 +356,9 @@ class TestAutomaticEmails(TestCase):
         tasks.no_diagnostic_first_reminder()
 
         # Email is only sent once to Jean
-        tasks._send_sib_template.assert_called()
-        self.assertEqual(tasks._send_sib_template.call_count, 2)
-        call_args_list = tasks._send_sib_template.call_args_list
+        tasks.send_sib_template.assert_called()
+        self.assertEqual(tasks.send_sib_template.call_count, 2)
+        call_args_list = tasks.send_sib_template.call_args_list
         recipients = [x[0][2] for x in call_args_list]
         self.assertIn("jean.serien@example.com", recipients)
         self.assertIn("anna.logue@example.com", recipients)
@@ -388,7 +388,7 @@ class TestAutomaticEmails(TestCase):
         Canteen.objects.filter(pk=canteen_no_diagnostics.id).update(creation_date=(today - timedelta(weeks=2)))
 
         tasks.no_diagnostic_first_reminder()
-        tasks._send_sib_template.assert_not_called()
+        tasks.send_sib_template.assert_not_called()
 
         canteen_no_diagnostics.refresh_from_db()
         self.assertIsNone(canteen_no_diagnostics.email_no_diagnostic_first_reminder)
@@ -413,7 +413,7 @@ class TestAutomaticEmails(TestCase):
         )
         tasks.no_canteen_first_reminder()
 
-        tasks._send_sib_template.assert_not_called()
+        tasks.send_sib_template.assert_not_called()
 
         self.assertIsNone(jean.email_no_canteen_first_reminder)
 
@@ -438,7 +438,7 @@ class TestAutomaticEmails(TestCase):
         )
         tasks.no_canteen_second_reminder()
 
-        tasks._send_sib_template.assert_not_called()
+        tasks.send_sib_template.assert_not_called()
 
         marie.refresh_from_db()
 
@@ -478,9 +478,9 @@ class TestAutomaticEmails(TestCase):
         tasks.no_diagnostic_first_reminder()
 
         # Email is only sent once to Anna
-        tasks._send_sib_template.assert_called
-        self.assertEqual(tasks._send_sib_template.call_count, 1)
-        call_args_list = tasks._send_sib_template.call_args_list
+        tasks.send_sib_template.assert_called
+        self.assertEqual(tasks.send_sib_template.call_count, 1)
+        call_args_list = tasks.send_sib_template.call_args_list
         self.assertEqual(call_args_list[0][0][2], "anna.logue@example.com")
 
         # DB objects are updated
@@ -526,7 +526,7 @@ class TestAutomaticEmails(TestCase):
         tasks.no_diagnostic_first_reminder()
 
         # Email is only sent once to Jean
-        tasks._send_sib_template.assert_not_called()
+        tasks.send_sib_template.assert_not_called()
 
         # DB objects remain unchanged
         canteen_no_diagnostics.refresh_from_db()

--- a/macantine/tests/test_brevo_user_data.py
+++ b/macantine/tests/test_brevo_user_data.py
@@ -47,22 +47,6 @@ class TestBrevoUserData(TestCase):
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_TD_DONNEES_2021"), False)
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_PUBLICATION"), False)
 
-    # @mock.patch("macantine.brevo.contacts_api_instance.create_contact")
-    # @mock.patch("macantine.brevo.contacts_api_instance.update_batch_contacts")
-    # def test_update_batch_users(self, batch_update_mock, create_contact_mock):
-    #     """
-    #     If the batch update fails then the user will be created/updated individually
-    #     """
-    #     new_user = UserFactory.create()
-    #     batch_update_mock.side_effect = Exception("Error !")
-
-    #     tasks.update_brevo_contacts()
-    #     batch_update_mock.assert_called_once()
-    #     create_contact_mock.assert_called_once()
-
-    #     payload = create_contact_mock.call_args[0][0]
-    #     self.assertEqual(payload.email, new_user.email)
-
     @mock.patch("macantine.brevo.contacts_api_instance.create_contact")
     @mock.patch("macantine.brevo.contacts_api_instance.update_batch_contacts")
     def test_user_has_empty_canteen(self, batch_update_mock, create_contact_mock):

--- a/macantine/tests/test_brevo_user_data.py
+++ b/macantine/tests/test_brevo_user_data.py
@@ -48,8 +48,8 @@ class TestBrevoUserData(TestCase):
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_TD_DONNEES_2021"), False)
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_PUBLICATION"), False)
 
-    @mock.patch("macantine.tasks.contacts_api_instance.create_contact")
-    @mock.patch("macantine.tasks.contacts_api_instance.update_batch_contacts")
+    @mock.patch("macantine.brevo.contacts_api_instance.create_contact")
+    @mock.patch("macantine.brevo.contacts_api_instance.update_batch_contacts")
     def test_create_user(self, batch_update_mock, create_contact_mock):
         """
         If the batch update fails then the user will be created/updated individually
@@ -64,8 +64,8 @@ class TestBrevoUserData(TestCase):
         payload = create_contact_mock.call_args[0][0]
         self.assertEqual(payload.email, new_user.email)
 
-    @mock.patch("macantine.tasks.contacts_api_instance.create_contact")
-    @mock.patch("macantine.tasks.contacts_api_instance.update_batch_contacts")
+    @mock.patch("macantine.brevo.contacts_api_instance.create_contact")
+    @mock.patch("macantine.brevo.contacts_api_instance.update_batch_contacts")
     def test_user_has_empty_canteen(self, batch_update_mock, create_contact_mock):
         """
         As soon as a user has a canteen, pending actions will follow and all paramteres
@@ -90,8 +90,8 @@ class TestBrevoUserData(TestCase):
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_TD_DONNEES_2021"), True)
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_PUBLICATION"), True)
 
-    @mock.patch("macantine.tasks.contacts_api_instance.create_contact")
-    @mock.patch("macantine.tasks.contacts_api_instance.update_batch_contacts")
+    @mock.patch("macantine.brevo.contacts_api_instance.create_contact")
+    @mock.patch("macantine.brevo.contacts_api_instance.update_batch_contacts")
     def test_user_has_published_canteen(self, batch_update_mock, create_contact_mock):
         user = UserFactory.create()
         canteen = CanteenFactory.create(publication_status=Canteen.PublicationStatus.PUBLISHED)
@@ -112,8 +112,8 @@ class TestBrevoUserData(TestCase):
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_TD_DONNEES_2021"), True)
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_PUBLICATION"), False)
 
-    @mock.patch("macantine.tasks.contacts_api_instance.create_contact")
-    @mock.patch("macantine.tasks.contacts_api_instance.update_batch_contacts")
+    @mock.patch("macantine.brevo.contacts_api_instance.create_contact")
+    @mock.patch("macantine.brevo.contacts_api_instance.update_batch_contacts")
     def test_user_has_canteen_with_diag(self, batch_update_mock, create_contact_mock):
         user = UserFactory.create()
         canteen = CanteenFactory.create()
@@ -137,8 +137,8 @@ class TestBrevoUserData(TestCase):
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_TD_DONNEES_2021"), True)
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_PUBLICATION"), True)
 
-    @mock.patch("macantine.tasks.contacts_api_instance.create_contact")
-    @mock.patch("macantine.tasks.contacts_api_instance.update_batch_contacts")
+    @mock.patch("macantine.brevo.contacts_api_instance.create_contact")
+    @mock.patch("macantine.brevo.contacts_api_instance.update_batch_contacts")
     def test_user_has_canteen_with_td(self, batch_update_mock, create_contact_mock):
         user = UserFactory.create()
         canteen = CanteenFactory.create()
@@ -177,8 +177,8 @@ class TestBrevoUserData(TestCase):
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_TD_DONNEES_2021"), False)
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_PUBLICATION"), True)
 
-    @mock.patch("macantine.tasks.contacts_api_instance.create_contact")
-    @mock.patch("macantine.tasks.contacts_api_instance.update_batch_contacts")
+    @mock.patch("macantine.brevo.contacts_api_instance.create_contact")
+    @mock.patch("macantine.brevo.contacts_api_instance.update_batch_contacts")
     def test_user_has_sat_canteen_with_cc_diag(self, batch_update_mock, create_contact_mock):
         user = UserFactory.create()
         central_kitchen = CanteenFactory.create(production_type=Canteen.ProductionType.CENTRAL, siret="65815950319874")
@@ -213,8 +213,8 @@ class TestBrevoUserData(TestCase):
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_TD_DONNEES_2021"), True)
         self.assertEqual(attributes.get("MA_CANTINE_MANQUE_PUBLICATION"), True)
 
-    @mock.patch("macantine.tasks.contacts_api_instance.create_contact")
-    @mock.patch("macantine.tasks.contacts_api_instance.update_batch_contacts")
+    @mock.patch("macantine.brevo.contacts_api_instance.create_contact")
+    @mock.patch("macantine.brevo.contacts_api_instance.update_batch_contacts")
     def test_user_has_sat_canteen_with_cc_td(self, batch_update_mock, create_contact_mock):
         user = UserFactory.create()
         central_kitchen = CanteenFactory.create(production_type=Canteen.ProductionType.CENTRAL, siret="65815950319874")

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ cssselect2==0.7.0
 defusedxml==0.7.1
 Deprecated==1.2.14
 dill==0.3.9
-distlib==0.3.8
+distlib==0.3.9
 Django==5.0.8
 django-anymail==10.3
 django-celery-results==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ async-timeout==4.0.3
 attrs==24.2.0
 Authlib==1.3.2
 beautifulsoup4==4.12.3
-billiard==4.2.0
+billiard==4.2.1
 black==24.8.0
 boto3==1.34.158
 botocore==1.34.158


### PR DESCRIPTION
* Fix : Changer l'ordre pour commencer par la création des nouveaux contacts
* Fix : Modifier le niveau de logging 
* Refacto : Création d'un ficher brevo.py


Nous mettons à jour régulièrement les contact Brevo en filtrant nos contacts par le champ `last_brevo_update`. Il existe deux cas : 
* le champ est null : le contact est nouveau et n'existe pas encore sur Brevo
* le champ contient une date. Si le délai dépasse un seuil, nous mettons à jour ce contact.

La mise à jour se fait par Batch via l'API de Brevo. L'API de Brevo fait planter tout le batch en cas d'erreur (cf cette [issue](https://github.com/sendinblue/APIv3-php-library/issues/257)). Or un contact non existant est une erreur.

Les contacts non existants sont crées dans un second temps. 

Solution #1 : Cette erreur n'est pas grave. Il faut donc baisser le niveau de logging.

Solution #2 : D'abord créer les contacts non existants puis MAJ par batch des contacts existants 