### PR TITLE
improve(Cantines): afficher l'info du SIREN de l'unité légale dans l'application

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -486,6 +486,7 @@ class CanteenActionsSerializer(serializers.ModelSerializer):
             "id",
             "name",
             "siret",
+            "siren_unite_legale",
             "city",
             "production_type",
             "daily_meal_count",

--- a/api/templates/canteen_join_request.html
+++ b/api/templates/canteen_join_request.html
@@ -1,7 +1,14 @@
 {% extends 'email_base.html' %}
 
 {% block content %}
-    <p>{{ name }} ({{ email }}) veut rejoindre l'équipe de gestion de la cantine « {{ canteen }} » (SIRET {{ siret }}).</p>
+    <p>{{ name }} ({{ email }}) veut rejoindre l'équipe de gestion de la cantine « {{ canteen }} »
+        {% if siret %}
+            <span>(SIRET {{ siret }})</span>
+        {% endif %}
+        {% if siren_unite_legale %}
+            <span>(SIREN {{ siren_unite_legale }})</span>.
+        {% endif %}
+    </p>
 
     {% if message %}
         <p>Voici son message :</p>

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -775,8 +775,6 @@ class TeamJoinRequestView(APIView):
                 "siren_unite_legale": canteen.siren_unite_legale,
             }
 
-            print(context)
-
             recipients = list(canteen.managers.values_list("email", flat=True))
 
             if not recipients:

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -772,7 +772,10 @@ class TeamJoinRequestView(APIView):
                 "url": url,
                 "canteen": canteen.name,
                 "siret": canteen.siret,
+                "siren_unite_legale": canteen.siren_unite_legale,
             }
+
+            print(context)
 
             recipients = list(canteen.managers.values_list("email", flat=True))
 

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -105,8 +105,8 @@
             <router-link :to="toCanteen(item)">{{ item.name }}</router-link>
           </template>
           <template v-slot:[`item.siret`]="{ item }">
-            {{ item.siret || "inconnu" }}
-            <span v-if="item.sirenUniteLegale" class="caption">({{ item.sirenUniteLegale }})</span>
+            <span v-if="item.sirenUniteLegale">SIREN : {{ item.sirenUniteLegale }}</span>
+            <span v-else>SIRET : {{ item.siret }}</span>
           </template>
           <template v-slot:[`item.productionType`]="{ item }">
             {{ typeDisplay[item.productionType] }}
@@ -165,7 +165,7 @@ export default {
       },
       headers: [
         { text: "Nom", value: "name" },
-        { text: "Siret", value: "siret" },
+        { text: "Siret ou Siren", value: "siret" },
         { text: "Type", value: "productionType" },
         { text: "Action", value: "action" },
       ],

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -105,7 +105,8 @@
             <router-link :to="toCanteen(item)">{{ item.name }}</router-link>
           </template>
           <template v-slot:[`item.siret`]="{ item }">
-            {{ item.siret }}
+            {{ item.siret || "inconnu" }}
+            <span v-if="item.sirenUniteLegale" class="caption">({{ item.sirenUniteLegale }})</span>
           </template>
           <template v-slot:[`item.productionType`]="{ item }">
             {{ typeDisplay[item.productionType] }}

--- a/frontend/src/components/DiagnosticSummary/CanteenSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/CanteenSummary.vue
@@ -9,7 +9,11 @@
           <p class="my-0 fr-text-sm grey--text text--darken-1">Nom de la cantine</p>
           <p class="my-0">{{ canteen.name }}</p>
           <p class="mb-0 mt-2 fr-text-sm grey--text text--darken-1">SIRET</p>
-          <p class="my-0">{{ canteen.siret || "—" }}</p>
+          <p class="my-0">{{ canteen.siret || "inconnu" }}</p>
+          <p v-if="canteen.sirenUniteLegale" class="mb-0 mt-2 fr-text-sm grey--text text--darken-1">
+            SIREN de l'unité légale
+          </p>
+          <p class="my-0">{{ canteen.sirenUniteLegale }}</p>
         </div>
       </v-col>
       <v-col cols="12" md="6" class="d-flex align-center pa-0 my-4 my-md-0 left-border">

