### PR TITLE
improve(Imports): Cantines: ajout du champ ministère_tutelle (seulement pour les admins)

### DIFF
--- a/api/tests/files/canteens/canteens_staff_good_new_canteen.csv
+++ b/api/tests/files/canteens/canteens_staff_good_new_canteen.csv
@@ -1,3 +1,3 @@
-siret,nom,code_insee_commune,code_postal_commune,siret_livreur_repas,nombre_repas_jour,nombre_repas_an,secteurs,type_production,type_gestion,modèle_économique,gestionnaires_additionnels,admin_gestionnaires_additionnels,admin_source_donnees
-21340172201787,Canteen for two,,54460,,700,14000,Cliniques,site,conceded,public,,"user1@example.com,user2@example.com",Automated test
-73282932000074,Staff canteen,,54460,,700,14000,Cliniques,site,conceded,public,user1@example.com,"authenticate@example.com,user2@example.com",Automated test
+siret,nom,code_insee_commune,code_postal_commune,siret_livreur_repas,nombre_repas_jour,nombre_repas_an,secteurs,type_production,type_gestion,modèle_économique,gestionnaires_additionnels,admin_ministère_tutelle,admin_gestionnaires_additionnels,admin_source_donnees
+21340172201787,Canteen for two,,54460,,700,14000,Cliniques,site,conceded,public,,sante,"user1@example.com,user2@example.com",Automated test
+73282932000074,Staff canteen,,54460,,700,14000,Cliniques,site,conceded,public,user1@example.com,,"authenticate@example.com,user2@example.com",Automated test

--- a/api/tests/test_import_canteens.py
+++ b/api/tests/test_import_canteens.py
@@ -169,7 +169,7 @@ class TestCanteenImport(APITestCase):
     @authenticate
     def test_import_only_canteens(self):
         """
-        Should be able to import canteens from a file that doesn't have commas for the optional fields
+        Should be able to import canteens
         """
         file_path = "./api/tests/files/canteens/canteens_good.csv"
         with open(file_path) as canteen_file:

--- a/api/tests/test_import_canteens.py
+++ b/api/tests/test_import_canteens.py
@@ -294,6 +294,7 @@ class TestCanteenImport(APITestCase):
         self.assertIsNotNone(ManagerInvitation.objects.get(canteen=canteen1, email="user1@example.com"))
         self.assertIsNotNone(ManagerInvitation.objects.get(canteen=canteen1, email="user2@example.com"))
         self.assertEqual(canteen1.managers.count(), 0)
+        self.assertEqual(canteen1.line_ministry, Canteen.Ministries.SANTE)
         self.assertEqual(canteen1.import_source, "Automated test")
 
         canteen2 = Canteen.objects.get(siret="73282932000074")
@@ -301,6 +302,7 @@ class TestCanteenImport(APITestCase):
         self.assertIsNotNone(ManagerInvitation.objects.get(canteen=canteen2, email="user2@example.com"))
         self.assertEqual(canteen2.managers.count(), 1)
         self.assertEqual(canteen2.managers.first(), user)
+        self.assertEqual(canteen2.line_ministry, None)
         self.assertEqual(canteen2.import_source, "Automated test")
 
         email = mail.outbox[0]

--- a/api/views/canteenimport.py
+++ b/api/views/canteenimport.py
@@ -33,7 +33,7 @@ class ImportCanteensView(APIView):
     permission_classes = [IsAuthenticated]
     value_error_regex = re.compile(r"Field '(.+)' expected .+? got '(.+)'.")
     manager_column_idx = 11  # gestionnaires_additionnels
-    silent_manager_idx = 11 + 1  # admin_gestionnaires_additionnels
+    silent_manager_idx = 11 + 2  # admin_gestionnaires_additionnels
     annotated_sectors = Sector.objects.annotate(name_lower=Lower("name"))
 
     def __init__(self, **kwargs):
@@ -337,6 +337,7 @@ class ImportCanteensView(APIView):
         canteen.management_type = row[9].strip().lower()
         canteen.economic_model = row[10].strip().lower() if row[10] else None
         if self.is_admin_import:
+            canteen.line_ministry = row[12].strip().lower() if row[12] else None
             canteen.import_source = import_source
         if satellite_canteens_count:
             canteen.satellite_canteens_count = satellite_canteens_count

--- a/data/schemas/imports/cantines_admin.json
+++ b/data/schemas/imports/cantines_admin.json
@@ -190,6 +190,41 @@
     },
     {
       "constraints": {
+        "pattern": "^ *(affaires_etrangeres|agriculture|armee|territoires|culture|economie|jeunesse|enseignement_superieur|ecologie|transformation|interieur|justice|mer|administration_territoriale|autorites_independantes|premier_ministre|sante|sport|travail|outre_mer|autre) *$",
+        "required": false
+      },
+      "description": "",
+      "doc_enum": [
+        "affaires_etrangeres",
+        "agriculture",
+        "armee",
+        "territoires",
+        "culture",
+        "economie",
+        "jeunesse",
+        "enseignement_superieur",
+        "ecologie",
+        "transformation",
+        "interieur",
+        "justice",
+        "mer",
+        "administration_territoriale",
+        "autorites_independantes",
+        "premier_ministre",
+        "sante",
+        "sport",
+        "travail",
+        "outre_mer",
+        "autre"
+      ],
+      "example": "agriculture",
+      "format": "default",
+      "name": "admin_ministère_tutelle",
+      "title": "Ministère de tutelle",
+      "type": "string"
+    },
+    {
+      "constraints": {
         "required": false
       },
       "description": "Ces gestionnaires auront la main sur la gestion de l'établissement.",


### PR DESCRIPTION
Suite de #5049

Modifications apportées : 
- ajoute le champ `admin_ministère_tutelle` dans le schéma `cantines_admin.json`
- améliore les tests