### PR TITLE
improve(Cantines): Imports: autoriser les admin à modifier des cantines dont ils ne sont pas gestionnaires

### DIFF
--- a/api/tests/files/canteens/canteens_admin_good_new_canteen.csv
+++ b/api/tests/files/canteens/canteens_admin_good_new_canteen.csv
@@ -1,3 +1,4 @@
 siret,nom,code_insee_commune,code_postal_commune,siret_livreur_repas,nombre_repas_jour,nombre_repas_an,secteurs,type_production,type_gestion,modèle_économique,gestionnaires_additionnels,admin_ministère_tutelle,admin_gestionnaires_additionnels,admin_source_donnees
 21340172201787,Canteen for two,,54460,,700,14000,Cliniques,site,conceded,public,,sante,"user1@example.com,user2@example.com",Automated test
 73282932000074,Staff canteen,,54460,,700,14000,Cliniques,site,conceded,public,user1@example.com,,"authenticate@example.com,user2@example.com",Automated test
+82399356058716,Canteen update,,54460,,700,14000,Cliniques,site,conceded,public,,sante,"user1@example.com,user2@example.com",Automated test

--- a/api/tests/test_import_canteens.py
+++ b/api/tests/test_import_canteens.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from data.factories import CanteenFactory, SectorFactory, UserFactory
+from data.factories import SectorFactory, UserFactory
 from data.models import Canteen, ImportFailure, ImportType, ManagerInvitation
 
 from .utils import authenticate
@@ -231,7 +231,7 @@ class TestCanteenImport(APITestCase):
         )
 
         # not the canteen manager error
-        CanteenFactory.create(siret="82399356058716")
+        Canteen.objects.create(siret="82399356058716")
         file_path = "./api/tests/files/canteens/canteens_bad_nearly_good_2.csv"
         with open(file_path) as canteen_file:
             response = self.client.post(reverse("import_canteens"), {"file": canteen_file})
@@ -266,28 +266,30 @@ class TestCanteenImport(APITestCase):
         )
 
     @authenticate
-    def test_staff_import_new_canteens(self):
+    def test_admin_import(self):
         """
-        Staff get to specify extra columns and have fewer requirements on what data is required.
+        Admin get to specify extra columns and have fewer requirements on what data is required.
         - new canteen: managers are added without sending emails to them.
         - new canteen: the importer isn't added to the canteen unless specified.
+        - updated canteen: admin doesn't have to be a manager.
         """
+        Canteen.objects.create(siret="82399356058716", name="Canteen initial")
         user = authenticate.user
         user.is_staff = True
         user.email = "authenticate@example.com"
         user.save()
 
-        file_path = "./api/tests/files/canteens/canteens_staff_good_new_canteen.csv"
+        file_path = "./api/tests/files/canteens/canteens_admin_good_new_canteen.csv"
         with open(file_path) as canteen_file:
             response = self.client.post(reverse("import_canteens"), {"file": canteen_file})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
 
-        self.assertEqual(body["count"], 2)
-        self.assertEqual(len(body["canteens"]), 2)
+        self.assertEqual(body["count"], 3)
+        self.assertEqual(len(body["canteens"]), 3)
         self.assertEqual(len(body["errors"]), 0)
-        self.assertEqual(Canteen.objects.count(), 2)
-        self.assertEqual(ManagerInvitation.objects.count(), 4)
+        self.assertEqual(Canteen.objects.count(), 3)
+        self.assertEqual(ManagerInvitation.objects.count(), 2 + 2 + 2)
         self.assertEqual(len(mail.outbox), 1)
 
         canteen1 = Canteen.objects.get(siret="21340172201787")
@@ -305,47 +307,13 @@ class TestCanteenImport(APITestCase):
         self.assertEqual(canteen2.line_ministry, None)
         self.assertEqual(canteen2.import_source, "Automated test")
 
