### PR TITLE
refactor(Diagnostique): renomme les enum végé (MenuType & MenuFrequency) pour clarifier

### DIFF
--- a/api/templatetags/diagnostic_extras.py
+++ b/api/templatetags/diagnostic_extras.py
@@ -8,7 +8,7 @@ def menu_frequency(key):
     if not key:
         return None
     try:
-        return Diagnostic.MenuFrequency[key].label
+        return Diagnostic.VegetarianMenuFrequency[key].label
     except Exception:
         return None
 

--- a/api/templatetags/diagnostic_extras.py
+++ b/api/templatetags/diagnostic_extras.py
@@ -18,6 +18,6 @@ def menu_type(key):
     if not key:
         return None
     try:
-        return Diagnostic.MenuType[key].label
+        return Diagnostic.VegetarianMenuType[key].label
     except Exception:
         return None

--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -53,7 +53,7 @@ class TestCanteenStatsApi(APITestCase):
                         "value_egalim_others_ht": None,
                         "has_waste_diagnostic": False,
                         "waste_actions": [],
-                        "vegetarian_weekly_recurrence": Diagnostic.MenuFrequency.DAILY,
+                        "vegetarian_weekly_recurrence": Diagnostic.VegetarianMenuFrequency.DAILY,
                         "plastic_tableware_substituted": False,
                         "communicates_on_food_quality": False,
                     },
@@ -64,7 +64,7 @@ class TestCanteenStatsApi(APITestCase):
                         "value_sustainable_ht": 0,
                         "value_externality_performance_ht": 0,
                         "value_egalim_others_ht": 0,
-                        "vegetarian_weekly_recurrence": Diagnostic.MenuFrequency.DAILY,
+                        "vegetarian_weekly_recurrence": Diagnostic.VegetarianMenuFrequency.DAILY,
                     },
                 ],
             },
@@ -84,7 +84,7 @@ class TestCanteenStatsApi(APITestCase):
                         "has_waste_diagnostic": True,
                         "waste_actions": ["action1", "action2"],
                         "has_donation_agreement": True,
-                        "vegetarian_weekly_recurrence": Diagnostic.MenuFrequency.LOW,
+                        "vegetarian_weekly_recurrence": Diagnostic.VegetarianMenuFrequency.LOW,
                         "cooking_plastic_substituted": True,
                         "serving_plastic_substituted": True,
                         "plastic_bottles_substituted": True,
@@ -409,23 +409,27 @@ class TestCanteenStatsApi(APITestCase):
         high_canteen.sectors.remove(primaire)
         high_canteen.sectors.remove(secondaire)
         DiagnosticFactory.create(
-            canteen=high_canteen, vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.HIGH.value
+            canteen=high_canteen, vegetarian_weekly_recurrence=Diagnostic.VegetarianMenuFrequency.HIGH.value
         )
 
         low_canteen = CanteenFactory.create()
         low_canteen.sectors.add(primaire)
-        DiagnosticFactory.create(canteen=low_canteen, vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.LOW.value)
+        DiagnosticFactory.create(
+            canteen=low_canteen, vegetarian_weekly_recurrence=Diagnostic.VegetarianMenuFrequency.LOW.value
+        )
 
         # --- canteens which earn diversification badge:
         daily_vege = CanteenFactory.create()
         daily_vege.sectors.remove(primaire)
         daily_vege.sectors.remove(secondaire)
-        DiagnosticFactory.create(canteen=daily_vege, vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.DAILY.value)
+        DiagnosticFactory.create(
+            canteen=daily_vege, vegetarian_weekly_recurrence=Diagnostic.VegetarianMenuFrequency.DAILY.value
+        )
 
         scolaire_mid_vege = CanteenFactory.create()
         scolaire_mid_vege.sectors.add(secondaire)
         DiagnosticFactory.create(
-            canteen=scolaire_mid_vege, vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.MID.value
+            canteen=scolaire_mid_vege, vegetarian_weekly_recurrence=Diagnostic.VegetarianMenuFrequency.MID.value
         )
 
         badges = badges_for_queryset(Diagnostic.objects.all())

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -828,7 +828,7 @@ def badges_for_queryset(diagnostic_year_queryset):
     diversification_badge_query = diagnostic_year_queryset.exclude(vegetarian_weekly_recurrence__isnull=True)
     diversification_badge_query = diversification_badge_query.exclude(vegetarian_weekly_recurrence="")
     diversification_badge_query = diversification_badge_query.exclude(
-        vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.LOW
+        vegetarian_weekly_recurrence=Diagnostic.VegetarianMenuFrequency.LOW
     )
     scolaire_sectors = Sector.objects.filter(category="education")
     if scolaire_sectors.count():
