### PR TITLE
fix(Cantines): Répare les règles concernant le champ 'Administration de tutelle' au moment de la TD

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -595,9 +595,13 @@ export const hasSatelliteInconsistency = (canteen) => {
 }
 
 export const lineMinistryRequired = (canteen, allSectors) => {
+  // 2 rules
+  // - canteen must be Public
+  // - canteen has Sector(s) with line_ministry
+  if (canteen.economicModel !== "public") return false
   const concernedSectors = allSectors.filter((x) => !!x.hasLineMinistry).map((x) => x.id)
   if (concernedSectors.length === 0) return false
-  return canteen.sectors.some((x) => concernedSectors.indexOf(x) > -1)
+  return canteen.sectors?.some((x) => concernedSectors.indexOf(x) > -1)
 }
 
 export const missingCanteenData = (canteen, sectors) => {

--- a/frontend/src/views/CanteenEditor/CanteenForm.vue
+++ b/frontend/src/views/CanteenEditor/CanteenForm.vue
@@ -334,7 +334,7 @@
 
 <script>
 import validators from "@/validators"
-import { getObjectDiff, sectorsSelectList, readCookie } from "@/utils"
+import { getObjectDiff, sectorsSelectList, readCookie, lineMinistryRequired } from "@/utils"
 import TechnicalControlDialog from "./TechnicalControlDialog"
 import SiretCheck from "./SiretCheck"
 import Constants from "@/constants"
@@ -432,11 +432,7 @@ export default {
       return this.canteen.productionType && this.canteen.productionType !== "central"
     },
     showMinistryField() {
-      // 2 rules: Public + Sector(s) with line_ministry
-      if (this.canteen.economicModel !== "public") return false
-      const concernedSectors = this.sectors.filter((x) => !!x.hasLineMinistry).map((x) => x.id)
-      if (concernedSectors.length === 0) return false
-      return this.canteen.sectors?.some((x) => concernedSectors.indexOf(parseInt(x, 10)) > -1)
+      return lineMinistryRequired(this.canteen, this.sectors)
     },
     usesCentralProducer() {
       return this.canteen.productionType === "site_cooked_elsewhere"


### PR DESCRIPTION
Suite à #4788 on avait rajouté une règle indiquant que les cantines non "public" n'étaient pas concernées par le champ `line_ministry`.

Mais on avait fait la modif seulement sur le formulaire de création de modification.
Cette PR fait aussi la modification au moment du Progress/TD.
J'en ai profité pour faire un peu de refactoring. SAUF que la page CanteenCreation est en cours de migration vue 3 ^^