### PR TITLE
Tunnel gaspillage alimentaire : renommer 'gaspillage alimentaire' en 'déchets alimentaires'

### DIFF
--- a/2024-frontend/src/components/SourceChart.vue
+++ b/2024-frontend/src/components/SourceChart.vue
@@ -25,7 +25,7 @@ const measurementGraphValues = computed(() => {
       props.measurement.unservedTotalMass,
       props.measurement.leftoversTotalMass,
     ]),
-    x: JSON.stringify(["Excédents de préparation", "Denrées non servies", "Reste-assiette"]),
+    x: JSON.stringify(["Excédents de préparation", "Denrées non servies", "Reste assiette"]),
   }
 })
 
@@ -77,7 +77,7 @@ const displayOption = ref("chart")
           {{ formatNumber(measurementPercentageValues.unserved) }} %
         </li>
         <li>
-          Reste-assiette : {{ formatNumber(measurement.leftoversTotalMass) }} kg, soit
+          Reste assiette : {{ formatNumber(measurement.leftoversTotalMass) }} kg, soit
           {{ formatNumber(measurementPercentageValues.leftovers) }} %
         </li>
       </ul>

--- a/2024-frontend/src/components/SourceChart.vue
+++ b/2024-frontend/src/components/SourceChart.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, ref } from "vue"
 import { formatNumber, getPercentage } from "@/utils"
+import Constants from "@/constants.js"
 
 const props = defineProps(["measurement"])
 
@@ -25,7 +26,11 @@ const measurementGraphValues = computed(() => {
       props.measurement.unservedTotalMass,
       props.measurement.leftoversTotalMass,
     ]),
-    x: JSON.stringify(["Excédents de préparation", "Denrées non servies", "Reste assiette"]),
+    x: JSON.stringify([
+      Constants.WasteMeasurement.preparation.title,
+      Constants.WasteMeasurement.unserved.title,
+      Constants.WasteMeasurement.leftovers.title,
+    ]),
   }
 })
 
@@ -69,15 +74,15 @@ const displayOption = ref("chart")
     <div v-else-if="displayOption === 'text'">
       <ul>
         <li>
-          Excédents de préparation : {{ formatNumber(measurement.preparationTotalMass) }} kg, soit
-          {{ formatNumber(measurementPercentageValues.preparation) }} %
+          {{ Constants.WasteMeasurement.preparation.title }} : {{ formatNumber(measurement.preparationTotalMass) }} kg,
+          soit {{ formatNumber(measurementPercentageValues.preparation) }} %
         </li>
         <li>
-          Denrées présentées mais non servies : {{ formatNumber(measurement.unservedTotalMass) }} kg, soit
+          {{ Constants.WasteMeasurement.unserved.title }} : {{ formatNumber(measurement.unservedTotalMass) }} kg, soit
           {{ formatNumber(measurementPercentageValues.unserved) }} %
         </li>
         <li>
-          Reste assiette : {{ formatNumber(measurement.leftoversTotalMass) }} kg, soit
+          {{ Constants.WasteMeasurement.leftovers.title }} : {{ formatNumber(measurement.leftoversTotalMass) }} kg, soit
           {{ formatNumber(measurementPercentageValues.leftovers) }} %
         </li>
       </ul>