@@ -836,11 +836,11 @@ def badges_for_queryset(diagnostic_year_queryset):
             Q(
                 canteen__sectors__in=scolaire_sectors,
                 vegetarian_weekly_recurrence__in=[
-                    Diagnostic.MenuFrequency.MID,
-                    Diagnostic.MenuFrequency.HIGH,
+                    Diagnostic.VegetarianMenuFrequency.MID,
+                    Diagnostic.VegetarianMenuFrequency.HIGH,
                 ],
             )
-            | Q(vegetarian_weekly_recurrence=Diagnostic.MenuFrequency.DAILY)
+            | Q(vegetarian_weekly_recurrence=Diagnostic.VegetarianMenuFrequency.DAILY)
         ).distinct()
     badge_querysets["diversification"] = diversification_badge_query
 

--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -319,7 +319,7 @@ class TeledeclarationPdfView(APIView):
                 for x in (teledeclaration_data.get("diversification_plan_actions") or [])
             ],
             "vegetarian_weekly_recurrence": (
-                Diagnostic.MenuFrequency(teledeclaration_data["vegetarian_weekly_recurrence"]).label
+                Diagnostic.VegetarianMenuFrequency(teledeclaration_data["vegetarian_weekly_recurrence"]).label
                 if teledeclaration_data.get("vegetarian_weekly_recurrence")
                 else None
             ),

--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -324,7 +324,7 @@ class TeledeclarationPdfView(APIView):
                 else None
             ),
             "vegetarian_menu_type": (
-                Diagnostic.MenuType(teledeclaration_data["vegetarian_menu_type"]).label
+                Diagnostic.VegetarianMenuType(teledeclaration_data["vegetarian_menu_type"]).label
                 if teledeclaration_data.get("vegetarian_menu_type")
                 else None
             ),

--- a/data/factories/diagnostic.py
+++ b/data/factories/diagnostic.py
@@ -35,7 +35,7 @@ class DiagnosticFactory(factory.django.DjangoModelFactory):
 
     has_diversification_plan = factory.Faker("boolean")
     vegetarian_weekly_recurrence = fuzzy.FuzzyChoice(list(Diagnostic.VegetarianMenuFrequency))
-    vegetarian_menu_type = fuzzy.FuzzyChoice(list(Diagnostic.MenuType))
+    vegetarian_menu_type = fuzzy.FuzzyChoice(list(Diagnostic.VegetarianMenuType))
 
     cooking_plastic_substituted = factory.Faker("boolean")
     serving_plastic_substituted = factory.Faker("boolean")
@@ -73,7 +73,7 @@ class CompleteDiagnosticFactory(factory.django.DjangoModelFactory):
 
     has_diversification_plan = factory.Faker("boolean")
     vegetarian_weekly_recurrence = fuzzy.FuzzyChoice(list(Diagnostic.VegetarianMenuFrequency))
-    vegetarian_menu_type = fuzzy.FuzzyChoice(list(Diagnostic.MenuType))
+    vegetarian_menu_type = fuzzy.FuzzyChoice(list(Diagnostic.VegetarianMenuType))
 
     cooking_plastic_substituted = factory.Faker("boolean")
     serving_plastic_substituted = factory.Faker("boolean")

--- a/data/factories/diagnostic.py
+++ b/data/factories/diagnostic.py
@@ -34,7 +34,7 @@ class DiagnosticFactory(factory.django.DjangoModelFactory):
     has_donation_agreement = factory.Faker("boolean")
 
     has_diversification_plan = factory.Faker("boolean")
