### PR TITLE
Backend: répare une typo dans le code

### DIFF
--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -124,9 +124,9 @@ class TestCanteenApi(APITestCase):
         for user_canteen in user_canteens:
             self.assertTrue(any(x["id"] == user_canteen.id for x in body))
 
-        for recieved_canteen in body:
-            self.assertEqual(recieved_canteen["managers"][0]["email"], user.email)
-            self.assertTrue("email" in recieved_canteen["managerInvitations"][0])
+        for received_canteen in body:
+            self.assertEqual(received_canteen["managers"][0]["email"], user.email)
+            self.assertTrue("email" in received_canteen["managerInvitations"][0])
 
         for other_canteen in other_canteens:
             self.assertFalse(any(x["id"] == other_canteen.id for x in body))

--- a/api/tests/test_import_diagnostics.py
+++ b/api/tests/test_import_diagnostics.py
@@ -531,7 +531,7 @@ class TestImportDiagnosticsAPI(APITestCase):
         This file contains one diagnostic with three emails for managers. The first two
         already have an account with ma cantine, so they should be added. The third one
         has no account, so an invitation should be sent.
-        All the managers would recieve an email, either a notification or an invitation.
+        All the managers would receive an email, either a notification or an invitation.
         """
         gestionnaire_1 = UserFactory(email="gestionnaire1@example.com")
         gestionnaire_2 = UserFactory(email="gestionnaire2@example.com")

--- a/api/tests/test_public_canteen_previews.py
+++ b/api/tests/test_public_canteen_previews.py
@@ -44,9 +44,9 @@ class TestPublicCanteenPreviewsApi(APITestCase):
         for private_canteen in private_canteens:
             self.assertFalse(any(x["id"] == private_canteen.id for x in results))
 
-        for recieved_canteen in results:
-            self.assertFalse("managers" in recieved_canteen)
-            self.assertFalse("managerInvitations" in recieved_canteen)
+        for received_canteen in results:
+            self.assertFalse("managers" in received_canteen)
+            self.assertFalse("managerInvitations" in received_canteen)
 
     @override_settings(PUBLISH_BY_DEFAULT=True)
     def test_get_published_canteens(self):
@@ -80,9 +80,9 @@ class TestPublicCanteenPreviewsApi(APITestCase):
         for private_canteen in private_canteens:
             self.assertFalse(any(x["id"] == private_canteen.id for x in results))
 
-        for recieved_canteen in results:
-            self.assertFalse("managers" in recieved_canteen)
-            self.assertFalse("managerInvitations" in recieved_canteen)
+        for received_canteen in results:
+            self.assertFalse("managers" in received_canteen)
+            self.assertFalse("managerInvitations" in received_canteen)
 
     def test_get_single_public_canteen_preview(self):
         """
@@ -109,7 +109,7 @@ class TestPublicCanteenPreviewsApi(APITestCase):
         response = self.client.get(reverse("single_public_canteen_preview", kwargs={"pk": 99}))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_recieve_expected_keys_in_preview(self):
+    def test_receive_expected_keys_in_preview(self):
         """
         Should get summary data in a public preview
         """


### PR DESCRIPTION
### Quoi

Remplace `recieve` par `receive`