### PR TITLE
improve(Cantines): permettre aux cantines sans SIRET (mais avec un siren_unite_legale) de TD

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -594,6 +594,10 @@ export const hasSatelliteInconsistency = (canteen) => {
   return canteen.satelliteCanteensCount !== canteen.satellites.length
 }
 
+export const siretOrSirenUniteLegaleRequired = (canteen) => {
+  return !!canteen.siret && !!canteen.siren_unite_legale
+}
+
 export const lineMinistryRequired = (canteen, allSectors) => {
   // 2 rules
   // - canteen must be Public
@@ -605,8 +609,12 @@ export const lineMinistryRequired = (canteen, allSectors) => {
 }
 
 export const missingCanteenData = (canteen, sectors) => {
-  // TODO: what location data to we require at minimum?
-  const requiredFields = ["siret", "name", "cityInseeCode", "productionType", "managementType"]
+  // some canteens might not have a SIRET
+  if (siretOrSirenUniteLegaleRequired(canteen)) return true
+
+  // basic canteen fields
+  // TODO: what location data do we require at minimum?
+  const requiredFields = ["name", "cityInseeCode", "productionType", "managementType"]
   const missingFieldLambda = (f) => !canteen[f]
   const missingSharedRequiredData = requiredFields.some(missingFieldLambda)
   if (missingSharedRequiredData) return true


### PR DESCRIPTION
Modifie le check "missingCanteenData" pour gérer les cantines qui n'ont pas de champ `siret` mais qui ont un champ `siren_unite_legale`
--> permet de ne pas avoir le bouton "Compléter votre établissement" qui s'affiche
--> et ainsi de TD (j'ai testé, ca fonctionne)