### PR TITLE
refactor(API): Imports: Achats: séparer le check sur la présence du header

### DIFF
--- a/api/tests/files/achats/purchases_bad_partial_header.csv
+++ b/api/tests/files/achats/purchases_bad_partial_header.csv
@@ -1,0 +1,3 @@
+siret,description,fournisseur,date,prix_ht,famille_produits,caracteristiques
+82399356058716,"Pommes, rouges",Le bon traiteur ,2022-05-02,90.11, PRODUITS_LAITIERS ,"BIO, LOCAL"
+82399356058716,"Pommes, vertes",Le bon traiteur ,2022-05-03,910.11, PRODUITS_LAITIERS ,"BIO, LOCAL"

--- a/api/tests/files/achats/purchases_good_no_local_def.csv
+++ b/api/tests/files/achats/purchases_good_no_local_def.csv
@@ -1,3 +1,3 @@
 siret,description,fournisseur,date,prix_ht,famille_produits,caracteristiques,definition_local
-82399356058716,"Pommes, rouges",Le bon traiteur ,2022-05-02,90.11, PRODUITS_LAITIERS ,"BIO"
-82399356058716,"Pommes, vertes",Le bon traiteur ,2022-05-03,910.11, PRODUITS_LAITIERS ,"BIO"
+82399356058716,"Pommes, rouges",Le bon traiteur ,2022-05-02,90.11, PRODUITS_LAITIERS ,"BIO",
+82399356058716,"Pommes, vertes",Le bon traiteur ,2022-05-03,910.11, PRODUITS_LAITIERS ,"BIO",

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -220,7 +220,7 @@ class TestPurchaseImport(APITestCase):
         )
         self.assertEqual(
             errors.pop(0)["message"],
-            "Format fichier : 7-8 colonnes attendues, 6 trouvées.",
+            "Format fichier : 8 colonnes attendues, 6 trouvées.",
         )
 
     @authenticate

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -173,6 +173,46 @@ class TestPurchaseImport(APITestCase):
         self.assertEqual(errors[0]["status"], 400)
 
     @authenticate
+    def test_import_no_header(self):
+        """
+        A file should not be valid if doesn't contain a header
+        """
+        canteen = CanteenFactory.create(siret="82399356058716")
+        canteen.managers.add(authenticate.user)
+        self.assertEqual(Purchase.objects.count(), 0)
+
+        with open("./api/tests/files/achats/purchases_bad_no_header.csv", "rb") as diag_file:
+            response = self.client.post(f"{reverse('import_purchases')}", {"file": diag_file})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["count"], 0)
+        self.assertEqual(len(body["errors"]), 1)
+        self.assertEqual(
+            body["errors"][0]["message"], "La première ligne du fichier doit contenir les bon noms de colonnes"
+        )
+
+    @authenticate
+    def test_import_partial_header(self):
+        """
+        A file should not be valid if doesn't contain a valid header
+        """
+        canteen = CanteenFactory.create(siret="82399356058716")
+        canteen.managers.add(authenticate.user)
+        self.assertEqual(Purchase.objects.count(), 0)
+
+        with open("./api/tests/files/achats/purchases_bad_partial_header.csv", "rb") as diag_file:
+            response = self.client.post(f"{reverse('import_purchases')}", {"file": diag_file})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["count"], 0)
+        self.assertEqual(len(body["errors"]), 1)
+        self.assertEqual(
+            body["errors"][0]["message"], "La première ligne du fichier doit contenir les bon noms de colonnes"
+        )
+
+    @authenticate
     def test_import_bad_purchases(self):
         """
         Test that the right errors are thrown
@@ -340,24 +380,4 @@ class TestPurchaseImport(APITestCase):
         self.assertEqual(
             first_error["message"],
             "Ce fichier est au format application/vnd.oasis.opendocument.spreadsheet, merci d'exporter votre fichier au format CSV et réessayer.",
-        )
-
-    @authenticate
-    def test_no_header(self):
-        """
-        A file should not be valid if doesn't contain a valid header
-        """
-        canteen = CanteenFactory.create(siret="82399356058716")
-        canteen.managers.add(authenticate.user)
-        self.assertEqual(Purchase.objects.count(), 0)
-
-        with open("./api/tests/files/achats/purchases_bad_no_header.csv", "rb") as diag_file:
-            response = self.client.post(f"{reverse('import_purchases')}", {"file": diag_file})
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-        self.assertEqual(body["count"], 0)
-        self.assertEqual(len(body["errors"]), 1)
-        self.assertEqual(
-            body["errors"][0]["message"], "La première ligne du fichier doit contenir les bon noms de colonnes"
         )

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -150,7 +150,7 @@ class ImportPurchasesView(APIView):
             try:
                 # first check that the number of columns is good
                 #   to throw error if badly formatted early on.
-                if len(row) < 7:
+                if len(row) < len(self.expected_header):
                     raise BadRequest()
                 siret = row.pop(0)
                 if siret == "":
@@ -268,7 +268,7 @@ class ImportPurchasesView(APIView):
         elif isinstance(e, BadRequest):
             errors.append(
                 {
-                    "message": f"Format fichier : 7-8 colonnes attendues, {len(row)} trouvées.",
+                    "message": f"Format fichier : {len(self.expected_header)} colonnes attendues, {len(row)} trouvées.",
                     "code": 400,
                 }
             )

--- a/common/utils/file_import.py
+++ b/common/utils/file_import.py
@@ -1,5 +1,6 @@
 import csv
 import hashlib
+import io
 import logging
 
 import chardet
@@ -54,3 +55,13 @@ def get_csv_file_dialect(file):
     row_1 = file.readline()
     (decoded_row, _) = decode_bytes(row_1)
     return csv.Sniffer().sniff(decoded_row)
+
+
+def verify_first_line_is_header(file, file_dialect, expected_header):
+    file.seek(0)
+    row_1 = file.readline()
+    (decoded_row, _) = decode_bytes(row_1)
+    csvreader = csv.reader(io.StringIO("".join(decoded_row)), file_dialect)
+    header = next(csvreader)
+    if header != expected_header:
+        raise ValidationError("La première ligne du fichier doit contenir les bon noms de colonnes")


### PR DESCRIPTION
### Quoi

Suite de #4936

Rajoute une méthode supplémentaire à la lib générique `common/utils/file_import.py` : verify_first_line_is_header
- seulement pour les imports d'achats (à défaut de le faire marcher sur les diagnostics & cantines, cf #4972)
- j'ai rajouté un test avec un header partiel