### PR TITLE
improve(Cantines): Card : afficher le badge 'Non-télédéclarée' en rouge

### DIFF
--- a/frontend/src/views/ManagementPage/CanteenCard.vue
+++ b/frontend/src/views/ManagementPage/CanteenCard.vue
@@ -81,7 +81,7 @@ export default {
         }
       } else {
         return {
-          color: "grey lighten-4",
+          color: "red lighten-4",
           text: `Non-télédéclarée (${this.teledeclarationYear})`,
         }
       }

--- a/frontend/src/views/ManagementPage/CentralKitchenCard.vue
+++ b/frontend/src/views/ManagementPage/CentralKitchenCard.vue
@@ -81,7 +81,7 @@ export default {
         }
       } else {
         return {
-          color: "grey lighten-4",
+          color: "red lighten-4",
           text: `Non-télédéclarée (${this.teledeclarationYear})`,
         }
       }


### PR DESCRIPTION
### Quoi

Si la cantine n'a pas encore télédéclaré pour l'année en cours, afficher le badge en rouge.

### Captures d'écran

|Avant|Après|
|-|-|
|![image](https://github.com/user-attachments/assets/fabed0fc-5182-42e3-9ab8-fa4a3b151916)|![image](https://github.com/user-attachments/assets/8c13d125-08cc-4112-bb1f-09defec9b3d5)|