### PR TITLE
refactor(TD): bouger les queryset de stats dans les modèles

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -36,25 +36,32 @@ class DiagnosticQuerySet(models.QuerySet):
             teledeclaration__status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
         )
 
-    def for_stat(self, year):
-        year = int(year)
-
+    def canteen_for_stat(self, year):
         return (
             self.select_related("canteen")
-            .td_submitted_for_year(year)
             .filter(
                 canteen__id__isnull=False,
                 canteen__siret__isnull=False,
-                value_total_ht__isnull=False,
-                value_bio_ht__isnull=False,
             )
+            .exclude(canteen__siret="")
             .exclude(
                 canteen__deletion_date__range=(
                     CAMPAIGN_DATES[year]["start_date"],
                     CAMPAIGN_DATES[year]["end_date"],
                 )
             )
-            .exclude(canteen__siret="")
+        )
+
+    def for_stat(self, year):
+        year = int(year)
+
+        return (
+            self.canteen_for_stat(year)
+            .td_submitted_for_year(year)
+            .filter(
+                value_total_ht__isnull=False,
+                value_bio_ht__isnull=False,
+            )
         )
 
 

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -27,7 +27,7 @@ class DiagnosticQuerySet(models.QuerySet):
         year = int(year)
         from .teledeclaration import Teledeclaration
 
