### PR TITLE
improve(Teledeclaration): Améliore la visibilité du statut et de la progression de la télédéclaration

### DIFF
--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -31,7 +31,7 @@ export default {
     body() {
       if (this.hasActiveTeledeclaration) return "Bilan télédéclaré"
       if (this.currentYear) return "Année en cours"
-      if (this.missingData) return "Bilan à compléter"
+      if (this.missingData) return "Données à compléter"
       if (this.readyToTeledeclare) return "Bilan à télédéclarer"
       return null
     },

--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -37,6 +37,7 @@ export default {
     },
     mode() {
       if (this.hasActiveTeledeclaration) return "SUCCESS"
+      else if (this.missingData || this.readyToTeledeclare) return "ERROR"
       return "INFO"
     },
   },

--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -37,6 +37,7 @@ export default {
     },
     mode() {
       if (this.hasActiveTeledeclaration) return "SUCCESS"
+      else if (this.currentYear) return "INFO"
       else if (this.missingData || this.readyToTeledeclare) return "ERROR"
       return "INFO"
     },

--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -31,7 +31,7 @@ export default {
     body() {
       if (this.hasActiveTeledeclaration) return "Bilan télédéclaré"
       if (this.currentYear) return "Année en cours"
-      if (this.missingData) return "Données à compléter"
+      if (this.missingData) return "Bilan à compléter"
       if (this.readyToTeledeclare) return "Bilan à télédéclarer"
       return null
     },

--- a/frontend/src/components/DsfrBadge.vue
+++ b/frontend/src/components/DsfrBadge.vue
@@ -7,7 +7,7 @@
     small
     label
   >
-    <v-icon :color="modes[mode].color" small class="mr-2">{{ badgeIcon }}</v-icon>
+    <v-icon v-if="showIcon" :color="modes[mode].color" small class="mr-2">{{ badgeIcon }}</v-icon>
     <slot />
   </v-chip>
 </template>
@@ -24,6 +24,10 @@ export default {
     icon: {
       type: String,
       optional: true,
+    },
+    showIcon: {
+      type: Boolean,
+      default: true,
     },
   },
   data() {

--- a/frontend/src/components/DsfrNativeSelect.vue
+++ b/frontend/src/components/DsfrNativeSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <label :for="inputId" :class="labelClasses">
+    <label v-if="label" :for="inputId" :class="labelClasses">
       {{ label }}
       <span v-if="hint" class="fr-hint-text">{{ hint }}</span>
     </label>
@@ -45,7 +45,6 @@ export default {
     },
     label: {
       type: String,
-      required: true,
     },
     labelClasses: {
       default: "mb-2 text-sm-subtitle-1 text-body-2 text-left",

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -83,6 +83,7 @@
             v-for="(tab, key) in tabHeaders"
             class="mb-1 progress-checkbox"
             readonly
+            :disabled="usesSatelliteDiagnosticForMeasure(tab)"
             :key="tab.id"
             :input-value="tab.isCompleted"
             :label="tab.text"

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -91,7 +91,7 @@
             </div>
           </div>
           <div v-else>
-            <p>Pour télédéclarer, veuillez :</p>
+            <p>Pour télédéclarer veuillez :</p>
             <ul>
               <li v-if="missingApproDiagnostic" class="mb-2">
                 <router-link

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -7,7 +7,7 @@
       ]"
     />
     <v-row align="end">
-      <v-col cols="12" md="10">
+      <v-col cols="12" md="9" lg="10">
         <DataInfoBadge v-if="hasActiveTeledeclaration" class="my-2" :hasActiveTeledeclaration="true" />
         <DataInfoBadge
           v-else-if="inTeledeclarationCampaign"
@@ -19,7 +19,7 @@
         <ProductionTypeTag v-if="canteen" :canteen="canteen" class="ml-3" />
         <h1 class="fr-h3 mt-1 mb-0" v-if="canteen">{{ canteen.name }} : Télédéclaration</h1>
       </v-col>
-      <v-col cols="12" sm="5" md="2">
+      <v-col cols="12" md="3" lg="2">
         <v-btn
           v-if="canteenPreviews.length > 1"
           outlined

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -6,10 +6,18 @@
         { to: { name: 'DashboardManager' }, title: canteen ? canteen.name : 'Dashboard' },
       ]"
     />
-    <v-row align="center">
+    <v-row align="end">
       <v-col cols="12" md="10">
-        <ProductionTypeTag v-if="canteen" :canteen="canteen" class="mt-n2" />
-        <h1 class="fr-h3 mt-1 mb-2" v-if="canteen">Télédéclaration : {{ canteen.name }}</h1>
+        <DataInfoBadge v-if="hasActiveTeledeclaration" class="my-2" :hasActiveTeledeclaration="true" />
+        <DataInfoBadge
+          v-else-if="inTeledeclarationCampaign"
+          class="my-2"
+          :readyToTeledeclare="readyToTeledeclare"
+          :missingData="!readyToTeledeclare"
+        />
+        <DataInfoBadge v-else-if="+year >= currentYear" class="my-2" :currentYear="+year === currentYear" />
+        <ProductionTypeTag v-if="canteen" :canteen="canteen" class="ml-3" />
+        <h1 class="fr-h3 mt-1 mb-0" v-if="canteen">Télédéclaration : {{ canteen.name }}</h1>
       </v-col>
       <v-col cols="12" sm="5" md="2">
         <v-btn

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -9,7 +9,7 @@
     <v-row align="center">
       <v-col cols="12" md="10">
         <ProductionTypeTag v-if="canteen" :canteen="canteen" class="mt-n2" />
-        <h1 class="fr-h3 mt-1 mb-2" v-if="canteen">{{ canteen.name }}</h1>
+        <h1 class="fr-h3 mt-1 mb-2" v-if="canteen">Télédéclaration : {{ canteen.name }}</h1>
       </v-col>
       <v-col cols="12" sm="5" md="2">
         <v-btn
@@ -23,12 +23,16 @@
         </v-btn>
       </v-col>
     </v-row>
-    <v-row>
-      <DsfrNativeSelect label="Année" v-model="selectedYear" :items="yearOptions" />
-    </v-row>
     <v-row v-if="canteen" class="mt-5 mt-md-10">
-      <v-col cols="12" sm="9" md="3" lg="2" style="border-left: 1px solid #DDD;" class="fr-text-sm order-md-last pr-0">
-        <h2 class="fr-h5 mb-2">Télédéclaration</h2>
+      <v-col
+        cols="12"
+        sm="9"
+        md="3"
+        lg="2"
+        style="border-left: 1px solid #DDD;"
+        class="fr-text-sm order-md-last pr-0 pt-1"
+      >
+        <DsfrNativeSelect v-model="selectedYear" :items="yearOptions" class="mb-3" />
         <div v-if="hasActiveTeledeclaration">
           <DataInfoBadge class="my-2" :hasActiveTeledeclaration="true" />
           <p>

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -6,21 +6,25 @@
         { to: { name: 'DashboardManager' }, title: canteen ? canteen.name : 'Dashboard' },
       ]"
     />
