### PR TITLE
feat(open-data): Publication jeu données résultat de la campagne 2023

### DIFF
--- a/macantine/etl/etl.py
+++ b/macantine/etl/etl.py
@@ -86,6 +86,10 @@ class ETL(ABC):
         else:
             return True
 
+    def _format_decimals(self, columns):
+        for col in columns:
+            self.df[col] = self.df[col].apply(lambda x: round(x, 4) if not pd.isnull(x) else x)
+
 
 class EXTRACTOR(ETL):
     @abstractmethod

--- a/macantine/etl/open_data.py
+++ b/macantine/etl/open_data.py
@@ -255,8 +255,8 @@ class ETL_OPEN_DATA_TELEDECLARATIONS(etl.TELEDECLARATIONS, OPEN_DATA):
 
         logger.info("TD campagne : Clean dataset...")
         self._clean_dataset()
-        logger.info("TD campagne : Filter value total null or value bio null...")
-        self._filter_null_values()
+        logger.info("TD campagne : Format the decimals...")
+        self._format_decimals(['teledeclaration_ratio_bio', 'teledeclaration_ratio_egalim_hors_bio'])
         logger.info("TD campagne : Filter by ministry...")
         self._filter_by_ministry()
         logger.info("TD campagne : Filter errors...")

--- a/macantine/etl/open_data.py
+++ b/macantine/etl/open_data.py
@@ -253,10 +253,12 @@ class ETL_OPEN_DATA_TELEDECLARATIONS(etl.TELEDECLARATIONS, OPEN_DATA):
         if "central_kitchen_siret" in self.df.columns:
             self.df["canteen.central_kitchen_siret"] = self.df["central_kitchen_siret"]
 
+        logger.info("TD campagne : Add additionnal filters (that couldn't be processed at queryset)")
+        self.filter_teledeclarations()
         logger.info("TD campagne : Clean dataset...")
         self._clean_dataset()
         logger.info("TD campagne : Format the decimals...")
-        self._format_decimals(['teledeclaration_ratio_bio', 'teledeclaration_ratio_egalim_hors_bio'])
+        self._format_decimals(["teledeclaration_ratio_bio", "teledeclaration_ratio_egalim_hors_bio"])
         logger.info("TD campagne : Filter by ministry...")
         self._filter_by_ministry()
         logger.info("TD campagne : Filter errors...")

--- a/macantine/management/commands/export_dataset.py
+++ b/macantine/management/commands/export_dataset.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from macantine.tasks import export_datasets
+from macantine.tasks import manual_datasets_export
 
 
 class Command(BaseCommand):
@@ -9,4 +9,4 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        export_datasets()
+        manual_datasets_export()

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -361,6 +361,7 @@ def manual_datasets_export():
     datasets = {
         "campagne teledeclaration 2021": ETL_OPEN_DATA_TELEDECLARATIONS(2021),
         "campagne teledeclaration 2022": ETL_OPEN_DATA_TELEDECLARATIONS(2022),
+        "campagne teledeclaration 2023": ETL_OPEN_DATA_TELEDECLARATIONS(2023),
     }
     export_datasets(datasets)
 

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -72,6 +72,7 @@ class TestETLOpenData(TestCase):
                 "canteen": {
                     "id": 1,
                     "name": "Papa rayon lien.",
+                    "yearly_meal_count": 1000,
                     "sectors": [],
                 },
                 "version": "10",


### PR DESCRIPTION
La commande se lance manuellement depuis la prod (ou un PC connecté à la prod en lecture seule).

Une fois la commande lancée, on ajoute manuellement le fichier dans data gouv, en le liant à son URL sur le s3