### PR TITLE
fix(Affiche): répare une erreur dans la console pour certaines cantines

### DIFF
--- a/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
@@ -344,9 +344,9 @@ export default {
           disabled: tabs.length < 2,
         }
         tabs.push(compareTab)
+        this.tabs = tabs
+        this.tab = tabs[0].value
       }
-      this.tabs = tabs
-      this.tab = tabs[0].value
     },
   },
   mounted() {


### PR DESCRIPTION
Closes #4395

Certaines cantines n'ont ni Diagnostics ni Achats, cela provoque une erreur (dans la console uniquement) lors de la création de la section "Qualité des produits" de leur affiche.