### PR TITLE
improve(Statistiques territoire): étoffer les stats dans la section EGalim. clean du CSS

### DIFF
--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -104,7 +104,7 @@
         <v-icon>mdi-office-building</v-icon>
         {{ sectorsText }}
       </p>
-      <v-row :class="{ 'flex-column': $vuetify.breakpoint.smAndDown, 'mt-8': true }">
+      <v-row>
         <v-col cols="12" sm="6">
           <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
             <v-card-text>
@@ -138,10 +138,9 @@
           </GraphComponent>
         </v-col>
       </v-row>
+
       <v-row class="mt-10 mb-2 px-3 align-center">
-        <h3 class="text-h6 font-weight-bold">
-          À propos des objectifs EGalim
-        </h3>
+        <h2 class="text-h5 font-weight-bold">À propos des objectifs EGalim</h2>
         <div>
           <label for="select-year" class="d-sr-only">
             Année
@@ -156,35 +155,69 @@
           />
         </div>
       </v-row>
+      <p v-if="locationText" class="text-body-2 mt-4 grey--text text--darken-2">
+        <v-icon>mdi-map-marker</v-icon>
+        {{ locationText }}
+      </p>
+      <p v-if="sectorsText" class="text-body-2 mt-4 grey--text text--darken-2">
+        <v-icon>mdi-office-building</v-icon>
+        {{ sectorsText }}
+      </p>
+      <v-row>
+        <v-col cols="12" sm="4">
+          <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
+            <v-card-text>
+              <p class="mb-0">
+                <span class="text-h5 font-weight-black">{{ statistics.canteenCount }}</span>
+                <span class="text-body-2">
+                  cantines inscrites
+                </span>
+              </p>
+            </v-card-text>
+          </v-card>
+        </v-col>
+        <v-col cols="12" sm="4">
+          <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
+            <v-card-text>
+              <p class="mb-0">
+                <span class="text-h5 font-weight-black">{{ statistics.diagnosticsCount }}</span>
+                <span class="text-body-2">
+                  cantines qui ont télédéclaré
+                </span>
+              </p>
+            </v-card-text>
+          </v-card>
+        </v-col>
+        <v-col cols="12" sm="4">
+          <v-card class="fill-height text-center pt-4 pb-2 px-3 d-flex flex-column" outlined>
+            <v-img max-width="30" contain src="/static/images/badges/appro.svg" class="mx-auto" alt=""></v-img>
+            <v-card-text class="grey--text text--darken-2 px-1">
+              <p class="mb-0">
+                <span class="text-h5 font-weight-black" style="line-height: inherit;">
+                  {{ statistics.approPercent }} %
+                </span>
+                <span class="text-body-2">
+                  ont réussi l'objectif d'approvisionnement EGalim
+                </span>
+              </p>
+            </v-card-text>
+            <v-card-actions class="px-1">
+              <router-link :to="{ name: 'KeyMeasurePage', params: { id: approMeasure.id } }" class="text-body-2">
+                La mesure
+              </router-link>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+      </v-row>
       <div v-if="statistics.diagnosticsCount === 0">
         <p class="mt-8 caption">
           Aucune cantine n'a renseigné des données relatives à la loi EGalim pour l'année {{ year }}.
         </p>
       </div>
       <div v-else>
-        <p class="mb-8">Parmi les {{ statistics.diagnosticsCount }} cantines qui ont télédéclaré&nbsp;:</p>
+        <p class="mt-4">Parmi les {{ statistics.diagnosticsCount }} cantines qui ont télédéclaré&nbsp;:</p>
         <v-row class="px-2">
-          <v-col class="pl-0 pr-1" cols="12" sm="6" md="4">
-            <v-card class="fill-height text-center pt-4 pb-2 px-3 d-flex flex-column" outlined>
-              <v-img max-width="30" contain src="/static/images/badges/appro.svg" class="mx-auto" alt=""></v-img>
-              <v-card-text class="grey--text text--darken-2 px-1">
-                <p class="mb-0">
-                  <span class="text-h5 font-weight-black" style="line-height: inherit;">
-                    {{ statistics.approPercent }} %
-                  </span>
-                  <span class="text-body-2">
-                    ont réussi l'objectif d'approvisionnement EGalim
-                  </span>
-                </p>
-              </v-card-text>
-              <v-card-actions class="px-1">
-                <router-link :to="{ name: 'KeyMeasurePage', params: { id: approMeasure.id } }" class="text-body-2">
-                  La mesure
-                </router-link>
-              </v-card-actions>
-            </v-card>
-          </v-col>
-          <v-col class="px-1" cols="12" sm="6" md="3">
+          <v-col class="px-1" cols="12" sm="6">
             <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
               <v-card-text>
                 <p class="mb-0">
@@ -199,7 +232,7 @@
               </div>
             </v-card>
           </v-col>
-          <v-col class="pl-1 pr-0" cols="12" sm="6" md="5">
+          <v-col class="pl-1 pr-0" cols="12" sm="6">
             <v-card class="fill-height text-center py-4 d-flex flex-column justify-center" outlined>
               <v-card-text>
                 <p class="mb-0">
@@ -229,8 +262,8 @@
         <h3 class="text-h6 font-weight-bold mt-10 mb-2">
           Ces cantines ont aussi réalisé les mesures suivantes en {{ year }}
         </h3>
-        <p class="mb-8">Parmi les mêmes {{ statistics.diagnosticsCount }} cantines &nbsp;:</p>
-        <v-row class="my-8">
+        <p>Parmi les mêmes {{ statistics.diagnosticsCount }} cantines &nbsp;:</p>
+        <v-row>
           <v-col cols="12" sm="6" md="5" v-for="measure in otherMeasures" :key="measure.id" class="mb-4">
             <BadgeCard :measure="measure" :percentageAchieved="statistics[measure.badgeId + 'Percent']" />
           </v-col>


### PR DESCRIPTION
https://www.notion.so/Sprints-produit-1844a08edabc807ea592eae32c074243?p=1884a08edabc80d6abf6f241d6f8eecf&pm=s

### Quoi

Etoffe un peu la section "EGalim" de la page `/statistiques-regionales`
- remettre la card "X cantines inscrites" (elle apparait en "double" car présente dans la section au dessus)
- créer une carte "X cantines qui ont télédélcarées"
- remonter la card "X% ont réussi l'objectif EGalim"

J'ai aussi pas mal simplifié les class de padding utilisées #ménage

### Captures d'écran

|Avant|Après|
|-|-|
|![image](https://github.com/user-attachments/assets/44b46f4d-3281-44cb-a465-d4b15186f6e9)|![image](https://github.com/user-attachments/assets/9da29d3f-cc4b-44d7-9d6d-b09493eb0bfe)|