### PR TITLE
improve(Imports): Cantines: mieux gérer les imports admin (schéma dédié, erreurs, tests)

### DIFF
--- a/api/tests/files/canteens/canteens_staff_good_new_canteen.csv
+++ b/api/tests/files/canteens/canteens_staff_good_new_canteen.csv
@@ -1,0 +1,3 @@
+siret,nom,code_insee_commune,code_postal_commune,siret_livreur_repas,nombre_repas_jour,nombre_repas_an,secteurs,type_production,type_gestion,modèle_économique,gestionnaires_additionnels,admin_gestionnaires_additionnels,admin_source_donnees
+21340172201787,Canteen for two,,54460,,700,14000,Cliniques,site,conceded,public,,"user1@example.com,user2@example.com",Automated test
+73282932000074,Staff canteen,,54460,,700,14000,Cliniques,site,conceded,public,user1@example.com,"authenticate@example.com,user2@example.com",Automated test

--- a/api/tests/test_import_canteens.py
+++ b/api/tests/test_import_canteens.py
@@ -325,5 +325,7 @@ class TestCanteenImport(APITestCase):
         self.assertEqual(len(body["errors"]), 1)
         self.assertEqual(body["errors"][0]["status"], 401)
         self.assertTrue(
-            body["errors"][0]["message"].startswith("Vous n'êtes pas autorisé à importer des cantines administratifs"),
+            body["errors"][0]["message"].startswith(
+                "Vous n'êtes pas autorisé à importer des cantines avec des champs administratifs"
+            ),
         )

--- a/api/tests/test_import_diagnostics.py
+++ b/api/tests/test_import_diagnostics.py
@@ -343,6 +343,7 @@ class TestImportDiagnosticsAPI(APITestCase):
         with open(file_path) as diag_file:
             response = self.client.post(reverse("import_diagnostics"), {"file": diag_file})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Canteen.objects.count(), 0)
         self.assertEqual(Diagnostic.objects.count(), 0)
         self._assertImportFailureCreated(authenticate.user, ImportType.DIAGNOSTIC_SIMPLE, file_path)
         body = response.json()

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -119,7 +119,7 @@ class ImportDiagnosticsView(ABC, APIView):
         self.is_admin_import = any("admin_" in column for column in header)
         if self.is_admin_import and not self.request.user.is_staff:
             raise PermissionDenied(
-                detail="Vous n'êtes pas autorisé à importer des diagnostics administratifs. Veillez supprimer les colonnes commençant par 'admin_'"
+                detail="Vous n'êtes pas autorisé à importer des diagnostics avec des champs administratifs. Veuillez supprimer les colonnes commençant par 'admin_'"
             )
 
     def _process_file(self, file):

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -47,6 +47,7 @@ class ImportDiagnosticsView(ABC, APIView):
         self.start_time = None
         self.encoding_detected = None
         self.file = None
+        self.is_admin_import = False
         self.data_schema_canteen = json.load(open("data/schemas/imports/cantines.json"))
         self.data_schema_diagnostics = json.load(open("data/schemas/imports/diagnostics.json"))
         self.data_schema_diagnostics_cc = json.load(open("data/schemas/imports/diagnostics_cc.json"))
@@ -115,8 +116,8 @@ class ImportDiagnosticsView(ABC, APIView):
         )
 
     def check_admin_values(self, header):
-        is_admin_import = any("admin_" in column for column in header)
-        if is_admin_import and not self.request.user.is_staff:
+        self.is_admin_import = any("admin_" in column for column in header)
+        if self.is_admin_import and not self.request.user.is_staff:
             raise PermissionDenied(
                 detail="Vous n'êtes pas autorisé à importer des diagnostics administratifs. Veillez supprimer les colonnes commençant par 'admin_'"
             )

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -41,6 +41,7 @@ class ImportPurchasesView(APIView):
         self.is_duplicate_file = False
         self.duplicate_purchases = []
         self.duplicate_purchase_count = 0
+        self.header = None
         self.schema_url = (
             "https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/staging/data/schemas/imports/achats.json"
         )
@@ -62,7 +63,7 @@ class ImportPurchasesView(APIView):
             self._check_duplication()
 
             self.dialect = file_import.get_csv_file_dialect(self.file)
-            file_import.verify_first_line_is_header(self.file, self.dialect, self.expected_header)
+            self.header = file_import.verify_first_line_is_header(self.file, self.dialect, self.expected_header)
 
             # Step 2: Schema validation (Validata)
             report = validata.validate_file_against_schema(self.file, self.schema_url)

--- a/common/utils/file_import.py
+++ b/common/utils/file_import.py
@@ -69,3 +69,17 @@ def verify_first_line_is_header(file, file_dialect, expected_header):
         raise ValidationError(
             "La première ligne du fichier doit contenir les bon noms de colonnes ET dans le bon ordre"
         )
