### PR TITLE
Tunnel diagnostique : Menu végé : changements cosmétiques sur l'étape 1

### DIFF
--- a/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
@@ -60,7 +60,7 @@
           class="mt-1"
           v-model="payload.diversificationPlanActions"
           :multiple="true"
-          v-for="item in diversificationPlanActions"
+          v-for="item in planActions"
           :key="item.value"
           :value="item.value"
           :label="item.label"
@@ -97,32 +97,10 @@ export default {
   data() {
     return {
       steps: [],
-      diversificationPlanActions: [
-        {
-          label: "Les plats et les produits (diversification, gestion des quantités, recette traditionnelle, goût...)",
-          value: "PRODUCTS",
-        },
-        {
-          label: "La manière dont les aliments sont présentés aux convives (visuellement attrayants)",
-          value: "PRESENTATION",
-        },
-        {
-          label: "La manière dont les menus sont conçus en soulignant attributs positifs des plats",
-          value: "MENU",
-        },
-        {
-          label: "La mise en avant des produits (plats recommandés, dégustation, mode de production...)",
-          value: "PROMOTION",
-        },
-        {
-          label:
-            "La formation du personnel, la sensibilisation des convives, l’investissement dans de nouveaux équipements de cuisine...",
-          value: "TRAINING",
-        },
-      ],
       frequency: Constants.VegetarianRecurrence,
       menuTypes: Constants.VegetarianMenuTypes,
       menuBases: Constants.VegetarianMenuBases,
+      planActions: Constants.DiversificationPlanActions,
       payload: {},
       fields: [
         "vegetarianWeeklyRecurrence",

--- a/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
@@ -47,11 +47,10 @@
           protéines végétales"
         v-model="payload.hasDiversificationPlan"
         hide-details
-        optionsRow
         yesNo
         optional
       />
-      <fieldset class="my-3">
+      <fieldset class="mt-8 mb-3">
         <legend class="text-left mb-1 mt-3" :class="{ 'grey--text': !payload.hasDiversificationPlan }">
           Ce plan comporte, par exemple, les actions suivantes (voir guide du CNRC) :
           <span :class="`fr-hint-text mt-2 ${!payload.hasDiversificationPlan && 'grey--text'}`">Optionnel</span>


### PR DESCRIPTION
### Quoi

Léger refactoring et homogénéisations sur l'étape 1 du tunnel
- aligner les checkbox verticalement (comme c'est le cas aux autres étapes du diag)
- ajout d'un margin-top entre les 2 champs (`mt-8` comme ailleurs)
- choix : réutiliser le wording existant pour simplifier le code

### Capture d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/user-attachments/assets/7bc94ea3-983e-41b0-a5e4-4c55c9b80277)|![image](https://github.com/user-attachments/assets/31f7dc2e-237e-47ba-8a6a-217957baa9c6)|