### PR TITLE
Tunnel diagnostique : renommer 'gaspillage alimentaire' en 'déchets alimentaires'

### DIFF
--- a/frontend/src/components/DiagnosticSummary/WasteMeasureSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/WasteMeasureSummary.vue
@@ -4,19 +4,19 @@
       <li v-if="diagnostic.hasWasteDiagnostic">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>
-          J’ai réalisé un diagnostic sur les causes probables de gaspillage alimentaire
+          J’ai réalisé un diagnostic sur les causes probables de mes déchets alimentaires
         </div>
       </li>
       <li v-else-if="diagnosticUsesNullAsFalse || diagnostic.hasWasteDiagnostic === false">
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
         <div>
-          Je n’ai pas encore réalisé un diagnostic sur les causes probables de gaspillage alimentaire
+          Je n’ai pas encore réalisé un diagnostic sur les causes probables de mes déchets alimentaires
         </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$question-line</v-icon>
         <div>
-          Avez-vous réalisé un diagnostic sur les causes probables de gaspillage alimentaire ?
+          Avez-vous réalisé un diagnostic sur les causes probables de vos déchets alimentaires ?
         </div>
       </li>
 
@@ -45,7 +45,7 @@
       <li v-if="diagnostic.hasWasteMeasures">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>
-          J’ai réalisé des mesures de mon gaspillage alimentaire :
+          J’ai réalisé des mesures de mes déchets alimentaires :
           <ul role="list" class="mt-2">
             <li class="fr-text-xs mb-1" v-for="measure in wasteMeasures" :key="measure.label">
               {{ measure.label }} :
@@ -57,13 +57,13 @@
       <li v-else-if="diagnosticUsesNullAsFalse || diagnostic.hasWasteMeasures === false">
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
         <div>
-          Je n’ai pas encore réalisé des mesures de mon gaspillage alimentaire
+          Je n’ai pas encore réalisé des mesures de mes déchets alimentaires
         </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$question-line</v-icon>
         <div>
-          Avez-vous réalisé des mesures de votre gaspillage alimentaire ?
+          Avez-vous réalisé des mesures de vos déchets alimentaires ?
         </div>
       </li>
 

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -10,7 +10,7 @@
       />
       <DsfrRadio
         v-model="payload.hasWasteDiagnostic"
-        label="J’ai réalisé un diagnostic sur les causes probables de gaspillage alimentaire"
+        label="J’ai réalisé un diagnostic sur les causes probables de mes déchets alimentaires"
         yesNo
         hide-details
       />
@@ -29,7 +29,7 @@
         <v-col cols="12" sm="6">
           <DsfrRadio
             v-model="payload.hasWasteMeasures"
-            label="J’ai réalisé des mesures de mon gaspillage alimentaire"
+            label="J’ai réalisé des mesures de mes déchets alimentaires"
             yesNo
             optional
             hide-details
@@ -128,7 +128,7 @@
     </div>
     <fieldset v-else-if="stepUrlSlug === 'actions'">
       <legend class="my-3">
-        J’ai réalisé les actions de lutte contre le gaspillage alimentaire suivantes :
+        J’ai réalisé les actions suivantes de lutte contre les déchets alimentaires :
         <span class="fr-hint-text mt-2">Optionnel</span>
       </legend>
       <v-checkbox
@@ -218,7 +218,7 @@
                 Autres commentaires
                 <span class="fr-hint-text mt-2">
                   Optionnel : toute précision que vous souhaiteriez apporter sur votre situation et/ou sur vos actions
-                  mises en place pour lutter contre le gaspillage alimentaire
+                  mises en place pour lutter contre les déchets alimentaires
                 </span>
               </label>
             </template>
