### PR TITLE
improve(Ajouter une cantine): vérification des champs avant l'envoi du formulaire de création #5086 

### DIFF
--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -44,7 +44,7 @@ const initFields = () => {
 initFields()
 
 /* Fields verification */
-const { required, integer, minValue, requiredIf, sameAs, not } = useValidators()
+const { required, integer, minValue, requiredIf, sameAs, not, minLength, maxLength } = useValidators()
 const dailyMealRequired = computed(() => form.productionType !== "central")
 const yearlyMealMinValue = computed(() => form.dailyMealCount || 0)
 const rules = {
@@ -68,6 +68,9 @@ const rules = {
       "Le numéro SIRET du livreur ne peut pas être le même que celui de la cantine",
       not(sameAs(form.siret))
     ),
+    integer,
+    minLength: helpers.withMessage("Le numéro SIRET doit contenir 14 caractères", minLength(14)),
+    maxLength: helpers.withMessage("Le numéro SIRET doit contenir 14 caractères", maxLength(14)),
   },
 }
 const v$ = useVuelidate(rules, form)

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -3,6 +3,7 @@ import "@/css/dsfr-multi-select.css"
 import { ref, reactive, computed } from "vue"
 import { useVuelidate } from "@vuelidate/core"
 import { useValidators } from "@/validators.js"
+import { formatError } from "@/utils.js"
 import sectorsService from "@/services/sectors"
 import { createCanteen } from "@/services/canteens"
 import options from "@/constants/canteen-creation-form-options"
