### PR TITLE
refactor(API): Imports: nouvelle librairie de gestion des imports (qui check le format, la taille max, et si déjà uploadé)

### DIFF
--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -99,6 +99,7 @@ class EmailDiagnosticImportFileView(CSVImportApiView):
         try:
             self.file = request.data["file"]
             super()._verify_file_size()
+            super()._verify_file_format()
             email = request.data.get("email", request.user.email).strip()
             context = {
                 "from": email,

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -24,8 +24,7 @@ from api.permissions import (
 )
 from api.serializers import DiagnosticAndCanteenSerializer, ManagerDiagnosticSerializer
 from api.views.utils import update_change_reason_with_auth
-from common import file_import as file_import
-from common.utils import send_mail
+from common.utils import file_import, send_mail
 from data.models import Canteen, Teledeclaration
 from data.models.diagnostic import Diagnostic
 

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -15,6 +15,7 @@ from django.db.models.functions import Lower
 from django.http import JsonResponse
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.views import APIView
 from simple_history.utils import update_change_reason
 
 from api.permissions import IsAuthenticated
@@ -31,7 +32,7 @@ from .utils import camelize
 logger = logging.getLogger(__name__)
 
 
-class ImportDiagnosticsView(ABC):
+class ImportDiagnosticsView(ABC, APIView):
     permission_classes = [IsAuthenticated]
     value_error_regex = re.compile(r"Field '(.+)' expected .+? got '(.+)'.")
     annotated_sectors = Sector.objects.annotate(name_lower=Lower("name"))

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -80,8 +80,8 @@ class ImportDiagnosticsView(ABC, CSVImportApiView):
         try:
             with transaction.atomic():
                 self.file = request.data["file"]
-                ImportDiagnosticsView._verify_file_format(self.file)
                 super()._verify_file_size()
+                super()._verify_file_format()
                 self._process_file(self.file)
 
                 if self.errors:
@@ -112,13 +112,6 @@ class ImportDiagnosticsView(ABC, CSVImportApiView):
             details=message,
             import_type=self.import_type,
         )
-
-    @staticmethod
-    def _verify_file_format(file):
-        if file.content_type != "text/csv" and file.content_type != "text/tab-separated-values":
-            raise ValidationError(
-                f"Ce fichier est au format {file.content_type}, merci d'exporter votre fichier au format CSV et réessayer."
-            )
 
     def check_admin_values(self, header):
         is_admin_import = any("admin_" in column for column in header)

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -19,7 +19,7 @@ from simple_history.utils import update_change_reason
 
 from api.permissions import IsAuthenticated
 from api.serializers import FullCanteenSerializer
-from api.views.utils import CSVImportApiView
+from common import file_import
 from common.utils.siret import normalise_siret
 from data.models import Canteen, ImportFailure, ImportType, Sector
 from data.models.diagnostic import Diagnostic
@@ -31,7 +31,7 @@ from .utils import camelize, decode_bytes
 logger = logging.getLogger(__name__)
 
 
-class ImportDiagnosticsView(ABC, CSVImportApiView):
+class ImportDiagnosticsView(ABC):
     permission_classes = [IsAuthenticated]
     value_error_regex = re.compile(r"Field '(.+)' expected .+? got '(.+)'.")
     annotated_sectors = Sector.objects.annotate(name_lower=Lower("name"))
@@ -80,8 +80,8 @@ class ImportDiagnosticsView(ABC, CSVImportApiView):
         try:
             with transaction.atomic():
                 self.file = request.data["file"]
-                super()._verify_file_size()
-                super()._verify_file_format()
+                file_import.validate_file_size(self.file)
+                file_import.validate_file_format(self.file)
                 self._process_file(self.file)
 
                 if self.errors:

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -19,14 +19,14 @@ from simple_history.utils import update_change_reason
 
 from api.permissions import IsAuthenticated
 from api.serializers import FullCanteenSerializer
-from common import file_import
+from common.utils import file_import
 from common.utils.siret import normalise_siret
 from data.models import Canteen, ImportFailure, ImportType, Sector
 from data.models.diagnostic import Diagnostic
 from data.models.teledeclaration import Teledeclaration
 
 from .canteen import AddManagerView
-from .utils import camelize, decode_bytes
+from .utils import camelize
 
 logger = logging.getLogger(__name__)
 
@@ -161,7 +161,7 @@ class ImportDiagnosticsView(ABC):
             self._update_location_data(locations_csv_str)
 
     def _decode_file(self, file):
