### PR TITLE
improve(Achats): Admin: Quelques améliorations dans la vue list (lien vers la cantine, colonne Suppr, date de création)

### DIFF
--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -111,7 +111,7 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         "source_des_données",
         "management_type",
         "visible_au_public",
-        "supprimée",
+        "deleted",
     )
     filter_vertical = (
         "sectors",
@@ -151,9 +151,6 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
 
     def source_des_données(self, obj):
         return obj.import_source
-
-    def supprimée(self, obj):
-        return "🗑️ Supprimée" if obj.deletion_date else ""
 
 
 class CanteenInline(admin.TabularInline):

--- a/data/admin/purchase.py
+++ b/data/admin/purchase.py
@@ -9,8 +9,8 @@ from .utils import get_arrayfield_list_filter
 @admin.register(Purchase)
 class PurchaseAdmin(SoftDeletionAdmin):
     fields = (
-        "canteen",
         "date",
+        "canteen",
         "description",
         "provider",
         "family",
@@ -21,6 +21,7 @@ class PurchaseAdmin(SoftDeletionAdmin):
         "local_definition",
         "import_source",
         "deletion_date",
+        "creation_date",
     )
     readonly_fields = (
         "canteen",
@@ -34,14 +35,17 @@ class PurchaseAdmin(SoftDeletionAdmin):
         "invoice_file",
         "local_definition",
         "import_source",
+        "creation_date",
     )
     list_display = (
         "date",
+        "canteen",
         "description",
         "family",
         "characteristics",
-        "canteen",
         "price_ht",
+        "deletion_status",
+        "creation_date",
     )
     list_filter = (
         "family",

--- a/data/admin/purchase.py
+++ b/data/admin/purchase.py
@@ -56,11 +56,11 @@ class PurchaseAdmin(SoftDeletionAdmin):
         "deletion_date",
     )
     search_fields = (
-        "description",
-        "canteen__name",
         "canteen__siret",
+        "description",
         "import_source",
     )
+    search_help_text = f"Cherche sur les champs : Cantine (SIRET), {Purchase._meta.get_field('description').verbose_name.capitalize()}, {Purchase._meta.get_field('import_source').verbose_name.capitalize()}"
 
     def canteen_name(self, obj):
         return obj.canteen.name

--- a/data/admin/purchase.py
+++ b/data/admin/purchase.py
@@ -46,7 +46,7 @@ class PurchaseAdmin(SoftDeletionAdmin):
         "family",
         "characteristics",
         "price_ht",
-        "deletion_status",
+        "deleted",
         "creation_date",
     )
     list_filter = (

--- a/data/admin/purchase.py
+++ b/data/admin/purchase.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.urls import reverse
+from django.utils.html import format_html
 
 from data.models import Purchase
 
@@ -39,7 +41,7 @@ class PurchaseAdmin(SoftDeletionAdmin):
     )
     list_display = (
         "date",
-        "canteen",
+        "canteen_with_link",
         "description",
         "family",
         "characteristics",
@@ -62,3 +64,9 @@ class PurchaseAdmin(SoftDeletionAdmin):
 
     def canteen_name(self, obj):
         return obj.canteen.name
+
+    def canteen_with_link(self, obj):
+        url = reverse("admin:data_canteen_change", args=[obj.canteen_id])
+        return format_html(f'<a href="{url}">{obj.canteen}</a>')
+
+    canteen_with_link.short_description = Purchase._meta.get_field("canteen").verbose_name

--- a/data/admin/softdeletionadmin.py
+++ b/data/admin/softdeletionadmin.py
@@ -23,8 +23,13 @@ class SoftDeletionAdmin(admin.ModelAdmin):
     def delete_queryset(self, request, queryset):
         return queryset.hard_delete()
 
+    def deleted(self, obj):
+        return "🗑️ Supprimée" if obj.deletion_date else ""
+
+    deleted.short_description = "Supprimée"
+
     def deletion_status(self, obj):
-        return "🗑️ Supprimée" if bool(obj.deletion_date) else "✔️ Active"
+        return "🗑️ Supprimée" if obj.deletion_date else "✔️ Active"
 
     deletion_status.short_description = "Statut de suppression"
 

--- a/data/admin/softdeletionadmin.py
+++ b/data/admin/softdeletionadmin.py
@@ -23,13 +23,18 @@ class SoftDeletionAdmin(admin.ModelAdmin):
     def delete_queryset(self, request, queryset):
         return queryset.hard_delete()
 
+    def deletion_status(self, obj):
+        return "🗑️ Supprimée" if bool(obj.deletion_date) else "✔️ Active"
+
+    deletion_status.short_description = "Statut de suppression"
+
 
 class SoftDeletionHistoryAdmin(SoftDeletionAdmin, SimpleHistoryAdmin):
     pass
 
 
 class SoftDeletionStatusFilter(admin.SimpleListFilter):
-    title = "status de suppression par l'utilisateur"
+    title = "statut de suppression par l'utilisateur"
 
     parameter_name = "deletion_status"
 


### PR DESCRIPTION
### Quoi

Suite à une fausse manip dans l'admin et la suppression d'une centaine d'achats, j'ai mis un peu le nez dans l'admin.
Quelques modifs pour homogénéiser l'affichage et le rendre un peu plus transparent.

Modifications apportées : 
- décalé la colonne "canteen" à gauche + lien direct vers la page admin de la cantine
- ajouté la colonne "Supprimée" à droite (même comportement que coté Cantine)
- ajouté la colonne "Date de création" à droite (et dans la vue détails)
- recheche : enlevé la possibilité de chercher par nom de cantine (pour forcer à une recherche précise par SIRET) + ajout d'un help_text

### Captures d'écran 

|Admin|Image|
|---|---|
|Avant|![image](https://github.com/user-attachments/assets/d8ad0792-ead1-487e-b46b-e75bdf6c74d0)|
|Après|![image](https://github.com/user-attachments/assets/14ab9a2e-dd89-40a5-9f53-563f80b34090)|