--- a/frontend/src/components/TeledeclarationPreview/PreviewTable.vue
+++ b/frontend/src/components/TeledeclarationPreview/PreviewTable.vue
@@ -134,7 +134,7 @@ export default {
       const ministryDetail = this.$store.state.lineMinistries.find((x) => x.value === this.canteen.lineMinistry)
       let items = [
         { value: this.canteen.name, label: "Nom de la cantine" },
-        { value: this.canteen.siret, label: "Numéro SIRET" },
+        { value: this.canteen.siret || "inconnu", label: "Numéro SIRET" },
         { value: this.canteen.sirenUniteLegale, label: "Numéro SIREN de l'unité légale" },
         { value: this.canteen.city, label: "Ville" },
         { value: managementTypeDetail ? managementTypeDetail.text : "", label: "Mode de gestion" },

--- a/frontend/src/components/TeledeclarationPreview/PreviewTable.vue
+++ b/frontend/src/components/TeledeclarationPreview/PreviewTable.vue
@@ -135,6 +135,7 @@ export default {
       let items = [
         { value: this.canteen.name, label: "Nom de la cantine" },
         { value: this.canteen.siret, label: "Numéro SIRET" },
+        { value: this.canteen.sirenUniteLegale, label: "Numéro SIREN de l'unité légale" },
         { value: this.canteen.city, label: "Ville" },
         { value: managementTypeDetail ? managementTypeDetail.text : "", label: "Mode de gestion" },
         { value: productionTypeDetail ? productionTypeDetail.body : "", label: "Type d'établissement" },

--- a/frontend/src/views/DashboardManager/CanteenInfoWidget.vue
+++ b/frontend/src/views/DashboardManager/CanteenInfoWidget.vue
@@ -13,7 +13,11 @@
           </p>
           <p class="mb-0">
             SIRET :
-            <span class="font-weight-medium">{{ canteen.siret }}</span>
+            <span class="font-weight-medium">{{ canteen.siret || "inconnu" }}</span>
+          </p>
+          <p v-if="canteen.sirenUniteLegale" class="mb-0">
+            SIREN de l'unité légale :
+            <span class="font-weight-medium">{{ canteen.sirenUniteLegale }}</span>
           </p>
           <p class="mb-0">
             Commune :

--- a/frontend/src/views/DashboardManager/index.vue
+++ b/frontend/src/views/DashboardManager/index.vue
@@ -2,7 +2,10 @@
   <div class="text-left" v-if="canteen">
     <ProductionTypeTag :canteen="canteen" class="mt-2" />
     <h1 class="fr-h3 mt-2 mb-2">{{ canteen.name }}</h1>
-    <p>SIRET : {{ canteen.siret }}</p>
+    <p>
+      SIRET : {{ canteen.siret || "inconnu" }}
+      <span v-if="canteen.sirenUniteLegale">(SIREN de l'unité légale : {{ canteen.sirenUniteLegale }})</span>
+    </p>
     <v-row v-if="canteenPreviews.length > 1">
       <v-col>
         <v-btn outlined color="primary" class="fr-btn--tertiary" :to="{ name: 'ManagementPage' }">

--- a/frontend/src/views/DashboardManager/index.vue
+++ b/frontend/src/views/DashboardManager/index.vue
@@ -1,11 +1,16 @@
 <template>
   <div class="text-left" v-if="canteen">
-    <ProductionTypeTag :canteen="canteen" class="mt-2" />
-    <h1 class="fr-h3 mt-2 mb-2">{{ canteen.name }}</h1>
-    <p>
-      SIRET : {{ canteen.siret || "inconnu" }}
-      <span v-if="canteen.sirenUniteLegale">(SIREN de l'unité légale : {{ canteen.sirenUniteLegale }})</span>
-    </p>
+    <v-row>
+      <v-col>
+        <ProductionTypeTag :canteen="canteen" class="mt-2" />
+        <h1 class="fr-h3 mt-2 mb-2">{{ canteen.name }}</h1>
+        <p class="mb-0">SIRET : {{ canteen.siret || "inconnu" }}</p>
+        <p v-if="canteen.sirenUniteLegale" class="mb-0">
+          <span>SIREN de l'unité légale : {{ canteen.sirenUniteLegale }}</span>
+        </p>
+      </v-col>
+    </v-row>
+
     <v-row v-if="canteenPreviews.length > 1">
       <v-col>
         <v-btn outlined color="primary" class="fr-btn--tertiary" :to="{ name: 'ManagementPage' }">

--- a/frontend/src/views/ManagementPage/CanteenCard.vue
+++ b/frontend/src/views/ManagementPage/CanteenCard.vue
@@ -5,7 +5,8 @@
       <h3 class="fr-h6 font-weight-bold mb-1">{{ canteen.name }}</h3>
     </v-card-title>
     <v-card-subtitle class="pb-0 mx-n1">
-      <p class="pl-1 mb-2">SIRET : {{ canteen.siret }}</p>
+      <p class="pl-1 mb-2">SIRET : {{ canteen.siret || "inconnu" }}</p>
+      <p v-if="canteen.sirenUniteLegale" class="pl-1 mb-2">SIREN de l'unité légale : {{ canteen.sirenUniteLegale }}</p>
       <DsfrTag
         v-if="teledeclarationIsActive && !usesCentralKitchenDiagnostics"
         :text="teledeclarationStatus.text"

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -18,7 +18,10 @@
         <DataInfoBadge v-else-if="+year >= currentYear" class="my-2" :currentYear="+year === currentYear" />
         <ProductionTypeTag v-if="canteen" :canteen="canteen" class="ml-3" />
         <h1 class="fr-h3 mt-1 mb-2" v-if="canteen">{{ canteen.name }} : Télédéclaration</h1>
-        <p>SIRET : {{ canteen.siret }}</p>
+        <p>
+          SIRET : {{ canteen.siret || "inconnu" }}
+          <span v-if="canteen.sirenUniteLegale">(SIREN de l'unité légale : {{ canteen.sirenUniteLegale }})</span>
+        </p>
       </v-col>
       <v-col cols="12" md="3" lg="2">
         <v-btn

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -18,9 +18,9 @@
         <DataInfoBadge v-else-if="+year >= currentYear" class="my-2" :currentYear="+year === currentYear" />
         <ProductionTypeTag v-if="canteen" :canteen="canteen" class="ml-3" />
         <h1 class="fr-h3 mt-1 mb-2" v-if="canteen">{{ canteen.name }} : Télédéclaration</h1>
-        <p>
-          SIRET : {{ canteen.siret || "inconnu" }}
-          <span v-if="canteen.sirenUniteLegale">(SIREN de l'unité légale : {{ canteen.sirenUniteLegale }})</span>
+        <p class="mb-0">SIRET : {{ canteen.siret || "inconnu" }}</p>
+        <p v-if="canteen.sirenUniteLegale" class="mb-0">
+          <span>SIREN de l'unité légale : {{ canteen.sirenUniteLegale }}</span>
         </p>
       </v-col>
       <v-col cols="12" md="3" lg="2">


### PR DESCRIPTION
### Quoi

Afficher le "SIREN de l'unité légale" aux différents endroits de l'application

### Captures d'écran

|composant|image|
|-|-|
|CanteenCard|![image](https://github.com/user-attachments/assets/dcd4484c-d7e1-45f7-a407-2b3dc1bec3c4)|
|AnnualActionableCanteensTable + modif dans le serializer `CanteenActionsSerializer`|<img width="923" alt="Capture d’écran 2025-03-14 à 19 04 31" src="https://github.com/user-attachments/assets/d1c5e6cb-4e09-4c77-a352-868d252d73d1" />|
|MyProgress, DashboardManager|![image](https://github.com/user-attachments/assets/f6705afd-0be2-4263-bcae-560387cd43ce)|
|CanteenSummary|![image](https://github.com/user-attachments/assets/ea7eecaa-8ef0-4d04-af93-01d7312b9677)|
|CanteenInfoWidget|![image](https://github.com/user-attachments/assets/6d08ab6c-99f3-42fc-b07b-2ad09bd92b19)|
|PreviewTD|<img width="893" alt="Capture d’écran 2025-03-14 à 18 58 59" src="https://github.com/user-attachments/assets/f43826dd-9bbe-4402-8873-9688a251480a" />|


