### PR TITLE
Tunnel gaspillage alimentaire : Synthèse : remonter la date & le bouton modifier

### DIFF
--- a/2024-frontend/src/components/EdibleChart.vue
+++ b/2024-frontend/src/components/EdibleChart.vue
@@ -43,25 +43,23 @@ const displayOption = ref("chart")
       <div class="fr-col-md-7 fr-mb-2w">
         <h3 class="fr-h6 fr-my-0">Part de comestible</h3>
       </div>
-      <div class="fr-col fr-mb-2w">
-        <div class="fr-grid-row">
-          <DsfrSegmentedSet
-            name="Part de comestible"
-            label="Choix d'affichage"
-            :options="[
-              {
-                label: 'Charte',
-                value: 'chart',
-              },
-              {
-                label: 'Texte',
-                value: 'text',
-              },
-            ]"
-            v-model="displayOption"
-            small
-          />
-        </div>
+      <div class="fr-col fr-mb-2w" style="text-align: right;">
+        <DsfrSegmentedSet
+          name="Part de comestible"
+          label="Choix d'affichage"
+          :options="[
+            {
+              label: 'Charte',
+              value: 'chart',
+            },
+            {
+              label: 'Texte',
+              value: 'text',
+            },
+          ]"
+          v-model="displayOption"
+          small
+        />
       </div>
     </div>
     <div v-if="displayOption === 'chart'" class="fr-py-2w fr-pr-8w">

--- a/2024-frontend/src/components/SourceChart.vue
+++ b/2024-frontend/src/components/SourceChart.vue
@@ -43,25 +43,23 @@ const displayOption = ref("chart")
       <div class="fr-col-md-7 fr-mb-2w">
         <h3 class="fr-h6 fr-my-0">Origine du gaspillage</h3>
       </div>
-      <div class="fr-col fr-mb-2w">
-        <div class="fr-grid-row">
-          <DsfrSegmentedSet
-            name="Origine du gaspillage"
-            label="Choix d'affichage"
-            :options="[
-              {
-                label: 'Charte',
-                value: 'chart',
-              },
-              {
-                label: 'Texte',
-                value: 'text',
-              },
-            ]"
-            v-model="displayOption"
-            small
-          />
-        </div>
+      <div class="fr-col fr-mb-2w" style="text-align: right;">
+        <DsfrSegmentedSet
+          name="Origine du gaspillage"
+          label="Choix d'affichage"
+          :options="[
+            {
+              label: 'Charte',
+              value: 'chart',
+            },
+            {
+              label: 'Texte',
+              value: 'text',
+            },
+          ]"
+          v-model="displayOption"
+          small
+        />
       </div>
     </div>
     <div v-if="displayOption === 'chart'" class="fr-py-2w fr-pr-8w">

--- a/2024-frontend/src/components/WasteMeasurementSummary.vue
+++ b/2024-frontend/src/components/WasteMeasurementSummary.vue
@@ -51,10 +51,36 @@ const activeAccordion = ref("")
   <div>
     <div v-if="displayMeasurement" class="fr-grid-row">
       <div class="fr-col fr-mb-4w">
+        <div v-if="editable" class="fr-grid-row fr-grid-row--bottom fr-mb-4w">
+          <div class="fr-col-12 fr-col-md-6 fr-pr-4w">
+            <DsfrSelect v-model="chosenMeasurementIdx" label="Date de l'évaluation" :options="measurementChoices" />
+          </div>
+        </div>
+        <div v-else class="grey-text">
+          <p class="fr-mb-1w">Date de l'évaluation</p>
+          <p>
+            <b>
+              {{
+                formatDate(displayMeasurement.periodStartDate, {
+                  month: "short",
+                  day: "numeric",
+                })
+              }}
+              - {{ formatDate(displayMeasurement.periodEndDate) }}
+            </b>
+          </p>
+        </div>
         <EmphasiseText :emphasisText="`${formatNumber(wastePerMeal)} g`" contextText="par repas" class="brown" />
