### PR TITLE
ci: enlève Helen de la liste des auto-reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -4,8 +4,7 @@
 addReviewers: true
 
 # A list of reviewers to be added to pull requests (GitHub user name)
-reviewers: # gip-inclusion/admins-le-marche
-  - hfroot
+reviewers:
   - qloridant
   - raphodn
   - Charline-L


### PR DESCRIPTION
Suite au départ de @hfroot (et pour ne pas la notifier à chaque ouverture de PR :grimacing: )