--- a/2024-frontend/src/components/WasteMeasurementDetail.vue
+++ b/2024-frontend/src/components/WasteMeasurementDetail.vue
@@ -7,68 +7,68 @@ const props = defineProps(["measurement"])
 const detailedFields = [
   {
     key: "totalMass",
-    label: "Masse totale des déchets alimentaires relevée sur la période de mesure",
+    label: Constants.WasteMeasurement.totalMass.title,
   },
   {
     key: "daysInPeriod",
-    label: "Période de mesure de mes déchets alimentaires",
+    label: Constants.WasteMeasurement.daysInPeriod.title,
     unit: "jours",
   },
   {
-    label: "Nombre de couverts sur la période",
-    unit: "couverts",
     key: "mealCount",
+    label: Constants.WasteMeasurement.mealCount.title,
+    unit: "couverts",
   },
   {
     key: "totalYearlyWasteEstimation",
-    label: "Masse totale de gaspillage sur l'année",
+    label: "Masse totale de déchets alimentaires sur l'année",
     unit: "kg",
     tooltip:
-      "Calculé en prenant le gaspillage par repas pour la période, multiplié par le nombre de couverts par année pour l'établissement",
+      "Calculé en prenant les déchets alimentaires par repas pour la période, multiplié par le nombre de couverts par année pour l'établissement",
   },
   {
     heading: Constants.WasteMeasurement.preparation.title,
   },
   {
-    label: "Gaspillage total",
+    label: "Total",
     key: "preparationTotalMass",
   },
   {
-    label: "Gaspillage de denrées comestibles",
+    label: "Denrées comestibles",
     key: "preparationEdibleMass",
   },
   {
-    label: "Gaspillage de denrées non comestibles",
+    label: "Denrées non comestibles",
     key: "preparationInedibleMass",
   },
   {
     heading: Constants.WasteMeasurement.unserved.title,
   },
   {
-    label: "Gaspillage total",
+    label: "Total",
     key: "unservedTotalMass",
   },
   {
-    label: "Gaspillage de denrées comestibles",
+    label: "Denrées comestibles",
     key: "unservedEdibleMass",
   },
   {
-    label: "Gaspillage de denrées non comestibles",
+    label: "Denrées non comestibles",
     key: "unservedInedibleMass",
   },
   {
     heading: Constants.WasteMeasurement.leftovers.title,
   },
   {
-    label: "Gaspillage total",
+    label: "Total",
     key: "leftoversTotalMass",
   },
   {
-    label: "Gaspillage de denrées comestibles",
+    label: "Denrées comestibles",
     key: "leftoversEdibleMass",
   },
   {
-    label: "Gaspillage de denrées non comestibles",
+    label: "Denrées non comestibles",
     key: "leftoversInedibleMass",
   },
 ]

--- a/2024-frontend/src/components/WasteMeasurementDetail.vue
+++ b/2024-frontend/src/components/WasteMeasurementDetail.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { formatNumber } from "@/utils"
+import Constants from "@/constants.js"
 
 const props = defineProps(["measurement"])
 
