### PR TITLE
feat(Tunnel diagnostique): Menu végé : nouvelle étape "options proposées aux convives"

### DIFF
--- a/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
@@ -5,8 +5,7 @@
         <span v-if="diagnostic.hasDiversificationPlan">
           <v-icon color="primary" class="mr-1">$check-line</v-icon>
           <span>
-            J'ai mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base de
-            protéines végétales
+            {{ constantsDiversificationMeasureStep.hasDiversificationPlan.title }}
             <ul role="list" class="mt-2" v-if="appliedDiversificationActions && appliedDiversificationActions.length">
               <li class="fr-text-xs mb-1" v-for="action in appliedDiversificationActions" :key="action">
                 {{ action }}
@@ -14,7 +13,7 @@
             </ul>
             <ul role="list" class="mt-2" v-else>
               <li class="fr-text-xs mb-1">
-                Aucune action du plan renseignée
+                {{ constantsDiversificationMeasureStep.diversificationPlanActions.empty }}
               </li>
             </ul>
           </span>
@@ -22,15 +21,13 @@
         <span v-else-if="diagnosticUsesNullAsFalse || diagnostic.hasDiversificationPlan === false">
           <v-icon color="primary" class="mr-1">$close-line</v-icon>
           <span>
-            Je n'ai pas mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à
-            base de protéines végétales
+            {{ constantsDiversificationMeasureStep.hasDiversificationPlan.false }}
           </span>
         </span>
         <span v-else>
           <v-icon color="primary" class="mr-1">$question-line</v-icon>
           <span>
-            Avez-vous mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base
-            de protéines végétales ?
+            {{ constantsDiversificationMeasureStep.hasDiversificationPlan.empty }}
           </span>
         </span>
       </li>
@@ -38,34 +35,31 @@
       <li v-if="diagnostic.serviceType">
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>
-          Le service proposé est en :
+          {{ constantsDiversificationMeasureStep.serviceType.title }}
           <span class="font-weight-bold">{{ serviceType }}</span>
         </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$question-line</v-icon>
         <div>
-          Je n'ai pas renseigné le type de service
+          {{ constantsDiversificationMeasureStep.serviceType.empty }}
         </div>
       </li>
 
-      <li v-if="diagnostic.vegetarianWeeklyRecurrence === 'NEVER'">
-        <v-icon color="primary" class="mr-2">$close-line</v-icon>
+      <li v-if="diagnostic.vegetarianWeeklyRecurrence">
+        <v-icon v-if="diagnostic.vegetarianWeeklyRecurrence === 'NEVER'" color="primary" class="mr-2">
+          $close-line
+        </v-icon>
+        <v-icon v-else color="primary" class="mr-2">$check-line</v-icon>
         <div>
-          Je ne propose pas de menu végétarien
-        </div>
-      </li>
-      <li v-else-if="diagnostic.vegetarianWeeklyRecurrence">
-        <v-icon color="primary" class="mr-2">$check-line</v-icon>
-        <div>
-          J'ai mis en place un menu végétarien :
+          {{ constantsDiversificationMeasureStep.vegetarianWeeklyRecurrence.title }}
           <span class="font-weight-bold">{{ vegetarianWeeklyRecurrence }}</span>
         </div>
       </li>
       <li v-else>
         <v-icon color="primary" class="mr-2">$question-line</v-icon>
         <div>
-          Je n'ai pas renseigné la périodicité du menu végétarien
+          {{ constantsDiversificationMeasureStep.vegetarianWeeklyRecurrence.empty }}
         </div>
       </li>
 
@@ -73,14 +67,14 @@
         <li v-if="diagnostic.vegetarianMenuType">
           <v-icon color="primary" class="mr-2">$check-line</v-icon>
           <div>
-            Le menu végétarien proposé est :
+            {{ constantsDiversificationMeasureStep.vegetarianMenuType.title }}
             <span class="font-weight-bold">{{ vegetarianMenuType }}</span>
           </div>
         </li>
         <li v-else>
           <v-icon color="primary" class="mr-2">$question-line</v-icon>
           <div>
-            Je n'ai pas renseigné le type de menu végétarien servi
+            {{ constantsDiversificationMeasureStep.vegetarianMenuType.empty }}
           </div>
         </li>
       </div>
@@ -89,7 +83,7 @@
         <li v-if="diagnostic.vegetarianMenuBases && diagnostic.vegetarianMenuBases.length">
           <v-icon color="primary" class="mr-2">$check-line</v-icon>
           <div>