-        (result, encoding) = decode_bytes(file.read())
+        (result, encoding) = file_import.decode_bytes(file.read())
         self.encoding_detected = encoding
         return result
 

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -20,7 +20,6 @@ from api.views.utils import CSVImportApiView
 from common.utils.siret import normalise_siret
 from data.models import Canteen, ImportFailure, ImportType, Purchase
 
-from .diagnosticimport import ImportDiagnosticsView
 from .utils import camelize, decode_bytes
 
 logger = logging.getLogger(__name__)
@@ -52,7 +51,7 @@ class ImportPurchasesView(CSVImportApiView):
         try:
             self.file = request.data["file"]
             super()._verify_file_size()
-            ImportDiagnosticsView._verify_file_format(self.file)
+            super()._verify_file_format()
             with transaction.atomic():
                 self._process_file()
 

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -20,7 +20,7 @@ from common.utils import file_import
 from common.utils.siret import normalise_siret
 from data.models import Canteen, ImportFailure, ImportType, Purchase
 
-from .utils import camelize, normalise_siret
+from .utils import camelize
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class ImportPurchasesView(APIView):
             self.file_digest = file_import.get_file_digest(self.file)
             self._check_duplication()
 
-            self.file_dialect = file_import.get_csv_file_dialect(self.file)
+            self.dialect = file_import.get_csv_file_dialect(self.file)
 
             with transaction.atomic():
                 self._process_file()

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -2,10 +2,19 @@ import json
 import logging
 
 import chardet
+from django.conf import settings
+from django.core.exceptions import ValidationError
 from djangorestframework_camel_case.render import CamelCaseJSONRenderer
+from rest_framework.views import APIView
 from simple_history.utils import update_change_reason
 
 logger = logging.getLogger(__name__)
+
+
+class CSVImportApiView(APIView):
+    def _verify_file_size(self):
+        if self.file.size > settings.CSV_IMPORT_MAX_SIZE:
+            raise ValidationError("Ce fichier est trop grand, merci d'utiliser un fichier de moins de 10Mo")
 
 
 def camelize(data):

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -16,6 +16,12 @@ class CSVImportApiView(APIView):
         if self.file.size > settings.CSV_IMPORT_MAX_SIZE:
             raise ValidationError("Ce fichier est trop grand, merci d'utiliser un fichier de moins de 10Mo")
 
+    def _verify_file_format(self):
+        if self.file.content_type not in ["text/csv", "text/tab-separated-values"]:
+            raise ValidationError(
+                f"Ce fichier est au format {self.file.content_type}, merci d'exporter votre fichier au format CSV et réessayer."
+            )
+
 
 def camelize(data):
     camel_case_bytes = CamelCaseJSONRenderer().render(data)

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 
@@ -23,6 +24,12 @@ class CSVImportApiView(APIView):
             raise ValidationError(
                 f"Ce fichier est au format {self.file.content_type}, merci d'exporter votre fichier au format CSV et réessayer."
             )
+
+    def _get_file_digest(self):
+        file_hash = hashlib.md5()
+        for row in self.file:
+            file_hash.update(row)
+        return file_hash.hexdigest()
 
 
 def camelize(data):

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -14,7 +14,9 @@ logger = logging.getLogger(__name__)
 class CSVImportApiView(APIView):
     def _verify_file_size(self):
         if self.file.size > settings.CSV_IMPORT_MAX_SIZE:
-            raise ValidationError("Ce fichier est trop grand, merci d'utiliser un fichier de moins de 10Mo")
+            raise ValidationError(
+                f"Ce fichier est trop grand, merci d'utiliser un fichier de moins de {settings.CSV_IMPORT_MAX_SIZE_PRETTY}"
+            )
 
     def _verify_file_format(self):
         if self.file.content_type not in ["text/csv", "text/tab-separated-values"]:

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -1,35 +1,11 @@
-import hashlib
 import json
 import logging
 
 import chardet
-from django.conf import settings
-from django.core.exceptions import ValidationError
 from djangorestframework_camel_case.render import CamelCaseJSONRenderer
-from rest_framework.views import APIView
 from simple_history.utils import update_change_reason
 
 logger = logging.getLogger(__name__)
-
-
-class CSVImportApiView(APIView):
-    def _verify_file_size(self):
-        if self.file.size > settings.CSV_IMPORT_MAX_SIZE:
-            raise ValidationError(
-                f"Ce fichier est trop grand, merci d'utiliser un fichier de moins de {settings.CSV_IMPORT_MAX_SIZE_PRETTY}"
-            )
-
-    def _verify_file_format(self):
-        if self.file.content_type not in ["text/csv", "text/tab-separated-values"]:
-            raise ValidationError(
-                f"Ce fichier est au format {self.file.content_type}, merci d'exporter votre fichier au format CSV et réessayer."
-            )
-
-    def _get_file_digest(self):
-        file_hash = hashlib.md5()
-        for row in self.file:
-            file_hash.update(row)
-        return file_hash.hexdigest()
 
 
 def camelize(data):

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -1,7 +1,6 @@
 import json
 import logging
 
