### PR TITLE
refactor(Validata): Achats: Modifie le schéma pour accepter des espaces dans les champs enum

### DIFF
--- a/2024-frontend/src/services/schemas.js
+++ b/2024-frontend/src/services/schemas.js
@@ -20,7 +20,9 @@ const getFieldType = (field) => {
   if (field.constraints) {
     if (field.constraints.enum) {
       return types[`${field.type}_enum`]
-    } else if (field.constraints.pattern && field.doc_enum_multiple) {
+    } else if (field.constraints.pattern && field.doc_enum && !field.doc_enum_multiple) {
+      return types[`${field.type}_enum`]
+    } else if (field.constraints.pattern && field.doc_enum && field.doc_enum_multiple) {
       return types[`${field.type}_enum_multiple`]
     }
   }

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -1,9 +1,12 @@
 import hashlib
+import json
+import re
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
 from unittest.mock import patch
 
+from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
@@ -13,6 +16,36 @@ from data.factories import CanteenFactory
 from data.models.purchase import Purchase
 
 from .utils import authenticate
+
+
+class TestPurchaseSchema(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.schema = json.load(open("data/schemas/imports/achats.json"))
+
+    def test_famille_produits_regex(self):
+        field_index = next((i for i, f in enumerate(self.schema["fields"]) if f["name"] == "famille_produits"), None)
+        pattern = self.schema["fields"][field_index]["constraints"]["pattern"]
+        for VALUE_OK in ["PRODUITS_LAITIERS", "PRODUITS_LAITIERS ", " PRODUITS_LAITIERS "]:
+            self.assertTrue(re.match(pattern, VALUE_OK))
+        for VALUE_NOT_OK in ["", "TEST", "PRODUITS_LAITIERS,", "PRODUITS_LAITIERS,VIANDES_VOLAILLES"]:
+            self.assertFalse(re.match(pattern, VALUE_NOT_OK))
+
+    def test_caracteristiques_regex(self):
+        field_index = next((i for i, f in enumerate(self.schema["fields"]) if f["name"] == "caracteristiques"), None)
+        pattern = self.schema["fields"][field_index]["constraints"]["pattern"]
+        for VALUE_OK in ["BIO", "BIO ", " BIO ", "BIO,LOCAL", "BIO,LOCAL ", " BIO,LOCAL ", " BIO, LOCAL "]:
+            self.assertTrue(re.match(pattern, VALUE_OK))
+        for VALUE_NOT_OK in ["", "TEST"]:
+            self.assertFalse(re.match(pattern, VALUE_NOT_OK))
+
+    def test_definition_local_regex(self):
+        field_index = next((i for i, f in enumerate(self.schema["fields"]) if f["name"] == "definition_local"), None)
+        pattern = self.schema["fields"][field_index]["constraints"]["pattern"]
+        for VALUE_OK in ["DEPARTMENT", "DEPARTMENT ", " DEPARTMENT "]:
+            self.assertTrue(re.match(pattern, VALUE_OK))
+        for VALUE_NOT_OK in ["", "TEST", "DEPARTMENT,", "DEPARTMENT,REGION"]:
+            self.assertFalse(re.match(pattern, VALUE_NOT_OK))
 
 
 class TestPurchaseImport(APITestCase):

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -34,7 +34,16 @@ class TestPurchaseSchema(TestCase):
     def test_caracteristiques_regex(self):
         field_index = next((i for i, f in enumerate(self.schema["fields"]) if f["name"] == "caracteristiques"), None)
         pattern = self.schema["fields"][field_index]["constraints"]["pattern"]
-        for VALUE_OK in ["BIO", "BIO ", " BIO ", "BIO,LOCAL", "BIO,LOCAL ", " BIO,LOCAL ", " BIO, LOCAL "]:
+        for VALUE_OK in [
+            "BIO",
+            "BIO ",
+            "BIO,LOCAL",
+            "BIO,LOCAL ",
+            " BIO,LOCAL ",
+            " BIO, LOCAL ",
+            " BIO,      LOCAL ",
+            "BIO,BIO",
+        ]:
             self.assertTrue(re.match(pattern, VALUE_OK))
         for VALUE_NOT_OK in ["", "TEST"]:
             self.assertFalse(re.match(pattern, VALUE_NOT_OK))

--- a/data/schemas/imports/achats.json
+++ b/data/schemas/imports/achats.json
@@ -60,19 +60,20 @@
     },
     {
       "constraints": {
-        "enum": [
-          "VIANDES_VOLAILLES",
-          "CHARCUTERIE",
-          "PRODUITS_DE_LA_MER",
-          "FRUITS_ET_LEGUMES",
-          "PRODUITS_LAITIERS",
-          "BOULANGERIE",
-          "BOISSONS",
-          "AUTRES"
-        ],
+        "pattern": "^ *(VIANDES_VOLAILLES|CHARCUTERIE|PRODUITS_DE_LA_MER|FRUITS_ET_LEGUMES|PRODUITS_LAITIERS|BOULANGERIE|BOISSONS|AUTRES) *$",
         "required": false
       },
       "description": "",
+      "doc_enum": [
+        "VIANDES_VOLAILLES",
+        "CHARCUTERIE",
+        "PRODUITS_DE_LA_MER",
+        "FRUITS_ET_LEGUMES",
+        "PRODUITS_LAITIERS",
+        "BOULANGERIE",
+        "BOISSONS",
+        "AUTRES"
+      ],
       "example": "VIANDES_VOLAILLES",
       "format": "default",
       "name": "famille_produits",
@@ -81,7 +82,7 @@
     },
     {
       "constraints": {
-        "pattern": "(?:(?:^|,)(BIO|LABEL_ROUGE|AOCAOP|IGP|STG|HVE|PECHE_DURABLE|RUP|COMMERCE_EQUITABLE|FERMIER|EXTERNALITES|PERFORMANCE|FRANCE|SHORT_DISTRIBUTION|LOCAL))+$",
+        "pattern": "^ *(BIO|LABEL_ROUGE|AOCAOP|IGP|STG|HVE|PECHE_DURABLE|RUP|COMMERCE_EQUITABLE|FERMIER|EXTERNALITES|PERFORMANCE|FRANCE|SHORT_DISTRIBUTION|LOCAL)( *, *(BIO|LABEL_ROUGE|AOCAOP|IGP|STG|HVE|PECHE_DURABLE|RUP|COMMERCE_EQUITABLE|FERMIER|EXTERNALITES|PERFORMANCE|FRANCE|SHORT_DISTRIBUTION|LOCAL))* *$",
         "required": false
       },
       "description": "",
@@ -112,15 +113,16 @@
     },
     {
       "constraints": {
-        "enum": [
-          "AUTOUR_SERVICE",
-          "DEPARTMENT",
-          "REGION",
-          "AUTRE"
-        ],
+        "pattern": "^ *(AUTOUR_SERVICE|DEPARTMENT|REGION|AUTRE) *$",
         "required": false
       },
       "description": "Obligatoire si l'achat a la caractéristique de LOCAL.",
+      "doc_enum": [
+        "AUTOUR_SERVICE",
+        "DEPARTMENT",
+        "REGION",
+        "AUTRE"
+      ],
       "example": "AUTOUR_SERVICE",
       "format": "default",
       "name": "definition_local",


### PR DESCRIPTION
Suite de #4889

On modifie les regex de nos 3 enum - famille_produits, caracteristiques, definition_local - pour autoriser les espaces.
J'ai ajouté des tests pour montrer les différents cas possibles !