### PR TITLE
Option pour ajouter des évaluations déchets depuis le tunnel bilan gaspillage

### DIFF
--- a/2024-frontend/src/router/index.js
+++ b/2024-frontend/src/router/index.js
@@ -161,7 +161,7 @@ const router = createRouter({
 
 router.beforeEach(async (to) => {
   if (!to.path.startsWith(VUE3_PREFIX)) {
-    location.href = location.origin + to.path
+    location.href = location.origin + to.fullPath
     return false
   }
   if (!to.meta.authenticationRequired) return

--- a/2024-frontend/src/views/WasteMeasurementTunnel/index.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/index.vue
@@ -74,7 +74,7 @@ const formIsValid = () => {
 
 const continueAction = () => {
   if (step.value.isSynthesis) {
-    router.push({ name: "WasteMeasurements" })
+    quit()
     return
   }
   if (!formIsValid()) {

--- a/2024-frontend/src/views/WasteMeasurementTunnel/index.vue
+++ b/2024-frontend/src/views/WasteMeasurementTunnel/index.vue
@@ -4,9 +4,11 @@ import { useRouter } from "vue-router"
 import WasteMeasurementSteps from "./WasteMeasurementSteps/index.vue"
 import WasteSummary from "./WasteSummary.vue"
 import { BadRequestError } from "@/utils"
+import { useRoute } from "vue-router"
 
 import { useRootStore } from "@/stores/root"
 const store = useRootStore()
+const route = useRoute()
 
 const props = defineProps(["canteenUrlComponent", "id", "étape"])
 
@@ -129,8 +131,11 @@ const saveAndQuit = () => {
     .catch(handleServerError)
 }
 
+const returnHref = ref(route.query?.return)
+
 const quit = () => {
-  router.push({ name: "WasteMeasurements" })
+  if (returnHref.value) document.location.href = returnHref.value
+  else router.push({ name: "WasteMeasurements" })
 }
 
 let v$

--- a/api/views/wastemeasurement.py
+++ b/api/views/wastemeasurement.py
@@ -2,6 +2,7 @@ import logging
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import JsonResponse
+from django_filters import rest_framework as django_filters
 from rest_framework import status
 from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView
@@ -14,10 +15,26 @@ from data.models import Canteen, WasteMeasurement
 logger = logging.getLogger(__name__)
 
 
+class WasteMeasurementFilterSet(django_filters.FilterSet):
+    period_start_date = django_filters.DateFromToRangeFilter()
+    period_end_date = django_filters.DateFromToRangeFilter()
+
+    class Meta:
+        model = WasteMeasurement
+        fields = (
+            "period_start_date",
+            "period_end_date",
+        )
+
+
 class CanteenWasteMeasurementsView(ListCreateAPIView):
     permission_classes = [IsAuthenticated]
     model = WasteMeasurement
     serializer_class = WasteMeasurementSerializer
+    filter_backends = [
+        django_filters.DjangoFilterBackend,
+    ]
+    filterset_class = WasteMeasurementFilterSet
 
     def _get_canteen(self):
         canteen_id = self.request.parser_context.get("kwargs").get("canteen_pk")

--- a/frontend/src/components/DiagnosticSummary/WasteMeasureSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/WasteMeasureSummary.vue
@@ -42,7 +42,7 @@
         </span>
       </li>
 
-      <li v-if="diagnostic.hasWasteMeasures">
+      <li v-if="diagnostic.hasWasteMeasures && hasOldWasteMeasures">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>
           J’ai réalisé des mesures de mes déchets alimentaires :
@@ -53,6 +53,12 @@
             </li>
           </ul>
         </div>
+      </li>
+      <li v-else-if="diagnostic.hasWasteMeasures">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        <span>
+          J’ai réalisé des mesures de mes déchets alimentaires
+        </span>
       </li>
       <li v-else-if="diagnosticUsesNullAsFalse || diagnostic.hasWasteMeasures === false">
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
@@ -176,6 +182,18 @@ export default {
         },
         { label: "Reste de composantes", value: isDefined(diag.sideLeftovers) ? `${diag.sideLeftovers} kg/an` : "—" },
       ]
+    },
+    hasOldWasteMeasures() {
+      // for the campaign of 2025, we no longer ask for waste measures in the diagnostic, but in the anti-waste tool
+      const diag = this.diagnostic
+      return (
+        !!diag.totalLeftovers ||
+        !!diag.durationLeftoversMeasurement ||
+        !!diag.breadLeftovers ||
+        !!diag.servedLeftovers ||
+        !!diag.unservedLeftovers ||
+        !!diag.sideLeftovers
+      )
     },
     displayDonationAgreementSegment() {
       return applicableDiagnosticRules(this.canteen).hasDonationAgreement

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -611,6 +611,10 @@ const vue3Routes = [
     },
     sitemapGroup: Constants.SitemapGroups.DIAG,
   },
+  {
+    path: "/evaluation-gaspillage-alimentaire/:canteenUrlComponent/:id?",
+    name: "WasteMeasurementTunnel",
+  },
 ]
 const VUE3_PREFIX = "/v2"
 vue3Routes.forEach((r) => {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -658,7 +658,7 @@ function chooseAuthorisedRoute(to, from, next) {
 
 function handleVue3(to) {
   if (to.path.startsWith(VUE3_PREFIX)) {
-    window.location.href = location.origin + to.path
+    window.location.href = location.origin + to.fullPath
   }
 }
 

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -365,6 +365,14 @@ export const formatDate = (dateString) => {
   return date.toLocaleString("fr", options)
 }
 
+export const formatNumber = (value) => {
+  if (value || value === 0) {
+    const formatter = new Intl.NumberFormat("fr-FR")
+    return formatter.format(value)
+  }
+  return "—"
+}
+
 export const sectorsSelectList = (sectors, category = null) => {
   sectors = JSON.parse(JSON.stringify(sectors))
   if (category) {

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -320,6 +320,7 @@
           :to="{
             name: 'WasteMeasurementTunnel',
             params: { canteenUrlComponent },
+            query,
           }"
         >
           Ajouter une nouvelle
@@ -438,6 +439,9 @@ export default {
           totalMass: 2000,
         },
       ],
+      query: {
+        return: document.location.href,
+      },
     }
   },
   computed: {

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -299,12 +299,13 @@
     </div>
     <div v-else-if="stepUrlSlug === 'évaluations'" class="fr-text">
       <p>Complèter vos évaluations de vos déchets alimentaires</p>
-      <ul class="mb-2">
+      <ul class="mb-6">
         <li v-for="m in measurements" :key="m.id">
           <router-link
             :to="{
               name: 'WasteMeasurementTunnel',
               params: { canteenUrlComponent, id: m.id },
+              query: { return: href },
             }"
           >
             {{ m.periodStartDate }} - {{ m.periodEndDate }}
@@ -315,15 +316,14 @@
       <div>
         <v-btn
           color="primary"
-          outlined
-          small
+          :outlined="!measurements || !!measurements.length"
           :to="{
             name: 'WasteMeasurementTunnel',
             params: { canteenUrlComponent },
-            query,
+            query: { return: href },
           }"
         >
-          Ajouter une nouvelle
+          Saisir une nouvelle évaluation
         </v-btn>
       </div>
     </div>
@@ -426,9 +426,6 @@ export default {
         "donationFoodType",
       ],
       measurements: undefined,
-      query: {
-        return: document.location.href,
-      },
     }
   },
   computed: {
@@ -466,6 +463,9 @@ export default {
     },
     year() {
       return this.diagnostic.year
+    },
+    href() {
+      return document.location.href
     },
   },
   methods: {

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -300,7 +300,7 @@
     <div v-else-if="stepUrlSlug === 'évaluations'" class="fr-text">
       <p>Complèter vos évaluations de vos déchets alimentaires</p>
       <ul class="mb-2">
-        <li v-for="m in exampleMeasurements" :key="m.id">
+        <li v-for="m in measurements" :key="m.id">
           <router-link
             :to="{
               name: 'WasteMeasurementTunnel',
@@ -425,20 +425,7 @@ export default {
         "donationQuantity",
         "donationFoodType",
       ],
-      exampleMeasurements: [
-        {
-          id: 1,
-          periodStartDate: "2023-03-04",
-          periodEndDate: "2023-03-14",
-          totalMass: 2000,
-        },
-        {
-          id: 2,
-          periodStartDate: "2023-11-18",
-          periodEndDate: "2023-11-23",
-          totalMass: 2000,
-        },
-      ],
+      measurements: undefined,
       query: {
         return: document.location.href,
       },
@@ -483,6 +470,7 @@ export default {
       const payload = {}
       this.fields.forEach((f) => (payload[f] = this.diagnostic[f]))
       this.$set(this, "payload", payload)
+      this.fetchWasteMeasurements()
     },
     updatePayload() {
       this.$emit("update-payload", { payload: this.payload, formIsValid: this.formIsValid })
@@ -512,6 +500,14 @@ export default {
       const parsedValue = parseFunction(val)
       if (parsedValue === 0) return 0
       return parsedValue || val
+    },
+    fetchWasteMeasurements() {
+      // TODO: only fetch for TD year
+      fetch(`/api/v1/canteens/${this.canteen.id}/wasteMeasurements`)
+        .then((response) => response.json())
+        .then((response) => {
+          this.measurements = response
+        })
     },
   },
   mounted() {

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -44,101 +44,6 @@
           </DsfrCallout>
         </v-col>
       </v-row>
-      <v-row>
-        <v-col cols="12">
-          <fieldset :disabled="!payload.hasWasteMeasures">
-            <legend class="my-3 font-weight-bold">
-              Mesures des déchets
-              <span :class="`fr-hint-text mt-2 ${payload.hasWasteMeasures ? '' : 'grey--text'}`">
-                Optionnel
-              </span>
-            </legend>
-            <v-row>
-              <v-col cols="12" sm="6" class="pb-0">
-                <DsfrTextField
-                  v-model.number="payload.totalLeftovers"
-                  :rules="payload.hasWasteMeasures ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []"
-                  validate-on-blur
-                  label="Total des déchets alimentaires"
-                  suffix="kg"
-                  :readonly="!payload.hasWasteMeasures"
-                  :disabled="!payload.hasWasteMeasures"
-                  :hideOptional="true"
-                />
-              </v-col>
-              <v-col cols="12" sm="6" class="pb-0">
-                <DsfrTextField
-                  :value="payload.durationLeftoversMeasurement"
-                  @input="(x) => (payload.durationLeftoversMeasurement = integerInputValue(x))"
-                  :rules="
-                    payload.hasWasteMeasures
-                      ? [validators.nonNegativeOrEmpty, validators.isInteger, validators.lteOrEmpty(365)]
-                      : []
-                  "
-                  validate-on-blur
-                  label="Période de mesure"
-                  suffix="jours"
-                  :readonly="!payload.hasWasteMeasures"
-                  :disabled="!payload.hasWasteMeasures"
-                  :hideOptional="true"
-                />
-              </v-col>
-            </v-row>
-            <v-row>
-              <v-col cols="12" sm="6" class="pb-0">
-                <DsfrTextField
-                  v-model.number="payload.breadLeftovers"
-                  :rules="payload.hasWasteMeasures ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []"
-                  validate-on-blur
-                  label="Reste de pain"
-                  suffix="kg/an"
-                  :readonly="!payload.hasWasteMeasures"
-                  :disabled="!payload.hasWasteMeasures"
-                  :hideOptional="true"
-                />
-              </v-col>
-              <v-col cols="12" sm="6" class="pb-0">
-                <DsfrTextField
-                  v-model.number="payload.servedLeftovers"
-                  :rules="payload.hasWasteMeasures ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []"
-                  validate-on-blur
-                  label="Reste plateau"
-                  suffix="kg/an"
-                  :readonly="!payload.hasWasteMeasures"
-                  :disabled="!payload.hasWasteMeasures"
-                  :hideOptional="true"
-                />
-              </v-col>
-            </v-row>
-            <v-row>
-              <v-col cols="12" sm="6" class="pb-0">
-                <DsfrTextField
-                  v-model.number="payload.unservedLeftovers"
-                  :rules="payload.hasWasteMeasures ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []"
-                  validate-on-blur
-                  label="Reste en production (non servi)"
-                  suffix="kg/an"
-                  :readonly="!payload.hasWasteMeasures"
-                  :disabled="!payload.hasWasteMeasures"
-                  :hideOptional="true"
-                />
-              </v-col>
-              <v-col cols="12" sm="6" class="pb-0">
-                <DsfrTextField
-                  v-model.number="payload.sideLeftovers"
-                  :rules="payload.hasWasteMeasures ? [validators.nonNegativeOrEmpty, validators.decimalPlaces(2)] : []"
-                  validate-on-blur
-                  label="Reste de composantes (entrée, plat dessert...)"
-                  suffix="kg/an"
-                  :readonly="!payload.hasWasteMeasures"
-                  :disabled="!payload.hasWasteMeasures"
-                  :hideOptional="true"
-                />
-              </v-col>
-            </v-row>
-          </fieldset>
-        </v-col>
-      </v-row>
     </div>
     <fieldset v-else-if="stepUrlSlug === 'actions'">
       <legend class="my-3">
@@ -298,7 +203,11 @@
       </v-dialog>
     </div>
     <div v-else-if="stepUrlSlug === 'évaluations'" class="fr-text">
-      <p>Complèter vos évaluations de vos déchets alimentaires</p>
+      <p>
+        Suivre les mesures de vos déchets alimentaires dans notre outil pour visualiser les sources principales de vos
+        déchets, et pour recevoir des conseils personnalisés à votre situation.
+      </p>
+      <p>Il est conseillé de faire au moins deux évaluations par an.</p>
       <ul class="mb-6">
         <li v-for="m in measurements" :key="m.id">
           <router-link
@@ -308,9 +217,9 @@
               query: { return: href },
             }"
           >
-            {{ m.periodStartDate }} - {{ m.periodEndDate }}
+            {{ formatDate(m.periodStartDate) }} - {{ formatDate(m.periodEndDate) }}
           </router-link>
-          : {{ m.totalMass }} kg
+          : {{ formatNumber(m.totalMass) }} kg en total
         </li>
       </ul>
       <div>
@@ -331,7 +240,7 @@
 </template>
 
 <script>
-import { applicableDiagnosticRules } from "@/utils"
+import { applicableDiagnosticRules, formatDate, formatNumber } from "@/utils"
 import validators from "@/validators"
 import LastYearAutofillOption from "../LastYearAutofillOption"
 import DsfrCallout from "@/components/DsfrCallout"
@@ -367,7 +276,7 @@ const STEPS = [
     urlSlug: "expérimentation",
   },
   {
-    title: "Mesure de mes déchets alimentaires (pt 2)",
+    title: "Détail des mesures de mes déchets alimentaires",
     urlSlug: "évaluations",
   },
   {
@@ -511,6 +420,12 @@ export default {
         .then((response) => {
           this.measurements = response
         })
+    },
+    formatDate(str) {
+      return formatDate(str)
+    },
+    formatNumber(str) {
+      return formatNumber(str)
     },
   },
   mounted() {

--- a/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/WasteMeasureSteps/index.vue
@@ -464,6 +464,9 @@ export default {
     canteenUrlComponent() {
       return this.$store.getters.getCanteenUrlComponent(this.canteen)
     },
+    year() {
+      return this.diagnostic.year
+    },
   },
   methods: {
     initialisePayload() {
@@ -502,8 +505,8 @@ export default {
       return parsedValue || val
     },
     fetchWasteMeasurements() {
-      // TODO: only fetch for TD year
-      fetch(`/api/v1/canteens/${this.canteen.id}/wasteMeasurements`)
+      const query = `period_start_date_after=${this.year}-01-01&period_end_date_before=${this.year + 1}-01-01`
+      fetch(`/api/v1/canteens/${this.canteen.id}/wasteMeasurements?${query}`)
         .then((response) => response.json())
         .then((response) => {
           this.measurements = response


### PR DESCRIPTION
closes #4665 

## Cible

En tant que gestionnaire, je veux reseigner mes évaluations de mes déchets alimentaires au moment de completion de la bilan/télédéclaration.

## Approche

Je propose une nouvelle étape dans le bilan gaspi pour introduire le nouveau outil, et pour lister les évaluations saisies pour l'année du bilan.

L'idée c'est que quand on arrive dans le tunnel évaluation depuis le tunnel bilan, une fois qu'on termine avec le tunnel éval on revient au tunnel bilan et non pas la page évaluations. 

J'ai du ajouter l'option de filtrer par date côté back pour afficher les évaluations faites sur l'année en question.

Cette nouvelle étape sera affichée que si l'utilisateur à indiqué qu'iel a fait des mesures plus tôt dans le bilan


[Screencast from 2024-11-25 15-12-56.webm](https://github.com/user-attachments/assets/3a3b2ca6-43b2-492d-a9fd-d555c461e033)

![Screenshot 2024-11-25 at 15-07-35 Mesure de mes déchets alimentaires - 2024 - ROOT ACCESS - ma cantine](https://github.com/user-attachments/assets/fd19b268-b4f6-45be-bd42-c3a1088f455b)

![Screenshot 2024-11-25 at 14-44-59 Détail des mesures de mes déchets alimentaires - 2024 - ROOT ACCESS - ma cantine](https://github.com/user-attachments/assets/b4290ebf-6b09-4fd8-a2a0-7e200f69eb28)

Les anciennes mesures déchets sont affichées dans le synthèse que si elles ont été remplit

![Screenshot 2024-12-02 at 10-03-04 Ma progression - ma cantine](https://github.com/user-attachments/assets/5a2766a4-66ed-4b34-817d-23e702b8d007)
![Screenshot 2024-12-02 at 10-03-15 Ma progression - ma cantine](https://github.com/user-attachments/assets/a0be0bfe-68f0-4a68-b1fd-754eb41b96a8)
