### PR TITLE
fix(ETL Teledeclarations): Correction du différentiel de valeurs statistiques sur les TD entre les stats et les exports  

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -38,7 +38,7 @@ from .partnertype import PartnerTypeSerializer  # noqa: F401
 from .blogpost import BlogPostSerializer  # noqa: F401
 from .password import PasswordSerializer  # noqa: F401
 from .managerinvitation import ManagerInvitationSerializer  # noqa: F401
-from .teledeclaration import ShortTeledeclarationSerializer  # noqa: F401
+from .teledeclaration import ShortTeledeclarationSerializer, OpenDataTeledeclarationSerializer  # noqa: F401
 from .purchase import (  # noqa: F401
     PurchaseSerializer,
     PurchaseSummarySerializer,

--- a/api/serializers/teledeclaration.py
+++ b/api/serializers/teledeclaration.py
@@ -13,3 +13,14 @@ class ShortTeledeclarationSerializer(serializers.ModelSerializer):
             "status",
         )
         read_only_fields = fields
+
+
+class OpenDataTeledeclarationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Teledeclaration
+
+        fields = (
+            "id",
+            "creation_date",
+        )
+        read_only_fields = fields

--- a/api/serializers/teledeclaration.py
+++ b/api/serializers/teledeclaration.py
@@ -16,11 +16,27 @@ class ShortTeledeclarationSerializer(serializers.ModelSerializer):
 
 
 class OpenDataTeledeclarationSerializer(serializers.ModelSerializer):
+
+    value_total_ht = serializers.SerializerMethodField()
+    value_bio_ht = serializers.SerializerMethodField()
+    diagnostic_type = serializers.SerializerMethodField()
+
     class Meta:
         model = Teledeclaration
 
-        fields = (
-            "id",
-            "creation_date",
-        )
+        fields = ("id", "canteen_id", "creation_date", "value_total_ht", "value_bio_ht", "diagnostic_type")
         read_only_fields = fields
+
+    def get_value_total_ht(self, obj):
+        if "value_total_ht" in obj.declared_data["teledeclaration"]:
+            return obj.declared_data["teledeclaration"]["value_total_ht"]
+
+    def get_value_bio_ht(self, obj):
+        if "value_bio_ht" in obj.declared_data["teledeclaration"]:
+            return obj.declared_data["teledeclaration"]["value_bio_ht"]
+
+    def get_diagnostic_type(self, obj):
+        try:
+            obj.declared_data["teledeclaration"]["diagnostic_type"]
+        except Exception:
+            return None

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -63,6 +63,7 @@ from .sector import SectorListView  # noqa: F401
 from .statistics import CanteenStatisticsView  # noqa: F401
 from .subscription import SubscribeNewsletter  # noqa: F401
 from .teledeclaration import (  # noqa: F401
+    OpenDataTeleDeclarationsListView,
     TeledeclarationCancelView,
     TeledeclarationCreateView,
     TeledeclarationPdfView,

--- a/macantine/etl/utils.py
+++ b/macantine/etl/utils.py
@@ -207,13 +207,6 @@ def map_sectors():
     return sectors_mapper
 
 
-def filter_empty_values(df: pd.DataFrame, col_name) -> pd.DataFrame:
-    """
-    Filtering out the teledeclarations for wich a certain field is empty
-    """
-    return df.dropna(subset=col_name)
-
-
 def fetch_commune_detail(code_insee_commune, commune_details, geo_detail_type):
     """
     Provide EPCI code/ Department code/ Region code for a city, given the insee code of the city


### PR DESCRIPTION
Bon nombre de TD filtrées pour l'exemple 2023

* Vérifier que le **queryset** surchargeant `for_stats()` avec des TD au lieu de diagnostics n'affecte pas les stats publiques
* Pouvoir passer une liste `years` dans `for_stats`
* Compléter le serialiser
* Tests

* MAJ Chaîne de traitement sur Metabase (filtre 5)