### PR TITLE
Bug fix : aider les satellites à compléter leurs TDs

### DIFF
--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -65,31 +65,26 @@
           <p>Votre livreur des repas va faire le bilan pour votre établissement.</p>
         </div>
         <div v-else-if="inTeledeclarationCampaign">
+          <DataInfoBadge class="my-2" :readyToTeledeclare="readyToTeledeclare" :missingData="!readyToTeledeclare" />
           <div v-if="isSatelliteWithApproCentralDiagnostic">
             <p>Votre livreur des repas va déclarer les données d'approvisionnement pour votre établissement.</p>
             <p>Pour aller plus loin, vous pouvez télédéclarer les autres volets du bilan.</p>
-            <v-btn v-if="readyToTeledeclare" outlined color="primary" @click="showTeledeclarationPreview = true">
-              Télédéclarer
-            </v-btn>
           </div>
-          <div v-else-if="readyToTeledeclare">
-            <DataInfoBadge class="my-2" :readyToTeledeclare="true" />
+          <div v-if="readyToTeledeclare">
             <div v-if="hasFinishedMeasureTunnel">
               <p>Votre bilan est complet !</p>
-              <v-btn color="primary" @click="showTeledeclarationPreview = true">Télédéclarer</v-btn>
             </div>
-            <div v-else>
+            <div v-else-if="!isSatelliteWithApproCentralDiagnostic">
               <p>Vous pouvez télédéclarer dès maintenant.</p>
               <p v-if="!isCentralKitchen || diagnostic.centralKitchenDiagnosticMode !== 'APPRO'">
                 Pour aller plus loin, vous pouvez également compléter les autres volets du bilan.
               </p>
-              <v-btn outlined color="primary" @click="showTeledeclarationPreview = true">
-                Télédéclarer
-              </v-btn>
             </div>
+            <v-btn color="primary" :outlined="!hasFinishedMeasureTunnel" @click="showTeledeclarationPreview = true">
+              Télédéclarer
+            </v-btn>
           </div>
           <div v-else>
-            <DataInfoBadge class="my-2" :missingData="true" />
             <p>Pour télédéclarer, veuillez :</p>
             <ul>
               <li v-if="missingApproDiagnostic" class="mb-2">


### PR DESCRIPTION
Quand un satellite est créé par une cuisine centrale depuis la page suivante :

![Screenshot 2024-11-13 at 17-51-27 Gérer mes satellites - ma cantine](https://github.com/user-attachments/assets/d3be7efb-9ad9-4e13-8fb6-2d850e964f22)

Il manque quelques données de l'établissement pour le satellite si il veut completer les autres volets et faire une TD. Ces données ne sont pas soulévées ajd dans le "sidebar" de la page ma progression, quand normalement c'est bien le cas.

![Screenshot 2024-11-13 at 17-19-18 Ma progression - ma cantine](https://github.com/user-attachments/assets/6f0222cc-56a1-4bb1-b557-766727b7a6c6)

Cette PR bouge la logique pour que la liste de données manquantes est visible aux satellites avec un CC diag avec que l'appro.

## Le resultat

![Screenshot 2024-11-13 at 17-18-56 Ma progression - ma cantine](https://github.com/user-attachments/assets/4e554e8b-f87e-43f8-8c3e-d130687bc4c5)