-        email = mail.outbox[0]
-        self.assertEqual(email.to[0], "user1@example.com")
-        self.assertNotIn("Canteen for two", email.body)
-        self.assertIn("Staff canteen", email.body)
-
-    @authenticate
-    def test_staff_import_update_canteens(self):
-        Canteen.objects.create(siret="21340172201787", name="Canteen for one")
-        user = authenticate.user
-        user.is_staff = True
-        user.email = "authenticate@example.com"
-        user.save()
-
-        file_path = "./api/tests/files/canteens/canteens_staff_good_new_canteen.csv"
-        with open(file_path) as canteen_file:
-            response = self.client.post(reverse("import_canteens"), {"file": canteen_file})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-
-        self.assertEqual(body["count"], 2)
-        self.assertEqual(len(body["canteens"]), 2)
-        self.assertEqual(len(body["errors"]), 0)
-        self.assertEqual(Canteen.objects.count(), 2)
-        self.assertEqual(ManagerInvitation.objects.count(), 4)
-        self.assertEqual(len(mail.outbox), 1)
-
-        canteen1 = Canteen.objects.get(siret="21340172201787")
-        self.assertIsNotNone(ManagerInvitation.objects.get(canteen=canteen1, email="user1@example.com"))
-        self.assertIsNotNone(ManagerInvitation.objects.get(canteen=canteen1, email="user2@example.com"))
-        self.assertEqual(canteen1.managers.count(), 0)
-        self.assertEqual(canteen1.name, "Canteen for two")  # updated
-        self.assertEqual(canteen1.line_ministry, Canteen.Ministries.SANTE)
-        self.assertEqual(canteen1.import_source, "Automated test")
-
-        canteen2 = Canteen.objects.get(siret="73282932000074")
-        self.assertIsNotNone(ManagerInvitation.objects.get(canteen=canteen2, email="user1@example.com"))
-        self.assertIsNotNone(ManagerInvitation.objects.get(canteen=canteen2, email="user2@example.com"))
-        self.assertEqual(canteen2.managers.count(), 1)
-        self.assertEqual(canteen2.managers.first(), user)
-        self.assertEqual(canteen2.line_ministry, None)
-        self.assertEqual(canteen2.import_source, "Automated test")
+        canteen3 = Canteen.objects.get(siret="82399356058716")
+        self.assertIsNotNone(ManagerInvitation.objects.get(canteen=canteen3, email="user1@example.com"))
+        self.assertIsNotNone(ManagerInvitation.objects.get(canteen=canteen3, email="user2@example.com"))
+        self.assertEqual(canteen3.managers.count(), 0)
+        self.assertEqual(canteen3.name, "Canteen update")  # updated
+        self.assertEqual(canteen3.line_ministry, Canteen.Ministries.SANTE)
+        self.assertEqual(canteen3.import_source, "Automated test")
 
         email = mail.outbox[0]
         self.assertEqual(email.to[0], "user1@example.com")
@@ -357,7 +325,7 @@ class TestCanteenImport(APITestCase):
         """
         Non-staff users shouldn't have staff import capabilities
         """
-        file_path = "./api/tests/files/canteens/canteens_staff_good_new_canteen.csv"
+        file_path = "./api/tests/files/canteens/canteens_admin_good_new_canteen.csv"
         with open(file_path) as canteen_file:
             response = self.client.post(reverse("import_canteens"), {"file": canteen_file})
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/views/canteenimport.py
+++ b/api/views/canteenimport.py
@@ -301,6 +301,9 @@ class ImportCanteensView(APIView):
         return manager_emails
 
     def _has_canteen_permission(self, canteen):
+        # admin bypass the is_canteen_manager check
+        if self.is_admin_import and self.request.user.is_staff:
+            return True
         return self.request.user in canteen.managers.all()
 
     def _update_or_create_canteen(

--- a/data/factories/canteen.py
+++ b/data/factories/canteen.py
@@ -35,6 +35,6 @@ class CanteenFactory(factory.django.DjangoModelFactory):
         if extracted:
             for manager in extracted:
                 self.managers.add(manager)
-        else:
+        else:  # TODO: missing an option to create canteens without managers
             for _ in range(random.randint(1, 2)):
                 self.managers.add(UserFactory.create())


### PR DESCRIPTION
Permettre aux admin de skip la règle nécessitant d'être gestionnaire pour pouvoir modifier une cantine + ajouts de tests