-            Le plat principal de mon menu végétarien est majoritairement à base de :
+            {{ constantsDiversificationMeasureStep.vegetarianMenuBases.title }}
             <ul role="list" class="mt-2" v-if="vegetarianMenuBases && vegetarianMenuBases.length">
               <li class="fr-text-xs mb-1" v-for="base in vegetarianMenuBases" :key="base">
                 {{ base }}
@@ -100,7 +94,7 @@
         <li v-else>
           <v-icon color="primary" class="mr-2">$question-line</v-icon>
           <div>
-            Je n'ai pas renseigné les bases utilisées pour mon menu végétarien
+            {{ constantsDiversificationMeasureStep.vegetarianMenuBases.empty }}
           </div>
         </li>
       </div>
@@ -121,21 +115,26 @@ export default {
       required: true,
     },
   },
+  data() {
+    return {
+      constantsDiversificationMeasureStep: Constants.DiversificationMeasureStep,
+    }
+  },
   computed: {
     serviceType() {
-      const items = selectListToObject(Constants.DiversificationMeasureStep.serviceType.items)
+      const items = selectListToObject(this.constantsDiversificationMeasureStep.serviceType.items)
       return items[this.diagnostic.serviceType]
     },
     vegetarianWeeklyRecurrence() {
-      const items = selectListToObject(Constants.DiversificationMeasureStep.vegetarianWeeklyRecurrence.items)
+      const items = selectListToObject(this.constantsDiversificationMeasureStep.vegetarianWeeklyRecurrence.items)
       return items[this.diagnostic.vegetarianWeeklyRecurrence]
     },
     vegetarianMenuType() {
-      const items = selectListToObject(Constants.DiversificationMeasureStep.vegetarianMenuType.items)
+      const items = selectListToObject(this.constantsDiversificationMeasureStep.vegetarianMenuType.items)
       return items[this.diagnostic.vegetarianMenuType]
     },
     vegetarianMenuBases() {
-      const items = selectListToObject(Constants.DiversificationMeasureStep.vegetarianMenuBases.items)
+      const items = selectListToObject(this.constantsDiversificationMeasureStep.vegetarianMenuBases.items)
       return this.diagnostic.vegetarianMenuBases.map((x) => items[x])
     },
     displayDiversificationPlanSegment() {
@@ -143,7 +142,7 @@ export default {
     },
     appliedDiversificationActions() {
       const diversificationPlanActions = selectListToObject(
-        Constants.DiversificationMeasureStep.diversificationPlanActions.items
+        this.constantsDiversificationMeasureStep.diversificationPlanActions.items
       )
       if (!this.diagnostic.diversificationPlanActions?.length) return null
       return this.diagnostic.diversificationPlanActions.map((x) => diversificationPlanActions[x]).filter((x) => !!x)

--- a/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/DiversificationMeasureSummary.vue
@@ -34,6 +34,21 @@
           </span>
         </span>
       </li>
+
+      <li v-if="diagnostic.serviceType">
+        <v-icon color="primary" class="mr-2">$check-line</v-icon>
+        <div>
+          Le service proposé est en :
+          <span class="font-weight-bold">{{ serviceType }}</span>
+        </div>
+      </li>
+      <li v-else>
+        <v-icon color="primary" class="mr-2">$question-line</v-icon>
+        <div>
+          Je n'ai pas renseigné le type de service
+        </div>
+      </li>
+
       <li v-if="diagnostic.vegetarianWeeklyRecurrence === 'NEVER'">
         <v-icon color="primary" class="mr-2">$close-line</v-icon>
         <div>
@@ -44,7 +59,7 @@
         <v-icon color="primary" class="mr-2">$check-line</v-icon>
         <div>
           J'ai mis en place un menu végétarien :
-          <span class="font-weight-bold">{{ weeklyRecurrence }}</span>
+          <span class="font-weight-bold">{{ vegetarianWeeklyRecurrence }}</span>
         </div>
       </li>
       <li v-else>
@@ -59,7 +74,7 @@
           <v-icon color="primary" class="mr-2">$check-line</v-icon>
           <div>
             Le menu végétarien proposé est :
-            <span class="font-weight-bold">{{ menuType }}</span>
+            <span class="font-weight-bold">{{ vegetarianMenuType }}</span>
           </div>
         </li>
         <li v-else>
@@ -75,8 +90,8 @@
           <v-icon color="primary" class="mr-2">$check-line</v-icon>
           <div>
             Le plat principal de mon menu végétarien est majoritairement à base de :
-            <ul role="list" class="mt-2" v-if="menuBases && menuBases.length">
-              <li class="fr-text-xs mb-1" v-for="base in menuBases" :key="base">
+            <ul role="list" class="mt-2" v-if="vegetarianMenuBases && vegetarianMenuBases.length">
+              <li class="fr-text-xs mb-1" v-for="base in vegetarianMenuBases" :key="base">
                 {{ base }}
               </li>
             </ul>
@@ -107,15 +122,19 @@ export default {
     },
   },
   computed: {
-    weeklyRecurrence() {
+    serviceType() {
+      const items = selectListToObject(Constants.DiversificationMeasureStep.serviceType.items)
+      return items[this.diagnostic.serviceType]
+    },
+    vegetarianWeeklyRecurrence() {
       const items = selectListToObject(Constants.DiversificationMeasureStep.vegetarianWeeklyRecurrence.items)
       return items[this.diagnostic.vegetarianWeeklyRecurrence]
     },
-    menuType() {
+    vegetarianMenuType() {
       const items = selectListToObject(Constants.DiversificationMeasureStep.vegetarianMenuType.items)
       return items[this.diagnostic.vegetarianMenuType]
     },
-    menuBases() {
+    vegetarianMenuBases() {
       const items = selectListToObject(Constants.DiversificationMeasureStep.vegetarianMenuBases.items)
       return this.diagnostic.vegetarianMenuBases.map((x) => items[x])
     },

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -572,6 +572,10 @@ export default Object.freeze({
     hasDiversificationPlan: {
       title:
         "J'ai mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base de protéines végétales",
+      false:
+        "Je n'ai pas mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base de protéines végétales",
+      empty:
+        "Avez-vous mis en place un plan pluriannuel de diversification des protéines incluant des alternatives à base de protéines végétales ?",
     },
     diversificationPlanActions: {
       title: "Ce plan comporte, par exemple, les actions suivantes (voir guide du CNRC) :",
@@ -599,6 +603,7 @@ export default Object.freeze({
           value: "TRAINING",
         },
       ],
+      empty: "Aucune action du plan renseignée",
     },
     serviceType: {
       title: "Le service est en :",
@@ -616,6 +621,7 @@ export default Object.freeze({
           value: "MULTIPLE_RESERVATION",
         },
       ],
+      empty: "Je n'ai pas renseigné le type de service",
     },
     vegetarianWeeklyRecurrence: {
       title: "J'ai mis en place un menu végétarien :",
@@ -641,6 +647,7 @@ export default Object.freeze({
           value: "NEVER",
         },
       ],
+      empty: "Je n'ai pas renseigné la périodicité du menu végétarien",
     },
     vegetarianMenuType: {
       title: "Le menu végétarien proposé est :",
@@ -658,6 +665,7 @@ export default Object.freeze({
           value: "ALTERNATIVES",
         },
       ],
+      empty: "Je n'ai pas renseigné le type de menu végétarien servi",
     },
     vegetarianMenuBases: {
       title: "Le plat principal de mon menu végétarien est majoritairement à base de :",
@@ -683,6 +691,7 @@ export default Object.freeze({
           value: "READYMADE",
         },
       ],
+      empty: "Je n'ai pas renseigné les bases utilisées pour mon menu végétarien",
     },
   },
   CommunicationFrequencies: [

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -600,6 +600,23 @@ export default Object.freeze({
         },
       ],
     },
+    serviceType: {
+      title: "Le service est en :",
+      items: [
+        {
+          label: "Menu unique",
+          value: "UNIQUE",
+        },
+        {
+          label: "Choix multiple en libre-service",
+          value: "MULTIPLE_SELF",
+        },
+        {
+          label: "Choix multiple avec réservation à l’avance au jour le jour",
+          value: "MULTIPLE_RESERVATION",
+        },
+      ],
+    },
     vegetarianWeeklyRecurrence: {
       title: "J'ai mis en place un menu végétarien :",
       items: [

--- a/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
@@ -90,7 +90,7 @@ const stepList = [
     urlSlug: "plan",
   },
   {
-    title: "Service proposé aux convives",
+    title: "Options proposées aux convives",
     urlSlug: "service",
   },
   {
@@ -98,7 +98,7 @@ const stepList = [
     urlSlug: "menu",
   },
   {
-    title: "Options proposées aux convives",
+    title: "Options végétariennes proposées aux convives",
     urlSlug: "options",
   },
   {

--- a/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/DiversificationMeasureSteps/index.vue
@@ -1,6 +1,41 @@
 <template>
   <v-form @submit.prevent>
-    <div v-if="stepUrlSlug === 'menu'">
+    <div v-if="stepUrlSlug === 'plan'">
+      <DsfrRadio
+        :label="stepConstants.hasDiversificationPlan.title"
+        v-model="payload.hasDiversificationPlan"
+        hide-details
+        yesNo
+        optional
+      />
+      <fieldset class="mt-8 mb-3">
+        <legend class="text-left mb-1 mt-3" :class="{ 'grey--text': !payload.hasDiversificationPlan }">
+          {{ stepConstants.diversificationPlanActions.title }}
+          <span :class="`fr-hint-text mt-2 ${!payload.hasDiversificationPlan && 'grey--text'}`">Optionnel</span>
+        </legend>
+        <v-checkbox
+          hide-details="auto"
+          class="mt-1"
+          v-model="payload.diversificationPlanActions"
+          :multiple="true"
+          v-for="item in stepConstants.diversificationPlanActions.items"
+          :key="item.value"
+          :value="item.value"
+          :label="item.label"
+          :readonly="!payload.hasDiversificationPlan"
+          :disabled="!payload.hasDiversificationPlan"
+        />
+      </fieldset>
+    </div>
+    <DsfrRadio
+      v-else-if="stepUrlSlug === 'service'"
+      :label="stepConstants.serviceType.title"
+      :items="stepConstants.serviceType.items"
+      v-model="payload.serviceType"
+      hide-details
+      optional
+    />
+    <div v-else-if="stepUrlSlug === 'menu'">
       <LastYearAutofillOption
         :canteen="canteen"
         :diagnostic="diagnostic"
@@ -40,33 +75,6 @@
         :label="item.label"
       />
     </fieldset>
-    <div v-else-if="stepUrlSlug === 'plan'">
-      <DsfrRadio
-        :label="stepConstants.hasDiversificationPlan.title"
-        v-model="payload.hasDiversificationPlan"
-        hide-details
-        yesNo
-        optional
-      />
-      <fieldset class="mt-8 mb-3">
-        <legend class="text-left mb-1 mt-3" :class="{ 'grey--text': !payload.hasDiversificationPlan }">
-          {{ stepConstants.diversificationPlanActions.title }}
-          <span :class="`fr-hint-text mt-2 ${!payload.hasDiversificationPlan && 'grey--text'}`">Optionnel</span>
-        </legend>
-        <v-checkbox
-          hide-details="auto"
-          class="mt-1"
-          v-model="payload.diversificationPlanActions"
-          :multiple="true"
-          v-for="item in stepConstants.diversificationPlanActions.items"
-          :key="item.value"
-          :value="item.value"
-          :label="item.label"
-          :readonly="!payload.hasDiversificationPlan"
-          :disabled="!payload.hasDiversificationPlan"
-        />
-      </fieldset>
-    </div>
   </v-form>
 </template>
 
@@ -80,6 +88,10 @@ const stepList = [
   {
     title: "Mise en place d’actions de diversification des protéines",
     urlSlug: "plan",
+  },
+  {
+    title: "Service proposé aux convives",
+    urlSlug: "service",
   },
   {
     title: "Mise en place d’un menu végétarien",
@@ -122,11 +134,12 @@ export default {
       stepConstants: Constants.DiversificationMeasureStep,
       payload: {},
       fields: [
+        "hasDiversificationPlan",
+        "diversificationPlanActions",
+        "serviceType",
         "vegetarianWeeklyRecurrence",
         "vegetarianMenuType",
         "vegetarianMenuBases",
-        "hasDiversificationPlan",
-        "diversificationPlanActions",
       ],
     }
   },
@@ -141,6 +154,7 @@ export default {
         idx = steps.findIndex((step) => step.urlSlug === "plan")
         if (idx > -1) steps.splice(idx, 1)
       }
+      // - 2024-12: hide options step (replaced with service step)
       // - hide options & composition steps if no vegetarian menu
       if (this.payload.vegetarianWeeklyRecurrence === "NEVER") {
         idx = steps.findIndex((step) => step.urlSlug === "options")


### PR DESCRIPTION
### Quoi

Suite de #4720 où l'on a créé un nouveau champ `Diagnostic.service_type`

Modifications apportées dans le tunnel diagnostique > Menus végés : 
- ajout d'une nouvelle étape dans le tunnel + synthèse (voir capture d'écran ci-dessous)
- on archive l'étape existante qui demandait le service proposé des menus végés (voir issue)
- j'en ai profité pour sortir la liste des steps (refactoring similaire déjà effectué dans #4647)

### Captures d'écran

|Page|Image|
|---|---|
|Nouvelle étape 2|![image](https://github.com/user-attachments/assets/8ca4f0c8-019c-40c4-8400-1bb894e01f0f)|
|Synthèse|![image](https://github.com/user-attachments/assets/cbfeacc7-04bd-4ac1-86ec-5ec103adff6d)|