### PR TITLE
refactor(Cantines): Serializer : remplace PublicationStatusMixin par une property sur le modèle

### DIFF
--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -373,6 +373,14 @@ class Canteen(SoftDeletionModel):
         )
         return has_canteen_td or has_central_kitchen_td
 
+    @property
+    def publication_status_display_to_public(self):
+        if not settings.PUBLISH_BY_DEFAULT:
+            return self.publication_status
+        if self.line_ministry == Canteen.Ministries.ARMEE:
+            return Canteen.PublicationStatus.DRAFT
+        return Canteen.PublicationStatus.PUBLISHED
+
     def __str__(self):
         return f'Cantine "{self.name}"'
 


### PR DESCRIPTION
### Quoi

Il y avait de la logique "métier" dans le serializer, je l'ai basculé dans le modèle.
Aucun impact, les test passent toujours :)

### Pourquoi

- pour simplifier le code
- pour réduire la logique métier coté serializer
- en lien avec #4842 (PR frontend à venir)