### PR TITLE
fix(Import cantines): reparer le cas où on veut ajouter des gestionnaires mais on n'a pas des colonnes vides en plus

### DIFF
--- a/api/tests/files/canteen_manager_import.csv
+++ b/api/tests/files/canteen_manager_import.csv
@@ -1,0 +1,1 @@
+21340172201787,A canteen,,54460,,700,14000,,site,conceded,,manager@example.com

--- a/api/tests/test_import_diagnostics.py
+++ b/api/tests/test_import_diagnostics.py
@@ -286,6 +286,22 @@ class TestImportDiagnosticsAPI(APITestCase):
         self.assertEqual(Canteen.objects.first().economic_model, None)
 
     @authenticate
+    def test_import_canteens_with_managers(self, _):
+        """
+        Should be able to import canteens from a file that doesn't contain any diagnostic fields
+        """
+        manager = UserFactory(email="manager@example.com")
+        with open("./api/tests/files/canteen_manager_import.csv") as diag_file:
+            response = self.client.post(reverse("import_diagnostics"), {"file": diag_file})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["count"], 0)
+        self.assertEqual(len(body["errors"]), 0, body["errors"])
+        self.assertEqual(Diagnostic.objects.count(), 0)
+        self.assertEqual(Canteen.objects.count(), 1)
+        self.assertIn(manager, Canteen.objects.first().managers.all())
+
+    @authenticate
     def test_staff_import(self, _):
         """
         Staff get to specify extra columns and have fewer requirements on what data is required.

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -332,7 +332,7 @@ class ImportDiagnosticsView(ABC, APIView):
     def _get_manager_emails_to_notify(self, row):
         try:
             manager_emails = []
-            if len(row) > self.manager_column_idx + 1 and row[self.manager_column_idx]:
+            if len(row) > self.manager_column_idx and row[self.manager_column_idx]:
                 manager_emails = ImportDiagnosticsView._get_manager_emails(row[self.manager_column_idx])
         except Exception:
             raise ValidationError(


### PR DESCRIPTION
Remonté : #4678 

Description du bug : en gros c'est possible d'importer un fichier pour créer des cantines sans avoir les colonnes en plus qui sont utilisés pour créer les diagnostics. Le check pour ne pas faire un IndexError sur la liste a été legèrement faux, qui fait que les gestionnaires n'ont pas été rajoutés si le fichier continent pas de colonne après.

Cette PR: j'ai ajouté un test pour recreer le bug et je repare la logique

Hors du scope : on offre un import pour les cantines seules, et on offre un import de cantines + diagnostics. Or, on n'offre pas de moyen à notre équipe pour rajouter les colonnes internes (gestionnaires non-notifiés, identifiant import etc) à l'import cantines sans ajouter des virgules pour toutes les colonnes vides du diagnostic. Une amélioration sera de séparer l'implementation de l'import `ImportSimpleDiagnosticsView` (et ecrire les tests necessaires et les fichiers d'example nécessaires pour les utilisateurs et notre équipe interne).