@@ -26,7 +27,7 @@ const detailedFields = [
       "Calculé en prenant le gaspillage par repas pour la période, multiplié par le nombre de couverts par année pour l'établissement",
   },
   {
-    heading: "Excédents de préparation",
+    heading: Constants.WasteMeasurement.preparation.title,
   },
   {
     label: "Gaspillage total",
@@ -41,7 +42,7 @@ const detailedFields = [
     key: "preparationInedibleMass",
   },
   {
-    heading: "Denrées présentées aux convives mais non servies",
+    heading: Constants.WasteMeasurement.unserved.title,
   },
   {
     label: "Gaspillage total",
@@ -56,7 +57,7 @@ const detailedFields = [
     key: "unservedInedibleMass",
   },
   {
-    heading: "Reste assiette",
+    heading: Constants.WasteMeasurement.leftovers.title,
   },
   {
     label: "Gaspillage total",

--- a/2024-frontend/src/components/WasteMeasurementDetail.vue
+++ b/2024-frontend/src/components/WasteMeasurementDetail.vue
@@ -6,11 +6,11 @@ const props = defineProps(["measurement"])
 const detailedFields = [
   {
     key: "totalMass",
-    label: "Masse totale de gaspillage relevée sur la période de mesure",
+    label: "Masse totale des déchets alimentaires relevée sur la période de mesure",
   },
   {
     key: "daysInPeriod",
-    label: "Période de mesure de mon gaspillage alimentaire",
+    label: "Période de mesure de mes déchets alimentaires",
     unit: "jours",
   },
   {

--- a/2024-frontend/src/components/WasteMeasurementSummary.vue
+++ b/2024-frontend/src/components/WasteMeasurementSummary.vue
@@ -61,7 +61,7 @@ const activeAccordion = ref("")
         </div>
         <div v-else>
           <DsfrAlert>
-            Triez votre gaspillage alimentaire par source pour mieux comprendre comment agir.
+            Triez vos déchets alimentaires par source pour mieux comprendre comment agir.
           </DsfrAlert>
         </div>
       </div>

--- a/2024-frontend/src/constants.js
+++ b/2024-frontend/src/constants.js
@@ -38,6 +38,15 @@ export default Object.freeze({
     },
   ],
   WasteMeasurement: {
+    daysInPeriod: {
+      title: "Période de mesure de mes déchets alimentaires",
+    },
+    mealCount: {
+      title: "Nombre de couverts sur la période",
+    },
+    totalMass: {
+      title: "Masse totale des déchets alimentaires relevée sur la période de mesure",
+    },
     preparation: {
       title: "Excédents de préparation dont stock",
     },

--- a/2024-frontend/src/constants.js
+++ b/2024-frontend/src/constants.js
@@ -37,4 +37,15 @@ export default Object.freeze({
         "Vous ne connaissez pas les données par cantine satellite, que par livreur de repas. Vous connaissez les labels et les familles de produits de vos achats",
     },
   ],
+  WasteMeasurement: {
+    preparation: {
+      title: "Excédents de préparation dont stock",
+    },
+    unserved: {
+      title: "Denrées présentées aux convives mais non servies",
+    },
+    leftovers: {
+      title: "Restes assiettes",
+    },
+  },
 })

--- a/2024-frontend/src/router/index.js
+++ b/2024-frontend/src/router/index.js
@@ -11,7 +11,7 @@ const routes = [
     component: WasteMeasurementTunnel,
     props: (route) => ({ ...route.query, ...route.params }),
     meta: {
-      title: "Évaluation gaspillage alimentaire",
+      title: "Évaluation déchets alimentaires",
       authenticationRequired: true,
       fullscreen: true,
     },
@@ -31,7 +31,7 @@ const routes = [
     component: WasteMeasurements,
     props: (route) => ({ ...route.params }),
     meta: {
-      title: "Gaspillage alimentaire",
+      title: "Déchets alimentaires",
       authenticationRequired: true,
       breadcrumbs: [
         { to: { name: "ManagementPage" }, title: "Mon tableau de bord" },

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/BreakdownBySource.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/BreakdownBySource.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { onMounted, reactive, watch, computed, inject, nextTick } from "vue"
+import Constants from "@/constants.js"
 import { useVuelidate } from "@vuelidate/core"
 import { formatError } from "@/utils.js"
 import HelpText from "./HelpText.vue"
@@ -15,7 +16,7 @@ const sources = {
     sortedKey: "preparationIsSorted",
     edibleKey: "preparationEdibleMass",
     inedibleKey: "preparationInedibleMass",
-    title: "Excédents de préparation",
+    title: Constants.WasteMeasurement.preparation.title,
     primaryLabel: "Masse de déchets alimentaire pour les excédents de préparation (en kg)",
     description:
       "Par exemple, si vous avez jeté des épluchures, des parures ou si vous avez des ingrédients excédentaires que vous ne réutiliserez pas, il s’agit d’excédents de préparation",
@@ -27,7 +28,7 @@ const sources = {
     sortedKey: "unservedIsSorted",
     edibleKey: "unservedEdibleMass",
     inedibleKey: "unservedInedibleMass",
-    title: "Denrées présentées aux convives mais non servies",
+    title: Constants.WasteMeasurement.unserved.title,
     primaryLabel: "Masse de déchets alimentaires pour les denrées présentées aux convives mais non servies (en kg)",
     description:
       "Par exemple, si vous présentez en vitrine un nombre excédentaire de salades, de parts de tarte aux pommes et que ces denrées supplémentaires ne sont ni consommées ni valorisées, il s’agit d’excédents présentés aux convives et non servis",
@@ -39,7 +40,7 @@ const sources = {
     sortedKey: "leftoversIsSorted",
     edibleKey: "leftoversEdibleMass",
     inedibleKey: "leftoversInedibleMass",
-    title: "Reste assiette",
+    title: Constants.WasteMeasurement.leftovers.title,
     primaryLabel: "Masse de déchets alimentaires pour le reste assiette (en kg)",
     description:
       "Il s’agit de l’ensemble des restes alimentaires des plateaux repas /assiettes incluant les os, noyaux et épluchures",

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/BreakdownBySource.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/BreakdownBySource.vue
@@ -17,7 +17,7 @@ const sources = {
     edibleKey: "preparationEdibleMass",
     inedibleKey: "preparationInedibleMass",
     title: Constants.WasteMeasurement.preparation.title,
-    primaryLabel: "Masse de déchets alimentaire pour les excédents de préparation (en kg)",
+    primaryLabel: "Masse de déchets alimentaires pour les excédents de préparation (en kg)",
     description:
       "Par exemple, si vous avez jeté des épluchures, des parures ou si vous avez des ingrédients excédentaires que vous ne réutiliserez pas, il s’agit d’excédents de préparation",
     edibleHelp:
@@ -166,7 +166,7 @@ onMounted(() => {
         <DsfrInputGroup
           v-model.number="payload.edibleKey"
           type="number"
-          label="Total des déchets alimentaires comestibles (assimilable à du gaspillage alimentaire) (en kg)"
+          label="Masse des déchets alimentaires comestibles (assimilable à du gaspillage alimentaire) (en kg)"
           hint="Optionnel"
           label-visible
           class="fr-mb-2w"
@@ -175,7 +175,7 @@ onMounted(() => {
         <DsfrInputGroup
           v-model.number="payload.inedibleKey"
           type="number"
-          label="Total des déchets alimentaires non comestibles (en kg)"
+          label="Masse des déchets alimentaires non comestibles (en kg)"
           hint="Optionnel"
           label-visible
           class="fr-mb-2w"

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/BreakdownBySource.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/BreakdownBySource.vue
@@ -28,7 +28,7 @@ const sources = {
     edibleKey: "unservedEdibleMass",
     inedibleKey: "unservedInedibleMass",
     title: "Denrées présentées aux convives mais non servies",
-    primaryLabel: "Masse de gaspillage pour les denrées présentées aux convives mais non servies",
+    primaryLabel: "Masse de déchets alimentaires pour les denrées présentées aux convives mais non servies (en kg)",
     description:
       "Par exemple, si vous présentez en vitrine un nombre excédentaire de salades, de parts de tarte aux pommes et que ces denrées supplémentaires ne sont ni consommées ni valorisées, il s’agit d’excédents présentés aux convives et non servis",
     edibleHelp:
@@ -40,7 +40,7 @@ const sources = {
     edibleKey: "leftoversEdibleMass",
     inedibleKey: "leftoversInedibleMass",
     title: "Reste assiette",
-    primaryLabel: "Masse de gaspillage pour le reste assiette",
+    primaryLabel: "Masse de déchets alimentaires pour le reste assiette (en kg)",
     description:
       "Il s’agit de l’ensemble des restes alimentaires des plateaux repas /assiettes incluant les os, noyaux et épluchures",
     edibleHelp:
@@ -165,8 +165,8 @@ onMounted(() => {
         <DsfrInputGroup
           v-model.number="payload.edibleKey"
           type="number"
-          label="Total du gaspillage de denrées comestibles"
-          hint="En kg (optionnel)"
+          label="Total des déchets alimentaires comestibles (assimilable à du gaspillage alimentaire) (en kg)"
+          hint="Optionnel"
           label-visible
           class="fr-mb-2w"
           :error-message="formatError(v$.edibleKey)"
@@ -174,8 +174,8 @@ onMounted(() => {
         <DsfrInputGroup
           v-model.number="payload.inedibleKey"
           type="number"
-          label="Total du gaspillage de denrées non comestibles"
-          hint="En kg (optionnel)"
+          label="Total des déchets alimentaires non comestibles (en kg)"
+          hint="Optionnel"
           label-visible
           class="fr-mb-2w"
           :error-message="formatError(v$.inedibleKey)"

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/BreakdownBySource.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/BreakdownBySource.vue
@@ -64,7 +64,7 @@ const sumCheck = () => {
   return payload.edibleKey + payload.inedibleKey === payload.totalKey
 }
 const combination = helpers.withMessage(
-  "La somme de denrées comestibles et non-comestibles devrait être égale au total",
+  "La somme de denrées comestibles et non comestibles devrait être égale au total",
   sumCheck
 )
 
@@ -138,7 +138,7 @@ onMounted(() => {
         <div :class="leftHandQuestionsClass">
           <DsfrBooleanRadio
             v-model="payload.sortedKey"
-            legend="Avez-vous trié entre comestible et non-comestible&nbsp;?"
+            legend="Avez-vous trié entre comestible et non comestible&nbsp;?"
             hint="Optionnel"
             name="sortedKey"
             class="fr-mb-2w"

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/BreakdownBySource.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/BreakdownBySource.vue
@@ -16,7 +16,7 @@ const sources = {
     edibleKey: "preparationEdibleMass",
     inedibleKey: "preparationInedibleMass",
     title: "Excédents de préparation",
-    primaryLabel: "Masse de gaspillage pour les excédents de préparation",
+    primaryLabel: "Masse de déchets alimentaire pour les excédents de préparation (en kg)",
     description:
       "Par exemple, si vous avez jeté des épluchures, des parures ou si vous avez des ingrédients excédentaires que vous ne réutiliserez pas, il s’agit d’excédents de préparation",
     edibleHelp:
@@ -120,7 +120,7 @@ onMounted(() => {
             v-model.number="payload.totalKey"
             type="number"
             :label="source.primaryLabel"
-            hint="En kg (optionnel)"
+            hint="Optionnel"
             label-visible
             class="fr-mb-2w"
             :error-message="formatError(v$.totalKey)"

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/MeasurementPeriod.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/MeasurementPeriod.vue
@@ -3,6 +3,7 @@ import { onMounted, reactive, watch, inject, computed } from "vue"
 import { useVuelidate } from "@vuelidate/core"
 import { formatError } from "@/utils.js"
 import HelpText from "./HelpText.vue"
+import Constants from "@/constants.js"
 
 import { helpers } from "@vuelidate/validators"
 import { useValidators } from "@/validators.js"
@@ -84,7 +85,7 @@ onMounted(() => {
     <div class="fr-grid-row fr-grid-row--middle">
       <div class="fr-col-12 fr-col-md-6">
         <fieldset class="fr-px-0 fr-pt-0 fr-mx-0">
-          <legend class="fr-text--lg fr-mb-1w fr-px-0">Période de mesure de mes déchets alimentaires</legend>
+          <legend class="fr-text--lg fr-mb-1w fr-px-0">{{ Constants.WasteMeasurement.daysInPeriod.title }}</legend>
           <div class="fr-col-md-7">
             <DsfrInputGroup
               v-model="payload.periodStartDate"
@@ -124,7 +125,7 @@ onMounted(() => {
             <DsfrInputGroup
               v-model.number="payload.mealCount"
               type="number"
-              label="Nombre de couverts sur la période"
+              :label="Constants.WasteMeasurement.mealCount.title"
               :hint="`${daysInPeriod || '?'} jours`"
               label-visible
               :error-message="formatError(v$.mealCount)"
@@ -162,7 +163,7 @@ onMounted(() => {
             <DsfrInputGroup
               v-model.number="payload.mealCount"
               type="number"
-              label="Nombre de couverts sur la période"
+              :label="Constants.WasteMeasurement.mealCount.title"
               :hint="`${daysInPeriod || '?'} jours`"
               label-visible
               :error-message="formatError(v$.mealCount)"

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/MeasurementPeriod.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/MeasurementPeriod.vue
@@ -84,7 +84,7 @@ onMounted(() => {
     <div class="fr-grid-row fr-grid-row--middle">
       <div class="fr-col-12 fr-col-md-6">
         <fieldset class="fr-px-0 fr-pt-0 fr-mx-0">
-          <legend class="fr-text--lg fr-mb-1w fr-px-0">Période de mesure de mon gaspillage alimentaire</legend>
+          <legend class="fr-text--lg fr-mb-1w fr-px-0">Période de mesure de mes déchets alimentaires</legend>
           <div class="fr-col-md-7">
             <DsfrInputGroup
               v-model="payload.periodStartDate"

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/TotalWaste.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/TotalWaste.vue
@@ -39,7 +39,7 @@ onMounted(() => {
       <DsfrInputGroup
         v-model.number="payload.totalMass"
         type="number"
-        label="Masse totale de gaspillage relevée sur la période de mesure"
+        label="Masse totale des déchets alimentaires relevée sur la période de mesure"
         hint="en kg"
         label-visible
         class="fr-mb-2w"

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/TotalWaste.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/TotalWaste.vue
@@ -2,6 +2,7 @@
 import { onMounted, reactive, watch, inject } from "vue"
 import { useVuelidate } from "@vuelidate/core"
 import { formatError } from "@/utils.js"
+import Constants from "@/constants.js"
 import HelpText from "./HelpText.vue"
 import { useValidators } from "@/validators.js"
 const { required, decimal, minValue } = useValidators()
@@ -39,7 +40,7 @@ onMounted(() => {
       <DsfrInputGroup
         v-model.number="payload.totalMass"
         type="number"
-        label="Masse totale des déchets alimentaires relevée sur la période de mesure"
+        :label="Constants.WasteMeasurement.totalMass.title"
         hint="en kg"
         label-visible
         class="fr-mb-2w"

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/TotalWaste.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/TotalWaste.vue
@@ -47,10 +47,10 @@ onMounted(() => {
       />
     </div>
     <div class="fr-col-sm-6">
-      <HelpText question="Dois-je compter les os et les épluchures ?">
+      <HelpText>
         <p class="fr-mb-0">
-          Inutile à ce stade de différencier les denrées comestibles et non comestibles. Si vous l’avez fait, vous
-          pourrez saisir les données détaillées aux étapes suivantes.
+          Les déchets alimentaires incluent une fraction comestible (assimilable à du gaspillage alimentaire) et une
+          fraction non comestible (os, épluchures, arêtes).
         </p>
       </HelpText>
     </div>

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/WasteDistinction.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/WasteDistinction.vue
@@ -38,7 +38,7 @@ onMounted(() => {
     <div class="fr-col-12 fr-col-sm-6">
       <DsfrBooleanRadio
         v-model="payload.isSortedBySource"
-        legend="Avez-vous trié votre gaspillage en fonction de sa source ?"
+        legend="Avez-vous trié vos déchets en fonction de leur source ?"
         name="isSortedBySource"
         class="fr-mb-2w"
         :error-message="formatError(v$.isSortedBySource)"
@@ -47,7 +47,7 @@ onMounted(() => {
     <div class="fr-col-sm-6">
       <HelpText>
         <p class="fr-mb-0">
-          Cela signifie procéder à des pesées séparées en fonction de la source de gaspillage : restes assiettes,
+          Cela signifie procéder à des pesées séparées en fonction de la source des déchets : restes assiettes,
           excédents présentés aux convives et non servis, et excédents de préparation.
         </p>
       </HelpText>

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/index.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/index.vue
@@ -16,31 +16,31 @@ const firstSteps = [
   },
   {
     urlSlug: "total",
-    title: "Masse totale de gaspillage",
+    title: "Masse totale des déchets alimentaires",
     component: markRaw(TotalWaste),
   },
   {
     urlSlug: "distinction",
-    title: "Distinction du gaspillage en fonction de la source",
+    title: "Distinction des déchets alimentaires en fonction de la source",
     component: markRaw(WasteDistinction),
   },
 ]
 const breakdownSteps = [
   {
     urlSlug: "preparation",
-    title: "Gaspillage lié aux excédents de préparation",
+    title: "Déchets alimentaires liés aux excédents de préparation",
     component: markRaw(BreakdownBySource),
     componentData: { source: "preparation" },
   },
   {
     urlSlug: "non-servies",
-    title: "Gaspillage lié aux denrées présentées aux convives mais non servies",
+    title: "Déchets alimentaires liés aux denrées présentées aux convives mais non servies",
     component: markRaw(BreakdownBySource),
     componentData: { source: "unserved" },
   },
   {
     urlSlug: "reste-assiette",
-    title: "Gaspillage lié au reste assiette",
+    title: "Déchets alimentaires liés au reste assiette",
     component: markRaw(BreakdownBySource),
     componentData: { source: "leftovers" },
   },

--- a/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/index.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/WasteMeasurementSteps/index.vue
@@ -40,7 +40,7 @@ const breakdownSteps = [
   },
   {
     urlSlug: "reste-assiette",
-    title: "Déchets alimentaires liés au reste assiette",
+    title: "Déchets alimentaires liés aux restes assiettes",
     component: markRaw(BreakdownBySource),
     componentData: { source: "leftovers" },
   },

--- a/2024-frontend/src/views/WasteMeasurements/index.vue
+++ b/2024-frontend/src/views/WasteMeasurements/index.vue
@@ -38,14 +38,14 @@ onMounted(() => {
 
 <template>
   <div>
-    <h1>Gaspillage alimentaire</h1>
+    <h1>Déchets alimentaires</h1>
     <p>
       {{ canteen.name }}&nbsp;
       <router-link :to="{ name: 'ManagementPage' }" class="fr-btn fr-btn--tertiary fr-btn--sm">
         Changer d'établissement
       </router-link>
     </p>
-    <h2>Mon gaspillage mesuré</h2>
+    <h2>Mes déchets alimentaires mesurés</h2>
     <div v-if="measurements.length">
       <WasteMeasurementSummary
         :measurements="measurements"
@@ -55,8 +55,8 @@ onMounted(() => {
     </div>
     <div v-else>
       <p>
-        Votre établissement est soumis à l'obligation de faire une analyse des causes du gaspillage alimentaire, et de
-        mettre en place une démarche de lutte contre le gaspillage alimentaire.
+        Votre établissement est soumis à l'obligation de faire une analyse des causes des déchets alimentaires, et de
+        mettre en place une démarche de lutte contre les déchets alimentaires.
       </p>
       <DsfrBadge label="Pas encore de données" type="none" />
       <EmphasiseText :emphasisText="`${formatNumber()} g`" contextText="par repas" />

--- a/2024-frontend/src/views/WasteMeasurements/index.vue
+++ b/2024-frontend/src/views/WasteMeasurements/index.vue
@@ -58,7 +58,7 @@ onMounted(() => {
         Votre établissement est soumis à l'obligation de faire une analyse des causes du gaspillage alimentaire, et de
         mettre en place une démarche de lutte contre le gaspillage alimentaire.
       </p>
-      <DsfrBadge label="Pas encore des données" type="none" />
+      <DsfrBadge label="Pas encore de données" type="none" />
       <EmphasiseText :emphasisText="`${formatNumber()} g`" contextText="par repas" />
       <router-link :to="newMeasurementRoute" class="fr-btn">
         Saisir une évaluation


### PR DESCRIPTION
Lié à #4627

Changements de wording : 
- remplace "gaspillage alimentaire" par "déchets alimentaires"
- hint : simplifier à "Optionnel" et mettre (en kg) dans le label
- remplacer "non-comestible" par "non comestible"

### Captures d'écran

étape 2 : modification du contenu de la bulle info
![image](https://github.com/user-attachments/assets/30090099-8095-49bd-a36f-dcf89bb1f863)
