### PR TITLE
improve(Formulaire cantine): Affiche le champ 'Administration de tutelle' seulement pour les cantines publiques

### DIFF
--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -436,6 +436,8 @@ export default {
       return this.canteen.productionType && this.canteen.productionType !== "central"
     },
     showMinistryField() {
+      // 2 rules: Public + Sector(s) with line_ministry
+      if (this.canteen.economicModel !== "public") return false
       const concernedSectors = this.sectors.filter((x) => !!x.hasLineMinistry).map((x) => x.id)
       if (concernedSectors.length === 0) return false
       return this.canteen.sectors?.some((x) => concernedSectors.indexOf(parseInt(x, 10)) > -1)


### PR DESCRIPTION
### Quoi

Voir #4752

Rajoute une règle sur l'affichage du champ "Administation générale de tutelle"
- la cantine doit être public
- la cantine doit avec un secteur concerné (règle déjà en place)