### PR TITLE
refactor(Import de masse): basculer la logique de documentation (schema -> table) dans un composant dédié

### DIFF
--- a/data/schemas/imports/achats.json
+++ b/data/schemas/imports/achats.json
@@ -98,6 +98,7 @@
           "LOCAL"
         ],
         "enum_multiple": true,
+        "enum_multiple_seperator": ",",
         "pattern": "(?:(?:^|;)(BIO|LABEL_ROUGE|AOCAOP|IGP|STG|HVE|PECHE_DURABLE|RUP|COMMERCE_EQUITABLE|FERMIER|EXTERNALITES|PERFORMANCE|FRANCE|SHORT_DISTRIBUTION|LOCAL))+$",
         "required": false
       },

--- a/frontend/src/components/SchemaTable.vue
+++ b/frontend/src/components/SchemaTable.vue
@@ -16,14 +16,13 @@
           <td>{{ field.name }}</td>
           <td>{{ field.title }}</td>
           <td>
-            <p>{{ field.description }}</p>
+            <p v-if="field.description">{{ field.description }}</p>
             <p v-if="field.constraints && field.constraints.enum">
               <span>Options acceptées :&#32;</span>
               <span v-for="(item, idx) in field.constraints.enum" :key="idx">
                 <code>{{ item }}</code>
                 <span v-if="idx < field.constraints.enum.length - 1">,&#32;</span>
               </span>
-              .
             </p>
             <p v-if="field.constraints && field.constraints.enum_multiple">
               Spécifiez plusieurs options en séparant avec un
@@ -45,8 +44,8 @@ const schemaTypes = {
   date: "Date (au format AAAA-MM-JJ)",
   integer: "Chiffre",
   number: "Chiffre",
-  siret: "14 chiffres, avec ou sans espaces",
-  string: "Texte",
+  siret: "14 chiffres (avec ou sans espaces)",
+  string: "Texte (libre)",
   string_enum: "Texte (choix unique)",
   string_enum_multiple: "Texte (choix multiples)",
 }

--- a/frontend/src/components/SchemaTable.vue
+++ b/frontend/src/components/SchemaTable.vue
@@ -41,7 +41,14 @@
 </template>
 
 <script>
-import Constants from "@/constants"
+const schemaTypes = {
+  siret: "14 chiffres, avec ou sans espaces",
+  string: "Texte",
+  string_enum: "Texte (choix unique)",
+  string_enum_multiple: "Texte (choix multiples)",
+  number: "Chiffre",
+  date: "Date (au format AAAA-MM-JJ)",
+}
 
 export default {
   props: {
@@ -64,16 +71,16 @@ export default {
         })
     },
     getSchemaFieldType(field) {
-      if (field.name in Constants.SchemaTypes) {
-        return Constants.SchemaTypes[field.name]
+      if (field.name in schemaTypes) {
+        return schemaTypes[field.name]
       }
       if (field.constraints && field.constraints.enum) {
         if (field.constraints.enum_multiple) {
-          return Constants.SchemaTypes[`${field.type}_enum_multiple`]
+          return schemaTypes[`${field.type}_enum_multiple`]
         }
-        return Constants.SchemaTypes[`${field.type}_enum`]
+        return schemaTypes[`${field.type}_enum`]
       }
-      return Constants.SchemaTypes[field.type]
+      return schemaTypes[field.type]
     },
   },
 }