+    return header
+
+
+def verify_first_line_is_header_list(file, file_dialect, expected_header_list):
+    file.seek(0)
+    row_1 = file.readline()
+    (decoded_row, _) = decode_bytes(row_1)
+    csvreader = csv.reader(io.StringIO("".join(decoded_row)), file_dialect)
+    header = next(csvreader)
+    if header not in expected_header_list:
+        raise ValidationError(
+            "La première ligne du fichier doit contenir les bon noms de colonnes ET dans le bon ordre"
+        )
+    return header

--- a/data/schemas/imports/cantines_admin.json
+++ b/data/schemas/imports/cantines_admin.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+  "encoding": "utf-8",
+  "fields": [
+    {
+      "constraints": {
+        "pattern": "^[0-9]{14}$",
+        "required": true,
+        "unique": true
+      },
+      "description": "Ce SIRET doit être unique car il correspond à un lieu physique.",
+      "example": "49463556926130",
+      "format": "default",
+      "name": "siret",
+      "title": "SIRET de l'établissement",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "required": true
+      },
+      "description": "",
+      "example": "Ecole Jean Jaurès",
+      "format": "default",
+      "name": "nom",
+      "title": "Nom de l'établissement",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "pattern": "^([013-9]\\d|2[AB1-9])\\d{3}$",
+        "required": false
+      },
+      "description": "",
+      "example": "75105",
+      "format": "default",
+      "name": "code_insee_commune",
+      "title": "Code INSEE de la commune",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "pattern": "^[0-9]{5}$",
+        "required": false
+      },
+      "description": "En cas d'absence de code INSEE, ce champ devient obligatoire.",
+      "example": "75100",
+      "format": "default",
+      "name": "code_postal_commune",
+      "title": "Code postal de la commune",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "pattern": "^[0-9]{14}$",
+        "required": false
+      },
+      "description": "Ce SIRET peut être vide ou utilisé pour plusieurs lignes, dans le cas où c'est le gestionnaire du livreur des repas qui remplit les lignes pour chaque cantine satellite.",
+      "example": "29969025300230",
+      "format": "default",
+      "name": "siret_livreur_repas",
+      "title": "SIRET du livreur de repas",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "required": true
+      },
+      "description": "",
+      "example": "300",
+      "format": "default",
+      "name": "nombre_repas_jour",
+      "title": "Nombre de repas servis, en moyenne, par jour dans la cantine",
+      "type": "integer"
+    },
+    {
+      "constraints": {
+        "required": true
+      },
+      "description": "Y compris les couverts livrés.",
+      "example": "67000",
+      "format": "default",
+      "name": "nombre_repas_an",
+      "title": "Nombre de repas servis, en moyenne, par an dans la cantine",
+      "type": "integer"
+    },
+    {
+      "constraints": {
+        "pattern": "^ *(Crèche|Etablissements de la PJJ|Secondaire lycée (hors agricole)|Etablissements d’enseignement agricole|Restaurants administratifs des collectivités territoriales|Restaurants d’entreprises|Restaurants inter-entreprises|Autres structures d’enseignement|Ecole primaire (maternelle et élémentaire)|Secondaire collège|Hôpitaux|Cliniques|Autres établissements de soins|Autres établissements sociaux et médico-sociaux|IME / ITEP, ESAT / Etablissements spécialisés|EHPAD / maisons de retraite / foyers de personnes âgées|Centre de vacances / sportif|Autres établissements de loisirs|Autres établissements non listés|Restaurants des prisons|Restaurants administratifs d’Etat (RA)|Restaurants des armées / police / gendarmerie|Etablissements publics d’Etat (EPA ou EPIC)|Supérieur et Universitaire|Restaurants inter-administratifs d’État (RIA))( *\\+ *(Crèche|Etablissements de la PJJ|Secondaire lycée (hors agricole)|Etablissements d’enseignement agricole|Restaurants administratifs des collectivités territoriales|Restaurants d’entreprises|Restaurants inter-entreprises|Autres structures d’enseignement|Ecole primaire (maternelle et élémentaire)|Secondaire collège|Hôpitaux|Cliniques|Autres établissements de soins|Autres établissements sociaux et médico-sociaux|IME / ITEP, ESAT / Etablissements spécialisés|EHPAD / maisons de retraite / foyers de personnes âgées|Centre de vacances / sportif|Autres établissements de loisirs|Autres établissements non listés|Restaurants des prisons|Restaurants administratifs d’Etat (RA)|Restaurants des armées / police / gendarmerie|Etablissements publics d’Etat (EPA ou EPIC)|Supérieur et Universitaire|Restaurants inter-administratifs d’État (RIA)))* *$",
+        "required": true
+      },
+      "description": "",
+      "doc_enum": [
+        "Crèche",
+        "Etablissements de la PJJ",
+        "Secondaire lycée (hors agricole)",
+        "Etablissements d’enseignement agricole",
+        "Restaurants administratifs des collectivités territoriales",
+        "Restaurants d’entreprises",
+        "Restaurants inter-entreprises",
+        "Autres structures d’enseignement",
+        "Ecole primaire (maternelle et élémentaire)",
+        "Secondaire collège",
+        "Hôpitaux",
+        "Cliniques",
+        "Autres établissements de soins",
+        "Autres établissements sociaux et médico-sociaux",
+        "IME / ITEP, ESAT / Etablissements spécialisés",
+        "EHPAD / maisons de retraite / foyers de personnes âgées",
+        "Centre de vacances / sportif",
+        "Autres établissements de loisirs",
+        "Autres établissements non listés",
+        "Restaurants des prisons",
+        "Restaurants administratifs d’Etat (RA)",
+        "Restaurants des armées / police / gendarmerie",
+        "Etablissements publics d’Etat (EPA ou EPIC)",
+        "Supérieur et Universitaire",
+        "Restaurants inter-administratifs d’État (RIA)"
+      ],
+      "doc_enum_multiple": true,
+      "doc_enum_multiple_seperator": "+",
+      "example": "Crèche+Secondaire lycée (hors agricole)",
+      "format": "default",
+      "name": "secteurs",
+      "title": "Secteurs d'activité de l'établissement",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "pattern": "^ *(central|central_serving|site|site_cooked_elsewhere) *$",
+        "required": true
+      },
+      "description": "Il existe 4 types différents : central (cuisine centrale sans lieu de consommation), central_serving (cuisine centrale qui accueille aussi des convives sur place), site (cantine qui produit les repas sur place), site_cooked_elsewhere (cantine qui sert des repas preparés par une cuisine centrale, appelé également satellite). Dans ce dernier cas, le champ central_producer_siret renseigne l'identifiant SIRET de la cuisine préparant les repas. Dans le cas d'une cantine qui cuisine pour d'autres cantines, le champ 'nombre_satellites' renseigne le nombre de cantines satellites.",
+      "doc_enum": [
+        "central",
+        "central_serving",
+        "site",
+        "site_cooked_elsewhere"
+      ],
+      "example": "central",
+      "format": "default",
+      "name": "type_production",
+      "title": "Lieu de production et de service des repas",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "pattern": "^ *(conceded|direct) *$",
+        "required": true
+      },
+      "description": "Elle peut être gérée directement ('direct') ou de manière concédée ('conceded'). Si de manière concédée, la délégation peut être totale ou partielle.",
+      "doc_enum": [
+        "conceded",
+        "direct"
+      ],
+      "example": "conceded",
+      "format": "default",
+      "name": "type_gestion",
+      "title": "Mode de gestion de la cantine",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "pattern": "^ *(public|private) *$",
+        "required": false
+      },
+      "description": "Il existe 2 types différents : cantine publique ('public'), et cantine privée ('private').",
+      "doc_enum": [
+        "public",
+        "private"
+      ],
+      "example": "public",
+      "format": "default",
+      "name": "modèle_économique",
+      "title": "Secteur économique",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "required": false
+      },
+      "description": "Ces gestionnaires auront la main sur la gestion de l'établissement.",
+      "doc_enum_multiple": true,
+      "doc_enum_multiple_seperator": ",",
+      "example": "gestionnaire1@example.com, gestionnaire2@example.com",
+      "format": "default",
+      "name": "gestionnaires_additionnels",
+      "title": "Adresses mél de gestionnaires additionnels",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "required": false
+      },
+      "description": "Ces gestionnaires auront la main sur la gestion de l'établissement.",
+      "doc_enum_multiple": true,
+      "doc_enum_multiple_seperator": ",",
+      "example": "gestionnaire1@example.com, gestionnaire2@example.com",
+      "format": "default",
+      "name": "admin_gestionnaires_additionnels",
+      "title": "Admin : Adresses mél de gestionnaires additionnels qui seront ajoutés sans être notifiés par email",
+      "type": "string"
+    },
+    {
+      "constraints": {
+        "required": false
+      },
+      "description": "",
+      "example": "resytal",
+      "format": "default",
+      "name": "admin_source_donnees",
+      "title": "Admin : Identifiant décrivant la source de données",
+      "type": "string"
+    }
+  ],
+  "homepage": "https://github.com/betagouv/ma-cantine",
+  "name": "import-cantines-admin",
+  "path": "https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/staging/data/schemas/imports/cantines_admin.json",
+  "title": "Schema import des cantines (admin)"
+}


### PR DESCRIPTION
En séparant la logique cantines & diagnostics, on avait cassé la possibilité donnée aux admin d'importer des champs additionnels.

Modifications apportées : 
- nouveau schéma dédié à l'import admin de cantines (2 champs supplémentaires)
- réintégré la logique admin
- rajouté des tests