### PR TITLE
refactor(API): Imports: séparer le check sur la présence du header

### DIFF
--- a/api/tests/files/achats/purchases_good_no_local_def.csv
+++ b/api/tests/files/achats/purchases_good_no_local_def.csv
@@ -1,3 +1,3 @@
 siret,description,fournisseur,date,prix_ht,famille_produits,caracteristiques,definition_local
-82399356058716,"Pommes, rouges",Le bon traiteur ,2022-05-02,90.11, PRODUITS_LAITIERS ,"BIO"
-82399356058716,"Pommes, vertes",Le bon traiteur ,2022-05-03,910.11, PRODUITS_LAITIERS ,"BIO"
+82399356058716,"Pommes, rouges",Le bon traiteur ,2022-05-02,90.11, PRODUITS_LAITIERS ,"BIO",
+82399356058716,"Pommes, vertes",Le bon traiteur ,2022-05-03,910.11, PRODUITS_LAITIERS ,"BIO",

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -178,7 +178,7 @@ class TestPurchaseImport(APITestCase):
         )
         self.assertEqual(
             errors.pop(0)["message"],
-            "Format fichier : 7-8 colonnes attendues, 6 trouvées.",
+            "Format fichier : 8 colonnes attendues, 6 trouvées.",
         )
 
     @authenticate

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -85,7 +85,6 @@ class ImportDiagnosticsView(ABC, APIView):
                 file_import.validate_file_format(self.file)
 
                 self.dialect = file_import.get_csv_file_dialect(self.file)
-                print(self.import_type)
                 if self.import_type == ImportType.CANTEEN_ONLY_OR_DIAGNOSTIC_SIMPLE:
                     file_import.verify_first_line_is_header_list(
                         self.file,
@@ -158,7 +157,7 @@ class ImportDiagnosticsView(ABC, APIView):
         header = next(csvreader)
         self.check_admin_values(header)
 
-        for row_number, row in enumerate(csvreader):
+        for row_number, row in enumerate(csvreader, start=1):
             try:
                 canteen, should_update_geolocation = self._save_data_from_row(row)
                 self.canteens[canteen.siret] = canteen
@@ -172,7 +171,7 @@ class ImportDiagnosticsView(ABC, APIView):
             except Exception as e:
                 for error in self._parse_errors(e, row):
                     self.errors.append(
-                        ImportDiagnosticsView._get_error(e, error["message"], error["code"], row_number + 1)
+                        ImportDiagnosticsView._get_error(e, error["message"], error["code"], row_number)
                     )
         if has_locations_to_find:
             self._update_location_data(locations_csv_str)

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -141,6 +141,7 @@ class ImportPurchasesView(APIView):
 
         decoded_chunk = self._decode_chunk(chunk)
         csvreader = csv.reader(io.StringIO("".join(decoded_chunk)), self.dialect)
+        next(csvreader)  # skip header
         for row_number, row in enumerate(csvreader, start=1):
             siret = None
 

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -142,6 +142,7 @@ class ImportPurchasesView(APIView):
         decoded_chunk = self._decode_chunk(chunk)
         csvreader = csv.reader(io.StringIO("".join(decoded_chunk)), self.dialect)
         next(csvreader)  # skip header
+
         for row_number, row in enumerate(csvreader, start=1):
             siret = None
 

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -147,6 +147,10 @@ class ImportPurchasesView(APIView):
             siret = None
 
             try:
+                # first check that the number of columns is good
+                # to throw error if badly formatted early on.
+                if len(row) < len(self.expected_header):
+                    raise BadRequest()
                 siret = row.pop(0)
                 if siret == "":
                     raise ValidationError({"siret": "Le siret de la cantine ne peut pas être vide"})
@@ -263,7 +267,7 @@ class ImportPurchasesView(APIView):
         elif isinstance(e, BadRequest):
             errors.append(
                 {
-                    "message": f"Format fichier : 7-8 colonnes attendues, {len(row)} trouvées.",
+                    "message": f"Format fichier : {len(self.expected_header)} colonnes attendues, {len(row)} trouvées.",
                     "code": 400,
                 }
             )

--- a/common/utils/file_import.py
+++ b/common/utils/file_import.py
@@ -62,6 +62,6 @@ def verify_first_line_is_header(file, file_dialect, expected_header):
     row_1 = file.readline()
     (decoded_row, _) = decode_bytes(row_1)
     csvreader = csv.reader(io.StringIO("".join(decoded_row)), file_dialect)
-    for header in csvreader:
-        if header != expected_header:
-            raise ValidationError("La première ligne du fichier doit contenir les bon noms de colonnes")
+    header = next(csvreader)
+    if header != expected_header:
+        raise ValidationError("La première ligne du fichier doit contenir les bon noms de colonnes")

--- a/common/utils/file_import.py
+++ b/common/utils/file_import.py
@@ -65,3 +65,13 @@ def verify_first_line_is_header(file, file_dialect, expected_header):
     header = next(csvreader)
     if header != expected_header:
         raise ValidationError("La première ligne du fichier doit contenir les bon noms de colonnes")
+
+
+def verify_first_line_is_header_list(file, file_dialect, expected_header_list):
+    file.seek(0)
+    row_1 = file.readline()
+    (decoded_row, _) = decode_bytes(row_1)
+    csvreader = csv.reader(io.StringIO("".join(decoded_row)), file_dialect)
+    header = next(csvreader)
+    if not any([set(header).issubset(set(expected_header)) for expected_header in expected_header_list]):
+        raise ValidationError("La première ligne du fichier doit contenir les bon noms de colonnes")

--- a/common/utils/file_import.py
+++ b/common/utils/file_import.py
@@ -1,5 +1,6 @@
 import csv
 import hashlib
+import io
 import logging
 
 import chardet
@@ -54,3 +55,13 @@ def get_csv_file_dialect(file):
     row_1 = file.readline()
     (decoded_row, _) = decode_bytes(row_1)
     return csv.Sniffer().sniff(decoded_row)
+
+
+def verify_first_line_is_header(file, file_dialect, expected_header):
+    file.seek(0)
+    row_1 = file.readline()
+    (decoded_row, _) = decode_bytes(row_1)
+    csvreader = csv.reader(io.StringIO("".join(decoded_row)), file_dialect)
+    for header in csvreader:
+        if header != expected_header:
+            raise ValidationError("La première ligne du fichier doit contenir les bon noms de colonnes")


### PR DESCRIPTION
Suite de #4936

Tente de rajouter des methodes supplémentaires à la lib générique `common/utils/file_import.py`
- verify_first_line_is_header