### PR TITLE
Bug fix : la première fois qu'une CC tombe sur la page ma progression

### DIFF
--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -402,7 +402,7 @@ export default {
       return !this.canteen || hasSatelliteInconsistency(this.canteen)
     },
     missingDeclarationMode() {
-      return this.isCentralKitchen && !this.diagnostic.centralKitchenDiagnosticMode
+      return this.isCentralKitchen && !this.diagnostic?.centralKitchenDiagnosticMode
     },
     hasFinishedMeasureTunnel() {
       return this.diagnostic && hasFinishedMeasureTunnel(this.diagnostic)


### PR DESCRIPTION
Ajd il y a un bug avec le check pour la mode de déclaration quand une CC veut commencer un nouveau bilan

## Avant

![Screenshot from 2024-11-13 17-08-37](https://github.com/user-attachments/assets/090ebd32-4247-4333-85dd-04dd68e042f7)

## Après

![Screenshot 2024-11-13 at 17-08-57 Ma progression - ma cantine](https://github.com/user-attachments/assets/70475af7-b08f-4e8b-8f88-b5e70a12eef4)