-    vegetarian_weekly_recurrence = fuzzy.FuzzyChoice(list(Diagnostic.MenuFrequency))
+    vegetarian_weekly_recurrence = fuzzy.FuzzyChoice(list(Diagnostic.VegetarianMenuFrequency))
     vegetarian_menu_type = fuzzy.FuzzyChoice(list(Diagnostic.MenuType))
 
     cooking_plastic_substituted = factory.Faker("boolean")
@@ -72,7 +72,7 @@ class CompleteDiagnosticFactory(factory.django.DjangoModelFactory):
     has_donation_agreement = factory.Faker("boolean")
 
     has_diversification_plan = factory.Faker("boolean")
-    vegetarian_weekly_recurrence = fuzzy.FuzzyChoice(list(Diagnostic.MenuFrequency))
+    vegetarian_weekly_recurrence = fuzzy.FuzzyChoice(list(Diagnostic.VegetarianMenuFrequency))
     vegetarian_menu_type = fuzzy.FuzzyChoice(list(Diagnostic.MenuType))
 
     cooking_plastic_substituted = factory.Faker("boolean")

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -78,7 +78,7 @@ class Diagnostic(models.Model):
         HIGH = "HIGH", "Plus d'une fois par semaine"
         DAILY = "DAILY", "De façon quotidienne"
 
-    class MenuType(models.TextChoices):
+    class VegetarianMenuType(models.TextChoices):
         UNIQUE = "UNIQUE", "Un menu végétarien en plat unique, sans choix"
         SEVERAL = (
             "SEVERAL",
@@ -442,7 +442,7 @@ class Diagnostic(models.Model):
     )
     vegetarian_menu_type = models.CharField(
         max_length=255,
-        choices=MenuType.choices,
+        choices=VegetarianMenuType.choices,
         blank=True,
         null=True,
         verbose_name="Menu végétarien proposé",

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -71,7 +71,7 @@ class Diagnostic(models.Model):
     class CreationSource(models.TextChoices):
         TUNNEL = "TUNNEL", "Tunnel"
 
-    class MenuFrequency(models.TextChoices):
+    class VegetarianMenuFrequency(models.TextChoices):
         NEVER = "NEVER", "Jamais"
         LOW = "LOW", "Moins d'une fois par semaine"
         MID = "MID", "Une fois par semaine"
@@ -435,7 +435,7 @@ class Diagnostic(models.Model):
     )
     vegetarian_weekly_recurrence = models.CharField(
         max_length=255,
-        choices=MenuFrequency.choices,
+        choices=VegetarianMenuFrequency.choices,
         null=True,
         blank=True,
         verbose_name="Menus végétariens par semaine",
@@ -1740,9 +1740,12 @@ class Diagnostic(models.Model):
 
     @property
     def diversification_badge(self) -> bool | None:
-        if self.vegetarian_weekly_recurrence == Diagnostic.MenuFrequency.DAILY:
+        if self.vegetarian_weekly_recurrence == Diagnostic.VegetarianMenuFrequency.DAILY:
             return True
-        elif self.vegetarian_weekly_recurrence in [Diagnostic.MenuFrequency.MID, Diagnostic.MenuFrequency.HIGH]:
+        elif self.vegetarian_weekly_recurrence in [
+            Diagnostic.VegetarianMenuFrequency.MID,
+            Diagnostic.VegetarianMenuFrequency.HIGH,
+        ]:
             # if the canteen is in the education sector, it can have a lower recurrence
             if self.canteen.in_education:
                 return True


### PR DESCRIPTION
### Quoi

Dans le modèle `Diagnostic` : 
- renommé l'enum `MenuFrequency` en `VegetarianMenuFrequency`
- renommé l'enum `MenuType` en `VegetarianMenuType`

### Pourquoi

- dans l'issue #4613 on a besoin de créer un nouveau champ + enum `ServiceType`
- pour clarifier (et homogénéiser avec les même enums coté frontend qui sont déjà prefixés de "vegetarian")