### PR TITLE
ci: Github Action pour checker que le nom des PR respecte le format Conventional Commits

### DIFF
--- a/.github/workflows/release-please-pr-title-check.yml
+++ b/.github/workflows/release-please-pr-title-check.yml
@@ -1,0 +1,21 @@
+name: "release-please: PR title check"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Ensure PR title matches the Conventional Commits spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Quoi

Avant-dernière brique du switch vers [release-please](https://github.com/googleapis/release-please-action) (cf #4379): 
il faut que le nom des PR respecte le format [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), pour qu'une fois mergées elles soit correctement prises en compte par release-please.

#### Conventional Commits ?

Ca demande simplement de prefixer le nom des PR avec feat/fix/refactor/ci/docs/chore... :)
par exemple
-  `refactor(Tunnel diag): Menu végés : inverser les étapes 2 et 3`
- `[WIP] feat: remplacer l'authentification MonComptePro par ProConnect`

### Plus d'infos

https://github.com/amannn/action-semantic-pull-request