### PR TITLE
improve(Cantines): gérer le nouveau champ siren_unite_legale dans les exports Metabase

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -619,6 +619,7 @@ class CanteenMetabaseSerializer(serializers.ModelSerializer):
             "id",
             "nom",
             "siret",
+            "siren_unite_legale",
             "code_insee_commune",
             "libelle_commune",
             "departement",

--- a/data/schemas/export_metabase/schema_cantines.json
+++ b/data/schemas/export_metabase/schema_cantines.json
@@ -22,6 +22,15 @@
     },
     {
       "constraints": {
+        "pattern": "^[0-9]{9}$",
+        "required": false
+      },
+      "example": "110070018",
+      "name": "siren_unite_legale",
+      "type": "string"
+    },
+    {
+      "constraints": {
         "pattern": "^([013-9]\\d|2[AB1-9])\\d{3}$",
         "required": false
       },

--- a/data/schemas/export_opendata/schema_cantines.json
+++ b/data/schemas/export_opendata/schema_cantines.json
@@ -22,6 +22,13 @@
       "type": "string"
     },
     {
+      "description": "Identifiant du [Système d'Identification du Répertoire des Entreprises](https://fr.wikipedia.org/wiki/Syst%C3%A8me_d%27identification_du_r%C3%A9pertoire_des_entreprises) (SIREN) qui identifie l'unité légale de la cantine (lorsqu'elle n'a pas de SIRET)",
+      "example": "200058220",
+      "name": "siren_unite_legale",
+      "title": "Siren de l'unité légale",
+      "type": "string"
+    },
+    {
       "description": "Ville dans laquelle se trouve la cantine",
       "example": "Marigny-Le-Lozon",
       "name": "city",


### PR DESCRIPTION
Suite de https://github.com/betagouv/ma-cantine/pull/5081