### PR TITLE
improve(Import de masse): utiliser le schema JSON des achats pour l'affichage du tableau aux utilisateurs

### DIFF
--- a/data/schemas/imports/achats.json
+++ b/data/schemas/imports/achats.json
@@ -69,7 +69,7 @@
           "BOISSONS",
           "AUTRES"
         ],
-        "required": true
+        "required": false
       },
       "description": "",
       "example": "VIANDES_VOLAILLES",
@@ -99,7 +99,7 @@
         ],
         "enum_multiple": true,
         "pattern": "(?:(?:^|;)(BIO|LABEL_ROUGE|AOCAOP|IGP|STG|HVE|PECHE_DURABLE|RUP|COMMERCE_EQUITABLE|FERMIER|EXTERNALITES|PERFORMANCE|FRANCE|SHORT_DISTRIBUTION|LOCAL))+$",
-        "required": true
+        "required": false
       },
       "description": "",
       "example": "BIO,IGP",
@@ -110,8 +110,13 @@
     },
     {
       "constraints": {
-        "enum": ["AUTOUR_SERVICE", "DEPARTMENT", "REGION", "AUTRE"],
-        "required": true
+        "enum": [
+          "AUTOUR_SERVICE",
+          "DEPARTMENT",
+          "REGION",
+          "AUTRE"
+        ],
+        "required": false
       },
       "description": "Obligatoire si l'achat a la caractéristique de LOCAL.",
       "example": "AUTOUR_SERVICE",

--- a/data/schemas/imports/achats.json
+++ b/data/schemas/imports/achats.json
@@ -3,85 +3,121 @@
   "fields": [
     {
       "constraints": {
+        "pattern": "^[0-9]{14}$",
         "required": true
       },
-      "description": "Le SIRET de la cantine ayant réalisé l'achat",
+      "description": "La cantine avec ce SIRET doit être déjà enregistrée sur notre plateforme.",
+      "example": "000 000 000 00000",
+      "format": "default",
       "name": "siret",
-      "pattern": "^[0-9]{14}$",
+      "title": "Le SIRET de la cantine ayant réalisé l'achat",
       "type": "string"
     },
     {
       "constraints": {
         "required": true
       },
-      "description": "Une description de l'achat",
+      "description": "",
+      "example": "Pommes de terre",
+      "format": "default",
       "name": "description",
+      "title": "Une description de l'achat",
       "type": "string"
     },
     {
       "constraints": {
         "required": true
       },
-      "description": "Le nom du fournisseur",
+      "description": "",
+      "example": "Le traiteur du village",
+      "format": "default",
       "name": "fournisseur",
+      "title": "Le nom du fournisseur",
       "type": "string"
     },
     {
       "constraints": {
         "required": true
       },
-      "description": "La date de l'achat",
+      "description": "",
+      "example": "2022-01-30",
       "format": "%Y-%m-%d",
       "name": "date",
+      "title": "La date de l'achat",
       "type": "date"
     },
     {
       "constraints": {
         "required": true
       },
-      "description": "Le prix HT de l'achat",
+      "description": "",
+      "example": "3290.23",
+      "format": "default",
       "name": "prix_ht",
+      "title": "Le prix HT de l'achat",
       "type": "number"
     },
     {
       "constraints": {
+        "enum": [
+          "VIANDES_VOLAILLES",
+          "CHARCUTERIE",
+          "PRODUITS_DE_LA_MER",
+          "FRUITS_ET_LEGUMES",
+          "PRODUITS_LAITIERS",
+          "BOULANGERIE",
+          "BOISSONS",
+          "AUTRES"
+        ],
         "required": true
       },
-      "description": "La famille de produits de l'achat",
-      "enum": [
-        "VIANDES_VOLAILLES",
-        "CHARCUTERIE",
-        "PRODUITS_DE_LA_MER",
-        "FRUITS_ET_LEGUMES",
-        "PRODUITS_LAITIERS",
-        "BOULANGERIE",
-        "BOISSONS",
-        "AUTRES"
-      ],
+      "description": "",
+      "example": "VIANDES_VOLAILLES",
+      "format": "default",
       "name": "famille_produits",
+      "title": "La famille de produits de l'achat",
       "type": "string"
     },
     {
       "constraints": {
+        "enum": [
+          "BIO",
+          "LABEL_ROUGE",
+          "AOCAOP",
+          "IGP",
+          "STG",
+          "HVE",
+          "PECHE_DURABLE",
+          "RUP",
+          "COMMERCE_EQUITABLE",
+          "FERMIER",
+          "EXTERNALITES",
+          "PERFORMANCE",
+          "FRANCE",
+          "SHORT_DISTRIBUTION",
+          "LOCAL"
+        ],
+        "enum_multiple": true,
         "pattern": "(?:(?:^|;)(BIO|LABEL_ROUGE|AOCAOP|IGP|STG|HVE|PECHE_DURABLE|RUP|COMMERCE_EQUITABLE|FERMIER|EXTERNALITES|PERFORMANCE|FRANCE|SHORT_DISTRIBUTION|LOCAL))+$",
-        "required": false
-      },
-      "description": "Les caractéristiques de l'achat",
-      "name": "caracteristiques",
-      "type": "string"
-    },
-    {
-      "constraints": {
         "required": true
       },
-      "description": "La définition de local si l'achat a la caractéristique de LOCAL",
-      "enum": [
-        "AUTOUR_SERVICE",
-        "DEPARTMENT",
-        "REGION",
-        "AUTRE"
-      ],
+      "description": "",
+      "example": "BIO,IGP",
+      "format": "default",
+      "name": "caracteristiques",
+      "title": "Les caractéristiques de l'achat",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "enum": ["AUTOUR_SERVICE", "DEPARTMENT", "REGION", "AUTRE"],
+        "required": true
+      },
+      "description": "Obligatoire si l'achat a la caractéristique de LOCAL.",
+      "example": "AUTOUR_SERVICE",
+      "format": "default",
       "name": "definition_local",
+      "title": "La définition de local",
       "type": "string"
     }
   ],

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -5,6 +5,14 @@ export default Object.freeze({
     ERROR: 3,
     IDLE: 4,
   },
+  SchemaTypes: {
+    siret: "14 chiffres, avec ou sans espaces",
+    string: "Texte",
+    string_enum: "Texte (choix unique)",
+    string_enum_multiple: "Texte (choix multiples)",
+    number: "Chiffre",
+    date: "Date (au format AAAA-MM-JJ)",
+  },
   DefaultDiagnostics: {
     id: null,
     year: null,

--- a/frontend/src/views/PurchasesImporter.vue
+++ b/frontend/src/views/PurchasesImporter.vue
@@ -112,10 +112,20 @@
           <tr v-for="(field, idx) in documentation" :key="idx">
             <td>{{ field.name }}</td>
             <td>{{ field.title }}</td>
-            <td v-html="field.description"></td>
+            <td>
+              <p>{{ field.description }}</p>
+              <p v-if="field.constraints && field.constraints.enum">
+                Options acceptées : {{ field.constraints.enum.join(", ") }}.
+              </p>
+              <p v-if="field.constraints && field.constraints.enum && field.constraints.enum_multiple">
+                Spécifiez plusieurs options en séparant avec un
+                <code>,</code>
+                .
+              </p>
+            </td>
             <td style="min-width: 150px;">{{ field.type }}</td>
             <td>{{ field.example }}</td>
-            <td class="text-center">{{ field.constraints ?? required ? "✔" : "✘" }}</td>
+            <td class="text-center">{{ field.constraints && field.constraints.required ? "✔" : "✘" }}</td>
           </tr>
         </tbody>
       </template>
@@ -152,9 +162,6 @@ import FileDrop from "@/components/FileDrop"
 import PurchasesTable from "@/components/PurchasesTable"
 import validators from "@/validators"
 
-// script to import the json from https://github.com/betagouv/ma-cantine/blob/import-de-masse-rendre-le-header-obligatoire-achats/data/schemas/imports/achats.json
-// and then paste it here
-
 export default {
   name: "ImportPurchases",
   components: { FileDrop, PurchasesTable },
@@ -181,14 +188,11 @@ export default {
   },
   methods: {
     fetchSchema() {
-      console.log("fetchSchema")
       fetch(
         "https://raw.githubusercontent.com/betagouv/ma-cantine/raphodn/import-de-masse-rendre-le-header-obligatoire-achats-json/data/schemas/imports/achats.json"
       )
         .then((response) => response.json())
         .then((json) => {
-          // console.log(json.fields)
-          // console.log(this.documentation)
           this.documentation = json.fields
         })
     },

--- a/frontend/src/views/PurchasesImporter.vue
+++ b/frontend/src/views/PurchasesImporter.vue
@@ -115,7 +115,11 @@
             <td>
               <p>{{ field.description }}</p>
               <p v-if="field.constraints && field.constraints.enum">
-                Options acceptées : {{ field.constraints.enum.join(", ") }}.
+                <span>Options acceptées :&#32;</span>
+                <span v-for="(item, idx) in field.constraints.enum" :key="idx">
+                  <code>{{ item }}</code>
+                  <span v-if="idx < field.constraints.enum.length - 1">,&#32;</span>
+                </span>
               </p>
               <p v-if="field.constraints && field.constraints.enum && field.constraints.enum_multiple">
                 Spécifiez plusieurs options en séparant avec un
@@ -123,7 +127,7 @@
                 .
               </p>
             </td>
-            <td style="min-width: 150px;">{{ field.type }}</td>
+            <td style="min-width: 150px;">{{ getSchemaFieldType(field) }}</td>
             <td>{{ field.example }}</td>
             <td class="text-center">{{ field.constraints && field.constraints.required ? "✔" : "✘" }}</td>
           </tr>
@@ -161,6 +165,7 @@
 import FileDrop from "@/components/FileDrop"
 import PurchasesTable from "@/components/PurchasesTable"
 import validators from "@/validators"
+import Constants from "@/constants"
 
 export default {
   name: "ImportPurchases",
@@ -195,6 +200,18 @@ export default {
         .then((json) => {
           this.documentation = json.fields
         })
+    },
+    getSchemaFieldType(field) {
+      if (field.name in Constants.SchemaTypes) {
+        return Constants.SchemaTypes[field.name]
+      }
+      if (field.constraints && field.constraints.enum) {
+        if (field.constraints.enum_multiple) {
+          return Constants.SchemaTypes[`${field.type}_enum_multiple`]
+        }
+        return Constants.SchemaTypes[`${field.type}_enum`]
+      }
+      return Constants.SchemaTypes[field.type]
     },
     upload() {
       this.importInProgress = true

--- a/frontend/src/views/PurchasesImporter.vue
+++ b/frontend/src/views/PurchasesImporter.vue
@@ -110,12 +110,12 @@
         </thead>
         <tbody>
           <tr v-for="(field, idx) in documentation" :key="idx">
-            <td>{{ field.title }}</td>
             <td>{{ field.name }}</td>
+            <td>{{ field.title }}</td>
             <td v-html="field.description"></td>
             <td style="min-width: 150px;">{{ field.type }}</td>
             <td>{{ field.example }}</td>
-            <td class="text-center">{{ field.optional ? "✘" : "✔" }}</td>
+            <td class="text-center">{{ field.constraints ?? required ? "✔" : "✘" }}</td>
           </tr>
         </tbody>
       </template>
@@ -151,14 +151,15 @@
 import FileDrop from "@/components/FileDrop"
 import PurchasesTable from "@/components/PurchasesTable"
 import validators from "@/validators"
-import Constants from "@/constants"
+
+// script to import the json from https://github.com/betagouv/ma-cantine/blob/import-de-masse-rendre-le-header-obligatoire-achats/data/schemas/imports/achats.json
+// and then paste it here
 
 export default {
   name: "ImportPurchases",
   components: { FileDrop, PurchasesTable },
   data() {
     const user = this.$store.state.loggedUser
-    const numberFormatExample = "En format <code>1234</code>/<code>1234.5</code>/<code>1234.56</code>."
     return {
       file: undefined,
       canteens: undefined,
@@ -169,73 +170,28 @@ export default {
       seconds: undefined,
       importInProgress: false,
       duplicatePurchases: null,
-      documentation: [
-        {
-          title: "siret",
-          name: "SIRET de la cantine ayant réalisé l'achat",
-          description: "La cantine avec ce SIRET doit être déjà enregistrée sur notre plateforme.",
-          type: "14 chiffres, avec ou sans espaces",
-          example: "000 000 000 00000",
-        },
-        {
-          title: "description",
-          name: "Description de l'achat",
-          example: "Pommes de terre",
-          type: "Texte libre",
-        },
-        {
-          title: "fournisseur",
-          name: "Fournisseur",
-          example: "Le traiteur du village",
-          type: "Texte libre",
-        },
-        {
-          title: "date",
-          name: "Date d'achat",
-          type: "Date en format AAAA-MM-JJ",
-          example: "2022-01-30",
-        },
-        {
-          title: "prix_ht",
-          name: "Prix HT",
-          description: numberFormatExample,
-          type: "Chiffre",
-          example: "3290.23",
-        },
-        {
-          title: "famille_produits",
-          name: "Famille de produits",
-          description: `Options acceptées : ${Object.keys(Constants.ProductFamilies).map(
-            (x) => " <code>" + x + "</code>"
-          )}`,
-          type: "Texte (choix unique)",
-          example: `${Object.keys(Constants.ProductFamilies)[0]}`,
-        },
-        {
-          title: "caracteristiques",
-          name: "Caractéristiques",
-          description: `Options acceptées : ${Object.keys(Constants.Characteristics).map(
-            (x) => " <code>" + x + "</code>"
-          )}. Spécifiez plusieurs en séparant avec un <code>,</code>.`,
-          type: "Texte",
-          example: `${Object.keys(Constants.Characteristics)[0]},${Object.keys(Constants.Characteristics)[3]}`,
-        },
-        {
-          title: "definition_local",
-          name: "Définition de local",
-          description: `Obligatoire si l'achat a la caractéristique de LOCAL. Options acceptées : ${Object.keys(
-            Constants.LocalDefinitions
-          ).map((x) => " <code>" + x + "</code>")}.`,
-          type: "Texte (choix unique)",
-          example: `${Object.keys(Constants.LocalDefinitions)[0]}`,
-        },
-      ],
+      documentation: [], // see mounted
       validators,
       isStaff: user.isStaff,
       duplicateFile: false,
     }
   },
+  mounted() {
+    this.fetchSchema()
+  },
   methods: {
+    fetchSchema() {
+      console.log("fetchSchema")
+      fetch(
+        "https://raw.githubusercontent.com/betagouv/ma-cantine/raphodn/import-de-masse-rendre-le-header-obligatoire-achats-json/data/schemas/imports/achats.json"
+      )
+        .then((response) => response.json())
+        .then((json) => {
+          // console.log(json.fields)
+          // console.log(this.documentation)
+          this.documentation = json.fields
+        })
+    },
     upload() {
       this.importInProgress = true
       this.duplicateFile = false

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -494,6 +494,7 @@ CSP_CONNECT_SRC = (
     "wss://client.relay.crisp.chat",
     "entreprise.data.gouv.fr",
     "plateforme.adresse.data.gouv.fr",
+    "raw.githubusercontent.com/betagouv/ma-cantine/",  # data/schemas/imports/
 )
 if DEBUG:
     CSP_CONNECT_SRC += CSP_DEBUG_DOMAINS


### PR DESCRIPTION
### Quoi

Suite de #4794

Le tableau de documentation est maintenant généré à partir de notre schema JSON. Stocké sur Github.
On a quand même besoin d'un petit mapping entre le field "type" (anglais) et une traduction française :)

J'ai dû faire des ajouts/modifs dans le schema `achats.json` 
https://specs.frictionlessdata.io/table-schema
- renommé description en title
- ajout de title, example

### Captures d'écran

||Image|
|---|---|
|Avant|![Screenshot from 2025-01-06 12-39-31](https://github.com/user-attachments/assets/c865091e-a16b-4873-bd2e-321e6ad89663)|
|Après|![Screenshot from 2025-01-07 08-46-53](https://github.com/user-attachments/assets/a2a0f7bf-8ad2-41a6-bd6b-7b39d1525e09)|
|Après correctifs|![image](https://github.com/user-attachments/assets/16c17e0c-391f-452f-ad48-204671171e28)|