### PR TITLE
improve(Imports): Cantines: rajoute une contrainte d'unicité sur le champ SIRET

### DIFF
--- a/api/tests/files/canteens/canteens_bad_nearly_good.csv
+++ b/api/tests/files/canteens/canteens_bad_nearly_good.csv
@@ -1,3 +1,4 @@
 siret,nom,code_insee_commune,code_postal_commune,siret_livreur_repas,nombre_repas_jour,nombre_repas_an,secteurs,type_production,type_gestion,modèle_économique,gestionnaires_additionnels
+21340172201787,A canteen,,54460,,700,14000,Cliniques+Hôpitaux,site,conceded,,
 21340172201787,A canteen,,54460,,700,,Cliniques+Hôpitaux,site,conceded,,
 82399356058716,Another canteen,,54460,,700,14000,Secteur inconnu,site,conceded,,

--- a/api/tests/test_import_canteens.py
+++ b/api/tests/test_import_canteens.py
@@ -187,7 +187,7 @@ class TestCanteenImport(APITestCase):
         If a cantine succeeds and another one doesn't, no canteen should be saved
         and the array of cantine should return zero
         """
-        # 2 format errors
+        # 3 format errors
         with open("./api/tests/files/canteens/canteens_bad_nearly_good.csv") as canteen_file:
             response = self.client.post(f"{reverse('import_canteens')}", {"file": canteen_file})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -196,7 +196,10 @@ class TestCanteenImport(APITestCase):
         errors = body["errors"]
         self.assertEqual(body["count"], 0)
         self.assertEqual(len(body["canteens"]), 0)
-        self.assertEqual(len(errors), 2, errors)
+        self.assertEqual(len(errors), 3, errors)
+        self.assertTrue(
+            errors.pop(0)["message"].startswith("Les valeurs de cette colonne doivent être uniques"),
+        )
         self.assertTrue(
             errors.pop(0)["message"].startswith("La valeur est obligatoire et doit être renseignée"),
         )

--- a/api/views/canteenimport.py
+++ b/api/views/canteenimport.py
@@ -42,7 +42,7 @@ class ImportCanteensView(APIView):
         self.start_time = None
         self.encoding_detected = None
         self.file = None
-        self.schema_url = "https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/staging/data/schemas/imports/cantines.json"
+        self.schema_url = "https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/raphodn/backend-import-canteens-schema-siret-unique/data/schemas/imports/cantines.json"
         self.schema_json = json.load(open("data/schemas/imports/cantines.json"))
         self.expected_header = [field["name"] for field in self.schema_json["fields"]]
         super().__init__(**kwargs)

--- a/data/schemas/imports/cantines.json
+++ b/data/schemas/imports/cantines.json
@@ -5,7 +5,8 @@
     {
       "constraints": {
         "pattern": "^[0-9]{14}$",
-        "required": true
+        "required": true,
+        "unique": true
       },
       "description": "Ce SIRET doit être unique car il correspond à un lieu physique.",
       "example": "49463556926130",


### PR DESCRIPTION
On rajoute une contrainte "unique" sur le champ `siret` du schema `cantines.json`

https://specs.frictionlessdata.io/table-schema/#constraints