### PR TITLE
improve(Cantine synthèse): réorganise les champs suite aux modifications dans le formulaire

### DIFF
--- a/frontend/src/components/DiagnosticSummary/CanteenSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/CanteenSummary.vue
@@ -8,7 +8,7 @@
         <div class="mt-n1">
           <p class="my-0 fr-text-sm grey--text text--darken-1">Nom de la cantine</p>
           <p class="my-0">{{ canteen.name }}</p>
-          <p class="my-0 fr-text-sm grey--text text--darken-1 mt-2">SIRET</p>
+          <p class="mb-0 mt-2 fr-text-sm grey--text text--darken-1">SIRET</p>
           <p class="my-0">{{ canteen.siret || "—" }}</p>
         </div>
       </v-col>
@@ -23,12 +23,16 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" class="d-flex align-center pa-0 my-4 my-md-0 left-border">
+      <v-col cols="12" md="6" class="d-flex align-center pa-0 my-4 my-md-0 left-border">
         <div class="mx-8">
           <v-icon color="primary" x-large>$team-line</v-icon>
         </div>
         <div class="mt-n1">
-          <p class="my-0 fr-text-sm grey--text text--darken-1">Type de production</p>
+          <p class="my-0 fr-text-sm grey--text text--darken-1">Type d'établissement</p>
+          <p class="my-0">{{ economicModel || "—" }}</p>
+          <p class="mb-0 mt-2 fr-text-sm grey--text text--darken-1">Mode de gestion</p>
+          <p class="my-0">{{ managementType || "—" }}</p>
+          <p class="mb-0 mt-2 fr-text-sm grey--text text--darken-1">Type de production</p>
           <p class="my-0">{{ productionType || "—" }}</p>
           <div v-if="isSatellite">
             <p class="mb-0 mt-2 fr-text-sm grey--text text--darken-1">SIRET du livreur</p>
@@ -39,27 +43,6 @@
               {{ canteen.centralProducerSiret || "—" }}
             </p>
           </div>
-          <p class="mb-0 mt-2 fr-text-sm grey--text text--darken-1">Mode de gestion</p>
-          <p class="my-0">{{ managementType || "—" }}</p>
-        </div>
-      </v-col>
-    </v-row>
-    <v-row>
-      <v-col cols="12" md="6" class="d-flex align-center pa-0 my-4 my-md-0 left-border">
-        <div class="mx-8">
-          <v-icon color="primary" x-large>$building-line</v-icon>
-        </div>
-        <div class="mt-n1">
-          <p class="my-0 fr-text-sm grey--text text--darken-1">Secteur d'activité</p>
-          <p class="my-0">{{ sectors || "—" }}</p>
-          <div v-if="lineMinistryRequired">
-            <p class="my-0 mt-2 fr-text-sm grey--text text--darken-1">
-              Administration générale de tutelle
-            </p>
-            <p class="my-0">{{ lineMinistry || "—" }}</p>
-          </div>
-          <p class="mb-0 mt-2 fr-text-sm grey--text text--darken-1">Type d'établissement</p>
-          <p class="my-0">{{ economicModel || "—" }}</p>
         </div>
       </v-col>
       <v-col cols="12" md="6" class="d-flex align-center pa-0 my-4 my-md-0 left-border">
@@ -86,6 +69,23 @@
                 canteen.satelliteCanteensCount ? parseInt(canteen.satelliteCanteensCount).toLocaleString("fr-FR") : "—"
               }}
             </p>
+          </div>
+        </div>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="12" class="d-flex align-center pa-0 my-4 my-md-0 left-border">
+        <div class="mx-8">
+          <v-icon color="primary" x-large>$building-line</v-icon>
+        </div>
+        <div class="mt-n1">
+          <p class="my-0 fr-text-sm grey--text text--darken-1">Secteur d'activité</p>
+          <p class="my-0">{{ sectors || "—" }}</p>
+          <div v-if="lineMinistryRequired">
+            <p class="mb-0 mt-2 fr-text-sm grey--text text--darken-1">
+              Administration générale de tutelle
+            </p>
+            <p class="my-0">{{ lineMinistry || "—" }}</p>
           </div>
         </div>
       </v-col>


### PR DESCRIPTION
### Quoi

Suite aux modifications dans #4752, il y avait des différences d'affichages entre l'ordre des champs du formulaire et de la synthèse.

Cette PR modifie l'affichage de la synthèse : 
- remonte le champ "type d'établissement"
- bascule les champs "nombre de couverts" en face
- homogénéise les classes de margin

### Captures d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/user-attachments/assets/9f5009d8-f98f-4633-b945-623edf67ee13)|![image](https://github.com/user-attachments/assets/0ccfe172-5541-4273-b19a-67fd9aef46be)|