### PR TITLE
refactor(Imports de masse): Achats: renvoyer toutes les erreurs (c'était limité au 30 premières)

### DIFF
--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -351,7 +351,7 @@ class TestPurchaseImport(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
         body = response.json()
-        self.assertEqual(len(body["errors"]), 30)
+        self.assertEqual(len(body["errors"]), 56)
         self.assertEqual(body["errorCount"], 56)
 
     @authenticate

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 class ImportPurchasesView(APIView):
     permission_classes = [IsAuthenticated]
-    max_error_items = 30
 
     def __init__(self, **kwargs):
         self.purchases = []
@@ -234,7 +233,7 @@ class ImportPurchasesView(APIView):
             {
                 "count": 0 if self.errors else len(self.purchases),
                 "errorCount": len(self.errors),
-                "errors": self.errors[: self.max_error_items],
+                "errors": self.errors,
                 "seconds": time.time() - self.start,
                 "duplicatePurchases": camelize(PurchaseSerializer(self.duplicate_purchases, many=True).data),
                 "duplicateFile": self.is_duplicate_file,


### PR DESCRIPTION
Cette limite existait seulement sur l'import achats