### PR TITLE
ci: Github Action pour lancer release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,8 +16,8 @@ jobs:
           changelog-types: |
             [
               {"type":"feat","section":"Nouveautés","hidden":false},
-              {"type":"refactor","section":"Améliorations","hidden":false},
               {"type":"fix","section":"Corrections (bugs, typos...)","hidden":false},
+              {"type":"refactor","section":"Technique","hidden":false},
               {"type":"style","section":"Technique","hidden":false},
               {"type":"docs","section":"Technique","hidden":false},
               {"type":"test","section":"Technique","hidden":false},

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,27 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - staging
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v3.7.13
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: simple
+          changelog-types: |
+            [
+              {"type":"feat","section":"Nouveautés","hidden":false},
+              {"type":"refactor","section":"Améliorations","hidden":false},
+              {"type":"fix","section":"Corrections (bugs, typos...)","hidden":false},
+              {"type":"style","section":"Technique","hidden":false},
+              {"type":"docs","section":"Technique","hidden":false},
+              {"type":"test","section":"Technique","hidden":false},
+              {"type":"chore","section":"Technique","hidden":false},
+              {"type":"perf","section":"Technique","hidden":false},
+              {"type":"ci","section":"Technique","hidden":false}
+            ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Journal des modifications
+
+Ressources :
+- [CHANGELOG recommendations](https://keepachangelog.com/)
+- [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
+- [release-please](https://github.com/google-github-actions/release-please-action) (automated releases)
+- [Semantic Versioning](https://semver.org/) & [Calendar Versioning](https://calver.org/)
+
+## [2024-12-09](https://github.com/betagouv/ma-cantine/compare/2024-11-29...2024-12-09)
+
+### Outil suivi déchets alimentaires
+
+- Tunnel gaspillage alimentaire : ajouter plus de contexte dans la synthèse évaluation déchets
+
+### Tunnel bilan/TD
+
+- Menu végé : changements cosmétiques sur l'étape 1, renommer le champ de l'étape 2
+- Option pour ajouter des évaluations déchets alimentaires depuis le tunnel bilan gaspillage
+
+- refactor(Page Ma Collectivité) : Maj des filtres des diagnostics afin d'avoir les mêmes données que le rapport
+
+### Bug fix
+
+- fix(Tunnel Diagnostique): Gaspillage: répare la fermeture de la modale XP réservation
+
+### Téchnique
+
+- CI : Homogénéisation des versions utilisées par pre-commit pour vue3
+- MAJ dépendences
+
+## New Contributors
+
+- @Charline-L made their first contribution in https://github.com/betagouv/ma-cantine/pull/4728


### PR DESCRIPTION
### Quoi

Dernière brique du switch vers [release-please](https://github.com/googleapis/release-please-action) (cf #4379, suite de #4700) : 
à chaque fois qu'une PR sera mergée, cette CI se lancera et mettra à jour une PR de release

#### Configuration

En regardant un peu nos releases historiques, j'ai séparé les changements en 4 sections : 
- Nouveautés (feat)
- Améliorations (refactor)
- Corrections (fix)
- Technique (style, docs, test, chore, perf, ci)

### Plus d'infos

Voir l'issue #4379 :)