### PR TITLE
fix(Imports de masse): Cantines : enlève annee_bilan du schema

### DIFF
--- a/api/tests/files/diagnostics/canteen_import.csv
+++ b/api/tests/files/diagnostics/canteen_import.csv
@@ -1,2 +1,2 @@
-siret,nom,code_insee_commune,code_postal_commune,siret_livreur_repas,nombre_repas_jour,nombre_repas_an,secteurs,type_production,type_gestion,modèle_économique,gestionnaires_additionnels,année_bilan
+siret,nom,code_insee_commune,code_postal_commune,siret_livreur_repas,nombre_repas_jour,nombre_repas_an,secteurs,type_production,type_gestion,modèle_économique,gestionnaires_additionnels
 21340172201787,A canteen,,54460,,700,14000,,site,conceded

--- a/api/tests/files/diagnostics/canteen_manager_import.csv
+++ b/api/tests/files/diagnostics/canteen_manager_import.csv
@@ -1,2 +1,2 @@
-siret,nom,code_insee_commune,code_postal_commune,siret_livreur_repas,nombre_repas_jour,nombre_repas_an,secteurs,type_production,type_gestion,modèle_économique,gestionnaires_additionnels,année_bilan
-21340172201787,A canteen,,54460,,700,14000,,site,conceded,,manager@example.com,
+siret,nom,code_insee_commune,code_postal_commune,siret_livreur_repas,nombre_repas_jour,nombre_repas_an,secteurs,type_production,type_gestion,modèle_économique,gestionnaires_additionnels
+21340172201787,A canteen,,54460,,700,14000,,site,conceded,,manager@example.com

--- a/data/schemas/imports/cantines.json
+++ b/data/schemas/imports/cantines.json
@@ -91,13 +91,6 @@
       "name": "gestionnaires_additionnels",
       "title": "Gestionnaires Additionnels",
       "type": "string"
-    },
-    {
-      "description": "Année du diagnostic. Réfère à l'année des données et non l'année de déclaration",
-      "example": "2021",
-      "name": "annee_diagnostic",
-      "title": "Année diagnostic",
-      "type": "integer"
     }
   ],
   "format": "csv",


### PR DESCRIPTION
### Quoi

Modifications apportées sur le schema `cantines.json` : 
- enlevé `annee_diagnostic` (n'a pas lieu d'être)

### Notes

- ce schema n'est pas encore utilisé pour l'affichage aux utilisateurs (PR à venir) 