### PR TITLE
improve(Ajouter une cantine): divers correctifs et améliorations de wordings

### DIFF
--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -342,7 +342,7 @@ const resetForm = () => {
           :error-message="formatError(v$.name)"
         />
         <div v-if="showCitySelector" class="fr-grid-row fr-grid-row--gutters">
-          <div class="fr-col-6">
+          <div class="fr-col-12 fr-col-md-6">
             <DsfrInputGroup
               v-model="form.postalCode"
               label="Code postal *"
@@ -351,8 +351,9 @@ const resetForm = () => {
               @update:modelValue="changePostal()"
             />
           </div>
-          <div class="fr-col-6">
+          <div class="fr-col-12 fr-col-md-6">
             <DsfrSelect
+              class="fr-mb-0"
               v-model="form.citySelector"
               label="Ville *"
               :label-visible="true"
@@ -433,7 +434,7 @@ const resetForm = () => {
       <fieldset class="fr-mb-4w">
         <legend class="fr-h5 fr-mb-2w">5. Nombre de repas</legend>
         <div class="fr-grid-row fr-grid-row--gutters">
-          <div class="fr-col-6">
+          <div class="fr-col-12 fr-col-md-6">
             <DsfrInputGroup
               :class="{
                 hide: hideDailyMealCount,
@@ -447,7 +448,7 @@ const resetForm = () => {
               :error-message="formatError(v$.dailyMealCount)"
             />
           </div>
-          <div class="fr-col-6">
+          <div class="fr-col-12 fr-col-md-6">
             <DsfrInputGroup
               v-model="form.yearlyMealCount"
               label="Par an *"

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -243,13 +243,13 @@ const rules = {
     maxLength: helpers.withMessage("Le numéro SIRET doit contenir 14 caractères", maxLength(14)),
   },
   oneDelivery: {
-    required: requiredIf(showCheckboxOneDelivery),
+    beChecked: helpers.withMessage("La case doit être cochée", (value) => !showCheckboxOneDelivery.value || value),
   },
   manyDelivery: {
-    required: requiredIf(showCheckboxManyDelivery),
+    beChecked: helpers.withMessage("La case doit être cochée", (value) => !showCheckboxManyDelivery.value || value),
   },
   noSiret: {
-    required: requiredIf(showCheckboxNoSiret),
+    beChecked: helpers.withMessage("La case doit être cochée", (value) => !showCheckboxNoSiret.value || value),
   },
 }
 const v$ = useVuelidate(rules, form)

--- a/2024-frontend/src/components/CanteenCreationForm.vue
+++ b/2024-frontend/src/components/CanteenCreationForm.vue
@@ -346,6 +346,7 @@ const resetForm = () => {
             <DsfrInputGroup
               v-model="form.postalCode"
               label="Code postal *"
+              hint="Indiquer le code postal pour pouvoir sélectionner une ville dans la liste"
               :label-visible="true"
               :error-message="formatError(v$.postalCode)"
               @update:modelValue="changePostal()"
@@ -356,6 +357,7 @@ const resetForm = () => {
               class="fr-mb-0"
               v-model="form.citySelector"
               label="Ville *"
+              description="Indiquer le code postal pour pouvoir sélectionner une ville dans la liste"
               :label-visible="true"
               :error-message="emptyCity || formatError(v$.citySelector)"
               :options="citiesOptions"

--- a/2024-frontend/src/components/CanteenCreationResult.vue
+++ b/2024-frontend/src/components/CanteenCreationResult.vue
@@ -13,7 +13,7 @@ const linkedCanteensLabel = computed(() => {
   const count = props.linkedCanteens.length
   const establishment = count === 1 ? "établissement" : "établissements"
   const exist = count === 1 ? "existe" : "existent"
-  return `${count} ${establishment} ${exist} déjà pour cette unité locale`
+  return `${count} ${establishment} ${exist} déjà pour cette unité légale`
 })
 </script>
 

--- a/2024-frontend/src/components/CanteenCreationResult.vue
+++ b/2024-frontend/src/components/CanteenCreationResult.vue
@@ -68,7 +68,7 @@ const linkedCanteensLabel = computed(() => {
       </div>
       <div class="fr-grid-row fr-grid-row--center">
         <DsfrButton
-          label="Sélectionner cet établissement comme unité légale"
+          label="Créer un nouvel établissement rattaché à cette unité légale"
           icon="fr-icon-add-circle-fill"
           secondary
           @click="$emit('select')"

--- a/2024-frontend/src/components/CanteenCreationSearch.vue
+++ b/2024-frontend/src/components/CanteenCreationSearch.vue
@@ -39,7 +39,8 @@ const errorNotFound = ref()
 const errorMessage = computed(() => {
   if (errorNotFound.value) return errorNotFound.value
   if (props.errorRequired && !canteen.find) return props.errorRequired
-  if (props.errorRequired && canteen.find) return `Vous devez sélectionner un établissement`
+  if (props.errorRequired && canteen.find && props.hasSiret) return "Vous devez sélectionner un établissement"
+  if (props.errorRequired && canteen.find && !props.hasSiret) return "Vous devez sélectionner ou créer un établissement"
   else return ""
 })
 const hasSelected = ref(false)

--- a/2024-frontend/src/components/CanteenCreationSearch.vue
+++ b/2024-frontend/src/components/CanteenCreationSearch.vue
@@ -20,7 +20,7 @@ const label = computed(() => `Rechercher un établissement par son numéro ${num
 /* Canteen fields */
 const canteen = reactive({})
 const initFields = () => {
-  canteen.find = false
+  canteen.found = false
   canteen.status = null
   canteen.name = null
   canteen.siret = null
@@ -38,9 +38,10 @@ const search = ref("")
 const errorNotFound = ref()
 const errorMessage = computed(() => {
   if (errorNotFound.value) return errorNotFound.value
-  if (props.errorRequired && !canteen.find) return props.errorRequired
-  if (props.errorRequired && canteen.find && props.hasSiret) return "Vous devez sélectionner un établissement"
-  if (props.errorRequired && canteen.find && !props.hasSiret) return "Vous devez sélectionner ou créer un établissement"
+  if (props.errorRequired && !canteen.found) return props.errorRequired
+  if (props.errorRequired && canteen.found && props.hasSiret) return "Vous devez sélectionner un établissement"
+  if (props.errorRequired && canteen.found && !props.hasSiret)
+    return "Vous devez sélectionner ou créer un établissement"
   else return ""
 })
 const hasSelected = ref(false)
@@ -54,31 +55,31 @@ const searchByNumber = () => {
     .then((response) => {
       switch (true) {
         case response.length === 0:
-          canteen.find = false
+          canteen.found = false
           errorNotFound.value = `D’après l'annuaire-des-entreprises le numéro ${numberName.value} « ${cleanNumber} » ne correspond à aucun établissement`
           break
         case !response.id && !response.siren:
-          canteen.find = true
+          canteen.found = true
           canteen.status = "can-be-created"
           break
         case !response.id && response.siren !== "":
-          canteen.find = true
+          canteen.found = true
           canteen.status = "can-be-linked"
           break
         case response.isManagedByUser:
-          canteen.find = true
+          canteen.found = true
           canteen.status = "managed-by-user"
           break
         case response.canBeClaimed:
-          canteen.find = true
+          canteen.found = true
           canteen.status = "can-be-claimed"
           break
         case !response.canBeClaimed:
-          canteen.find = true
+          canteen.found = true
           canteen.status = "ask-to-join"
           break
       }
-      if (canteen.find) saveCanteenInfos(response)
+      if (canteen.found) saveCanteenInfos(response)
     })
     .catch((e) => store.notifyServerError(e))
 }
@@ -132,7 +133,7 @@ const unselectCanteen = () => {
       </template>
     </DsfrInputGroup>
     <CanteenCreationResult
-      v-if="canteen.find"
+      v-if="canteen.found"
       :name="canteen.name"
       :siret="canteen.siret"
       :siren="canteen.siren"
@@ -143,7 +144,7 @@ const unselectCanteen = () => {
       :linked-canteens="canteen.linkedCanteens"
       @select="selectCanteen()"
     />
-    <p v-if="canteen.find && !hasSelected" class="fr-text--xs fr-mb-0 fr-mt-1w ma-cantine--text-center">
+    <p v-if="canteen.found && !hasSelected" class="fr-text--xs fr-mb-0 fr-mt-1w ma-cantine--text-center">
       Ce n’est pas le bon établissement ? Refaites une recherche via le bon numéro {{ numberName }}, ou trouvez
       l’information dans
       <a href="https://annuaire-entreprises.data.gouv.fr/" target="_blank">l'annuaire-des-entreprises</a>

--- a/2024-frontend/src/components/CanteenCreationSearch.vue
+++ b/2024-frontend/src/components/CanteenCreationSearch.vue
@@ -48,6 +48,7 @@ const hasSelected = ref(false)
 const searchByNumber = () => {
   const cleanNumber = search.value.replaceAll(" ", "")
   if (cleanNumber.length === 0) return
+  initFields()
   errorNotFound.value = ""
   const searchBy = numberName.value.toLowerCase()
   canteensService

--- a/2024-frontend/src/components/CanteenCreationSearch.vue
+++ b/2024-frontend/src/components/CanteenCreationSearch.vue
@@ -118,7 +118,7 @@ const unselectCanteen = () => {
     <p class="fr-hint-text">
       Nous utilisons le site
       <a href="https://annuaire-entreprises.data.gouv.fr/" target="_blank">annuaire-des-entreprises</a>
-      afin de retrouver les informations de {{ establishment }}
+      afin de retrouver les informations de {{ establishment }}.
     </p>
     <DsfrInputGroup :error-message="errorMessage">
       <template #default>

--- a/2024-frontend/src/constants/canteen-creation-form-options.js
+++ b/2024-frontend/src/constants/canteen-creation-form-options.js
@@ -7,7 +7,7 @@ const hasSiret = [
   {
     label: "Non, je suis rattaché à une unité légale",
     hint:
-      "Seuls certains établissement peuvent être rattachés au SIREN d’une unité légale, vérifier votre éligibilité dans nos conditions d’utilisation.",
+      "Seuls certains établissements peuvent être rattachés au SIREN d’une unité légale, vérifiez votre éligibilité dans nos conditions d’utilisation.",
     img: "/static/images/picto-dsfr/flow-list.svg",
     value: "no-siret",
   },

--- a/2024-frontend/src/constants/canteen-creation-form-options.js
+++ b/2024-frontend/src/constants/canteen-creation-form-options.js
@@ -7,7 +7,7 @@ const hasSiret = [
   {
     label: "Non, je suis rattaché à une unité légale",
     hint:
-      "Seuls certains établissement peuvent être rattachés au SIRET d’une unité légale, vérifier votre éligibilité dans nos conditions d’utilisation.",
+      "Seuls certains établissement peuvent être rattachés au SIREN d’une unité légale, vérifier votre éligibilité dans nos conditions d’utilisation.",
     img: "/static/images/picto-dsfr/flow-list.svg",
     value: "no-siret",
   },


### PR DESCRIPTION
## Description 
Cette PR comprends les correctifs suivant : 
- la vérification des cases à cocher qui avec un "required" seul, passait si un utilisateur cochait puis décochait la case
- l'affichage responsive des champs de saisie en 2 colonnes sur version desk
- l'ajout d'un champ descriptif pour le remplissage de la ville et du code postal : j'ai volontairement mis les 2 mêmes textes, car ça évite d'avoir des champs non alignés, et ça permet de garder les 2 colonnes que Raphael aime tant 😁. Et bon je me dit qu'au moins l'utilisateur à bien l'info au dessus du champ qu'il sera entrain de voir remplir
- des corrections de wording