### PR TITLE
refactor(Validata): Imports achats: petits ajustements pour commencer à afficher les erreurs renvoyées par Validata

### DIFF
--- a/2024-frontend/src/components/ImportFileUpload.vue
+++ b/2024-frontend/src/components/ImportFileUpload.vue
@@ -46,13 +46,13 @@ const successUpload = (params) => {
 
 const duplicatedUpload = (purchases) => {
   const countPurchases = purchases.length
-  const description =
+  const message =
     countPurchases > 1
       ? `Ce fichier a déjà été utilisé pour importer ${countPurchases} achats :`
       : "Ce fichier a déjà été utilisé pour importer 1 achat :"
   hasErrors.list = [
     {
-      description,
+      message,
       purchases,
     },
   ]
@@ -62,12 +62,7 @@ const duplicatedUpload = (purchases) => {
 const errorUpload = (props) => {
   const { count, errors } = props
   showErrors(count)
-  hasErrors.list = errors.map((error) => {
-    return {
-      description: error.message,
-      row: error.row,
-    }
-  })
+  hasErrors.list = errors
 }
 
 const hasErrors = reactive({})
@@ -116,7 +111,9 @@ const showErrors = (count) => {
         <ul>
           <li v-for="(error, index) in hasErrors.list" :key="index" class="fr-text-default--error">
             <p class="fr-mb-1v ma-cantine--bold">
-              {{ error.description }}
+              <!-- TODO: merge Validata & other errors -->
+              <span v-if="error.title">{{ error.field }} : {{ error.title }}</span>
+              <span v-else>{{ error.message }}</span>
             </p>
             <ul v-if="error.purchases" class="ma-cantine--unstyled-list fr-text-default--grey">
               <li v-for="(purchase, index) in error.purchases" :key="index">
@@ -124,7 +121,7 @@ const showErrors = (count) => {
               </li>
             </ul>
             <p v-if="error.row" class="fr-text-default--grey fr-mb-0">
-              Ligne concernée par cette erreur : {{ error.row + 1 }}
+              Ligne concernée par cette erreur : {{ error.title ? error.row : error.row + 1 }}
             </p>
           </li>
         </ul>

--- a/2024-frontend/src/components/ImportFileUpload.vue
+++ b/2024-frontend/src/components/ImportFileUpload.vue
@@ -110,10 +110,13 @@ const showErrors = (count) => {
         <AppSeparator class="fr-my-3w" />
         <ul>
           <li v-for="(error, index) in hasErrors.list" :key="index" class="fr-text-default--error">
-            <p class="fr-mb-1v ma-cantine--bold">
-              <!-- TODO: merge Validata & other errors -->
-              <span v-if="error.title">{{ error.field }} : {{ error.title }}</span>
-              <span v-else>{{ error.message }}</span>
+            <!-- TODO: merge Validata & other errors -->
+            <p v-if="error.title" class="fr-mb-1v">
+              <span class="ma-cantine--bold">{{ error.field }} :</span>
+              {{ error.title }}
+            </p>
+            <p v-else class="fr-mb-1v">
+              {{ error.message }}
             </p>
             <ul v-if="error.purchases" class="ma-cantine--unstyled-list fr-text-default--grey">
               <li v-for="(purchase, index) in error.purchases" :key="index">


### PR DESCRIPTION
### Quoi

Suite de #4949

V1 de l'affichage des erreurs Validata dans le frontend.

### Captures d'écran

|Avant|Après v1|Après v2|
|---|---|---|
|![image](https://github.com/user-attachments/assets/1e6dc275-4dda-47f7-85d0-5947ab8d1fbd)|![image](https://github.com/user-attachments/assets/09836e51-cb03-4b26-ae30-de452578f38c)|![image](https://github.com/user-attachments/assets/edcbb2b5-0566-4feb-883e-b9ff4bc01caf)|