-import chardet
 from djangorestframework_camel_case.render import CamelCaseJSONRenderer
 from simple_history.utils import update_change_reason
 
@@ -21,10 +20,3 @@ def update_change_reason_with_auth(view, object):
     except Exception as e:
         logger.warning(f"Unable to set reason change on {view.__class__.__name__} for object ID : {object.id}: \n{e}")
         update_change_reason(object, "Unknown")
-
-
-def decode_bytes(bytes_string):
-    detection_result = chardet.detect(bytes_string)
-    encoding_detected = detection_result["encoding"]
-    logger.info(f"Encoding autodetected : {encoding_detected}")
-    return (bytes_string.decode(encoding_detected), encoding_detected)

--- a/common/utils/file_import.py
+++ b/common/utils/file_import.py
@@ -47,6 +47,9 @@ def get_file_digest(file):
 
 
 def get_csv_file_dialect(file):
+    """
+    Possible values: 'excel', 'excel-tab', 'unix'
+    """
     file.seek(0)
     row_1 = file.readline()
     (decoded_row, _) = decode_bytes(row_1)

--- a/common/utils/file_import.py
+++ b/common/utils/file_import.py
@@ -1,7 +1,19 @@
+import csv
 import hashlib
+import logging
 
+import chardet
 from django.conf import settings
 from django.core.exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+def decode_bytes(bytes_string):
+    detection_result = chardet.detect(bytes_string)
+    encoding_detected = detection_result["encoding"]
+    logger.info(f"Encoding autodetected : {encoding_detected}")
+    return (bytes_string.decode(encoding_detected), encoding_detected)
 
 
 def get_file_size(file):
@@ -32,3 +44,10 @@ def get_file_digest(file):
     for row in file:
         file_hash.update(row)
     return file_hash.hexdigest()
+
+
+def get_csv_file_dialect(file):
+    file.seek(0)
+    row_1 = file.readline()
+    (decoded_row, _) = decode_bytes(row_1)
+    return csv.Sniffer().sniff(decoded_row)

--- a/common/utils/file_import.py
+++ b/common/utils/file_import.py
@@ -1,0 +1,34 @@
+import hashlib
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+
+
+def get_file_size(file):
+    return file.size
+
+
+def validate_file_size(file):
+    if get_file_size(file) > settings.CSV_IMPORT_MAX_SIZE:
+        raise ValidationError(
+            f"Ce fichier est trop grand, merci d'utiliser un fichier de moins de {settings.CSV_IMPORT_MAX_SIZE_PRETTY}"
+        )
+
+
+def get_file_content_type(file):
+    return file.content_type
+
+
+def validate_file_format(file):
+    file_format = get_file_content_type(file)
+    if file_format not in ["text/csv", "text/tab-separated-values"]:
+        raise ValidationError(
+            f"Ce fichier est au format {file_format}, merci d'exporter votre fichier au format CSV et réessayer."
+        )
+
+
+def get_file_digest(file):
+    file_hash = hashlib.md5()
+    for row in file:
+        file_hash.update(row)
+    return file_hash.hexdigest()

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -420,6 +420,7 @@ if DEBUG_PERFORMANCE:
 
 # Maximum CSV import file size: 10Mo
 CSV_IMPORT_MAX_SIZE = 10485760
+CSV_IMPORT_MAX_SIZE_PRETTY = "10Mo"
 
 # Size of each chunk when processing files
 CSV_PURCHASE_CHUNK_LINES = 10000


### PR DESCRIPTION
### Quoi

Suite de #4934

Baby step pour commencer à factoriser les premières étapes de traitement d'un fichier CSV : 
- check sur le format
- check sur le taille maximale
- calcul du hash md5 (utile pour checker si le fichier a déjà été importé)
- sniffing du dialect (euh :sweat_smile: )

Du coup dans `PurchaseImport` le check pour savoir si le fichier a déjà été importé se fait en amont maintenant : 
- pour renvoyer une erreur early
- et isoler la logique du processing ligne par ligne (qui sera remplacé par Validata :robot: )

### Common

Dans un nouveau fichier `common/utils/file_import.py`