### PR TITLE
improve(Imports): Cantines: mieux documenter les champs admin (les remonter dans le tableau)

### DIFF
--- a/2024-frontend/src/components/ImportSchemaTable.vue
+++ b/2024-frontend/src/components/ImportSchemaTable.vue
@@ -53,6 +53,13 @@ const formatFields = (fields) => {
 <style lang="scss">
 .import-schema-table {
   tr {
+    &:has(.admin) {
+      background-color: var(--background-alt-blue-france) !important;
+      td:first-child,
+      td:nth-child(2) {
+        color: var(--text-title-blue-france) !important;
+      }
+    }
     &:has(.selected) {
       background-color: var(--background-alt-red-marianne) !important;
       td:first-child,

--- a/2024-frontend/src/components/ImportSchemaTableDescriptionCell.vue
+++ b/2024-frontend/src/components/ImportSchemaTableDescriptionCell.vue
@@ -10,6 +10,7 @@ const isSelected = computed(() => {
   const hash = route.hash.replace("#", "")
   return hash === props.id
 })
+const forAdmin = computed(() => props.id.startsWith("admin_"))
 </script>
 
 <template>
@@ -18,6 +19,7 @@ const isSelected = computed(() => {
     class="fr-text--sm fr-mb-1w"
     :class="{
       selected: isSelected,
+      admin: forAdmin,
     }"
   >
     {{ title }}

--- a/2024-frontend/src/components/ImportStaffCallout.vue
+++ b/2024-frontend/src/components/ImportStaffCallout.vue
@@ -7,8 +7,8 @@ const file = "/static/documents/admin_importer_des_cantines_exemple_ma_cantine.c
     <div class="fr-grid-row fr-grid-row--bottom fr-mt-3w">
       <div class="fr-col-12 fr-col-md-8">
         <p class="fr-mb-1w">
-          Vous pouvez ajouter 3 colonnes additionnelles à la fin du fichier CSV : admin_ministère_tutelle,
-          admin_gestionnaires_additionnels & admin_source_donnees.
+          our utiliser l'import admin, vous devez ajouter 3 colonnes additionnelles à la fin du fichier CSV :
+          admin_ministère_tutelle, admin_gestionnaires_additionnels & admin_source_donnees.
         </p>
         <p class="fr-mb-1w">
           Vous pouvez créer des cantines. Vous ne serez pas ajouté·e·s automatiquement à l'équipe de gestion, sauf si

--- a/2024-frontend/src/components/ImportStaffCallout.vue
+++ b/2024-frontend/src/components/ImportStaffCallout.vue
@@ -1,6 +1,4 @@
 <script setup>
-import AppCode from "@/components/AppCode.vue"
-
 const file = "/static/documents/admin_importer_des_cantines_exemple_ma_cantine.csv"
 </script>
 
@@ -8,32 +6,11 @@ const file = "/static/documents/admin_importer_des_cantines_exemple_ma_cantine.c
   <DsfrCallout title="En tant que membre de l'équipe ma cantine" titleTag="h3">
     <div class="fr-grid-row fr-grid-row--bottom fr-mt-3w">
       <div class="fr-col-12 fr-col-md-8">
-        <p>
-          Vous pouvez ajouter 3 colonnes additionnelles à la fin du fichier CSV :
+        <p class="fr-mb-1w">
+          Vous pouvez ajouter 3 colonnes additionnelles à la fin du fichier CSV : admin_ministère_tutelle,
+          admin_gestionnaires_additionnels & admin_source_donnees.
         </p>
-        <ul>
-          <li>
-            <p class="fr-mb-0">
-              <strong>admin_ministère_tutelle</strong>
-              : le ministère de tutelle. Par exemple :
-              <AppCode content="sante" />
-              .
-            </p>
-          </li>
-          <li>
-            <p class="fr-mb-0">
-              <strong>admin_gestionnaires_additionnels</strong>
-              : une liste d'adresses email de gestionnaires qui seront ajoutés sans être notifiés par email
-            </p>
-          </li>
-          <li>
-            <p class="fr-mb-0">
-              <strong>admin_source_donnees</strong>
-              : un identifiant décrivant la source de données
-            </p>
-          </li>
-        </ul>
-        <p>
+        <p class="fr-mb-1w">
           Vous pouvez créer des cantines. Vous ne serez pas ajouté·e·s automatiquement à l'équipe de gestion, sauf si
           votre mail se trouve dans une des colonnes de listes de gestionnaires.
         </p>

--- a/2024-frontend/src/views/ImportCanteens.vue
+++ b/2024-frontend/src/views/ImportCanteens.vue
@@ -12,7 +12,7 @@ import ImportHelp from "@/components/ImportHelp.vue"
 const store = useRootStore()
 
 /* Data */
-const schemaFile = "cantines.json"
+const schemaFile = store.loggedUser.isStaff ? "cantines_admin.json" : "cantines.json"
 const exampleFile = {
   name: "importer_des_cantines_exemple_ma_cantine.csv",
   size: "496 octets",


### PR DESCRIPTION
Suite à #5059 , on améliore l'affichage des champs réservés aux admins

### Captures d'écran

|Avant|Après|
|-|-|
|![image](https://github.com/user-attachments/assets/63b44cf6-9fd2-4158-aba5-7b519cca632e)|![Screenshot from 2025-02-27 18-20-45](https://github.com/user-attachments/assets/e99833d3-266f-4252-9e0d-cb819af3263d)|