### PR TITLE
fix(Contact Page): l'image empêchait de build le frontend vu3

### DIFF
--- a/2024-frontend/src/components/AppFormSendInquiry.vue
+++ b/2024-frontend/src/components/AppFormSendInquiry.vue
@@ -10,6 +10,9 @@ import AppLinkMailto from "@/components/AppLinkMailto.vue"
 /* Store */
 const store = useRootStore()
 
+/* Images */
+const sittingDoodle = "/static/images/doodles-dsfr/primary/SittingDoodle.png"
+
 /* Save user meta info */
 const meta = {
   userId: store.loggedUser?.id,
@@ -124,7 +127,7 @@ const sendInquiry = () => {
         </DsfrCallout>
       </div>
       <div class="fr-col-4 fr-hidden fr-unhidden-lg">
-        <img src="/static/images/doodles-dsfr/primary/SittingDoodle.png" class="app-form-send-inquiry__illustration" />
+        <img :src="sittingDoodle" class="app-form-send-inquiry__illustration" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Au moment du build Vite cherchait l'url de l'image mais le dossier static n'existait pas encore. Pour corriger cela : une solution est de rendre l'rul dynamique, ce qui fait qu'au build l'url n'est pas regardée et elle sera rendue par django ensuite.