### PR TITLE
Tunnel diagnostique : Menu végé : basculer certains textes réutilisés dans constants.js

### DIFF
--- a/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
@@ -107,22 +107,22 @@ export default {
   },
   computed: {
     weeklyRecurrence() {
-      const items = selectListToObject(Constants.VegetarianRecurrence)
+      const items = selectListToObject(Constants.vegetarianWeeklyRecurrence.items)
       return items[this.diagnostic.vegetarianWeeklyRecurrence]
     },
     menuType() {
-      const types = selectListToObject(Constants.VegetarianMenuTypes)
+      const types = selectListToObject(Constants.vegetarianMenuType.items)
       return types[this.diagnostic.vegetarianMenuType]
     },
     menuBases() {
-      const bases = selectListToObject(Constants.VegetarianMenuBases)
+      const bases = selectListToObject(Constants.vegetarianMenuBases.items)
       return this.diagnostic.vegetarianMenuBases.map((x) => bases[x])
     },
     displayDiversificationPlanSegment() {
       return applicableDiagnosticRules(this.canteen).hasDiversificationPlan
     },
     appliedDiversificationActions() {
-      const diversificationPlanActions = selectListToObject(Constants.DiversificationPlanActions)
+      const diversificationPlanActions = selectListToObject(Constants.diversificationPlanActions.items)
       if (!this.diagnostic.diversificationPlanActions?.length) return null
       return this.diagnostic.diversificationPlanActions.map((x) => diversificationPlanActions[x]).filter((x) => !!x)
     },

--- a/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
@@ -5,7 +5,8 @@
         <span v-if="diagnostic.hasDiversificationPlan">
           <v-icon color="primary" class="mr-1">$check-line</v-icon>
           <span>
-            {{ Constants.DiversificationMeasureStep.hasDiversificationPlan.title }}
+            J'ai mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base de
+            protéines végétales
             <ul role="list" class="mt-2" v-if="appliedDiversificationActions && appliedDiversificationActions.length">
               <li class="fr-text-xs mb-1" v-for="action in appliedDiversificationActions" :key="action">
                 {{ action }}
@@ -107,22 +108,24 @@ export default {
   },
   computed: {
     weeklyRecurrence() {
-      const items = selectListToObject(Constants.vegetarianWeeklyRecurrence.items)
+      const items = selectListToObject(Constants.DiversificationMeasureStep.vegetarianWeeklyRecurrence.items)
       return items[this.diagnostic.vegetarianWeeklyRecurrence]
     },
     menuType() {
-      const types = selectListToObject(Constants.vegetarianMenuType.items)
-      return types[this.diagnostic.vegetarianMenuType]
+      const items = selectListToObject(Constants.DiversificationMeasureStep.vegetarianMenuType.items)
+      return items[this.diagnostic.vegetarianMenuType]
     },
     menuBases() {
-      const bases = selectListToObject(Constants.vegetarianMenuBases.items)
-      return this.diagnostic.vegetarianMenuBases.map((x) => bases[x])
+      const items = selectListToObject(Constants.DiversificationMeasureStep.vegetarianMenuBases.items)
+      return this.diagnostic.vegetarianMenuBases.map((x) => items[x])
     },
     displayDiversificationPlanSegment() {
       return applicableDiagnosticRules(this.canteen).hasDiversificationPlan
     },
     appliedDiversificationActions() {
-      const diversificationPlanActions = selectListToObject(Constants.diversificationPlanActions.items)
+      const diversificationPlanActions = selectListToObject(
+        Constants.DiversificationMeasureStep.diversificationPlanActions.items
+      )
       if (!this.diagnostic.diversificationPlanActions?.length) return null
       return this.diagnostic.diversificationPlanActions.map((x) => diversificationPlanActions[x]).filter((x) => !!x)
     },

--- a/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
@@ -5,8 +5,7 @@
         <span v-if="diagnostic.hasDiversificationPlan">
           <v-icon color="primary" class="mr-1">$check-line</v-icon>
           <span>
-            J'ai mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base de
-            protéines végétales
+            {{ Constants.DiversificationMeasureStep.hasDiversificationPlan.title }}
             <ul role="list" class="mt-2" v-if="appliedDiversificationActions && appliedDiversificationActions.length">
               <li class="fr-text-xs mb-1" v-for="action in appliedDiversificationActions" :key="action">
                 {{ action }}

--- a/frontend/src/components/KeyMeasureDiagnostic/DiversificationMeasure.vue
+++ b/frontend/src/components/KeyMeasureDiagnostic/DiversificationMeasure.vue
@@ -4,7 +4,7 @@
       hide-details="auto"
       class="mb-4"
       v-model="diagnostic.hasDiversificationPlan"
-      label="J'ai mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base de protéines végétales"
+      :label="Constants.DiversificationMeasureStep.hasDiversificationPlan.title"
       :readonly="readonly"
       :disabled="readonly"
       v-if="applicableRules.hasDiversificationPlan"
@@ -12,7 +12,7 @@
 
     <fieldset class="my-3" v-if="applicableRules.hasDiversificationPlan">
       <legend class="text-left mb-2 mt-3" :class="{ 'grey--text': !diagnostic.hasDiversificationPlan }">
-        Ce plan comporte, par exemple, les actions suivantes (voir guide du CNRC) :
+        {{ Constants.DiversificationMeasureStep.diversificationPlanActions.title }}
       </legend>
       <v-checkbox
         hide-details="auto"
@@ -29,7 +29,7 @@
     </fieldset>
 
     <DsfrRadio
-      label="J'ai mis en place un menu végétarien :"
+      :label="Constants.DiversificationMeasureStep.vegetarianWeeklyRecurrence.title"
       v-model="diagnostic.vegetarianWeeklyRecurrence"
       hide-details
       :items="frequency"
@@ -40,7 +40,7 @@
     />
 
     <DsfrRadio
-      label="Le menu végétarien proposé est :"
+      :label="Constants.DiversificationMeasureStep.vegetarianMenuType.title"
       v-model="diagnostic.vegetarianMenuType"
       hide-details
       :items="menuTypes"
@@ -52,7 +52,7 @@
 
     <fieldset class="mt-3">
       <legend class="text-left mb-2 mt-3">
-        Le plat principal de mon menu végétarien est majoritairement à base de :
+        {{ Constants.DiversificationMeasureStep.vegetarianMenuBases.title }}
       </legend>
       <v-checkbox
         hide-details="auto"

--- a/frontend/src/components/KeyMeasureDiagnostic/DiversificationMeasure.vue
+++ b/frontend/src/components/KeyMeasureDiagnostic/DiversificationMeasure.vue
@@ -127,10 +127,10 @@ export default {
   data() {
     return {
       showExpeModal: false,
-      diversificationPlanActions: Constants.DiversificationPlanActions,
-      frequency: Constants.VegetarianRecurrence,
-      menuTypes: Constants.VegetarianMenuTypes,
-      menuBases: Constants.VegetarianMenuBases,
+      diversificationPlanActions: Constants.diversificationPlanActions.items,
+      frequency: Constants.vegetarianWeeklyRecurrence.items,
+      menuTypes: Constants.vegetarianMenuType.items,
+      menuBases: Constants.vegetarianMenuBases.items,
     }
   },
   computed: {

--- a/frontend/src/components/KeyMeasureDiagnostic/DiversificationMeasure.vue
+++ b/frontend/src/components/KeyMeasureDiagnostic/DiversificationMeasure.vue
@@ -4,7 +4,7 @@
       hide-details="auto"
       class="mb-4"
       v-model="diagnostic.hasDiversificationPlan"
-      :label="Constants.DiversificationMeasureStep.hasDiversificationPlan.title"
+      :label="constantsDiversificationMeasureStep.hasDiversificationPlan.title"
       :readonly="readonly"
       :disabled="readonly"
       v-if="applicableRules.hasDiversificationPlan"
@@ -12,14 +12,14 @@
 
     <fieldset class="my-3" v-if="applicableRules.hasDiversificationPlan">
       <legend class="text-left mb-2 mt-3" :class="{ 'grey--text': !diagnostic.hasDiversificationPlan }">
-        {{ Constants.DiversificationMeasureStep.diversificationPlanActions.title }}
+        {{ constantsDiversificationMeasureStep.diversificationPlanActions.title }}
       </legend>
       <v-checkbox
         hide-details="auto"
         class="ml-8 mt-2"
         v-model="diagnostic.diversificationPlanActions"
         :multiple="true"
-        v-for="item in diversificationPlanActions"
+        v-for="item in constantsDiversificationMeasureStep.diversificationPlanActions.items"
         :key="item.value"
         :value="item.value"
         :label="item.label"
@@ -29,10 +29,10 @@
     </fieldset>
 
     <DsfrRadio
-      :label="Constants.DiversificationMeasureStep.vegetarianWeeklyRecurrence.title"
+      :label="constantsDiversificationMeasureStep.vegetarianWeeklyRecurrence.title"
       v-model="diagnostic.vegetarianWeeklyRecurrence"
       hide-details
-      :items="frequency"
+      :items="constantsDiversificationMeasureStep.vegetarianWeeklyRecurrence.items"
       :readonly="readonly"
       :disabled="readonly"
       optionClasses="ml-8"
@@ -40,10 +40,10 @@
     />
 
     <DsfrRadio
-      :label="Constants.DiversificationMeasureStep.vegetarianMenuType.title"
+      :label="constantsDiversificationMeasureStep.vegetarianMenuType.title"
       v-model="diagnostic.vegetarianMenuType"
       hide-details
-      :items="menuTypes"
+      :items="constantsDiversificationMeasureStep.vegetarianMenuType.items"
       :readonly="readonly"
       :disabled="readonly"
       optionClasses="ml-8"
@@ -52,14 +52,14 @@
 
     <fieldset class="mt-3">
       <legend class="text-left mb-2 mt-3">
-        {{ Constants.DiversificationMeasureStep.vegetarianMenuBases.title }}
+        {{ constantsDiversificationMeasureStep.vegetarianMenuBases.title }}
       </legend>
       <v-checkbox
         hide-details="auto"
         class="ml-8 mt-2"
         v-model="diagnostic.vegetarianMenuBases"
         :multiple="true"
-        v-for="item in menuBases"
+        v-for="item in constantsDiversificationMeasureStep.vegetarianMenuBases.items"
         :key="item.value"
         :value="item.value"
         :label="item.label"
@@ -127,10 +127,7 @@ export default {
   data() {
     return {
       showExpeModal: false,
-      diversificationPlanActions: Constants.diversificationPlanActions.items,
-      frequency: Constants.vegetarianWeeklyRecurrence.items,
-      menuTypes: Constants.vegetarianMenuType.items,
-      menuBases: Constants.vegetarianMenuBases.items,
+      constantsDiversificationMeasureStep: Constants.DiversificationMeasureStep,
     }
   },
   computed: {

--- a/frontend/src/components/TeledeclarationPreview/PreviewTable.vue
+++ b/frontend/src/components/TeledeclarationPreview/PreviewTable.vue
@@ -607,25 +607,25 @@ export default {
     },
     getDiversificationPlanActions(diversificationPlanActions) {
       if (!diversificationPlanActions || !diversificationPlanActions.length) return "Non renseigné"
-      const actionItems = selectListToObject(Constants.DiversificationPlanActions)
+      const actionItems = selectListToObject(Constants.diversificationPlanActions.items)
       const labels = diversificationPlanActions.map((x) => actionItems[x]).filter((x) => !!x)
       return labels.join(", ")
     },
     getVegetarianWeeklyRecurrence(vegetarianWeeklyRecurrence) {
       if (!vegetarianWeeklyRecurrence) return "Non renseigné"
-      const items = selectListToObject(Constants.VegetarianRecurrence)
+      const items = selectListToObject(Constants.vegetarianWeeklyRecurrence.items)
       return items[vegetarianWeeklyRecurrence] || "Non renseigné"
     },
     getVegetarianMenuType(vegetarianMenuType) {
       if (this.diagnostic.vegetarianWeeklyRecurrence === "NEVER") return "Non applicable"
       if (!vegetarianMenuType) return "Non renseigné"
-      const items = selectListToObject(Constants.VegetarianMenuTypes)
+      const items = selectListToObject(Constants.vegetarianMenuType.items)
       return items[vegetarianMenuType] || "Non renseigné"
     },
     getVegetarianMenuBases(vegetarianMenuBases) {
       if (this.diagnostic.vegetarianWeeklyRecurrence === "NEVER") return "Non applicable"
       if (!vegetarianMenuBases || !vegetarianMenuBases.length) return "Non renseigné"
-      const actionItems = selectListToObject(Constants.VegetarianMenuBases)
+      const actionItems = selectListToObject(Constants.vegetarianMenuBases.items)
       const labels = vegetarianMenuBases.map((x) => actionItems[x]).filter((x) => !!x)
       return labels.join(", ")
     },

--- a/frontend/src/components/TeledeclarationPreview/PreviewTable.vue
+++ b/frontend/src/components/TeledeclarationPreview/PreviewTable.vue
@@ -607,25 +607,25 @@ export default {
     },
     getDiversificationPlanActions(diversificationPlanActions) {
       if (!diversificationPlanActions || !diversificationPlanActions.length) return "Non renseigné"
-      const actionItems = selectListToObject(Constants.diversificationPlanActions.items)
+      const actionItems = selectListToObject(Constants.DiversificationMeasureStep.diversificationPlanActions.items)
       const labels = diversificationPlanActions.map((x) => actionItems[x]).filter((x) => !!x)
       return labels.join(", ")
     },
     getVegetarianWeeklyRecurrence(vegetarianWeeklyRecurrence) {
       if (!vegetarianWeeklyRecurrence) return "Non renseigné"
-      const items = selectListToObject(Constants.vegetarianWeeklyRecurrence.items)
+      const items = selectListToObject(Constants.DiversificationMeasureStep.vegetarianWeeklyRecurrence.items)
       return items[vegetarianWeeklyRecurrence] || "Non renseigné"
     },
     getVegetarianMenuType(vegetarianMenuType) {
       if (this.diagnostic.vegetarianWeeklyRecurrence === "NEVER") return "Non applicable"
       if (!vegetarianMenuType) return "Non renseigné"
-      const items = selectListToObject(Constants.vegetarianMenuType.items)
+      const items = selectListToObject(Constants.DiversificationMeasureStep.vegetarianMenuType.items)
       return items[vegetarianMenuType] || "Non renseigné"
     },
     getVegetarianMenuBases(vegetarianMenuBases) {
       if (this.diagnostic.vegetarianWeeklyRecurrence === "NEVER") return "Non applicable"
       if (!vegetarianMenuBases || !vegetarianMenuBases.length) return "Non renseigné"
-      const actionItems = selectListToObject(Constants.vegetarianMenuBases.items)
+      const actionItems = selectListToObject(Constants.DiversificationMeasureStep.vegetarianMenuBases.items)
       const labels = vegetarianMenuBases.map((x) => actionItems[x]).filter((x) => !!x)
       return labels.join(", ")
     },

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -575,99 +575,99 @@ export default Object.freeze({
     },
     diversificationPlanActions: {
       title: "Ce plan comporte, par exemple, les actions suivantes (voir guide du CNRC) :",
+      items: [
+        {
+          label:
+            "Agir sur les plats et les produits (diversification, gestion des quantités, recette traditionnelle, gout...)",
+          value: "PRODUCTS",
+        },
+        {
+          label: "Agir sur la manière dont les aliments sont présentés aux convives (visuellement attrayants)",
+          value: "PRESENTATION",
+        },
+        {
+          label: "Agir sur la manière dont les menus sont conçus en soulignant attributs positifs des plats",
+          value: "MENU",
+        },
+        {
+          label: "Agir sur la mise en avant des produits (plats recommandés, dégustation, mode de production...)",
+          value: "PROMOTION",
+        },
+        {
+          label:
+            "Agir sur la formation du personnel, la sensibilisation des convives, l’investissement dans de nouveaux équipements de cuisine...",
+          value: "TRAINING",
+        },
+      ],
     },
     vegetarianWeeklyRecurrence: {
       title: "J'ai mis en place un menu végétarien :",
+      items: [
+        {
+          label: "De façon quotidienne",
+          value: "DAILY",
+        },
+        {
+          label: "Plus d'une fois par semaine",
+          value: "HIGH",
+        },
+        {
+          label: "Une fois par semaine",
+          value: "MID",
+        },
+        {
+          label: "Moins d'une fois par semaine",
+          value: "LOW",
+        },
+        {
+          label: "Je ne propose pas de menu végétarien",
+          value: "NEVER",
+        },
+      ],
     },
     vegetarianMenuType: {
       title: "Le menu végétarien proposé est :",
+      items: [
+        {
+          label: "Un menu végétarien en plat unique, sans choix",
+          value: "UNIQUE",
+        },
+        {
+          label: "Un menu végétarien composé de plusieurs choix de plats végétariens",
+          value: "SEVERAL",
+        },
+        {
+          label: "Un menu végétarien au choix, en plus d'autres plats non végétariens",
+          value: "ALTERNATIVES",
+        },
+      ],
     },
     vegetarianMenuBases: {
       title: "Le plat principal de mon menu végétarien est majoritairement à base de :",
+      items: [
+        {
+          label: "De céréales et/ou les légumes secs (hors soja)",
+          value: "GRAIN",
+        },
+        {
+          label: "De soja",
+          value: "SOY",
+        },
+        {
+          label: "De fromage",
+          value: "CHEESE",
+        },
+        {
+          label: "D’œufs",
+          value: "EGG",
+        },
+        {
+          label: "De plats transformés prêts à l'emploi",
+          value: "READYMADE",
+        },
+      ],
     },
   },
-  DiversificationPlanActions: [
-    {
-      label:
-        "Agir sur les plats et les produits (diversification, gestion des quantités, recette traditionnelle, gout...)",
-      value: "PRODUCTS",
-    },
-    {
-      label: "Agir sur la manière dont les aliments sont présentés aux convives (visuellement attrayants)",
-      value: "PRESENTATION",
-    },
-    {
-      label: "Agir sur la manière dont les menus sont conçus en soulignant attributs positifs des plats",
-      value: "MENU",
-    },
-    {
-      label: "Agir sur la mise en avant des produits (plats recommandés, dégustation, mode de production...)",
-      value: "PROMOTION",
-    },
-    {
-      label:
-        "Agir sur la formation du personnel, la sensibilisation des convives, l’investissement dans de nouveaux équipements de cuisine...",
-      value: "TRAINING",
-    },
-  ],
-  VegetarianMenuTypes: [
-    {
-      label: "Un menu végétarien en plat unique, sans choix",
-      value: "UNIQUE",
-    },
-    {
-      label: "Un menu végétarien composé de plusieurs choix de plats végétariens",
-      value: "SEVERAL",
-    },
-    {
-      label: "Un menu végétarien au choix, en plus d'autres plats non végétariens",
-      value: "ALTERNATIVES",
-    },
-  ],
-  VegetarianMenuBases: [
-    {
-      label: "De céréales et/ou les légumes secs (hors soja)",
-      value: "GRAIN",
-    },
-    {
-      label: "De soja",
-      value: "SOY",
-    },
-    {
-      label: "De fromage",
-      value: "CHEESE",
-    },
-    {
-      label: "D’œufs",
-      value: "EGG",
-    },
-    {
-      label: "De plats transformés prêts à l'emploi",
-      value: "READYMADE",
-    },
-  ],
-  VegetarianRecurrence: [
-    {
-      label: "Non, je n'ai pas mis en place un menu végétarien",
-      value: "NEVER",
-    },
-    {
-      label: "Moins d'une fois par semaine",
-      value: "LOW",
-    },
-    {
-      label: "Une fois par semaine",
-      value: "MID",
-    },
-    {
-      label: "Plus d'une fois par semaine",
-      value: "HIGH",
-    },
-    {
-      label: "De façon quotidienne",
-      value: "DAILY",
-    },
-  ],
   CommunicationFrequencies: [
     {
       label: "Régulièrement au cours de l’année",

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -568,6 +568,24 @@ export default Object.freeze({
       value: "REUSE",
     },
   ],
+  DiversificationMeasureStep: {
+    hasDiversificationPlan: {
+      title:
+        "J'ai mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base de protéines végétales",
+    },
+    diversificationPlanActions: {
+      title: "Ce plan comporte, par exemple, les actions suivantes (voir guide du CNRC) :",
+    },
+    vegetarianWeeklyRecurrence: {
+      title: "J'ai mis en place un menu végétarien :",
+    },
+    vegetarianMenuType: {
+      title: "Le menu végétarien proposé est :",
+    },
+    vegetarianMenuBases: {
+      title: "Le plat principal de mon menu végétarien est majoritairement à base de :",
+    },
+  },
   DiversificationPlanActions: [
     {
       label:

--- a/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
@@ -9,8 +9,8 @@
         class="mb-xs-6 mb-xl-16"
       />
       <DsfrRadio
-        :label="Constants.DiversificationMeasureStep.vegetarianWeeklyRecurrence.title"
-        :items="frequency"
+        :label="constantsDiversificationMeasureStep.vegetarianWeeklyRecurrence.title"
+        :items="constantsDiversificationMeasureStep.vegetarianWeeklyRecurrence.items"
         v-model="payload.vegetarianWeeklyRecurrence"
         @change="calculateSteps"
         hide-details
@@ -19,15 +19,15 @@
     </div>
     <DsfrRadio
       v-else-if="stepUrlSlug === 'options'"
-      :label="Constants.DiversificationMeasureStep.vegetarianMenuType.title"
-      :items="menuTypes"
+      :label="constantsDiversificationMeasureStep.vegetarianMenuType.title"
+      :items="constantsDiversificationMeasureStep.vegetarianMenuType.items"
       v-model="payload.vegetarianMenuType"
       hide-details
       optional
     />
     <fieldset v-else-if="stepUrlSlug === 'composition'">
       <legend class="text-left mb-2 mt-3">
-        {{ Constants.DiversificationMeasureStep.vegetarianMenuBases.title }}
+        {{ constantsDiversificationMeasureStep.vegetarianMenuBases.title }}
         <span class="fr-hint-text mt-2">Optionnel</span>
       </legend>
       <v-checkbox
@@ -35,7 +35,7 @@
         class="mt-2"
         v-model="payload.vegetarianMenuBases"
         :multiple="true"
-        v-for="item in menuBases"
+        v-for="item in constantsDiversificationMeasureStep.vegetarianMenuBases.items"
         :key="item.value"
         :value="item.value"
         :label="item.label"
@@ -43,7 +43,7 @@
     </fieldset>
     <div v-else-if="stepUrlSlug === 'plan'">
       <DsfrRadio
-        :label="Constants.DiversificationMeasureStep.hasDiversificationPlan.title"
+        :label="constantsDiversificationMeasureStep.hasDiversificationPlan.title"
         v-model="payload.hasDiversificationPlan"
         hide-details
         yesNo
@@ -51,7 +51,7 @@
       />
       <fieldset class="mt-8 mb-3">
         <legend class="text-left mb-1 mt-3" :class="{ 'grey--text': !payload.hasDiversificationPlan }">
-          {{ Constants.DiversificationMeasureStep.diversificationPlanActions.title }}
+          {{ constantsDiversificationMeasureStep.diversificationPlanActions.title }}
           <span :class="`fr-hint-text mt-2 ${!payload.hasDiversificationPlan && 'grey--text'}`">Optionnel</span>
         </legend>
         <v-checkbox
@@ -59,7 +59,7 @@
           class="mt-1"
           v-model="payload.diversificationPlanActions"
           :multiple="true"
-          v-for="item in planActions"
+          v-for="item in constantsDiversificationMeasureStep.diversificationPlanActions.items"
           :key="item.value"
           :value="item.value"
           :label="item.label"
@@ -96,10 +96,7 @@ export default {
   data() {
     return {
       steps: [],
-      frequency: Constants.vegetarianWeeklyRecurrence.items,
-      menuTypes: Constants.vegetarianMenuType.items,
-      menuBases: Constants.vegetarianMenuBases.items,
-      planActions: Constants.diversificationPlanActions.items,
+      constantsDiversificationMeasureStep: Constants.DiversificationMeasureStep,
       payload: {},
       fields: [
         "vegetarianWeeklyRecurrence",

--- a/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
@@ -9,8 +9,8 @@
         class="mb-xs-6 mb-xl-16"
       />
       <DsfrRadio
-        :label="constantsDiversificationMeasureStep.vegetarianWeeklyRecurrence.title"
-        :items="constantsDiversificationMeasureStep.vegetarianWeeklyRecurrence.items"
+        :label="stepConstants.vegetarianWeeklyRecurrence.title"
+        :items="stepConstants.vegetarianWeeklyRecurrence.items"
         v-model="payload.vegetarianWeeklyRecurrence"
         @change="calculateSteps"
         hide-details
@@ -19,15 +19,15 @@
     </div>
     <DsfrRadio
       v-else-if="stepUrlSlug === 'options'"
-      :label="constantsDiversificationMeasureStep.vegetarianMenuType.title"
-      :items="constantsDiversificationMeasureStep.vegetarianMenuType.items"
+      :label="stepConstants.vegetarianMenuType.title"
+      :items="stepConstants.vegetarianMenuType.items"
       v-model="payload.vegetarianMenuType"
       hide-details
       optional
     />
     <fieldset v-else-if="stepUrlSlug === 'composition'">
       <legend class="text-left mb-2 mt-3">
-        {{ constantsDiversificationMeasureStep.vegetarianMenuBases.title }}
+        {{ stepConstants.vegetarianMenuBases.title }}
         <span class="fr-hint-text mt-2">Optionnel</span>
       </legend>
       <v-checkbox
@@ -35,7 +35,7 @@
         class="mt-2"
         v-model="payload.vegetarianMenuBases"
         :multiple="true"
-        v-for="item in constantsDiversificationMeasureStep.vegetarianMenuBases.items"
+        v-for="item in stepConstants.vegetarianMenuBases.items"
         :key="item.value"
         :value="item.value"
         :label="item.label"
@@ -43,7 +43,7 @@
     </fieldset>
     <div v-else-if="stepUrlSlug === 'plan'">
       <DsfrRadio
-        :label="constantsDiversificationMeasureStep.hasDiversificationPlan.title"
+        :label="stepConstants.hasDiversificationPlan.title"
         v-model="payload.hasDiversificationPlan"
         hide-details
         yesNo
@@ -51,7 +51,7 @@
       />
       <fieldset class="mt-8 mb-3">
         <legend class="text-left mb-1 mt-3" :class="{ 'grey--text': !payload.hasDiversificationPlan }">
-          {{ constantsDiversificationMeasureStep.diversificationPlanActions.title }}
+          {{ stepConstants.diversificationPlanActions.title }}
           <span :class="`fr-hint-text mt-2 ${!payload.hasDiversificationPlan && 'grey--text'}`">Optionnel</span>
         </legend>
         <v-checkbox
@@ -59,7 +59,7 @@
           class="mt-1"
           v-model="payload.diversificationPlanActions"
           :multiple="true"
-          v-for="item in constantsDiversificationMeasureStep.diversificationPlanActions.items"
+          v-for="item in stepConstants.diversificationPlanActions.items"
           :key="item.value"
           :value="item.value"
           :label="item.label"
@@ -96,7 +96,7 @@ export default {
   data() {
     return {
       steps: [],
-      constantsDiversificationMeasureStep: Constants.DiversificationMeasureStep,
+      stepConstants: Constants.DiversificationMeasureStep,
       payload: {},
       fields: [
         "vegetarianWeeklyRecurrence",

--- a/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
@@ -9,7 +9,7 @@
         class="mb-xs-6 mb-xl-16"
       />
       <DsfrRadio
-        label="J'ai mis en place un menu végétarien :"
+        :label="Constants.DiversificationMeasureStep.vegetarianWeeklyRecurrence.title"
         :items="frequency"
         v-model="payload.vegetarianWeeklyRecurrence"
         @change="calculateSteps"
@@ -19,7 +19,7 @@
     </div>
     <DsfrRadio
       v-else-if="stepUrlSlug === 'options'"
-      label="Le menu végétarien proposé est :"
+      :label="Constants.DiversificationMeasureStep.vegetarianMenuType.title"
       :items="menuTypes"
       v-model="payload.vegetarianMenuType"
       hide-details
@@ -27,7 +27,7 @@
     />
     <fieldset v-else-if="stepUrlSlug === 'composition'">
       <legend class="text-left mb-2 mt-3">
-        Le plat principal de mon menu végétarien est majoritairement à base de :
+        {{ Constants.DiversificationMeasureStep.vegetarianMenuBases.title }}
         <span class="fr-hint-text mt-2">Optionnel</span>
       </legend>
       <v-checkbox
@@ -43,8 +43,7 @@
     </fieldset>
     <div v-else-if="stepUrlSlug === 'plan'">
       <DsfrRadio
-        label="J'ai mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base de
-          protéines végétales"
+        :label="Constants.DiversificationMeasureStep.hasDiversificationPlan.title"
         v-model="payload.hasDiversificationPlan"
         hide-details
         yesNo
@@ -52,7 +51,7 @@
       />
       <fieldset class="mt-8 mb-3">
         <legend class="text-left mb-1 mt-3" :class="{ 'grey--text': !payload.hasDiversificationPlan }">
-          Ce plan comporte, par exemple, les actions suivantes (voir guide du CNRC) :
+          {{ Constants.DiversificationMeasureStep.diversificationPlanActions.title }}
           <span :class="`fr-hint-text mt-2 ${!payload.hasDiversificationPlan && 'grey--text'}`">Optionnel</span>
         </legend>
         <v-checkbox

--- a/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
@@ -96,10 +96,10 @@ export default {
   data() {
     return {
       steps: [],
-      frequency: Constants.VegetarianRecurrence,
-      menuTypes: Constants.VegetarianMenuTypes,
-      menuBases: Constants.VegetarianMenuBases,
-      planActions: Constants.DiversificationPlanActions,
+      frequency: Constants.vegetarianWeeklyRecurrence.items,
+      menuTypes: Constants.vegetarianMenuType.items,
+      menuBases: Constants.vegetarianMenuBases.items,
+      planActions: Constants.diversificationPlanActions.items,
       payload: {},
       fields: [
         "vegetarianWeeklyRecurrence",


### PR DESCRIPTION
### Quoi

Tentative de refactorer un peu les labels et valeurs qui sont réutilisés entre les fichiers DiagnosticTunnel, DiagnosticSummary, et KeyMeasureDiagnostic :)

Un peu comme dans #4648 (Vue3), je bascule certains labels dans le fichier `Constants.js`

Pour l'instant j'ai juste modifié `DiversificationMeasure` , en lien avec les changements en cours de l'issue #4613

### Pourquoi

- pour avoir un seul endroit de "config"
- .js vs .json ? j'ai l'impression que .js est plus flexible, permet aussi de rajouter des commentaires
- d'avantage un POC qu'un choix sur le long terme, ca me permet aussi de voir les intrications entre tout ces components
- en espérant que ca puisse aussi simplifier à terme la migration vers vue 3 ??