### PR TITLE
improve(Statistiques territoire): cacher les chiffres en bas en attendant d'améliorer les requêtes backend

### DIFF
--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -225,6 +225,7 @@
             </v-card>
           </v-col>
         </v-row>
+        <!-- chiffres faux (requêtes à revoir), on cache en attendant
         <h3 class="text-h6 font-weight-bold mt-10 mb-2">
           Ces cantines ont aussi réalisé les mesures suivantes en {{ year }}
         </h3>
@@ -235,14 +236,15 @@
           </v-col>
         </v-row>
         <BadgesExplanation />
+        -->
       </div>
     </div>
   </div>
 </template>
 
 <script>
-import BadgeCard from "./BadgeCard"
-import BadgesExplanation from "./BadgesExplanation"
+// import BadgeCard from "./BadgeCard"
+// import BadgesExplanation from "./BadgesExplanation"
 import labels from "@/data/quality-labels.json"
 import keyMeasures from "@/data/key-measures.json"
 import jsonDepartments from "@/departments.json"
@@ -257,8 +259,8 @@ import GraphComponent from "@/components/GraphComponent"
 export default {
   name: "PublicCanteenStatisticsPage",
   components: {
-    BadgeCard,
-    BadgesExplanation,
+    // BadgeCard,
+    // BadgesExplanation,
     BreadcrumbsNav,
     DsfrAutocomplete,
     DsfrSelect,


### PR DESCRIPTION
### Quoi

Cacher la section en bas de la page `/statistiques-regionales`
> Ces cantines ont aussi réalisé les mesures suivantes en 2024

### Pourquoi

"les chiffres sont faux, cacher la section en attendant de revoir les requêtes backend"