### PR TITLE
feat(Ajouter une cantine): remplace l'ancienne url par la nouvelle dans l'application

### DIFF
--- a/2024-frontend/src/router/vue2.js
+++ b/2024-frontend/src/router/vue2.js
@@ -88,10 +88,6 @@ const vue2routes = [
     name: "WasteActionsHome",
   },
   {
-    path: "/nouvelle-cantine",
-    name: "NewCanteen",
-  },
-  {
     path: "/importer-diagnostics/:importUrlSlug",
     name: "DiagnosticImportPage",
   },

--- a/2024-frontend/src/views/ImportCanteens.vue
+++ b/2024-frontend/src/views/ImportCanteens.vue
@@ -34,7 +34,7 @@ const success = (count) => {
     Notre outil d’import de masse vous permet de créer vos cantines ou de modifier vos cantines existantes d’un coup.
     <strong>Il concerne uniquement les gestionnaires qui ont plus de 5&nbsp;cantines.</strong>
     Si vous avez moins de 5 cantines vous pouvez créer ou modifier des cantines depuis
-    <router-link :to="{ name: 'NewCanteen' }">notre formulaire</router-link>
+    <router-link :to="{ name: 'CanteenCreation' }">notre formulaire</router-link>
     .
   </p>
   <ImportExplanation :exampleFile />

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -309,24 +309,6 @@ const routes = [
     sitemapGroup: Constants.SitemapGroups.ACTION,
   },
   {
-    path: "/nouvelle-cantine",
-    name: "NewCanteen",
-    component: CanteenEditor,
-    redirect: { name: "NewCanteenForm" },
-    children: [
-      {
-        path: "",
-        name: "NewCanteenForm",
-        component: CanteenForm,
-        meta: {
-          title: "Ajouter ma cantine",
-          authenticationRequired: true,
-        },
-        sitemapGroup: Constants.SitemapGroups.ACTION,
-      },
-    ],
-  },
-  {
     path: "/modifier-ma-cantine/:canteenUrlComponent",
     name: "CanteenModification",
     props: true,
@@ -610,6 +592,14 @@ const vue3Routes = [
     path: "/importer-des-donnees/cantines",
     name: "ImportCanteens",
   },
+  {
+    path: "/ajouter-une-cantine",
+    name: "CanteenCreation",
+    meta: {
+      title: "Ajouter une cantine",
+    },
+    sitemapGroup: Constants.SitemapGroups.ACTION,
+  },
 ]
 const VUE3_PREFIX = "/v2"
 vue3Routes.forEach((r) => {
@@ -620,6 +610,11 @@ routes.push(...vue3Routes)
 routes.push({
   path: "/importer-achats",
   redirect: { name: "ImportPurchases" },
+})
+
+routes.push({
+  path: "/nouvelle-cantine",
+  redirect: { name: "CanteenCreation" },
 })
 
 routes.push({

--- a/frontend/src/views/GeneratePosterPage/index.vue
+++ b/frontend/src/views/GeneratePosterPage/index.vue
@@ -8,7 +8,7 @@
     </h1>
     <p v-if="!hasCanteens && isAuthenticated" class="mt-0">
       Remplissez le formulaire ci-dessous ou
-      <router-link :to="{ name: 'NewCanteen' }">créez votre cantine</router-link>
+      <router-link :to="{ name: 'CanteenCreation' }">créez votre cantine</router-link>
       pour que vos données soient automatiquement renseignées.
       <v-divider aria-hidden="true" role="presentation" class="mt-4"></v-divider>
     </p>

--- a/frontend/src/views/ManagementPage/CanteenCreationDialog.vue
+++ b/frontend/src/views/ManagementPage/CanteenCreationDialog.vue
@@ -13,7 +13,7 @@
           v-for="organization in organizations"
           :key="organization.id"
           class="text-left mb-4"
-          :to="{ name: 'NewCanteen', query: { siret: organization.siret } }"
+          :to="{ name: 'CanteenCreation' }"
         >
           <v-card-title>
             <h2 class="fr-h6 mb-0">{{ organization.label }}</h2>
@@ -23,7 +23,7 @@
           </v-card-text>
         </v-card>
         <v-divider aria-hidden="true" role="presentation" class="mb-4"></v-divider>
-        <v-card outlined class="text-left mb-4" :to="{ name: 'NewCanteen' }">
+        <v-card outlined class="text-left mb-4" :to="{ name: 'CanteenCreation' }">
           <v-card-title><h2 class="fr-h6 mb-0">Créer un autre établissement</h2></v-card-title>
         </v-card>
       </div>

--- a/frontend/src/views/ManagementPage/CanteensPagination.vue
+++ b/frontend/src/views/ManagementPage/CanteensPagination.vue
@@ -46,7 +46,7 @@
           outlined
           min-height="220"
           height="80%"
-          :to="{ name: 'NewCanteen' }"
+          :to="{ name: 'CanteenCreation' }"
         >
           <v-icon size="100" class="primary--text">mdi-plus</v-icon>
           <v-card-text class="font-weight-bold pt-0 text-center primary--text text-body-1">

--- a/frontend/src/views/ManagementPage/index.vue
+++ b/frontend/src/views/ManagementPage/index.vue
@@ -41,7 +41,7 @@
       <div v-if="showListView">
         <p>Actions en attente en {{ year }}</p>
         <AnnualActionableCanteensTable v-on:canteen-count="canteenCount = $event" />
-        <v-btn large color="primary" outlined :to="{ name: 'NewCanteen' }">
+        <v-btn large color="primary" outlined :to="{ name: 'CanteenCreation' }">
           <v-icon class="mr-2">mdi-plus</v-icon>
           Ajouter une cantine
         </v-btn>

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -301,7 +301,7 @@
           outlined
           min-height="220"
           height="80%"
-          :to="{ name: 'NewCanteen' }"
+          :to="{ name: 'CanteenCreation' }"
         >
           <v-icon size="100" class="primary--text">mdi-plus</v-icon>
           <v-card-text class="font-weight-bold pt-0 text-center primary--text">

--- a/web/views.py
+++ b/web/views.py
@@ -94,7 +94,7 @@ class RegisterUserView(FormView):
                 self.success_url = "/v2/developpement-et-apis"
             else:
                 has_canteens = not self.request.user.is_anonymous and self.request.user.canteens.count() > 0
-                self.success_url = reverse_lazy("app") if has_canteens else "/nouvelle-cantine"
+                self.success_url = reverse_lazy("app") if has_canteens else "/v2/ajouter-une-cantine"
             return super().form_valid(form)
 
 


### PR DESCRIPTION
## Description
Cette PR rend disponible "officiellement" la nouvelle url de création de cantine pour nos utilisateurs. Une redirection de l'ancienne url vers la nouvelle a été ajouté (au cas ou l'ancienne url ait été envoyée par mail, dans des communications marketing ou autre).

Concernés par cette modif : 
- tous les liens "Ajouter une cantine"
- le plan du site
- la fonctionnalité de pré-remplissage du numéro SIRET lorsqu'on arrive de Mon-Comptre-Pro n'a pas été développée, c'est pour cela que le paramètre n'est plus envoyé dans le router pour le composant `CanteenCreationDialog`