### PR TITLE
fix(Télédéclaration): supprime la pré-sélection du mode de saisie de la télédéclaration qui ne s'enregistrait pas

### DIFF
--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/index.vue
@@ -184,7 +184,7 @@ export default {
     initialisePayload() {
       const originalValues = {
         valueTotalHt: this.diagnostic.valueTotalHt,
-        diagnosticType: this.diagnostic.diagnosticType || "SIMPLE",
+        diagnosticType: this.diagnostic.diagnosticType || "",
         valueBioHt: this.diagnostic.valueBioHt,
         valueSustainableHt: this.diagnostic.valueSustainableHt,
         valueEgalimOthersHt: this.diagnostic.valueEgalimOthersHt,


### PR DESCRIPTION
## Quoi ? 

En pré-renseignant ce champ, lorsque l'on "passe à l'étape d'après" comme l'app ne détecte pas de changement entre la valeur sélectionnée et la valeur "précédente" elle ne l'enregistre pas.

Du coup réaction en chaine => 
- dans les TD le champ `type de déclaration` est null
- dans la liste des actions le bouton `télédéclarer en masse` compte les diagnostiques complet et avec un type
- donc on avait un nombre différent entre le bouton et ce qui est disponible dans le tableau car lui ne fait pas attention au champ

Et surtout cette info était fausse dans notre base ! 
TD 2024 => [6461 avec un type vide](https://ma-cantine-metabase.cleverapps.io/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjozLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjQyNSwiZmlsdGVyIjpbImFuZCIsWyI9IixbImZpZWxkIiw1NzY5LHsiYmFzZS10eXBlIjoidHlwZS9CaWdJbnRlZ2VyIn1dLDIwMjNdLFsiaXMtZW1wdHkiLFsiZmllbGQiLDU3MzEseyJiYXNlLXR5cGUiOiJ0eXBlL1RleHQifV1dXX19LCJkaXNwbGF5IjoidGFibGUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fSwib3JpZ2luYWxfY2FyZF9pZCI6bnVsbCwidHlwZSI6InF1ZXN0aW9uIn0=)
TD 2025 => [déjà 340 avec un type vide](https://ma-cantine-metabase.cleverapps.io/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjozLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjQyNSwiZmlsdGVyIjpbImFuZCIsWyI9IixbImZpZWxkIiw1NzY5LHsiYmFzZS10eXBlIjoidHlwZS9CaWdJbnRlZ2VyIn1dLDIwMjRdLFsiaXMtZW1wdHkiLFsiZmllbGQiLDU3MzEseyJiYXNlLXR5cGUiOiJ0eXBlL1RleHQifV1dXX19LCJkaXNwbGF5IjoidGFibGUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fSwib3JpZ2luYWxfY2FyZF9pZCI6bnVsbCwidHlwZSI6InF1ZXN0aW9uIn0=)