### PR TITLE
refactor(Cantines): nouvelle property pour savoir si il manque des infos

### DIFF
--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -163,5 +163,5 @@ class DiagnosticsToTeledeclareListView(ListAPIView):
         # all SQL requests when not needed. We are also not interested exactly in the kind of
         # completeness, just wether or not the canteen can teledeclare.
         # Possible to have this method in the model
-        complete_canteens = [canteen for canteen in canteens if canteen.has_complete_data()]
+        complete_canteens = [canteen for canteen in canteens if canteen.has_complete_data]
         return complete_canteens

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -163,31 +163,5 @@ class DiagnosticsToTeledeclareListView(ListAPIView):
         # all SQL requests when not needed. We are also not interested exactly in the kind of
         # completeness, just wether or not the canteen can teledeclare.
         # Possible to have this method in the model
-        def canteen_is_complete(canteen):
-            has_complete_data = (
-                canteen.yearly_meal_count
-                and canteen.daily_meal_count
-                and canteen.siret
-                and canteen.name
-                and canteen.city_insee_code
-                and canteen.production_type
-                and canteen.management_type
-                and canteen.economic_model
-            )
-            if has_complete_data and canteen.is_satellite:
-                has_complete_data = canteen.central_producer_siret and canteen.central_producer_siret != canteen.siret
-            if has_complete_data and canteen.is_central_cuisine:
-                has_complete_data = canteen.satellite_canteens_count
-                # We check again to avoid useless DB hits
-                if has_complete_data:
-                    has_complete_data = (
-                        Canteen.objects.filter(central_producer_siret=canteen.siret).count()
-                        == canteen.satellite_canteens_count
-                    )
-
-            if has_complete_data and canteen.sectors.filter(has_line_ministry=True).exists():
-                has_complete_data = canteen.line_ministry
-            return has_complete_data
-
-        complete_canteens = list(filter(canteen_is_complete, canteens))
+        complete_canteens = [canteen for canteen in canteens if canteen.has_complete_data()]
         return complete_canteens

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -374,6 +374,8 @@ class Canteen(SoftDeletionModel):
                     Canteen.objects.filter(central_producer_siret=self.siret).count() == self.satellite_canteens_count
                 )
         # sectors & line_ministry
+        if has_complete_data:
+            has_complete_data = self.sectors.exists()
         if has_complete_data and self.sectors.filter(has_line_ministry=True).exists():
             has_complete_data = bool(self.line_ministry)
         return has_complete_data

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -351,20 +351,20 @@ class Canteen(SoftDeletionModel):
     def has_complete_data(self) -> bool:
         # basic rules
         has_complete_data = (
-            self.yearly_meal_count
-            and (self.siret or self.siren_unite_legale)
-            and self.name
-            and self.city_insee_code
-            and self.production_type
-            and self.management_type
-            and self.economic_model
+            bool(self.name)
+            and bool(self.city_insee_code)
+            and bool(self.yearly_meal_count)
+            and bool(self.siret or self.siren_unite_legale)
+            and bool(self.production_type)
+            and bool(self.management_type)
+            and bool(self.economic_model)
         )
         # serving-specific rules
         if has_complete_data and self.is_serving:
             has_complete_data = bool(self.daily_meal_count)
         # satellite-specific rules
         if has_complete_data and self.is_satellite:
-            has_complete_data = self.central_producer_siret and self.central_producer_siret != self.siret
+            has_complete_data = bool(self.central_producer_siret and self.central_producer_siret != self.siret)
         # cc-specific rules
         if has_complete_data and self.is_central_cuisine:
             has_complete_data = bool(self.satellite_canteens_count)

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -87,3 +87,72 @@ class TestCanteenQueryset(TestCase):
         qs = Canteen.objects.publicly_hidden()
         self.assertEqual(qs.count(), 1)
         self.assertEqual(qs.first(), self.canteen_published_armee)
+
+
+class TestCanteenProperty(TestCase):
+    def test_has_complete_data(self):
+        COMMON = {
+            # CanteenFactory generates: name, city_insee_code, sectors
+            "yearly_meal_count": 1000,
+            "publication_status": Canteen.PublicationStatus.PUBLISHED,
+            "management_type": Canteen.ManagementType.DIRECT,
+            "economic_model": Canteen.EconomicModel.PUBLIC,
+        }
+        canteen_central = CanteenFactory(
+            **COMMON,
+            siret="75665621899905",
+            production_type=Canteen.ProductionType.CENTRAL,
+            satellite_canteens_count=1
+        )
+        canteen_central_incomplete = CanteenFactory(
+            **COMMON,
+            siret="75665621899905",
+            production_type=Canteen.ProductionType.CENTRAL,
+            satellite_canteens_count=0  # incomplete
+        )
+        canteen_central_serving = CanteenFactory(
+            **COMMON,
+            siret="75665621899905",
+            production_type=Canteen.ProductionType.CENTRAL_SERVING,
+            daily_meal_count=12,
+            satellite_canteens_count=1
+        )
+        canteen_central_serving_incomplete = CanteenFactory(
+            **COMMON,
+            siret="75665621899905",
+            production_type=Canteen.ProductionType.CENTRAL_SERVING,
+            daily_meal_count=0,  # incomplete
+            satellite_canteens_count=1
+        )
+        canteen_on_site = CanteenFactory(
+            **COMMON, siret="96766910375238", production_type=Canteen.ProductionType.ON_SITE, daily_meal_count=12
+        )
+        canteen_on_site_incomplete = CanteenFactory(
+            **COMMON,
+            siret="96766910375238",
+            production_type=Canteen.ProductionType.ON_SITE,
+            daily_meal_count=0  # incomplete
+        )
+        canteen_on_site_central = CanteenFactory(
+            **COMMON,
+            siret="96766910375238",
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+            daily_meal_count=12,
+            central_producer_siret="75665621899905"
+        )
+        canteen_on_site_central_incomplete = CanteenFactory(
+            **COMMON,
+            siret="96766910375238",
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+            daily_meal_count=12,
+            central_producer_siret=None  # incomplete
+        )
+        for canteen in [canteen_central, canteen_central_serving, canteen_on_site, canteen_on_site_central]:
+            self.assertTrue(canteen.has_complete_data)
+        for canteen in [
+            canteen_central_incomplete,
+            canteen_central_serving_incomplete,
+            canteen_on_site_incomplete,
+            canteen_on_site_central_incomplete,
+        ]:
+            self.assertFalse(canteen.has_complete_data)

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -614,7 +614,7 @@ export const missingCanteenData = (canteen, sectors) => {
 
   // basic canteen fields
   // TODO: what location data do we require at minimum?
-  const requiredFields = ["name", "cityInseeCode", "productionType", "managementType"]
+  const requiredFields = ["name", "cityInseeCode", "productionType", "managementType"] // "economicModel" ??
   const missingFieldLambda = (f) => !canteen[f]
   const missingSharedRequiredData = requiredFields.some(missingFieldLambda)
   if (missingSharedRequiredData) return true


### PR DESCRIPTION
### Quoi

Dans le modèle `Canteen`, j'ajoute une nouvelle property `has_complete_data`

La logique existait déjà dans `DiagnosticsToTeledeclareListView`, j'ai basculé + corrigé/amélioré
- `daily_meal_count` n'est pas toujours obligatoire
- `siret` n'est pas obligatoire si `siren_unite_legale` est rempli
- la cantine a besoin d'au moins 1 secteur
- renvoyer un boolean dans tous les cas