-    <v-row>
+    <v-row align="center">
       <v-col cols="12" md="10">
         <ProductionTypeTag v-if="canteen" :canteen="canteen" class="mt-n2" />
         <h1 class="fr-h3 mt-1 mb-2" v-if="canteen">{{ canteen.name }}</h1>
-        <v-row v-if="canteenPreviews.length > 1">
-          <v-col>
-            <v-btn outlined color="primary" class="fr-btn--tertiary" :to="{ name: 'ManagementPage' }">
-              Changer d'établissement
-            </v-btn>
-          </v-col>
-        </v-row>
       </v-col>
       <v-col cols="12" sm="5" md="2">
-        <DsfrNativeSelect label="Année" v-model="selectedYear" :items="yearOptions" />
+        <v-btn
+          v-if="canteenPreviews.length > 1"
+          outlined
+          color="primary"
+          class="fr-btn--tertiary"
+          :to="{ name: 'ManagementPage' }"
+        >
+          Changer d'établissement
+        </v-btn>
       </v-col>
+    </v-row>
+    <v-row>
+      <DsfrNativeSelect label="Année" v-model="selectedYear" :items="yearOptions" />
     </v-row>
     <v-row v-if="canteen" class="mt-5 mt-md-10">
       <v-col cols="12" sm="9" md="3" lg="2" style="border-left: 1px solid #DDD;" class="fr-text-sm order-md-last pr-0">

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -79,6 +79,7 @@
             <p>Votre livreur des repas va déclarer les données d'approvisionnement pour votre établissement.</p>
             <p>Pour aller plus loin, vous pouvez télédéclarer les autres volets du bilan.</p>
           </div>
