### PR TITLE
fix(Imports de masse): Diagnostics : corrige les position des champs siret & nom

### DIFF
--- a/data/schemas/imports/diagnostics.json
+++ b/data/schemas/imports/diagnostics.json
@@ -2,17 +2,17 @@
   "encoding": "utf-8",
   "fields": [
     {
-      "example": "Ecole Jean Jaurès",
-      "name": "nom",
-      "type": "string"
-    },
-    {
       "constraints": {
         "pattern": "^[0-9]{14}$",
         "required": true
       },
       "example": "11007001800012",
       "name": "siret",
+      "type": "string"
+    },
+    {
+      "example": "Ecole Jean Jaurès",
+      "name": "nom",
       "type": "string"
     },
     {

--- a/data/schemas/imports/diagnostics_admin.json
+++ b/data/schemas/imports/diagnostics_admin.json
@@ -2,17 +2,17 @@
   "encoding": "utf-8",
   "fields": [
     {
-      "example": "Ecole Jean Jaurès",
-      "name": "nom",
-      "type": "string"
-    },
-    {
       "constraints": {
         "pattern": "^[0-9]{14}$",
         "required": true
       },
       "example": "11007001800012",
       "name": "siret",
+      "type": "string"
+    },
+    {
+      "example": "Ecole Jean Jaurès",
+      "name": "nom",
       "type": "string"
     },
     {

--- a/data/schemas/imports/diagnostics_cc.json
+++ b/data/schemas/imports/diagnostics_cc.json
@@ -2,17 +2,17 @@
   "encoding": "utf-8",
   "fields": [
     {
-      "example": "Ecole Jean Jaurès",
-      "name": "nom",
-      "type": "string"
-    },
-    {
       "constraints": {
         "pattern": "^[0-9]{14}$",
         "required": true
       },
       "example": "11007001800012",
       "name": "siret",
+      "type": "string"
+    },
+    {
+      "example": "Ecole Jean Jaurès",
+      "name": "nom",
       "type": "string"
     },
     {

--- a/data/schemas/imports/diagnostics_complets.json
+++ b/data/schemas/imports/diagnostics_complets.json
@@ -3,17 +3,17 @@
   "encoding": "utf-8",
   "fields": [
     {
-      "example": "Ecole Jean Jaurès",
-      "name": "nom",
-      "type": "string"
-    },
-    {
       "constraints": {
         "pattern": "^[0-9]{14}$",
         "required": true
       },
       "example": "11007001800012",
       "name": "siret",
+      "type": "string"
+    },
+    {
+      "example": "Ecole Jean Jaurès",
+      "name": "nom",
       "type": "string"
     },
     {
@@ -793,6 +793,7 @@
   ],
   "format": "csv",
   "mediatype": "text/csv",
+  "name": "dark_query_cantines",
   "path": "dark_query_cantines.csv",
   "scheme": "file",
   "type": "table"

--- a/data/schemas/imports/diagnostics_complets_cc.json
+++ b/data/schemas/imports/diagnostics_complets_cc.json
@@ -3,17 +3,17 @@
   "encoding": "utf-8",
   "fields": [
     {
-      "example": "Ecole Jean Jaurès",
-      "name": "nom",
-      "type": "string"
-    },
-    {
       "constraints": {
         "pattern": "^[0-9]{14}$",
         "required": true
       },
       "example": "11007001800012",
       "name": "siret",
+      "type": "string"
+    },
+    {
+      "example": "Ecole Jean Jaurès",
+      "name": "nom",
       "type": "string"
     },
     {
@@ -800,6 +800,7 @@
   ],
   "format": "csv",
   "mediatype": "text/csv",
+  "name": "dark_query_cantines",
   "path": "dark_query_cantines.csv",
   "scheme": "file",
   "type": "table"


### PR DESCRIPTION
### Quoi

Dans les schéma des diagnostics, l'ordre des champs `siret` et `nom` est inversé.