@@ -159,6 +160,7 @@ const getSectorsID = (activitiesSelected) => {
           label="Nom de la cantine"
           :label-visible="true"
           hint="Choisir un nom précis pour votre établissement permet aux convives de vous trouver plus facilement. Par exemple :  École maternelle Olympe de Gouges, Centre Hospitalier de Bayonne..."
+          :error-message="formatError(v$.name)"
         />
       </fieldset>
       <fieldset class="fr-mb-3w">
@@ -169,24 +171,28 @@ const getSectorsID = (activitiesSelected) => {
           :small="true"
           :options="options.economicModel"
           @change="verifyLineMinistry()"
+          :error-message="formatError(v$.economicModel)"
         />
         <DsfrRadioButtonSet
           legend="Mode de gestion"
           v-model="form.managementType"
           :small="true"
           :options="options.managementType"
+          :error-message="formatError(v$.managementType)"
         />
         <DsfrRadioButtonSet
           legend="Mode de production"
           v-model="form.productionType"
           :small="true"
           :options="options.productionType"
+          :error-message="formatError(v$.productionType)"
         />
         <div v-if="showCentralProducerSiret" class="canteen-creation-form__central-producer-siret">
           <DsfrInputGroup
             v-model="form.centralProducerSiret"
             label="SIRET du livreur"
             :label-visible="true"
+            :error-message="formatError(v$.centralProducerSiret)"
           />
           <p class="fr-hint-text">
             Vous ne le connaissez pas ? Trouvez-le avec
@@ -201,6 +207,7 @@ const getSectorsID = (activitiesSelected) => {
           label="Nombre de cuisine satellite"
           hint="Nombre de cantines/lieux de service à qui je fournis des repas"
           :label-visible="true"
+          :error-message="formatError(v$.satelliteCanteensCount)"
         />
       </fieldset>
       <fieldset class="fr-mb-7w">
@@ -211,6 +218,7 @@ const getSectorsID = (activitiesSelected) => {
           labelVisible
           :options="sectorsCategoryOptions"
           @change="changeCategory()"
+          :error-message="formatError(v$.sectorCategory)"
         />
         <DsfrMultiselect
           v-model="form.sectorActivity"
@@ -222,6 +230,7 @@ const getSectorsID = (activitiesSelected) => {
           search
           :filtering-keys="['name']"
           @change="verifyLineMinistry()"
+          :error-message="formatError(v$.sectorActivity)"
         >
           <template #no-results>
             Sélectionner une catégorie de secteur pour pouvoir sélectionner des secteurs d'activité
@@ -234,6 +243,7 @@ const getSectorsID = (activitiesSelected) => {
           description="Hors fonction publique territoriale et hospitalière"
           labelVisible
           :options="ministryOptions"
+          :error-message="formatError(v$.ministry)"
         />
       </fieldset>
       <fieldset class="fr-mb-7w">
@@ -250,6 +260,7 @@ const getSectorsID = (activitiesSelected) => {
               :disabled="hideDailyMealCount"
               :hint="hideDailyMealCount ? 'Concerne uniquement les cantines recevant des convives' : ''"
               type="number"
+              :error-message="formatError(v$.dailyMealCount)"
             />
           </div>
           <div class="fr-col-6">
@@ -258,6 +269,7 @@ const getSectorsID = (activitiesSelected) => {
               label="Par an"
               :label-visible="true"
               type="number"
+              :error-message="formatError(v$.yearlyMealCount)"
             />
           </div>
         </div>

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -1,6 +1,8 @@
 <script setup>
 import "@/css/dsfr-multi-select.css"
 import { ref, reactive, computed } from "vue"
+import { useVuelidate } from "@vuelidate/core"
+import { useValidators } from "@/validators.js"
 import sectorsService from "@/services/sectors"
 import { createCanteen } from "@/services/canteens"
 import options from "@/constants/canteen-creation-form-options"
@@ -37,6 +39,12 @@ const initFields = () => {
   form.satelliteCanteensCount = ""
 }
 initFields()
+const v$ = useVuelidate(rules, form)
+const validateForm = () => {
+  v$.value.$validate()
+  if (v$.value.$invalid) return
+  sendCanteenForm()
+}
 
 /* Line Ministry */
 const ministries = reactive({})
@@ -112,7 +120,7 @@ const getSectorsID = (activitiesSelected) => {
   <section
     class="canteen-creation-form fr-background-alt--blue-france fr-p-3w fr-mt-4w fr-grid-row fr-grid-row--center"
   >
-    <form class="fr-col-12 fr-col-md-7 fr-background-default--grey fr-p-2w fr-p-md-7w" @submit.prevent="submit()">
+    <form class="fr-col-12 fr-col-md-7 fr-background-default--grey fr-p-2w fr-p-md-7w" @submit.prevent="validateForm()">
       <fieldset class="fr-mb-7w">
         <legend class="fr-h5">1. SIRET</legend>
       </fieldset>

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -74,7 +74,7 @@ const showSatelliteCanteensCount = computed(
 )
 
 /* Send Form */
-const submit = () => {
+const sendCanteenForm = () => {
   const payload = {
     siret: "00000000000000", // TODO à mettre en dynmaique ensuite
     postalCode: "73000", // TODO à mettre en dynmaique ensuite

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -39,6 +39,34 @@ const initFields = () => {
   form.satelliteCanteensCount = ""
 }
 initFields()
+
+/* Dynamics rules */
+const getDailyMealCountRules = (productionType) => {
+  const rules = {
+    required,
+    integer,
+    minValue: minValue(0),
+  }
+  if (productionType === "central") delete rules.required
+  return rules
+}
+
+/* Fields verification */
+const { required, integer, minValue } = useValidators()
+const dailyMealCountRules = computed(() => getDailyMealCountRules(form.productionType))
+const rules = {
+  name: { required },
+  economicModel: { required },
+  managementType: { required },
+  productionType: { required },
+  sectorCategory: { required },
+  sectorActivity: { required },
+  ministry: { required },
+  dailyMealCount: dailyMealCountRules,
+  yearlyMealCount: { required, integer, minValue: minValue(0) },
+  satelliteCanteensCount: { required, integer, minValue: minValue(0) },
+  centralProducerSiret: { required },
+}
 const v$ = useVuelidate(rules, form)
 const validateForm = () => {
   v$.value.$validate()

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -45,6 +45,7 @@ initFields()
 /* Fields verification */
 const { required, integer, minValue, requiredIf, sameAs, not } = useValidators()
 const dailyMealRequired = computed(() => form.productionType !== "central")
+const yearlyMealMinValue = computed(() => form.dailyMealCount || 0)
 const rules = {
   name: { required },
   economicModel: { required },
@@ -58,7 +59,7 @@ const rules = {
     integer,
     minValue: minValue(0),
   },
-  yearlyMealCount: { required, integer, minValue: minValue(0) },
+  yearlyMealCount: { required, integer, minValue: minValue(yearlyMealMinValue) },
   satelliteCanteensCount: { required, integer, minValue: minValue(0) },
   centralProducerSiret: { required, notSameSiret: not(sameAs(form.siret)) },
 }

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -111,9 +111,7 @@ const rules = {
 const v$ = useVuelidate(rules, form)
 const validateForm = () => {
   v$.value.$validate()
-  console.log("invalid", v$)
   if (v$.value.$invalid) return
-  console.log("validate")
   sendCanteenForm()
 }
 

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -135,8 +135,6 @@ const sendCanteenForm = () => {
     satelliteCanteensCount: Number(form.satelliteCanteensCount),
   }
 
-  console.log("createCanteen")
-
   createCanteen(payload).then((response) => {
     console.log("response", response)
   })

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -1,6 +1,7 @@
 <script setup>
 import "@/css/dsfr-multi-select.css"
 import { ref, reactive, computed } from "vue"
+import { helpers } from "@vuelidate/validators"
 import { useVuelidate } from "@vuelidate/core"
 import { useValidators } from "@/validators.js"
 import { formatError } from "@/utils.js"
@@ -61,7 +62,13 @@ const rules = {
   },
   yearlyMealCount: { required, integer, minValue: minValue(yearlyMealMinValue) },
   satelliteCanteensCount: { required, integer, minValue: minValue(0) },
-  centralProducerSiret: { required, notSameSiret: not(sameAs(form.siret)) },
+  centralProducerSiret: {
+    required,
+    notSameSiret: helpers.withMessage(
+      "Le numéro SIRET du livreur ne peut pas être le même que celui de la cantine",
+      not(sameAs(form.siret))
+    ),
+  },
 }
 const v$ = useVuelidate(rules, form)
 const validateForm = () => {

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -154,7 +154,7 @@ const getSectorsID = (activitiesSelected) => {
       </fieldset>
       <fieldset class="fr-mb-7w">
         <legend class="fr-h5">2. Coordonnées</legend>
-        <DsfrInput
+        <DsfrInputGroup
           v-model="form.name"
           label="Nom de la cantine"
           :label-visible="true"
@@ -182,16 +182,19 @@ const getSectorsID = (activitiesSelected) => {
           :small="true"
           :options="options.productionType"
         />
-        <DsfrInput v-if="showCentralProducerSiret" v-model="form.centralProducerSiret" :label-visible="true">
-          <template #label>
-            SIRET du livreur
-            <span class="fr-hint-text">
-              Vous ne le connaissez pas ? Trouvez-le avec
-              <a href="https://annuaire-entreprises.data.gouv.fr/" target="_blank">l'annuaire-des-entreprises</a>
-            </span>
-          </template>
-        </DsfrInput>
-        <DsfrInput
+        <div v-if="showCentralProducerSiret" class="canteen-creation-form__central-producer-siret">
+          <DsfrInputGroup
+            v-model="form.centralProducerSiret"
+            label="SIRET du livreur"
+            :label-visible="true"
+          />
+          <p class="fr-hint-text">
+            Vous ne le connaissez pas ? Trouvez-le avec
+            <a href="https://annuaire-entreprises.data.gouv.fr/" target="_blank">l'annuaire-des-entreprises</a>
+          </p>
+        </div>
+
+        <DsfrInputGroup
           v-if="showSatelliteCanteensCount"
           v-model="form.satelliteCanteensCount"
           type="number"
@@ -237,7 +240,7 @@ const getSectorsID = (activitiesSelected) => {
         <legend class="fr-h5">5. Nombre de repas</legend>
         <div class="fr-grid-row fr-grid-row--gutters">
           <div class="fr-col-6">
-            <DsfrInput
+            <DsfrInputGroup
               :class="{
                 hide: hideDailyMealCount,
               }"
@@ -250,7 +253,12 @@ const getSectorsID = (activitiesSelected) => {
             />
           </div>
           <div class="fr-col-6">
-            <DsfrInput v-model="form.yearlyMealCount" label="Par an" :label-visible="true" type="number" />
+            <DsfrInputGroup
+              v-model="form.yearlyMealCount"
+              label="Par an"
+              :label-visible="true"
+              type="number"
+            />
           </div>
         </div>
       </fieldset>
@@ -267,6 +275,12 @@ const getSectorsID = (activitiesSelected) => {
 .canteen-creation-form {
   .hide {
     display: none !important;
+  }
+
+  &__central-producer-siret {
+    .fr-input-group {
+      margin-bottom: 0.25rem !important;
+    }
   }
 }
 </style>

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -41,20 +41,9 @@ const initFields = () => {
 }
 initFields()
 
-/* Dynamics rules */
-const getDailyMealCountRules = (productionType) => {
-  const rules = {
-    required,
-    integer,
-    minValue: minValue(0),
-  }
-  if (productionType === "central") delete rules.required
-  return rules
-}
-
 /* Fields verification */
-const { required, integer, minValue } = useValidators()
-const dailyMealCountRules = computed(() => getDailyMealCountRules(form.productionType))
+const { required, integer, minValue, requiredIf } = useValidators()
+const dailyMealRequired = computed(() => form.productionType !== "central")
 const rules = {
   name: { required },
   economicModel: { required },
@@ -63,7 +52,11 @@ const rules = {
   sectorCategory: { required },
   sectorActivity: { required },
   ministry: { required },
-  dailyMealCount: dailyMealCountRules,
+  dailyMealCount: {
+    required: requiredIf(dailyMealRequired),
+    integer,
+    minValue: minValue(0),
+  },
   yearlyMealCount: { required, integer, minValue: minValue(0) },
   satelliteCanteensCount: { required, integer, minValue: minValue(0) },
   centralProducerSiret: { required },

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -28,7 +28,7 @@ const changeCategory = () => {
 /* Form fields */
 const form = reactive({})
 const initFields = () => {
-  form.siret = "000000000000000"
+  form.siret = ""
   form.name = ""
   form.economicModel = ""
   form.managementType = ""

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -27,6 +27,7 @@ const changeCategory = () => {
 /* Form fields */
 const form = reactive({})
 const initFields = () => {
+  form.siret = "000000000000000"
   form.name = ""
   form.economicModel = ""
   form.managementType = ""
@@ -42,7 +43,7 @@ const initFields = () => {
 initFields()
 
 /* Fields verification */
-const { required, integer, minValue, requiredIf } = useValidators()
+const { required, integer, minValue, requiredIf, sameAs, not } = useValidators()
 const dailyMealRequired = computed(() => form.productionType !== "central")
 const rules = {
   name: { required },
@@ -59,7 +60,7 @@ const rules = {
   },
   yearlyMealCount: { required, integer, minValue: minValue(0) },
   satelliteCanteensCount: { required, integer, minValue: minValue(0) },
-  centralProducerSiret: { required },
+  centralProducerSiret: { required, notSameSiret: not(sameAs(form.siret)) },
 }
 const v$ = useVuelidate(rules, form)
 const validateForm = () => {

--- a/2024-frontend/src/locales/fr.json
+++ b/2024-frontend/src/locales/fr.json
@@ -5,7 +5,6 @@
     "integer": "Ce champ doit être un nombre entier",
     "maxValue": "La valeur maximum est {max}",
     "minValue": "La valeur minimum est {min}",
-    "notSameSiret": "Le numéro SIRET du livreur ne peut pas être le même que celui de la cantine",
     "required": "Ce champ est obligatoire"
   }
 }

--- a/2024-frontend/src/locales/fr.json
+++ b/2024-frontend/src/locales/fr.json
@@ -5,6 +5,7 @@
     "integer": "Ce champ doit être un nombre entier",
     "maxValue": "La valeur maximum est {max}",
     "minValue": "La valeur minimum est {min}",
+    "notSameSiret": "Le numéro SIRET du livreur ne peut pas être le même que celui de la cantine",
     "required": "Ce champ est obligatoire"
   }
 }

--- a/2024-frontend/src/validators.js
+++ b/2024-frontend/src/validators.js
@@ -4,7 +4,7 @@ import { useI18n } from "vue-i18n"
 // To use more vuelidate validators, add the name of the validator to the appropriate array
 // and add the translation for the error message in @/locales/...
 const VUELIDATE_VALIDATORS = ["required", "integer", "decimal", "email"]
-const VUELIDATE_VALIDATORS_WITH_ARGS = ["minValue", "maxValue", "requiredIf", "not", "sameAs"]
+const VUELIDATE_VALIDATORS_WITH_ARGS = ["minValue", "maxValue", "requiredIf", "not", "sameAs", "minLength", "maxLength"]
 
 // https://github.com/vuelidate/vuelidate/issues/1164#issuecomment-2104538357
 export const useValidators = () => {

--- a/2024-frontend/src/validators.js
+++ b/2024-frontend/src/validators.js
@@ -4,7 +4,7 @@ import { useI18n } from "vue-i18n"
 // To use more vuelidate validators, add the name of the validator to the appropriate array
 // and add the translation for the error message in @/locales/...
 const VUELIDATE_VALIDATORS = ["required", "integer", "decimal", "email"]
-const VUELIDATE_VALIDATORS_WITH_ARGS = ["minValue", "maxValue", "requiredIf"]
+const VUELIDATE_VALIDATORS_WITH_ARGS = ["minValue", "maxValue", "requiredIf", "not", "sameAs"]
 
 // https://github.com/vuelidate/vuelidate/issues/1164#issuecomment-2104538357
 export const useValidators = () => {

--- a/2024-frontend/src/validators.js
+++ b/2024-frontend/src/validators.js
@@ -4,7 +4,7 @@ import { useI18n } from "vue-i18n"
 // To use more vuelidate validators, add the name of the validator to the appropriate array
 // and add the translation for the error message in @/locales/...
 const VUELIDATE_VALIDATORS = ["required", "integer", "decimal", "email"]
-const VUELIDATE_VALIDATORS_WITH_ARGS = ["minValue", "maxValue"]
+const VUELIDATE_VALIDATORS_WITH_ARGS = ["minValue", "maxValue", "requiredIf"]
 
 // https://github.com/vuelidate/vuelidate/issues/1164#issuecomment-2104538357
 export const useValidators = () => {


### PR DESCRIPTION
- Vérification des champ avant l'envoi du formulaire
- L'affichage des erreurs utilise le style DSFR
- Vérification dynamiques en fonction des champs, et des valeur du form
- Une régression est présente : la vérification du SIRET livreur n'utillise pas l'algo de luhn. Je me dit que c'est ok pour une V1 (comme on a ça actuellement dans les imports), et à améliorer en V2 ?

![Screenshot 2025-03-04 at 12-37-31 Ajouter une cantine - ma cantine](https://github.com/user-attachments/assets/c96b7716-2e36-424c-aa36-19546665113c)
