### PR TITLE
API: pouvoir mettre en favoris une ResourceAction

### DIFF
--- a/api/serializers/resourceaction.py
+++ b/api/serializers/resourceaction.py
@@ -13,6 +13,7 @@ class ResourceActionSerializer(serializers.ModelSerializer):
             "resource_id",
             "canteen_id",
             "is_done",
+            "is_favorite",
         )
 
 

--- a/api/tests/test_resource_actions.py
+++ b/api/tests/test_resource_actions.py
@@ -21,7 +21,7 @@ class TestResourceActionsApi(APITestCase):
         cls.canteen.managers.add(cls.user_with_canteen)
         cls.url = reverse("resource_action_create_or_update", kwargs={"resource_pk": cls.waste_action.id})
 
-    def test_create_resource_action(self):
+    def test_create_resource_action_error(self):
         # user is not authenticated
         response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": True})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -36,6 +36,8 @@ class TestResourceActionsApi(APITestCase):
         # user is authenticated and belongs to the canteen, but canteen_id is wrong
         response = self.client.post(self.url, data={"canteen_id": 999, "is_done": True})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_resource_action_success(self):
         # user is authenticated and belongs to the canteen
         self.client.force_login(user=self.user_with_canteen)
         response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": True})
@@ -44,34 +46,48 @@ class TestResourceActionsApi(APITestCase):
         self.assertEqual(body["resourceId"], self.waste_action.id)
         self.assertEqual(body["canteenId"], self.canteen.id)
         self.assertTrue(body["isDone"])
+        self.assertIsNone(body["isFavorite"])
         self.assertEqual(ResourceAction.objects.count(), 1)
         self.assertEqual(ResourceAction.objects.first().resource, self.waste_action)
         self.assertEqual(ResourceAction.objects.first().canteen, self.canteen)
         self.assertTrue(ResourceAction.objects.first().is_done)
+        self.assertIsNone(ResourceAction.objects.first().is_favorite)
 
     def test_update_resource_action(self):
-        # create an existing ResourceAction
+        # create a ResourceAction
         ResourceActionFactory(resource=self.waste_action, canteen=self.canteen, is_done=True)
         # user is authenticated and belongs to the canteen
         self.client.force_login(user=self.user_with_canteen)
+        # update is_done
         response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": False})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(ResourceAction.objects.count(), 1)
         self.assertEqual(ResourceAction.objects.first().resource, self.waste_action)
         self.assertEqual(ResourceAction.objects.first().canteen, self.canteen)
         self.assertFalse(ResourceAction.objects.first().is_done)
+        self.assertIsNone(ResourceAction.objects.first().is_favorite)
+        # update is_favorite
+        response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_favorite": True})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(ResourceAction.objects.count(), 1)
+        self.assertEqual(ResourceAction.objects.first().resource, self.waste_action)
+        self.assertEqual(ResourceAction.objects.first().canteen, self.canteen)
+        self.assertFalse(ResourceAction.objects.first().is_done)
+        self.assertTrue(ResourceAction.objects.first().is_favorite)
 
 
 class TestCanteenResourceActionApi(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.waste_action = WasteActionFactory()
+        cls.waste_action_1 = WasteActionFactory()
+        cls.waste_action_2 = WasteActionFactory()
         cls.user = UserFactory()
         cls.user_with_canteen = UserFactory()
         cls.canteen = CanteenFactory(publication_status=Canteen.PublicationStatus.PUBLISHED)
         cls.canteen_with_resource_action = CanteenFactory(publication_status=Canteen.PublicationStatus.PUBLISHED)
         cls.canteen_with_resource_action.managers.add(cls.user_with_canteen)
-        ResourceActionFactory(resource=cls.waste_action, canteen=cls.canteen_with_resource_action, is_done=True)
+        ResourceActionFactory(resource=cls.waste_action_1, canteen=cls.canteen_with_resource_action, is_done=True)
+        ResourceActionFactory(resource=cls.waste_action_2, canteen=cls.canteen_with_resource_action, is_favorite=True)
 
     def test_get_single_user_canteen_with_resource_actions(self):
         self.client.force_login(user=self.user_with_canteen)
@@ -81,10 +97,15 @@ class TestCanteenResourceActionApi(APITestCase):
         body = response.json()
         self.assertEqual(body["id"], self.canteen_with_resource_action.id)
         self.assertTrue("resourceActions" in body)
-        self.assertEqual(len(body["resourceActions"]), 1)
+        self.assertEqual(len(body["resourceActions"]), 2)
         self.assertTrue(body["resourceActions"][0]["isDone"])
-        self.assertEqual(body["resourceActions"][0]["resource"]["id"], self.waste_action.id)
+        self.assertIsNone(body["resourceActions"][0]["isFavorite"])
+        self.assertEqual(body["resourceActions"][0]["resource"]["id"], self.waste_action_1.id)
         self.assertEqual(body["resourceActions"][0]["canteen"]["id"], self.canteen_with_resource_action.id)
+        self.assertIsNone(body["resourceActions"][1]["isDone"])
+        self.assertTrue(body["resourceActions"][1]["isFavorite"])
+        self.assertEqual(body["resourceActions"][1]["resource"]["id"], self.waste_action_2.id)
+        self.assertEqual(body["resourceActions"][1]["canteen"]["id"], self.canteen_with_resource_action.id)
 
     def test_get_single_published_canteen_with_resource_actions(self):
         # canteen without resource_actions
@@ -102,7 +123,12 @@ class TestCanteenResourceActionApi(APITestCase):
         body = response.json()
         self.assertEqual(body["id"], self.canteen_with_resource_action.id)
         self.assertTrue("resourceActions" in body)
-        self.assertEqual(len(body["resourceActions"]), 1)
+        self.assertEqual(len(body["resourceActions"]), 2)
         self.assertTrue(body["resourceActions"][0]["isDone"])
-        self.assertEqual(body["resourceActions"][0]["resource"]["id"], self.waste_action.id)
+        self.assertIsNone(body["resourceActions"][0]["isFavorite"])
+        self.assertEqual(body["resourceActions"][0]["resource"]["id"], self.waste_action_1.id)
         self.assertEqual(body["resourceActions"][0]["canteen"]["id"], self.canteen_with_resource_action.id)
+        self.assertIsNone(body["resourceActions"][1]["isDone"])
+        self.assertTrue(body["resourceActions"][1]["isFavorite"])
+        self.assertEqual(body["resourceActions"][1]["resource"]["id"], self.waste_action_2.id)
+        self.assertEqual(body["resourceActions"][1]["canteen"]["id"], self.canteen_with_resource_action.id)


### PR DESCRIPTION
### Quoi ?

Suite à la création du champ `is_favorite` (dans #4612)

On modifie l'API pour permettre de créer/modifier une ResourceAction lorsque l'utilisateur met une WasteAction en favoris. Similaire à #4500 (`is_done`)
