### PR TITLE
improve(Statistiques territoire): Indiquer l'année de télédéclaration

### DIFF
--- a/frontend/src/views/PublicCanteenStatisticsPage/index.vue
+++ b/frontend/src/views/PublicCanteenStatisticsPage/index.vue
@@ -151,7 +151,9 @@
             hide-details
             id="select-year"
             class="ml-2"
-            style="max-width: 8em"
+            item-text="text"
+            item-value="key"
+            style="max-width: 24em"
           />
         </div>
       </v-row>
@@ -301,10 +303,10 @@ export default {
   },
   data() {
     const yearGenerator = function*() {
-      for (let n = 2020; n <= lastYear(); n += 1) yield n
+      for (let n = 2020; n <= lastYear(); n += 1) yield { key: n, text: `données ${n} (télédéclarées en ${n + 1})` }
     }
     return {
-      year: null,
+      year: lastYear(),
       yearsList: Array.from(yearGenerator()),
       labels,
       approMeasure: keyMeasures.find((measure) => measure.badgeId === "appro"),


### PR DESCRIPTION
https://www.notion.so/Sprints-produit-1844a08edabc807ea592eae32c074243?p=18a4a08edabc8080814ceba5a9fdbfc5&pm=s

### Quoi

Petit changement supplémentaire sur la page `/statistiques-regionales`
- indique dans le select l'année de télédéclaration (N+1)

### Capture d'écran

|Avant|Après|
|-|-|
|![image](https://github.com/user-attachments/assets/05fd5afc-818b-46b0-9ed8-f318f9f5bfda)|![image](https://github.com/user-attachments/assets/fefb2993-6950-4135-8d9d-ca4de0264e0d)|

