### PR TITLE
Tunnel gaspillage alimentaire : Rendre l'encart d'évaluation dynamique en fonction du remplissage du diagnostique effectué

### DIFF
--- a/frontend/src/views/MyProgress/ProgressTab.vue
+++ b/frontend/src/views/MyProgress/ProgressTab.vue
@@ -17,7 +17,7 @@
       <div v-if="showWasteTool">
         <DsfrCallout>
           <p class="fr-text font-weight-bold">Évaluation gaspillage alimentaire</p>
-          <p class="fr-text-sm grey-text text--darken-3">
+          <p v-if="!displayDiagnostic.hasWasteMeasures" class="fr-text-sm grey-text text--darken-3">
             Évaluez gaspillage alimentaire avant de continuer.
           </p>
           <v-row class="align-center my-2 mx-0">
@@ -27,7 +27,7 @@
               color="primary"
               :to="{ name: 'WasteMeasurements', params: { canteenUrlComponent } }"
             >
-              Compléter l'évaluation
+              {{ displayDiagnostic.hasWasteMeasures ? "Accéder à mon évaluation" : "Compléter l'évaluation" }}
             </v-btn>
           </v-row>
         </DsfrCallout>


### PR DESCRIPTION
Une fois que l'utilisateur a complété son évaluation du gaspillage alimentaire, je propose de changer le message de l'encart pour lui indiquer que son évaluation a bien été prise en compte. 

> J'ai hésité à écrire "Modifier mon évaluation" pour ressembler au bouton dessous "Modifier mes données", mais en testant j'ai trouvé que "accéder" était plus logique, car dans un premier temps on visualise et ensuite si on veut on modifie. Preneuse de votre avis :)  