### PR TITLE
fix(Imports): Remplacer ancien secteur "Secondaire lycée agricole" par "Etablissements d’enseignement agricole"

### DIFF
--- a/data/schemas/imports/cantines.json
+++ b/data/schemas/imports/cantines.json
@@ -86,7 +86,7 @@
         "enum": [
           "Crèche",
           "Secondaire lycée (hors agricole)",
-          "Secondaire lycée agricole",
+          "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",
           "Restaurants d’entreprises",
           "Restaurants inter-entreprises",

--- a/data/schemas/imports/cantines.json
+++ b/data/schemas/imports/cantines.json
@@ -85,6 +85,7 @@
       "constraints": {
         "enum": [
           "Crèche",
+          "Etablissements de la PJJ",
           "Secondaire lycée (hors agricole)",
           "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",

--- a/data/schemas/imports/diagnostics.json
+++ b/data/schemas/imports/diagnostics.json
@@ -86,7 +86,7 @@
         "enum": [
           "Crèche",
           "Secondaire lycée (hors agricole)",
-          "Secondaire lycée agricole",
+          "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",
           "Restaurants d’entreprises",
           "Restaurants inter-entreprises",

--- a/data/schemas/imports/diagnostics.json
+++ b/data/schemas/imports/diagnostics.json
@@ -85,6 +85,7 @@
       "constraints": {
         "enum": [
           "Crèche",
+          "Etablissements de la PJJ",
           "Secondaire lycée (hors agricole)",
           "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",

--- a/data/schemas/imports/diagnostics_admin.json
+++ b/data/schemas/imports/diagnostics_admin.json
@@ -86,7 +86,7 @@
         "enum": [
           "Crèche",
           "Secondaire lycée (hors agricole)",
-          "Secondaire lycée agricole",
+          "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",
           "Restaurants d’entreprises",
           "Restaurants inter-entreprises",

--- a/data/schemas/imports/diagnostics_admin.json
+++ b/data/schemas/imports/diagnostics_admin.json
@@ -85,6 +85,7 @@
       "constraints": {
         "enum": [
           "Crèche",
+          "Etablissements de la PJJ",
           "Secondaire lycée (hors agricole)",
           "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",

--- a/data/schemas/imports/diagnostics_cc.json
+++ b/data/schemas/imports/diagnostics_cc.json
@@ -86,7 +86,7 @@
         "enum": [
           "Crèche",
           "Secondaire lycée (hors agricole)",
-          "Secondaire lycée agricole",
+          "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",
           "Restaurants d’entreprises",
           "Restaurants inter-entreprises",

--- a/data/schemas/imports/diagnostics_cc.json
+++ b/data/schemas/imports/diagnostics_cc.json
@@ -85,6 +85,7 @@
       "constraints": {
         "enum": [
           "Crèche",
+          "Etablissements de la PJJ",
           "Secondaire lycée (hors agricole)",
           "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",

--- a/data/schemas/imports/diagnostics_complets.json
+++ b/data/schemas/imports/diagnostics_complets.json
@@ -87,7 +87,7 @@
         "enum": [
           "Crèche",
           "Secondaire lycée (hors agricole)",
-          "Secondaire lycée agricole",
+          "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",
           "Restaurants d’entreprises",
           "Restaurants inter-entreprises",

--- a/data/schemas/imports/diagnostics_complets.json
+++ b/data/schemas/imports/diagnostics_complets.json
@@ -86,6 +86,7 @@
       "constraints": {
         "enum": [
           "Crèche",
+          "Etablissements de la PJJ",
           "Secondaire lycée (hors agricole)",
           "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",

--- a/data/schemas/imports/diagnostics_complets_cc.json
+++ b/data/schemas/imports/diagnostics_complets_cc.json
@@ -87,7 +87,7 @@
         "enum": [
           "Crèche",
           "Secondaire lycée (hors agricole)",
-          "Secondaire lycée agricole",
+          "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",
           "Restaurants d’entreprises",
           "Restaurants inter-entreprises",

--- a/data/schemas/imports/diagnostics_complets_cc.json
+++ b/data/schemas/imports/diagnostics_complets_cc.json
@@ -86,6 +86,7 @@
       "constraints": {
         "enum": [
           "Crèche",
+          "Etablissements de la PJJ",
           "Secondaire lycée (hors agricole)",
           "Etablissements d’enseignement agricole",
           "Restaurants administratifs des collectivités territoriales",


### PR DESCRIPTION
Maj Indispensable pour les imports (doc et app d'import)
Voir le [nouveau nom du secteur](https://ma-cantine.agriculture.gouv.fr/admin/data/sector/27/change/)