### PR TITLE
refactor(Cantines): le champ daily_meal_count n'est pas obligatoire pour les cantines centrales sans lieu de consommation

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -1040,8 +1040,10 @@ class ActionableCanteensListView(ListAPIView):
         user_canteens = user_canteens.annotate(diagnostic_for_year=Subquery(diagnostics.values("id")[:1]))
         purchases_for_year = Purchase.objects.filter(canteen=OuterRef("pk"), date__year=year)
         user_canteens = user_canteens.annotate(has_purchases_for_year=Exists(purchases_for_year))
-        is_serving_query = Q(production_type=Canteen.ProductionType.CENTRAL_SERVING) | Q(
-            production_type=Canteen.ProductionType.ON_SITE | Q(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
+        is_serving_query = (
+            Q(production_type=Canteen.ProductionType.CENTRAL_SERVING)
+            | Q(production_type=Canteen.ProductionType.ON_SITE)
+            | Q(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
         )
         is_satellite_query = Q(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
         is_central_cuisine_query = Q(production_type=Canteen.ProductionType.CENTRAL) | Q(

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -1040,10 +1040,13 @@ class ActionableCanteensListView(ListAPIView):
         user_canteens = user_canteens.annotate(diagnostic_for_year=Subquery(diagnostics.values("id")[:1]))
         purchases_for_year = Purchase.objects.filter(canteen=OuterRef("pk"), date__year=year)
         user_canteens = user_canteens.annotate(has_purchases_for_year=Exists(purchases_for_year))
+        is_serving_query = Q(production_type=Canteen.ProductionType.CENTRAL_SERVING) | Q(
+            production_type=Canteen.ProductionType.ON_SITE | Q(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
+        )
+        is_satellite_query = Q(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
         is_central_cuisine_query = Q(production_type=Canteen.ProductionType.CENTRAL) | Q(
             production_type=Canteen.ProductionType.CENTRAL_SERVING
         )
-        is_satellite_query = Q(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
         # prep line ministry check
         canteen_sector_relation = apps.get_model(app_label="data", model_name="Canteen_sectors")
         has_sector_requiring_line_ministry = canteen_sector_relation.objects.filter(
@@ -1051,19 +1054,19 @@ class ActionableCanteensListView(ListAPIView):
         )
         user_canteens = user_canteens.annotate(requires_line_ministry=Exists(has_sector_requiring_line_ministry))
         incomplete_canteen_data_query = (
-            Q(yearly_meal_count=None)
-            | Q(daily_meal_count=None)
-            | Q(siret=None)
-            | Q(siret="")
-            | Q(name=None)
+            Q(name=None)
             | Q(city_insee_code=None)
             | Q(city_insee_code="")
+            | Q(yearly_meal_count=None)
+            | Q(siret=None)
+            | Q(siret="")
             | Q(production_type=None)
             | Q(management_type=None)
             | Q(economic_model=None)
-            | (is_central_cuisine_query & Q(satellite_canteens_count=None))
+            | Q(is_serving_query) & Q(daily_meal_count=None)
             | (is_satellite_query & (Q(central_producer_siret=None) | Q(central_producer_siret="")))
             | (is_satellite_query & Q(central_producer_siret=F("siret")))
+            | (is_central_cuisine_query & Q(satellite_canteens_count=None))
             | (Q(line_ministry=None) & Q(requires_line_ministry=True))
         )
 
@@ -1087,7 +1090,7 @@ class ActionableCanteensListView(ListAPIView):
         should_teledeclare = settings.ENABLE_TELEDECLARATION
         conditions = [
             When(
-                (Q(satellite_canteens_count__gt=0) & Q(nb_satellites_in_db=None) & is_central_cuisine_query),
+                (is_central_cuisine_query & Q(satellite_canteens_count__gt=0) & Q(nb_satellites_in_db=None)),
                 then=Value(Canteen.Actions.ADD_SATELLITES),
             ),
             When(nb_satellites_in_db__lt=F("satellite_canteens_count"), then=Value(Canteen.Actions.ADD_SATELLITES)),


### PR DESCRIPTION
### Quoi

Dans la vue `ActionableCanteensListView` on calcule l'action à afficher dans le frontend sur la page "liste" du TDB.
Mais on était trop restrictif dans la query `incomplete_canteen_data_query`
- j'applique maintenant le check "daily_meal_count" seulement aux cantines de type "is_serving"
- j'ai un petit peu réorganisé l'ordre des champs pour matcher avec la PR précédente (#5148) et l'ordre des champs sur le modèle