### PR TITLE
improve(Secteurs): Admin: afficher la colonne "Ministère de tutelle"

### DIFF
--- a/data/admin/sector.py
+++ b/data/admin/sector.py
@@ -24,6 +24,7 @@ class SectorAdmin(admin.ModelAdmin):
     list_display = (
         "name",
         "category",
+        "has_line_ministry",
         "creation_date",
     )
-    list_filter = ("category",)
+    list_filter = ("category", "has_line_ministry")

--- a/data/admin/sector.py
+++ b/data/admin/sector.py
@@ -15,10 +15,12 @@ class SectorForm(forms.ModelForm):
 class SectorAdmin(admin.ModelAdmin):
     form = SectorForm
     fields = (
-        "category",
         "name",
+        "category",
         "has_line_ministry",
+        "creation_date",
     )
+    readonly_fields = ("creation_date",)
     list_display = (
         "name",
         "category",


### PR DESCRIPTION
### Quoi

Dans l'admin > Secteurs d'activité, j'ai fait quelques petites améliorations : 
- afficher le champ "line_ministry" dans la vue liste
- afficher le champ "creation_date" dans la vue détail (en readonly)

### Pourquoi

Je manquais l'info de voir rapidement les secteurs qui nécessitent d'afficher le "Ministère de tutelle" (pour #4752)