+          <p class="mb-1 mt-2">Données à renseigner :</p>
           <v-checkbox
             v-for="(tab, key) in tabHeaders"
             class="mb-1 progress-checkbox"

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -80,8 +80,8 @@
             <p>Pour aller plus loin, vous pouvez télédéclarer les autres volets du bilan.</p>
           </div>
           <v-checkbox
-            v-for="tab in tabHeaders"
-            class="mb-1"
+            v-for="(tab, key) in tabHeaders"
+            class="mb-1 progress-checkbox"
             readonly
             :key="tab.id"
             :input-value="tab.isCompleted"
@@ -89,6 +89,7 @@
             :prepend-icon="tab.icon"
             :dense="true"
             :hide-details="true"
+            @click="changeTab(key)"
           />
           <ul>
             <li v-if="hasSatelliteInconsistency" class="mb-2">
@@ -544,6 +545,9 @@ export default {
           this.$store.dispatch("notifyServerError", e)
         })
     },
+    changeTab(tab) {
+      this.tab = tab
+    },
   },
   watch: {
     canteenUrlComponent() {
@@ -600,5 +604,14 @@ export default {
 }
 .close-icon {
   border-bottom: solid 1px;
+}
+.progress-checkbox {
+  align-items: center;
+}
+</style>
+
+<style>
+.progress-checkbox:hover * {
+  color: var(--v-primary-base) !important;
 }
 </style>

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -79,20 +79,24 @@
             <p>Votre livreur des repas va déclarer les données d'approvisionnement pour votre établissement.</p>
             <p>Pour aller plus loin, vous pouvez télédéclarer les autres volets du bilan.</p>
           </div>
-          <p class="mb-1 mt-2">Données à saisir :</p>
-          <v-checkbox
-            v-for="tab in tabHeaders"
-            class="mb-1 progress-checkbox"
-            readonly
-            :disabled="usesSatelliteDiagnosticForMeasure(tab)"
-            :key="tab.id"
-            :input-value="tab.isCompleted"
-            :label="tab.isRequired ? `${tab.text}*` : tab.text"
-            :dense="true"
-            :hide-details="true"
-          />
+          <ul class="progress-list">
+            <li
+              v-for="tab in tabHeaders"
+              :key="tab.id"
+              v-show="!usesSatelliteDiagnosticForMeasure(tab)"
+              class="mb-2 progress-list__item"
+            >
+              <p class="mb-0 font-weight-bold">
+                <v-icon small class="black--text">{{ tab.icon }}</v-icon>
+                {{ tab.text }}
+              </p>
+              <DsfrBadge v-if="tab.isCompleted" :showIcon="false" mode="SUCCESS">Complété</DsfrBadge>
+              <DsfrBadge v-else-if="tab.isRequired" :showIcon="false" mode="ERROR">À compléter (obligatoire)</DsfrBadge>
+              <DsfrBadge v-else :showIcon="false" mode="WARNING">À compléter (optionnel)</DsfrBadge>
+            </li>
+          </ul>
           <ul>
-            <li v-if="hasSatelliteInconsistency" class="mb-2">
+            <li v-if="hasSatelliteInconsistency" class="mb-1">
               <router-link
                 :to="{
                   name: 'SatelliteManagement',
@@ -102,7 +106,7 @@
                 Mettre à jour vos satellites
               </router-link>
             </li>
-            <li v-if="missingDeclarationMode" class="mb-2">
+            <li v-if="missingDeclarationMode">
               Choisir comment les données sont saisis pour vos satellites
             </li>
           </ul>
@@ -248,6 +252,7 @@
 import BreadcrumbsNav from "@/components/BreadcrumbsNav"
 import ProductionTypeTag from "@/components/ProductionTypeTag"
 import ProgressTab from "./ProgressTab"
+import DsfrBadge from "@/components/DsfrBadge"
 import DsfrTabsVue from "@/components/DsfrTabs"
 import DsfrNativeSelect from "@/components/DsfrNativeSelect"
 import DownloadLink from "@/components/DownloadLink"
@@ -275,6 +280,7 @@ export default {
     BreadcrumbsNav,
     ProductionTypeTag,
     ProgressTab,
+    DsfrBadge,
     DsfrTabsVue,
     DsfrNativeSelect,
     DownloadLink,
@@ -604,13 +610,11 @@ export default {
 .close-icon {
   border-bottom: solid 1px;
 }
-.progress-checkbox {
-  align-items: center;
+.progress-list {
+  padding-left: 0;
+  list-style: none;
 }
-</style>
-
-<style>
-.progress-checkbox * {
-  cursor: initial !important;
+.progress-list__item:last-child {
+  margin-bottom: 0.25rem !important;
 }
 </style>

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -86,7 +86,7 @@
             :disabled="usesSatelliteDiagnosticForMeasure(tab)"
             :key="tab.id"
             :input-value="tab.isCompleted"
-            :label="tab.text"
+            :label="tab.isRequired ? `${tab.text}*` : tab.text"
             :prepend-icon="tab.icon"
             :dense="true"
             :hide-details="true"
@@ -320,6 +320,7 @@ export default {
           title: measure.title,
           icon: measure.mdiIcon,
           to: { params: { measure: measure.id } },
+          isRequired: measure.id === "qualite-des-produits",
           isCompleted: hasStartedMeasureTunnel(this.diagnostic, measure),
         }
         tabHeaders.push(item)
@@ -332,6 +333,7 @@ export default {
         icon: "$building-fill",
         to: { params: { measure: this.establishmentId } },
         isCompleted: this.isCentralKitchen ? centralKitchenCompleted : !this.missingCanteenData,
+        isRequired: true,
       })
       return tabHeaders
     },

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -33,7 +33,7 @@
     </v-row>
     <v-row v-if="canteen" class="flex-row-reverse mt-5 mt-md-10">
       <v-col cols="12" sm="9" md="3" lg="2" style="border-right: 1px solid #DDD;" class="fr-text-sm order-md-last pt-1">
-        <DsfrNativeSelect v-model="selectedYear" :items="yearOptions" class="mb-3" />
+        <DsfrNativeSelect v-model="selectedYear" :items="yearOptions" class="mb-3 mt-2" />
         <div v-if="hasActiveTeledeclaration">
           <DataInfoBadge class="my-2" :hasActiveTeledeclaration="true" />
           <p>

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -79,19 +79,17 @@
             <p>Votre livreur des repas va déclarer les données d'approvisionnement pour votre établissement.</p>
             <p>Pour aller plus loin, vous pouvez télédéclarer les autres volets du bilan.</p>
           </div>
-          <p class="mb-1 mt-2">Données à renseigner :</p>
+          <p class="mb-1 mt-2">Onglets à compléter :</p>
           <v-checkbox
-            v-for="(tab, key) in tabHeaders"
+            v-for="tab in tabHeaders"
             class="mb-1 progress-checkbox"
             readonly
             :disabled="usesSatelliteDiagnosticForMeasure(tab)"
             :key="tab.id"
             :input-value="tab.isCompleted"
             :label="tab.isRequired ? `${tab.text}*` : tab.text"
-            :prepend-icon="tab.icon"
             :dense="true"
             :hide-details="true"
-            @click="changeTab(key)"
           />
           <ul>
             <li v-if="hasSatelliteInconsistency" class="mb-2">
@@ -549,9 +547,6 @@ export default {
           this.$store.dispatch("notifyServerError", e)
         })
     },
-    changeTab(tab) {
-      this.tab = tab
-    },
   },
   watch: {
     canteenUrlComponent() {
@@ -615,7 +610,7 @@ export default {
 </style>
 
 <style>
-.progress-checkbox:hover * {
-  color: var(--v-primary-base) !important;
+.progress-checkbox * {
+  cursor: initial !important;
 }
 </style>

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -89,9 +89,6 @@
                 Pour aller plus loin, vous pouvez également compléter les autres volets du bilan.
               </p>
             </div>
-            <v-btn color="primary" :outlined="!hasFinishedMeasureTunnel" @click="showTeledeclarationPreview = true">
-              Télédéclarer
-            </v-btn>
           </div>
           <div v-else>
             <p>Pour télédéclarer, veuillez :</p>
@@ -152,6 +149,13 @@
               </li>
             </ul>
           </div>
+          <v-btn
+            color="primary"
+            :disabled="!readyToTeledeclare && !hasFinishedMeasureTunnel"
+            @click="showTeledeclarationPreview = true"
+          >
+            Télédéclarer
+          </v-btn>
         </div>
         <div v-else-if="+year >= currentYear">
           <DataInfoBadge class="my-2" :currentYear="+year === currentYear" />

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -17,7 +17,7 @@
         />
         <DataInfoBadge v-else-if="+year >= currentYear" class="my-2" :currentYear="+year === currentYear" />
         <ProductionTypeTag v-if="canteen" :canteen="canteen" class="ml-3" />
-        <h1 class="fr-h3 mt-1 mb-0" v-if="canteen">Télédéclaration : {{ canteen.name }}</h1>
+        <h1 class="fr-h3 mt-1 mb-0" v-if="canteen">{{ canteen.name }} : Télédéclaration</h1>
       </v-col>
       <v-col cols="12" sm="5" md="2">
         <v-btn

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -31,8 +31,8 @@
         </v-btn>
       </v-col>
     </v-row>
-    <v-row v-if="canteen" class="flex-row-reverse mt-5 mt-md-10">
-      <v-col cols="12" sm="9" md="3" lg="2" style="border-right: 1px solid #DDD;" class="fr-text-sm order-md-last pt-1">
+    <v-row v-if="canteen" class="mt-5 mt-md-10">
+      <v-col cols="12" md="3" lg="2" style="border-right: 1px solid #DDD;" class="fr-text-sm pt-1">
         <DsfrNativeSelect v-model="selectedYear" :items="yearOptions" class="mb-3 mt-2" />
         <div v-if="hasActiveTeledeclaration">
           <DataInfoBadge class="my-2" :hasActiveTeledeclaration="true" />

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -79,7 +79,7 @@
             <p>Votre livreur des repas va déclarer les données d'approvisionnement pour votre établissement.</p>
             <p>Pour aller plus loin, vous pouvez télédéclarer les autres volets du bilan.</p>
           </div>
-          <p class="mb-1 mt-2">Onglets à compléter :</p>
+          <p class="mb-1 mt-2">Données à saisir :</p>
           <v-checkbox
             v-for="tab in tabHeaders"
             class="mb-1 progress-checkbox"

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -23,15 +23,8 @@
         </v-btn>
       </v-col>
     </v-row>
-    <v-row v-if="canteen" class="mt-5 mt-md-10">
-      <v-col
-        cols="12"
-        sm="9"
-        md="3"
-        lg="2"
-        style="border-left: 1px solid #DDD;"
-        class="fr-text-sm order-md-last pr-0 pt-1"
-      >
+    <v-row v-if="canteen" class="flex-row-reverse mt-5 mt-md-10">
+      <v-col cols="12" sm="9" md="3" lg="2" style="border-right: 1px solid #DDD;" class="fr-text-sm order-md-last pt-1">
         <DsfrNativeSelect v-model="selectedYear" :items="yearOptions" class="mb-3" />
         <div v-if="hasActiveTeledeclaration">
           <DataInfoBadge class="my-2" :hasActiveTeledeclaration="true" />


### PR DESCRIPTION
## Quoi 
Pour inciter les utilisateurs à bien déclarer leur bilan, plusieurs modifications : 
- changement de couleur pour le badge en le passant en rouge
- réorganisation des informations en groupant celles de la cantine (en haut), celles de la TD (en dessous)
- ajoute ~des cases à cocher, mais non cliquables~ des labels vert/jaune/rouge, qui permettent de visualiser les étapes remplies
- le bouton "Télédéclarer" est toujours visible il est juste désactivé si les infos obligatoires ne sont pas remplies

## Captures 

Avant : 
<img width="1680" alt="Capture d’écran 2024-12-19 à 18 32 16" src="https://github.com/user-attachments/assets/cb7b737a-4173-4251-aa71-28ea2e4fea61" />

Après v1
<img width="1680" alt="Capture d’écran 2024-12-19 à 18 32 45" src="https://github.com/user-attachments/assets/24441bf0-4339-482d-9964-34465876c2d9" />

Après v2
![image](https://github.com/user-attachments/assets/218d71d5-687f-4b64-a7b1-914222a25e1f)