-        return self.filter(
+        return self.select_related("teledeclaration").filter(
             year=year,
             teledeclaration__creation_date__range=(
                 CAMPAIGN_DATES[year]["start_date"],
@@ -40,7 +40,8 @@ class DiagnosticQuerySet(models.QuerySet):
         year = int(year)
 
         return (
-            self.td_submitted_for_year(year)
+            self.select_related("canteen")
+            .td_submitted_for_year(year)
             .filter(
                 canteen__id__isnull=False,
                 canteen__siret__isnull=False,

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -27,7 +27,7 @@ class DiagnosticQuerySet(models.QuerySet):
         year = int(year)
         from .teledeclaration import Teledeclaration
 
-        return self.select_related("teledeclaration").filter(
+        return self.filter(
             year=year,
             teledeclaration__creation_date__range=(
                 CAMPAIGN_DATES[year]["start_date"],

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -14,7 +14,7 @@ from data.utils import (
     get_diagnostic_upper_limit_year,
     make_optional_positive_decimal_field,
 )
-from macantine import utils
+from macantine.utils import CAMPAIGN_DATES
 
 from .canteen import Canteen
 
@@ -23,18 +23,25 @@ class DiagnosticQuerySet(models.QuerySet):
     """
     Fetching the diagnostics for wich the data has been validated for stats"""
 
-    def for_stat(self, year):
+    def td_submitted_for_year(self, year):
         year = int(year)
         from .teledeclaration import Teledeclaration
 
+        return self.filter(
+            year=year,
+            teledeclaration__creation_date__range=(
+                CAMPAIGN_DATES[year]["start_date"],
+                CAMPAIGN_DATES[year]["end_date"],
+            ),
+            teledeclaration__status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
+        )
+
+    def for_stat(self, year):
+        year = int(year)
+
         return (
-            self.filter(
-                year=year,
-                teledeclaration__creation_date__range=(
-                    utils.CAMPAIGN_DATES[year]["start_date"],
-                    utils.CAMPAIGN_DATES[year]["end_date"],
-                ),
-                teledeclaration__status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
+            self.td_submitted_for_year(year)
+            .filter(
                 canteen__id__isnull=False,
                 canteen__siret__isnull=False,
                 value_total_ht__isnull=False,
@@ -42,20 +49,12 @@ class DiagnosticQuerySet(models.QuerySet):
             )
             .exclude(
                 canteen__deletion_date__range=(
-                    utils.CAMPAIGN_DATES[year]["start_date"],
-                    utils.CAMPAIGN_DATES[year]["end_date"],
+                    CAMPAIGN_DATES[year]["start_date"],
+                    CAMPAIGN_DATES[year]["end_date"],
                 )
             )
             .exclude(canteen__siret="")
         )
-
-
-class DiagsForStatManager(models.Manager):
-    def get_queryset(self):
-        return DiagnosticQuerySet(self.model, using=self._db)
-
-    def for_stat(self, year):
-        return self.get_queryset().for_stat(year)
 
 
 class Diagnostic(models.Model):
@@ -162,6 +161,7 @@ class Diagnostic(models.Model):
         PUBLISHED = "published", "✅ Publié"
 
     objects = models.Manager.from_queryset(DiagnosticQuerySet)()
+
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
     history = HistoricalRecords()

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -35,23 +35,31 @@ class TeledeclarationQuerySet(models.QuerySet):
             status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
         )
 
-    def for_stat(self, year):
+    def canteen_for_stat(self, year):
         return (
-            self.select_related("canteen", "diagnostic")
-            .submitted_for_year(year)
+            self.select_related("canteen")
             .filter(
                 canteen_id__isnull=False,
                 canteen_siret__isnull=False,
-                diagnostic__value_total_ht__isnull=False,
-                diagnostic__value_bio_ht__isnull=False,
             )
+            .exclude(canteen_siret="")
             .exclude(
                 canteen__deletion_date__range=(
                     CAMPAIGN_DATES[year]["start_date"],
                     CAMPAIGN_DATES[year]["end_date"],
                 )
             )
-            .exclude(canteen_siret="")
+        )
+
+    def for_stat(self, year):
+        return (
+            self.canteen_for_stat(year)
+            .submitted_for_year(year)
+            .select_related("diagnostic")
+            .filter(
+                diagnostic__value_total_ht__isnull=False,
+                diagnostic__value_bio_ht__isnull=False,
+            )
         )
 
 

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from simple_history.models import HistoricalRecords
 
 from data.models import AuthenticationMethodHistoricalRecords, Canteen, Diagnostic
+from macantine.utils import CAMPAIGN_DATES
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,36 @@ class CustomJSONEncoder(DjangoJSONEncoder):
         if isinstance(o, Decimal):
             return float(o)
         return super(CustomJSONEncoder, self).default(o)
+
+
+class TeledeclarationQuerySet(models.QuerySet):
+    def submitted_for_year(self, year):
+        return self.filter(
+            year=year,
+            creation_date__range=(
+                CAMPAIGN_DATES[year]["start_date"],
+                CAMPAIGN_DATES[year]["end_date"],
+            ),
+            status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
+        )
+
+    def for_stat(self, year):
+        return (
+            self.submitted_for_year(year)
+            .filter(
+                canteen_id__isnull=False,
+                canteen_siret__isnull=False,
+                diagnostic__value_total_ht__isnull=False,
+                diagnostic__value_bio_ht__isnull=False,
+            )
+            .exclude(
+                canteen__deletion_date__range=(
+                    CAMPAIGN_DATES[year]["start_date"],
+                    CAMPAIGN_DATES[year]["end_date"],
+                )
+            )
+            .exclude(canteen_siret="")
+        )
 
 
 class Teledeclaration(models.Model):
@@ -49,6 +80,8 @@ class Teledeclaration(models.Model):
             "Cuisine centrale déclarant toutes les données EGalim pour ses cuisines satellites",
         )
         SITE = "SITE", "Cantine déclarant ses propres données"
+
+    objects = models.Manager.from_queryset(TeledeclarationQuerySet)()
 
     # Fields that pertain to the teledeclaration. These fields
     # will not change and should contain all information to be

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -37,7 +37,8 @@ class TeledeclarationQuerySet(models.QuerySet):
 
     def for_stat(self, year):
         return (
-            self.submitted_for_year(year)
+            self.select_related("canteen", "diagnostic")
+            .submitted_for_year(year)
             .filter(
                 canteen_id__isnull=False,
                 canteen_siret__isnull=False,

--- a/data/tests/test_teledeclaration.py
+++ b/data/tests/test_teledeclaration.py
@@ -15,7 +15,7 @@ mocked_campaign_dates = {
 }
 
 
-class DiagnosticQuerySetTest(TestCase):
+class TeledeclarationQuerySetTest(TestCase):
     def setUp(self):
         """
         Set up mock data for testing.
@@ -39,7 +39,9 @@ class DiagnosticQuerySetTest(TestCase):
             value_total_ht=1000.00,
             value_bio_ht=200.00,
         )
-        Teledeclaration.create_from_diagnostic(self.valid_canteen_diagnostic, applicant=UserFactory.create())
+        self.valid_canteen_td = Teledeclaration.create_from_diagnostic(
+            self.valid_canteen_diagnostic, applicant=UserFactory.create()
+        )
 
         self.invalid_canteen_diagnostic = Diagnostic.objects.create(
             year=year_data,
@@ -48,7 +50,9 @@ class DiagnosticQuerySetTest(TestCase):
             value_total_ht=1000.00,
             value_bio_ht=200.00,
         )
-        Teledeclaration.create_from_diagnostic(self.invalid_canteen_diagnostic, applicant=UserFactory.create())
+        self.invalid_canteen_td = Teledeclaration.create_from_diagnostic(
+            self.invalid_canteen_diagnostic, applicant=UserFactory.create()
+        )
 
         self.deleted_canteen_diagnostic = Diagnostic.objects.create(
             year=year_data,
@@ -57,20 +61,22 @@ class DiagnosticQuerySetTest(TestCase):
             value_total_ht=1000.00,
             value_bio_ht=200.00,
         )
-        Teledeclaration.create_from_diagnostic(self.deleted_canteen_diagnostic, applicant=UserFactory.create())
+        self.deleted_canteen_td = Teledeclaration.create_from_diagnostic(
+            self.deleted_canteen_diagnostic, applicant=UserFactory.create()
+        )
 
-    def test_td_submitted_for_year(self):
-        with patch("data.models.diagnostic.CAMPAIGN_DATES", mocked_campaign_dates):
-            diagnostics = Diagnostic.objects.td_submitted_for_year(year_data)
-        self.assertEqual(diagnostics.count(), 3)
-        self.assertIn(self.valid_canteen_diagnostic, diagnostics)
-        self.assertIn(self.invalid_canteen_diagnostic, diagnostics)
-        self.assertIn(self.deleted_canteen_diagnostic, diagnostics)
+    def test_submitted_for_year(self):
+        with patch("data.models.teledeclaration.CAMPAIGN_DATES", mocked_campaign_dates):
+            teledeclarations = Teledeclaration.objects.submitted_for_year(year_data)
+        self.assertEqual(teledeclarations.count(), 3)
+        self.assertIn(self.valid_canteen_td, teledeclarations)
+        self.assertIn(self.invalid_canteen_td, teledeclarations)
+        self.assertIn(self.deleted_canteen_td, teledeclarations)
 
     def test_for_stat(self):
-        with patch("data.models.diagnostic.CAMPAIGN_DATES", mocked_campaign_dates):
-            diagnostics = Diagnostic.objects.for_stat(year_data)
-        self.assertEqual(diagnostics.count(), 1)
-        self.assertIn(self.valid_canteen_diagnostic, diagnostics)
-        self.assertNotIn(self.invalid_canteen_diagnostic, diagnostics)  # canteen without siret
-        self.assertNotIn(self.deleted_canteen_diagnostic, diagnostics)  # canteen deleted
+        with patch("data.models.teledeclaration.CAMPAIGN_DATES", mocked_campaign_dates):
+            teledeclarations = Teledeclaration.objects.for_stat(year_data)
+        self.assertEqual(teledeclarations.count(), 1)
+        self.assertIn(self.valid_canteen_td, teledeclarations)
+        self.assertNotIn(self.invalid_canteen_td, teledeclarations)  # canteen without siret
+        self.assertNotIn(self.deleted_canteen_td, teledeclarations)  # canteen deleted

--- a/macantine/etl/analysis.py
+++ b/macantine/etl/analysis.py
@@ -212,7 +212,7 @@ class ETL_ANALYSIS_TELEDECLARATIONS(ANALYSIS, etl.TELEDECLARATIONS):
 
     def __init__(self):
         super().__init__()
-        self.years = utils.CAMPAIGN_DATES.keys()
+        self.years = CAMPAIGN_DATES.keys()
         self.extracted_table_name = "teledeclarations"
         self.warehouse = DataWareHouse()
         self.schema = json.load(open("data/schemas/export_metabase/schema_teledeclarations.json"))

--- a/macantine/etl/utils.py
+++ b/macantine/etl/utils.py
@@ -8,7 +8,6 @@ import pandas as pd
 import requests
 
 from data.models import Sector, Teledeclaration
-from macantine.utils import CAMPAIGN_DATES
 
 logger = logging.getLogger(__name__)
 
@@ -114,14 +113,7 @@ def map_canteens_td(year):
     Populate mapper for a given year. The mapper indicates if one canteen has participated in campaign
     """
     # Check and fetch Teledeclaration data from the database
-    tds = Teledeclaration.objects.filter(
-        year=year,
-        creation_date__range=(
-            CAMPAIGN_DATES[year]["start_date"],
-            CAMPAIGN_DATES[year]["end_date"],
-        ),
-        status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
-    ).values("canteen_id", "declared_data")
+    tds = Teledeclaration.objects.submitted_for_year(year).values("canteen_id", "declared_data")
 
     # Populate the mapper for the given year
     participation = []
@@ -139,7 +131,7 @@ def format_td_sector_column(row: pd.Series, sector_col_name: str):
     If there are multiple sectors, we
     """
     x = row[sector_col_name]
-    if type(x) == list:
+    if type(x) is list:
         if len(x) > 1:
             return "Secteurs multiples", "Catégories multiples"
         elif len(x) == 1:
@@ -268,7 +260,7 @@ def format_list_to_single_value(values, col_name) -> str:
     Splitting sectors information into two new columns, one for the sector, one for the category
     If there are multiple sectors, we
     """
-    if type(values) == list:
+    if type(values) is list:
         if len(values) > 1:
             return f"{col_name} multiples"
         elif len(values) == 1:


### PR DESCRIPTION
Modifications apportées en lien avec les stats : 
- séparer / ajouter des queryset supplémentaires dans les modèles `Diagnostic` & `Teledeclaration`
  - pour avoir la logique à un seul endroit : les modèles
  - changements à venir dans #5082
- import CAMPAIGN_DATES d'un seul endroit
- ajouter des select_related
- réparer les tests

||Diagnostic|Teledeclaration|
|-|-|-|
|Avant|Queryset `for_stat`||
|Après|Queryset `for_stat` & `td_submitted_for_year`|Queryset `for_stat` & `submitted_for_year`|