### PR TITLE
fix(Import achats): Améliorer le message d'erreur pour un fichier du mauvais format

### DIFF
--- a/api/tests/test_import_diagnostics.py
+++ b/api/tests/test_import_diagnostics.py
@@ -1297,7 +1297,7 @@ class TestImportDiagnosticsAPI(APITestCase):
         self.assertEqual(first_error["status"], 400)
         self.assertEqual(
             first_error["message"],
-            "Ce fichier est du format application/vnd.oasis.opendocument.spreadsheet, merci d'exporter votre fichier en format CSV et re-essayer.",
+            "Ce fichier est au format application/vnd.oasis.opendocument.spreadsheet, merci d'exporter votre fichier au format CSV et réessayer.",
         )
 
 

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -295,5 +295,5 @@ class TestPurchaseImport(APITestCase):
         self.assertEqual(first_error["status"], 400)
         self.assertEqual(
             first_error["message"],
-            "Ce fichier est du format application/vnd.oasis.opendocument.spreadsheet, merci d'exporter votre fichier en format CSV et re-essayer.",
+            "Ce fichier est au format application/vnd.oasis.opendocument.spreadsheet, merci d'exporter votre fichier au format CSV et réessayer.",
         )

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -283,3 +283,17 @@ class TestPurchaseImport(APITestCase):
         self.assertEqual(Purchase.objects.count(), 1)
         self.assertEqual(Purchase.objects.first().description, "deuxième pomme")
         self.assertEqual(body["encoding"], "ISO-8859-1")
+
+    @authenticate
+    def test_fail_import_bad_format(self):
+        with open("./api/tests/files/bad_format_file.ods", "rb") as diag_file:
+            response = self.client.post(reverse("import_purchases"), {"file": diag_file})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        errors = body["errors"]
+        first_error = errors.pop(0)
+        self.assertEqual(first_error["status"], 400)
+        self.assertEqual(
+            first_error["message"],
+            "Ce fichier est du format application/vnd.oasis.opendocument.spreadsheet, merci d'exporter votre fichier en format CSV et re-essayer.",
+        )

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -95,7 +95,7 @@ class ImportDiagnosticsView(ABC, APIView):
     def _verify_file_format(file):
         if file.content_type != "text/csv" and file.content_type != "text/tab-separated-values":
             raise ValidationError(
-                f"Ce fichier est du format {file.content_type}, merci d'exporter votre fichier en format CSV et re-essayer."
+                f"Ce fichier est au format {file.content_type}, merci d'exporter votre fichier au format CSV et réessayer."
             )
 
     @staticmethod

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -18,6 +18,7 @@ from api.permissions import IsAuthenticated
 from api.serializers import PurchaseSerializer
 from data.models import Canteen, ImportFailure, ImportType, Purchase
 
+from .diagnosticimport import ImportDiagnosticsView
 from .utils import camelize, decode_bytes, normalise_siret
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,7 @@ class ImportPurchasesView(APIView):
         try:
             self.file = request.data["file"]
             self._verify_file_size()
+            ImportDiagnosticsView._verify_file_format(self.file)
             with transaction.atomic():
                 self._process_file()
 


### PR DESCRIPTION
Closes #4492

## Avant

![Screenshot 2024-12-10 at 19-08-50 Importer des achats - ma cantine](https://github.com/user-attachments/assets/c8e4c77e-5ab6-4a86-a530-fc7848501d80)

## Après

![Screenshot 2024-12-10 at 19-07-37 Importer des achats - ma cantine](https://github.com/user-attachments/assets/c00b8cfb-de28-4b19-87e6-c7a1eed919d3)
