### PR TITLE
ci(Dependabot): change la fréquence de weekly à monthly 🤖

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,4 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
 version: 2
 updates:
@@ -9,14 +6,14 @@ updates:
     target-branch: "staging"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "npm"
     target-branch: "staging"
     directory: "/frontend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "npm"
     target-branch: "staging"
     directory: "/2024-frontend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
### Quoi

Avoir dependabot qui tourne tous les mois (au lieu de toutes les semaines - lundi)

### Pourquoi

Pour y passer moins de temps