### PR TITLE
refactor(Validata): Achats: Re-modifie le schéma pour accepter des decimal avec virgule (et sans limites de chiffres après la virgule)

### DIFF
--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -26,9 +26,9 @@ class TestPurchaseSchema(TestCase):
     def test_prix_ht_decimal(self):
         field_index = next((i for i, f in enumerate(self.schema["fields"]) if f["name"] == "prix_ht"), None)
         pattern = self.schema["fields"][field_index]["constraints"]["pattern"]
-        for VALUE_OK in ["1234", "1234.0", "1234.99", "1234,0", "1234,99"]:
+        for VALUE_OK in ["1234", "1234.0", "1234.99", "1234.99999", "1234,0", "1234,99", "1234,99999"]:
             self.assertTrue(re.match(pattern, VALUE_OK))
-        for VALUE_NOT_OK in ["", " ", "TEST", "1234.999", "1234.99.99", "1234,999", "1234,99,99"]:
+        for VALUE_NOT_OK in ["", " ", "TEST", "1234.99.99", "1234,99,99"]:
             self.assertFalse(re.match(pattern, VALUE_NOT_OK))
 
     def test_famille_produits_regex(self):

--- a/data/schemas/imports/achats.json
+++ b/data/schemas/imports/achats.json
@@ -49,7 +49,7 @@
     },
     {
       "constraints": {
-        "pattern": "^\\d+([.,]\\d{1,2})?$",
+        "pattern": "^\\d+([.,]\\d+)?$",
         "required": true
       },
       "description": "",


### PR DESCRIPTION
Suite à #5001 où l'on autorisait les décimaux avec séparateurs virgule (en plus du séparateur point).
J'ai modifié le regex pour être un peu plus laxiste sur le nombre de chiffres après la virgule.
- Avant : limité à 2 chiffres après la virgule
- Après : illimité