### PR TITLE
improve(Cantines): Card : cacher le badge 'Publiée'

### DIFF
--- a/frontend/src/views/ManagementPage/CanteenCard.vue
+++ b/frontend/src/views/ManagementPage/CanteenCard.vue
@@ -11,7 +11,12 @@
         :color="teledeclarationStatus.color"
         :small="true"
       />
-      <DsfrTag :text="publicationStatus.text" :color="publicationStatus.color" :small="true" />
+      <DsfrTag
+        v-if="publicationStatusIsNotPublished"
+        :text="publicationStatus.text"
+        :color="publicationStatus.color"
+        :small="true"
+      />
     </v-card-subtitle>
     <v-card-subtitle class="mt-0 pb-0 pt-2">
       <ProductionTypeTag :canteen="canteen" position="top-left" />
@@ -61,6 +66,9 @@ export default {
           text: "Publiée",
         },
       }[this.canteen.publicationStatus || "draft"]
+    },
+    publicationStatusIsNotPublished() {
+      return this.canteen.publicationStatus !== "published"
     },
     teledeclarationStatus() {
       const diagnostics = this.canteen.diagnostics

--- a/frontend/src/views/ManagementPage/CentralKitchenCard.vue
+++ b/frontend/src/views/ManagementPage/CentralKitchenCard.vue
@@ -11,7 +11,12 @@
         :color="teledeclarationStatus.color"
         :small="true"
       />
-      <DsfrTag :text="publicationStatus.text" :color="publicationStatus.color" :small="true" />
+      <DsfrTag
+        v-if="publicationStatusIsNotPublished"
+        :text="publicationStatus.text"
+        :color="publicationStatus.color"
+        :small="true"
+      />
     </v-card-subtitle>
     <v-card-subtitle class="mt-0 pb-0 pt-2">
       <ProductionTypeTag :canteen="canteen" position="top-left" />
@@ -61,6 +66,9 @@ export default {
           text: "Publiée",
         },
       }[this.canteen.publicationStatus || "draft"]
+    },
+    publicationStatusIsNotPublished() {
+      return this.canteen.publicationStatus !== "published"
     },
     teledeclarationStatus() {
       const diagnostics = this.canteen.diagnostics


### PR DESCRIPTION
### Quoi

Les cantines sont publiées par défaut. Donc on enlève le badge quand c'est le cas.
Rappel : les cantines armées & co ne sont pas publiées. Garder l'affichage pour ces cas là (logique géré dans le backend, cf #4900)

### Captures d'écran

|Avant|Après|
|-|-|
|![image](https://github.com/user-attachments/assets/cd05d154-53d6-416c-a597-e2b204ddf929)|![image](https://github.com/user-attachments/assets/2642a497-b447-42fb-9614-407a48f07ff2)|