### PR TITLE
fix(Tableau de bord): Pour l'année en cours, afficher la graphe appro des achats si l'outil suivi achats est utilisé

### DIFF
--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -200,7 +200,9 @@ export default {
       return null
     },
     approDiagnostic() {
-      return (this.isCurrentYear && this.purchasesSummary) || this.centralDiagnostic || this.canteenDiagnostic
+      if (this.isCurrentYear && this.purchasesSummary && this.purchasesSummary.valueTotalHt !== 0) {
+        return this.purchasesSummary
+      } else return this.centralDiagnostic || this.canteenDiagnostic
     },
     otherMeasuresDiagnostic() {
       if (this.centralDiagnostic?.centralKitchenDiagnosticMode === "ALL") {

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -202,7 +202,8 @@ export default {
     approDiagnostic() {
       if (this.isCurrentYear && this.purchasesSummary && this.purchasesSummary.valueTotalHt !== 0) {
         return this.purchasesSummary
-      } else return this.centralDiagnostic || this.canteenDiagnostic
+      }
+      return this.centralDiagnostic || this.canteenDiagnostic
     },
     otherMeasuresDiagnostic() {
       if (this.centralDiagnostic?.centralKitchenDiagnosticMode === "ALL") {


### PR DESCRIPTION
Closes #4733 

![Screenshot 2024-12-10 at 16-15-24 Tableau de bord - ma cantine](https://github.com/user-attachments/assets/530fde6d-f8e8-473f-8089-03f53843b08e)