--- a/frontend/src/components/SchemaTable.vue
+++ b/frontend/src/components/SchemaTable.vue
@@ -42,12 +42,13 @@
 
 <script>
 const schemaTypes = {
+  date: "Date (au format AAAA-MM-JJ)",
+  integer: "Chiffre",
+  number: "Chiffre",
   siret: "14 chiffres, avec ou sans espaces",
   string: "Texte",
   string_enum: "Texte (choix unique)",
   string_enum_multiple: "Texte (choix multiples)",
-  number: "Chiffre",
-  date: "Date (au format AAAA-MM-JJ)",
 }
 
 export default {

--- a/frontend/src/components/SchemaTable.vue
+++ b/frontend/src/components/SchemaTable.vue
@@ -1,0 +1,79 @@
+<template>
+  <v-simple-table class="my-6">
+    <template v-slot:default>
+      <thead>
+        <tr>
+          <th>Titre</th>
+          <th>Champ</th>
+          <th>Description</th>
+          <th>Type</th>
+          <th>Exemple</th>
+          <th>Obligatoire</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(field, idx) in fieldList" :key="idx">
+          <td>{{ field.name }}</td>
+          <td>{{ field.title }}</td>
+          <td>
+            <p>{{ field.description }}</p>
+            <p v-if="field.constraints && field.constraints.enum">
+              <span>Options acceptées :&#32;</span>
+              <span v-for="(item, idx) in field.constraints.enum" :key="idx">
+                <code>{{ item }}</code>
+                <span v-if="idx < field.constraints.enum.length - 1">,&#32;</span>
+              </span>
+            </p>
+            <p v-if="field.constraints && field.constraints.enum && field.constraints.enum_multiple">
+              Spécifiez plusieurs options en séparant avec un
+              <code>{{ field.constraints.enum_multiple_seperator }}</code>
+              .
+            </p>
+          </td>
+          <td style="min-width: 150px;">{{ getSchemaFieldType(field) }}</td>
+          <td>{{ field.example }}</td>
+          <td class="text-center">{{ field.constraints && field.constraints.required ? "✔" : "✘" }}</td>
+        </tr>
+      </tbody>
+    </template>
+  </v-simple-table>
+</template>
+
+<script>
+import Constants from "@/constants"
+
+export default {
+  props: {
+    schemaUrl: String,
+  },
+  data() {
+    return {
+      fieldList: [],
+    }
+  },
+  mounted() {
+    this.fetchSchema()
+  },
+  methods: {
+    fetchSchema() {
+      fetch(this.schemaUrl)
+        .then((response) => response.json())
+        .then((json) => {
+          this.fieldList = json.fields
+        })
+    },
+    getSchemaFieldType(field) {
+      if (field.name in Constants.SchemaTypes) {
+        return Constants.SchemaTypes[field.name]
+      }
+      if (field.constraints && field.constraints.enum) {
+        if (field.constraints.enum_multiple) {
+          return Constants.SchemaTypes[`${field.type}_enum_multiple`]
+        }
+        return Constants.SchemaTypes[`${field.type}_enum`]
+      }
+      return Constants.SchemaTypes[field.type]
+    },
+  },
+}
+</script>

--- a/frontend/src/components/SchemaTable.vue
+++ b/frontend/src/components/SchemaTable.vue
@@ -23,6 +23,7 @@
                 <code>{{ item }}</code>
                 <span v-if="idx < field.constraints.enum.length - 1">,&#32;</span>
               </span>
+              .
             </p>
             <p v-if="field.constraints && field.constraints.enum && field.constraints.enum_multiple">
               Spécifiez plusieurs options en séparant avec un

--- a/frontend/src/components/SchemaTable.vue
+++ b/frontend/src/components/SchemaTable.vue
@@ -12,7 +12,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="(field, idx) in fieldList" :key="idx">
+        <tr v-for="(field, idx) in schemaFieldList" :key="idx">
           <td>{{ field.name }}</td>
           <td>{{ field.title }}</td>
           <td>
@@ -49,7 +49,7 @@ export default {
   },
   data() {
     return {
-      fieldList: [],
+      schemaFieldList: [],
     }
   },
   mounted() {
@@ -60,7 +60,7 @@ export default {
       fetch(this.schemaUrl)
         .then((response) => response.json())
         .then((json) => {
-          this.fieldList = json.fields
+          this.schemaFieldList = json.fields
         })
     },
     getSchemaFieldType(field) {

--- a/frontend/src/components/SchemaTable.vue
+++ b/frontend/src/components/SchemaTable.vue
@@ -25,7 +25,7 @@
               </span>
               .
             </p>
-            <p v-if="field.constraints && field.constraints.enum && field.constraints.enum_multiple">
+            <p v-if="field.constraints && field.constraints.enum_multiple">
               Spécifiez plusieurs options en séparant avec un
               <code>{{ field.constraints.enum_multiple_seperator }}</code>
               .

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -5,14 +5,6 @@ export default Object.freeze({
     ERROR: 3,
     IDLE: 4,
   },
-  SchemaTypes: {
-    siret: "14 chiffres, avec ou sans espaces",
-    string: "Texte",
-    string_enum: "Texte (choix unique)",
-    string_enum_multiple: "Texte (choix multiples)",
-    number: "Chiffre",
-    date: "Date (au format AAAA-MM-JJ)",
-  },
   DefaultDiagnostics: {
     id: null,
     year: null,

--- a/frontend/src/views/PurchasesImporter.vue
+++ b/frontend/src/views/PurchasesImporter.vue
@@ -97,44 +97,7 @@
     </p>
     <p>Les données doivent être présentées dans l'ordre indiqué ci-dessous.</p>
     <h3 class="my-6">Colonnes</h3>
-    <v-simple-table class="my-6">
-      <template v-slot:default>
-        <thead>
-          <tr>
-            <th>Titre</th>
-            <th>Champ</th>
-            <th>Description</th>
-            <th>Type</th>
-            <th>Exemple</th>
-            <th>Obligatoire</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="(field, idx) in documentation" :key="idx">
-            <td>{{ field.name }}</td>
-            <td>{{ field.title }}</td>
-            <td>
-              <p>{{ field.description }}</p>
-              <p v-if="field.constraints && field.constraints.enum">
-                <span>Options acceptées :&#32;</span>
-                <span v-for="(item, idx) in field.constraints.enum" :key="idx">
-                  <code>{{ item }}</code>
-                  <span v-if="idx < field.constraints.enum.length - 1">,&#32;</span>
-                </span>
-              </p>
-              <p v-if="field.constraints && field.constraints.enum && field.constraints.enum_multiple">
-                Spécifiez plusieurs options en séparant avec un
-                <code>,</code>
-                .
-              </p>
-            </td>
-            <td style="min-width: 150px;">{{ getSchemaFieldType(field) }}</td>
-            <td>{{ field.example }}</td>
-            <td class="text-center">{{ field.constraints && field.constraints.required ? "✔" : "✘" }}</td>
-          </tr>
-        </tbody>
-      </template>
-    </v-simple-table>
+    <SchemaTable :schemaUrl="purchaseSchemaUrl" />
 
     <h3 class="my-6">Fichier exemple</h3>
     <p>
@@ -165,12 +128,12 @@
 <script>
 import FileDrop from "@/components/FileDrop"
 import PurchasesTable from "@/components/PurchasesTable"
+import SchemaTable from "@/components/SchemaTable"
 import validators from "@/validators"
-import Constants from "@/constants"
 
 export default {
   name: "ImportPurchases",
-  components: { FileDrop, PurchasesTable },
+  components: { FileDrop, PurchasesTable, SchemaTable },
   data() {
     const user = this.$store.state.loggedUser
     return {
@@ -183,35 +146,14 @@ export default {
       seconds: undefined,
       importInProgress: false,
       duplicatePurchases: null,
-      documentation: [], // see mounted
+      purchaseSchemaUrl:
+        "https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/main/data/schemas/imports/achats.json",
       validators,
       isStaff: user.isStaff,
       duplicateFile: false,
     }
   },
-  mounted() {
-    this.fetchSchema()
-  },
   methods: {
-    fetchSchema() {
-      fetch("https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/main/data/schemas/imports/achats.json")
-        .then((response) => response.json())
-        .then((json) => {
-          this.documentation = json.fields
-        })
-    },
-    getSchemaFieldType(field) {
-      if (field.name in Constants.SchemaTypes) {
-        return Constants.SchemaTypes[field.name]
-      }
-      if (field.constraints && field.constraints.enum) {
-        if (field.constraints.enum_multiple) {
-          return Constants.SchemaTypes[`${field.type}_enum_multiple`]
-        }
-        return Constants.SchemaTypes[`${field.type}_enum`]
-      }
-      return Constants.SchemaTypes[field.type]
-    },
     upload() {
       this.importInProgress = true
       this.duplicateFile = false


### PR DESCRIPTION
### Quoi

Suite à #4832, je bascule toute la logique dans un nouveau composant `SchemaTable.vue`

Utile pour réutiliser dans la/les PR à venir (à commencer par #4853)