@@ -302,7 +302,7 @@ const steps = [
     urlSlug: "plan-action",
   },
   {
-    title: "Mesure de mon gaspillage alimentaire",
+    title: "Mesure de mes déchets alimentaires",
     urlSlug: "mesure-gaspillage",
   },
   {

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -35,16 +35,26 @@
             hide-details
           />
         </v-col>
-        <v-col cols="12" sm="6">
+        <v-col>
+          <DsfrCallout>
+            <p class="fr-text-sm grey-text text--darken-3">
+              Les déchets alimentaires incluent une fraction comestible (assimilable à du gaspillage alimentaire) et une
+              fraction non comestible (os, épluchures, arêtes).
+            </p>
+          </DsfrCallout>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="12">
           <fieldset :disabled="!payload.hasWasteMeasures">
             <legend class="my-3 font-weight-bold">
-              Mesures du gaspillage
+              Mesures des déchets
               <span :class="`fr-hint-text mt-2 ${payload.hasWasteMeasures ? '' : 'grey--text'}`">
                 Optionnel
               </span>
             </legend>
             <v-row>
-              <v-col cols="12" md="6" class="pb-0">
+              <v-col cols="12" sm="6" class="pb-0">
                 <DsfrTextField
                   v-model.number="payload.totalLeftovers"
                   :rules="payload.hasWasteMeasures ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []"
@@ -56,7 +66,7 @@
                   :hideOptional="true"
                 />
               </v-col>
-              <v-col cols="12" md="6" class="pb-0">
+              <v-col cols="12" sm="6" class="pb-0">
                 <DsfrTextField
                   :value="payload.durationLeftoversMeasurement"
                   @input="(x) => (payload.durationLeftoversMeasurement = integerInputValue(x))"
@@ -73,7 +83,9 @@
                   :hideOptional="true"
                 />
               </v-col>
-              <v-col cols="12" md="6" class="pb-0">
+            </v-row>
+            <v-row>
+              <v-col cols="12" sm="6" class="pb-0">
                 <DsfrTextField
                   v-model.number="payload.breadLeftovers"
                   :rules="payload.hasWasteMeasures ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []"
@@ -85,7 +97,7 @@
                   :hideOptional="true"
                 />
               </v-col>
-              <v-col cols="12" md="6" class="pb-0">
+              <v-col cols="12" sm="6" class="pb-0">
                 <DsfrTextField
                   v-model.number="payload.servedLeftovers"
                   :rules="payload.hasWasteMeasures ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []"
@@ -97,7 +109,9 @@
                   :hideOptional="true"
                 />
               </v-col>
-              <v-col cols="12" md="6" class="pb-0">
+            </v-row>
+            <v-row>
+              <v-col cols="12" sm="6" class="pb-0">
                 <DsfrTextField
                   v-model.number="payload.unservedLeftovers"
                   :rules="payload.hasWasteMeasures ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []"
@@ -109,7 +123,7 @@
                   :hideOptional="true"
                 />
               </v-col>
-              <v-col cols="12" md="6" class="pb-0">
+              <v-col cols="12" sm="6" class="pb-0">
                 <DsfrTextField
                   v-model.number="payload.sideLeftovers"
                   :rules="payload.hasWasteMeasures ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []"
@@ -290,6 +304,7 @@
 import { applicableDiagnosticRules } from "@/utils"
 import validators from "@/validators"
 import LastYearAutofillOption from "../LastYearAutofillOption"
+import DsfrCallout from "@/components/DsfrCallout"
 import DsfrTextField from "@/components/DsfrTextField"
 import DsfrTextarea from "@/components/DsfrTextarea"
 import DsfrRadio from "@/components/DsfrRadio"
@@ -345,6 +360,7 @@ export default {
   },
   components: {
     LastYearAutofillOption,
+    DsfrCallout,
     DsfrTextField,
     DsfrTextarea,
     DsfrRadio,


### PR DESCRIPTION
Lié à #4627

Changements de wording :
- remplace "gaspillage alimentaire" par "déchets alimentaires"
- ajout d'une info-bulle sur une des étapes

### Captures d'écran

étape 2 : ajout d'une bulle info
![image](https://github.com/user-attachments/assets/85c8ec8b-a95f-4af8-a738-4d22b6f45e88)
