### PR TITLE
fix(Imports de masse): Achats: enlève temporairement le picto svg (souci de build vue 3)

### DIFF
--- a/2024-frontend/src/views/ImportPurchases/index.vue
+++ b/2024-frontend/src/views/ImportPurchases/index.vue
@@ -125,10 +125,7 @@ const showErrors = (count) => {
     id="file-upload"
     class="fr-px-6w fr-px-xl-9w fr-py-6w fr-background-alt--blue-france fr-mt-4w fr-grid-row fr-grid-row--middle"
   >
-    <div class="fr-hidden fr-unhidden-xl fr-col-3 fr-pr-6w fr-grid-row--center">
-      <img src="/static/pictos/document.svg" alt="" />
-    </div>
-    <div class="import-file-upload fr-col-12 fr-col-xl-9 fr-py-3w fr-px-4w fr-card">
+    <div class="import-file-upload fr-col-12 fr-py-3w fr-px-4w fr-card">
       <DsfrFileUpload
         label="Avant d’importer votre fichier en CSV, assurez-vous que vos données respectent le format ci-dessus"
         hint="Extension du fichier autorisé : CSV"


### PR DESCRIPTION
### Quoi

Suite au merge de #4923 on a un soucis sur staging, erreur 500 car Vue 3 n'arrive pas à build.
Souci identifié : il ne trouve pas le path de `document.svg`

Je préfère l'enlever rapido, et permettre à Thomas de tester, et corriger ensuite ! 

### Capture d'écran

![image](https://github.com/user-attachments/assets/57b657ee-e4f4-48fe-9d2d-05c70632679e)
