### PR TITLE
refactor(Validata): Achats: Modifie le schéma pour accepter des decimal avec virgule

### DIFF
--- a/2024-frontend/src/services/schemas.js
+++ b/2024-frontend/src/services/schemas.js
@@ -24,9 +24,13 @@ const getFieldType = (field) => {
       return types[`${field.type}_enum`]
     } else if (field.constraints.pattern && field.doc_enum && field.doc_enum_multiple) {
       return types[`${field.type}_enum_multiple`]
+    } else if (field.constaints.pattern && field.doc_pattern) {
+      // examples: 'number'
+      return types[field.doc_pattern]
     }
   }
   if (field.name in types) {
+    // examples: 'siret', 'siret_livreur_repas'
     return types[field.name]
   }
   return types[field.type]

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -23,6 +23,14 @@ class TestPurchaseSchema(TestCase):
     def setUpTestData(cls):
         cls.schema = json.load(open("data/schemas/imports/achats.json"))
 
+    def test_prix_ht_decimal(self):
+        field_index = next((i for i, f in enumerate(self.schema["fields"]) if f["name"] == "prix_ht"), None)
+        pattern = self.schema["fields"][field_index]["constraints"]["pattern"]
+        for VALUE_OK in ["1234", "1234.0", "1234.99", "1234,0", "1234,99"]:
+            self.assertTrue(re.match(pattern, VALUE_OK))
+        for VALUE_NOT_OK in ["", " ", "TEST", "1234.999", "1234.99.99", "1234,999", "1234,99,99"]:
+            self.assertFalse(re.match(pattern, VALUE_NOT_OK))
+
     def test_famille_produits_regex(self):
         field_index = next((i for i, f in enumerate(self.schema["fields"]) if f["name"] == "famille_produits"), None)
         pattern = self.schema["fields"][field_index]["constraints"]["pattern"]

--- a/data/schemas/imports/achats.json
+++ b/data/schemas/imports/achats.json
@@ -53,6 +53,7 @@
         "required": true
       },
       "description": "",
+      "doc_pattern": "number",
       "example": "1234.99",
       "format": "default",
       "name": "prix_ht",

--- a/data/schemas/imports/achats.json
+++ b/data/schemas/imports/achats.json
@@ -49,6 +49,7 @@
     },
     {
       "constraints": {
+        "pattern": "^\\d+([.,]\\d{1,2})?$",
         "required": true
       },
       "description": "",
@@ -56,7 +57,7 @@
       "format": "default",
       "name": "prix_ht",
       "title": "Prix HT de l'achat",
-      "type": "number"
+      "type": "string"
     },
     {
       "constraints": {


### PR DESCRIPTION
Suite de #4889 & #4973

Modification du schema pour le champ `prix_ht` , et permettre 2 formats de nombre decimaux : 
- avec séparateur point: 1234.99
- avec séparateur virgule: 1234,99

J'ai ajouté des tests pour montrer les différents cas possibles !
et modifié la doc d'affichage frontend