### PR TITLE
Tunnel diagnostique : Menu végé : renommer le champ de l'étape 2

### DIFF
--- a/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
@@ -37,20 +37,20 @@
       <li v-if="diagnostic.vegetarianWeeklyRecurrence === 'NEVER'">
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
         <div>
-          Je ne propose pas de menu végétarien dans ma cantine
+          Je ne propose pas de menu végétarien
         </div>
       </li>
       <li v-else-if="diagnostic.vegetarianWeeklyRecurrence">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>
-          J’ai mis en place un menu végétarien dans ma cantine :
+          J'ai mis en place un menu végétarien :
           <span class="font-weight-bold">{{ weeklyRecurrence }}</span>
         </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$question-line</v-icon>
         <div>
-          Je n'ai pas renseigné la périodicité du menu végétarien dans ma cantine
+          Je n'ai pas renseigné la périodicité du menu végétarien
         </div>
       </li>
 
@@ -65,7 +65,7 @@
         <li v-else>
           <v-icon color="primary" class="mr-2">$question-line</v-icon>
           <div>
-            Je n'ai pas renseigné le type de menu végétarien servi dans ma cantine
+            Je n'ai pas renseigné le type de menu végétarien servi
           </div>
         </li>
       </div>

--- a/frontend/src/components/KeyMeasureDiagnostic/DiversificationMeasure.vue
+++ b/frontend/src/components/KeyMeasureDiagnostic/DiversificationMeasure.vue
@@ -29,7 +29,7 @@
     </fieldset>
 
     <DsfrRadio
-      label="J'ai mis en place un menu végétarien dans ma cantine :"
+      label="J'ai mis en place un menu végétarien :"
       v-model="diagnostic.vegetarianWeeklyRecurrence"
       hide-details
       :items="frequency"

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -630,24 +630,24 @@ export default Object.freeze({
   ],
   VegetarianRecurrence: [
     {
-      label: "De façon quotidienne",
-      value: "DAILY",
-    },
-    {
-      label: "Plus d'une fois par semaine",
-      value: "HIGH",
-    },
-    {
-      label: "Une fois par semaine",
-      value: "MID",
+      label: "Non, je n'ai pas mis en place un menu végétarien",
+      value: "NEVER",
     },
     {
       label: "Moins d'une fois par semaine",
       value: "LOW",
     },
     {
-      label: "Je ne propose pas de menu végétarien",
-      value: "NEVER",
+      label: "Une fois par semaine",
+      value: "MID",
+    },
+    {
+      label: "Plus d'une fois par semaine",
+      value: "HIGH",
+    },
+    {
+      label: "De façon quotidienne",
+      value: "DAILY",
     },
   ],
   CommunicationFrequencies: [

--- a/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
@@ -9,7 +9,7 @@
         class="mb-xs-6 mb-xl-16"
       />
       <DsfrRadio
-        label="J'ai mis en place un menu végétarien dans ma cantine :"
+        label="J'ai mis en place un menu végétarien :"
         :items="frequency"
         v-model="payload.vegetarianWeeklyRecurrence"
         @change="calculateSteps"


### PR DESCRIPTION
### Quoi

Une partie de l'issue #4613
- renommé le label
- inversé l'ordre des choix

### Capture d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/user-attachments/assets/e7be7ca6-5558-454a-9581-eee0d5b2a144)|![image](https://github.com/user-attachments/assets/b3fa5610-65b0-4dbe-bb7e-9f7b3bd6a671)|