### PR TITLE
build: Création d'un script pour corriger l'erreur Webpack `ERR_OSSL_EVP_UNSUPPORTED` au lancement de l'app en local

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -208,6 +208,9 @@ cd frontend
 npm run serve
 ```
 
+> Un bug connu de code legacy avec Webpack sur les versions récentes entraine l'erreur suivante `code: 'ERR_OSSL_EVP_UNSUPPORTED'`. Pour éviter d'avoir à configurer une variable d'environnement en local on peut utiliser le script `npm run serve:ssl-legacy` qui intègre la configuration.
+
+
 ### Terminal Vue3
 
 ```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve:ssl-legacy": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
+    "serve:ossl-legacy": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test": "vue-cli-service test:unit",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "serve:ssl-legacy": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test": "vue-cli-service test:unit",


### PR DESCRIPTION
[Ticket lié #4715](https://github.com/betagouv/ma-cantine/issues/4715)

**Problème :**
Au lancement du projet en local sans utiliser docker il y a une erreur de Webpack qui empêche le lancement du frontend. Cette configuration node manquante ne peut pas être ajouter au global dans l'app sur nos machines et il faut donc faire une manipe à chaque lancement. 

**Solution :** 
Avoir un script spécifique qui intègre cette config, ce qui évite de modifier le script de dev qui est aussi utilisé avec Docker et qui fonctionne correctement.