### PR TITLE
fix(Tunnel Diagnostique): Gaspillage: répare la fermeture de la modale XP réservation

### DIFF
--- a/frontend/src/components/DiagnosticSummary/WasteMeasureSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/WasteMeasureSummary.vue
@@ -215,6 +215,11 @@ export default {
       required: true,
     },
   },
+  data() {
+    return {
+      xpReservationInfoDialog: false,
+    }
+  },
   computed: {
     appliedWasteActions() {
       if (!this.diagnostic.wasteActions?.length) return null


### PR DESCRIPTION
Suite à l'ajout de la modale dans #4693

J'avais oublié de rajouter la variable dans data() donc impossible de la fermer en cliquant sur le bouton "Fermer" :facepalm: 