### PR TITLE
fix(Ajouter une cantine): corrige le département manquant dans la réponse api de la recherche d'un l'établissement via SIRET ou SIREN

### DIFF
--- a/2024-frontend/src/components/CanteenCreationSearch.vue
+++ b/2024-frontend/src/components/CanteenCreationSearch.vue
@@ -86,7 +86,6 @@ const searchByNumber = () => {
 }
 
 const saveCanteenInfos = (response) => {
-  console.log("response", response)
   canteen.id = response.id
   canteen.name = response.name
   canteen.siret = response.siret

--- a/2024-frontend/src/components/CanteenCreationSearch.vue
+++ b/2024-frontend/src/components/CanteenCreationSearch.vue
@@ -86,13 +86,14 @@ const searchByNumber = () => {
 }
 
 const saveCanteenInfos = (response) => {
+  console.log("response", response)
   canteen.id = response.id
   canteen.name = response.name
   canteen.siret = response.siret
   canteen.city = response.city
   canteen.cityInseeCode = response.cityInseeCode
   canteen.postalCode = response.postalCode
-  canteen.department = response.postalCode.slice(0, 2)
+  canteen.department = response.department
   canteen.linkedCanteens = response.canteens
   canteen.siren = response.siren
 }

--- a/common/api/adresse.py
+++ b/common/api/adresse.py
@@ -12,7 +12,7 @@ REGIONS_LIB = {i.label.split(" - ")[1]: i.value for i in Region}
 def fetch_geo_data_from_api_entreprise_by_siret(response):
     try:
         location_response = requests.get(
-            f"https://api-adresse.data.gouv.fr/search/?q={response['city']}&citycode={response['cityInseeCode']}&type=municipality&autocomplete=1"
+            f"https://api-adresse.data.gouv.fr/search/?q={response['cityInseeCode']}&citycode={response['cityInseeCode']}&type=municipality&autocomplete=1"
         )
         if location_response.ok:
             location_response = location_response.json()

--- a/common/api/adresse.py
+++ b/common/api/adresse.py
@@ -12,7 +12,7 @@ REGIONS_LIB = {i.label.split(" - ")[1]: i.value for i in Region}
 def fetch_geo_data_from_api_entreprise_by_siret(response):
     try:
         location_response = requests.get(
-            f"https://api-adresse.data.gouv.fr/search/?q={response['cityInseeCode']}&citycode={response['cityInseeCode']}&type=municipality&autocomplete=1"
+            f"https://api-adresse.data.gouv.fr/search/?q={response['city']}&citycode={response['cityInseeCode']}&type=municipality&autocomplete=1"
         )
         if location_response.ok:
             location_response = location_response.json()

--- a/common/api/recherche_entreprises.py
+++ b/common/api/recherche_entreprises.py
@@ -67,6 +67,7 @@ def fetch_geo_data_from_siren(siren, response):
                 response["cityInseeCode"] = etablissement["commune"]
                 response["postalCode"] = etablissement["code_postal"]
                 response["city"] = etablissement["libelle_commune"]
+                response["department"] = etablissement["departement"]
                 return response
             except KeyError as e:
                 logger.error(


### PR DESCRIPTION
## Bug rencontré 
Le département n'était pas renvoyé par l'api mais calculé faussement en prenant uniquement les 2 premiers caractères du code postal. Ce calcul ne fonctionnait pas pour les DROM et les empêchait en créer une cantine.