### PR TITLE
test(Import): Vérifier que les imports uniformisent les apostrophes

### DIFF
--- a/api/tests/files/canteens/canteens_sectors.csv
+++ b/api/tests/files/canteens/canteens_sectors.csv
@@ -1,0 +1,3 @@
+siret,nom,code_insee_commune,code_postal_commune,siret_livreur_repas,nombre_repas_jour,nombre_repas_an,secteurs,type_production,type_gestion,modèle_économique,gestionnaires_additionnels
+21340172201787,Canteen 1,,54460,,700,14000,Restaurants administratifs d’Etat (RA),site,conceded,,
+58137739217041,Canteen 2,,54460,,700,14000,Restaurants administratifs d'Etat (RA),site,conceded,,

--- a/api/tests/test_import_canteens.py
+++ b/api/tests/test_import_canteens.py
@@ -382,4 +382,4 @@ class TestCanteenImport(APITestCase):
         )
 
         body = response.json()
-        self.assertEqual(body["errors"], 0)
+        self.assertEqual(body["errors"], [])


### PR DESCRIPTION
Ce travail de sanitazation est déjà fait par la fonction de Django `unaccent`
![image](https://github.com/user-attachments/assets/e3014ef5-e3f8-45c0-b971-8d92cd8a3787)

