### PR TITLE
refactor(common): centraliser la logique API Adresse dans un nouveau fichier api/adresse.py

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -65,6 +65,7 @@ from api.serializers import (
     SatelliteCanteenSerializer,
 )
 from api.views.utils import camelize, update_change_reason_with_auth
+from common.api.adresse import fetch_geo_data_from_api_entreprise_by_siret
 from common.api.insee import (
     fetch_geo_data_from_api_insee_sirene_by_siret,
     get_token_sirene,
@@ -80,7 +81,6 @@ from data.models import (
     Teledeclaration,
 )
 from data.region_choices import Region
-from macantine.utils import fetch_geo_data_from_api_entreprise_by_siret
 
 logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)

--- a/common/api/adresse.py
+++ b/common/api/adresse.py
@@ -1,0 +1,45 @@
+import logging
+
+import requests
+
+from data.region_choices import Region
+
+logger = logging.getLogger(__name__)
+
+REGIONS_LIB = {i.label.split(" - ")[1]: i.value for i in Region}
+
+
+def fetch_geo_data_from_api_entreprise_by_siret(response):
+    try:
+        location_response = requests.get(
+            f"https://api-adresse.data.gouv.fr/search/?q={response['cityInseeCode']}&citycode={response['cityInseeCode']}&type=municipality&autocomplete=1"
+        )
+        if location_response.ok:
+            location_response = location_response.json()
+            results = location_response["features"]
+            if results and results[0]:
+                try:
+                    result = results[0]["properties"]
+                    if result:
+                        response["city"] = result["label"]
+                        response["city_insee_code"] = result["citycode"]
+                        response["postal_code"] = result["postcode"]
+                        response["department"] = result["context"].split(",")[0]
+                        response["department_lib"] = result["context"].split(", ")[1]
+                        response["region_lib"] = result["context"].split(", ")[2]
+                        response["region"] = int(REGIONS_LIB[response["region_lib"]])
+                        return response
+                except KeyError as e:
+                    logger.warning(f"unexpected location response format : {location_response}. Unknown key : {e}")
+            else:
+                logger.warning(
+                    f"features array for city '{response['city']}' in location response format is non-existant or empty : {location_response}"
+                )
+        else:
+            logger.warning(
+                f"location fetching failed, code {location_response.status_code} : {location_response.json()}"
+            )
+    except Exception as e:
+        logger.exception(f"Error completing location data with SIRET for city: {response['city']}")
+        logger.exception(e)
+    return response

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -6,12 +6,8 @@ import redis as r
 import requests
 from django.conf import settings
 
-from data.region_choices import Region
-
 logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)
-
-REGIONS_LIB = {i.label.split(" - ")[1]: i.value for i in Region}
 
 CAMPAIGN_DATES = {
     2021: {
@@ -31,39 +27,3 @@ CAMPAIGN_DATES = {
         "end_date": datetime(2025, 3, 31, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
 }
-
-
-def fetch_geo_data_from_api_entreprise_by_siret(response):
-    try:
-        location_response = requests.get(
-            f"https://api-adresse.data.gouv.fr/search/?q={response['cityInseeCode']}&citycode={response['cityInseeCode']}&type=municipality&autocomplete=1"
-        )
-        if location_response.ok:
-            location_response = location_response.json()
-            results = location_response["features"]
-            if results and results[0]:
-                try:
-                    result = results[0]["properties"]
-                    if result:
-                        response["city"] = result["label"]
-                        response["city_insee_code"] = result["citycode"]
-                        response["postal_code"] = result["postcode"]
-                        response["department"] = result["context"].split(",")[0]
-                        response["department_lib"] = result["context"].split(", ")[1]
-                        response["region_lib"] = result["context"].split(", ")[2]
-                        response["region"] = int(REGIONS_LIB[response["region_lib"]])
-                        return response
-                except KeyError as e:
-                    logger.warning(f"unexpected location response format : {location_response}. Unknown key : {e}")
-            else:
-                logger.warning(
-                    f"features array for city '{response['city']}' in location response format is non-existant or empty : {location_response}"
-                )
-        else:
-            logger.warning(
-                f"location fetching failed, code {location_response.status_code} : {location_response.json()}"
-            )
-    except Exception as e:
-        logger.exception(f"Error completing location data with SIRET for city: {response['city']}")
-        logger.exception(e)
-    return response


### PR DESCRIPTION
### Quoi

Similaire à #4961 & #4962

Basculer la logique dédiée à l'API Adresse dans un fichier donné : common/api/adresse.py
- fetch_geo_data_from_api_entreprise_by_siret