-        <router-link v-if="editable" :to="newMeasurementRoute" class="fr-btn fr-btn--secondary fr-mt-sm-2w">
-          Saisir une nouvelle évaluation
-        </router-link>
+        <p v-if="editable">
+          <router-link :to="measurementTunnel" class="fr-btn fr-btn--secondary">
+            Modifier les données
+          </router-link>
+        </p>
+        <p v-if="editable">
+          <router-link :to="newMeasurementRoute" class="fr-btn fr-btn--secondary">
+            Saisir une nouvelle évaluation
+          </router-link>
+        </p>
       </div>
       <div class="fr-col-12 fr-col-sm-4 fr-mb-4w">
         <div v-if="displayMeasurement.isSortedBySource">
@@ -75,31 +101,6 @@ const activeAccordion = ref("")
     </div>
     <DsfrAccordionsGroup v-model="activeAccordion">
       <DsfrAccordion id="waste-measurement-detail" title="Données détaillées" class="fr-my-2w">
-        <div v-if="editable" class="fr-grid-row fr-grid-row--bottom fr-mb-4w">
-          <div class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-pr-4w">
-            <DsfrSelect v-model="chosenMeasurementIdx" label="Date de l'évaluation" :options="measurementChoices" />
-          </div>
-          <div v-if="editable" class="fr-col-12 fr-col-sm-4">
-            <router-link class="fr-btn fr-btn--tertiary" :to="measurementTunnel">
-              <span class="fr-icon-pencil-line fr-icon--sm fr-mr-1w"></span>
-              Modifier les données
-            </router-link>
-          </div>
-        </div>
-        <div v-else class="grey-text">
-          <p class="fr-mb-1w">Date de l'évaluation</p>
-          <p>
-            <b>
-              {{
-                formatDate(displayMeasurement.periodStartDate, {
-                  month: "short",
-                  day: "numeric",
-                })
-              }}
-              - {{ formatDate(displayMeasurement.periodEndDate) }}
-            </b>
-          </p>
-        </div>
         <MeasurementDetail :measurement="displayMeasurement" />
         <router-link v-if="editable" class="fr-btn fr-btn--tertiary fr-btn--sm" :to="measurementTunnel">
           <span class="fr-icon-pencil-line fr-icon--sm fr-mr-1w"></span>

--- a/2024-frontend/src/components/WasteMeasurementSummary.vue
+++ b/2024-frontend/src/components/WasteMeasurementSummary.vue
@@ -49,10 +49,10 @@ const activeAccordion = ref("")
 
 <template>
   <div>
-    <div v-if="displayMeasurement" class="fr-grid-row">
+    <div v-if="displayMeasurement" class="fr-grid-row fr-grid-row--gutters">
       <div class="fr-col fr-mb-4w">
         <div v-if="editable" class="fr-grid-row fr-grid-row--bottom fr-mb-4w">
-          <div class="fr-col-12 fr-col-md-6 fr-pr-4w">
+          <div class="fr-col-12 fr-pr-4w">
             <DsfrSelect v-model="chosenMeasurementIdx" label="Date de l'évaluation" :options="measurementChoices" />
           </div>
         </div>
@@ -72,12 +72,10 @@ const activeAccordion = ref("")
         </div>
         <EmphasiseText :emphasisText="`${formatNumber(wastePerMeal)} g`" contextText="par repas" class="brown" />
         <p v-if="editable">
-          <router-link :to="measurementTunnel" class="fr-btn fr-btn--secondary">
+          <router-link :to="measurementTunnel" class="fr-btn fr-btn--secondary fr-btn--sm fr-mr-1w fr-mb-1w">
             Modifier les données
           </router-link>
-        </p>
-        <p v-if="editable">
-          <router-link :to="newMeasurementRoute" class="fr-btn fr-btn--secondary">
+          <router-link :to="newMeasurementRoute" class="fr-btn fr-btn--primary fr-btn--sm">
             Saisir une nouvelle évaluation
           </router-link>
         </p>


### PR DESCRIPTION
Closes #4660

### Quoi

Modifications apportées sur la page Synthèse du tunnel v2
- remonter l'affichage/choix de la période
- basculé le bouton modifier en dessous (au lieu d'à coté, car avec #4650 on va manquer de place + CTA en haut ou en bas mais pas au milieu de la synthèse pour un-bloat la navigation)

### Captures d'écran

||Image|
|---|---|
|Avant|![image](https://github.com/user-attachments/assets/7117bdae-ae77-4f1d-8fae-ed42fa5a5fd3)|
|Après|![image](https://github.com/user-attachments/assets/59f5c632-86d8-4e90-a58c-79549f483546)|