### PR TITLE
refactor(api): Suppression de la création et annulation d'une télédéclaration depuis l'API par une tierce application

### DIFF
--- a/api/tests/test_signals.py
+++ b/api/tests/test_signals.py
@@ -4,7 +4,7 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 
 from data.factories import DiagnosticFactory
-from data.models import AuthenticationMethodHistoricalRecords
+from data.models import AuthenticationMethodHistoricalRecords, Teledeclaration
 
 from .utils import authenticate, get_oauth2_token
 
@@ -31,9 +31,9 @@ class TestSignals(APITestCase):
 
     @override_settings(ENABLE_TELEDECLARATION=True)
     @freeze_time("2021-01-20")
-    def test_authentication_method_created_with_api(self):
+    def test_td_creation_api_blocked_for_third_party(self):
         """
-        Teledeclarations created via a third party API should save the corresponding authentication method
+        Teledeclarations cannot be created  via a third party API
         """
         user, token = get_oauth2_token("canteen:write")
         diagnostic = DiagnosticFactory.create(year=2020)
@@ -41,10 +41,25 @@ class TestSignals(APITestCase):
         payload = {"diagnosticId": diagnostic.id}
 
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
-        self.client.post(reverse("teledeclaration_create"), payload)
+        response = self.client.post(reverse("teledeclaration_create"), payload)
+        self.assertEqual(response.status_code, 403)
 
         diagnostic.refresh_from_db()
-        td = diagnostic.teledeclaration_set.first()
-        self.assertEqual(
-            td.history.first().authentication_method, AuthenticationMethodHistoricalRecords.AuthMethodChoices.API
-        )
+        td = diagnostic.teledeclaration_set.all()
+        self.assertEqual(len(td), 0)
+
+    @override_settings(ENABLE_TELEDECLARATION=True)
+    @freeze_time("2021-01-20")
+    def test_td_deletion_api_blocked_for_third_party(self):
+        """
+        Teledeclarations cannot be deleted via a third party API
+        """
+        user, token = get_oauth2_token("canteen:write")
+        diagnostic = DiagnosticFactory.create(year=2020)
+        diagnostic.canteen.managers.add(user)
+        td = Teledeclaration.create_from_diagnostic(diagnostic, user, Teledeclaration.TeledeclarationStatus.CANCELLED)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+        response = self.client.post(reverse("teledeclaration_cancel", kwargs={"pk": td.id}))
+
+        self.assertEqual(response.status_code, 403)

--- a/api/tests/test_signals.py
+++ b/api/tests/test_signals.py
@@ -4,7 +4,7 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 
 from data.factories import DiagnosticFactory
-from data.models import AuthenticationMethodHistoricalRecords, Teledeclaration
+from data.models import AuthenticationMethodHistoricalRecords
 
 from .utils import authenticate, get_oauth2_token
 
@@ -47,19 +47,3 @@ class TestSignals(APITestCase):
         diagnostic.refresh_from_db()
         td = diagnostic.teledeclaration_set.all()
         self.assertEqual(len(td), 0)
-
-    @override_settings(ENABLE_TELEDECLARATION=True)
-    @freeze_time("2021-01-20")
-    def test_td_deletion_api_blocked_for_third_party(self):
-        """
-        Teledeclarations cannot be deleted via a third party API
-        """
-        user, token = get_oauth2_token("canteen:write")
-        diagnostic = DiagnosticFactory.create(year=2020)
-        diagnostic.canteen.managers.add(user)
-        td = Teledeclaration.create_from_diagnostic(diagnostic, user, Teledeclaration.TeledeclarationStatus.CANCELLED)
-
-        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
-        response = self.client.post(reverse("teledeclaration_cancel", kwargs={"pk": td.id}))
-
-        self.assertEqual(response.status_code, 403)

--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -103,7 +103,7 @@ class TeledeclarationCancelView(APIView):
     This view cancels a submitted teledeclaration
     """
 
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticatedOrTokenHasResourceScope]
     required_scopes = ["canteen"]
 
     def post(self, request, *args, **kwargs):

--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -14,7 +14,7 @@ from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.views import APIView
 from xhtml2pdf import pisa
 
-from api.permissions import IsAuthenticatedOrTokenHasResourceScope
+from api.permissions import IsAuthenticated, IsAuthenticatedOrTokenHasResourceScope
 from api.serializers import FullDiagnosticSerializer
 from data.models import Canteen, Diagnostic, Teledeclaration
 
@@ -37,7 +37,7 @@ class TeledeclarationCreateView(APIView):
     existing diagnostic.
     """
 
-    permission_classes = [IsAuthenticatedOrTokenHasResourceScope]
+    permission_classes = [IsAuthenticated]
     required_scopes = ["canteen"]
 
     @extend_schema(
@@ -103,7 +103,7 @@ class TeledeclarationCancelView(APIView):
     This view cancels a submitted teledeclaration
     """
 
-    permission_classes = [IsAuthenticatedOrTokenHasResourceScope]
+    permission_classes = [IsAuthenticated]
     required_scopes = ["canteen"]
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
Est-ce qu'il faut également supprimer l'annulation ? @Tdauvet89 

Sachant que l'annulation est obligatoire pour faire une modification :

éditer pendant la campagne = annuler TD + modifier diag + re télédéclarer