### PR TITLE
improve(Statistiques territoire): modification du titre de la page et du breadcrumb

### DIFF
--- a/2024-frontend/src/components/AppHeader.vue
+++ b/2024-frontend/src/components/AppHeader.vue
@@ -82,7 +82,7 @@ const navItems = [
         to: { name: "CanteenSearchLanding" },
       },
       {
-        text: "Dans ma collectivité",
+        text: "Sur mon territoire",
         to: { name: "PublicCanteenStatisticsPage" },
       },
       {

--- a/frontend/src/components/AppHeader/index.vue
+++ b/frontend/src/components/AppHeader/index.vue
@@ -269,7 +269,7 @@ export default {
               to: { name: "CanteenSearchLanding" },
             },
             {
-              text: "Dans ma collectivité",
+              text: "Sur mon territoire",
               to: { name: "PublicCanteenStatisticsPage" },
             },
             {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -413,7 +413,7 @@ const routes = [
     name: "PublicCanteenStatisticsPage",
     component: PublicCanteenStatisticsPage,
     meta: {
-      title: "Les cantines dans ma collectivité",
+      title: "Sur mon territoire",
     },
     sitemapGroup: Constants.SitemapGroups.LAW,
   },

--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="text-left grey--text text--darken-4">
     <BreadcrumbsNav />
-    <h1 class="text-h4 font-weight-black black--text mb-6">Découvrir les démarches chez vous</h1>
+    <h1 class="text-h4 font-weight-black black--text mb-6">Application de la loi EGalim sur mon territoire</h1>
 
     <v-card outlined>
       <v-card-text>
@@ -90,6 +90,7 @@
         </v-form>
       </v-card-text>
     </v-card>
+
     <div v-if="locationText" class="pt-8">
       <h2 class="text-h5 font-weight-bold">Les chiffres pour {{ locationText }}</h2>
       <p v-if="sectorsText" class="text-body-2 mt-4 grey--text text--darken-2">
@@ -584,7 +585,7 @@ export default {
       this.chosenSectors = this.$route.query.sectors?.split(",").map((s) => parseInt(s, 10)) || []
     },
     updateDocumentTitle() {
-      let title = `Les cantines dans ma collectivité - ${this.$store.state.pageTitleSuffix}`
+      let title = `Sur mon territoire - ${this.$store.state.pageTitleSuffix}`
       if (this.chosenRegions.length || this.chosenDepartments.length || this.chosenEpcis.length) {
         let locationText = this.createLocationText()
         if (locationText.startsWith("les")) {


### PR DESCRIPTION
https://www.notion.so/Roadmap-produit-1844a08edabc807ea592eae32c074243?p=1884a08edabc8085a3d0c7afb88efcf2&pm=s

### Quoi

Changements sur la page `/statistiques-regionales`
- changement du titre (SEO) & breadcrumb à "Sur mon territoire"
- changement du h1 à "Application de la loi EGalim sur mon territoire"