### PR TITLE
fix(Ajouter et modifier une cantine): corrige la valeur minimale attendue pour être supérieure à zéro

### DIFF
--- a/2024-frontend/src/components/CanteenEstablishmentForm.vue
+++ b/2024-frontend/src/components/CanteenEstablishmentForm.vue
@@ -246,7 +246,7 @@ const resetDynamicInputValues = () => {
 /* Fields verification */
 const { required, integer, minValue, requiredIf, minLength, maxLength } = useValidators()
 const dailyMealRequired = computed(() => form.productionType !== "central")
-const yearlyMealMinValue = computed(() => form.dailyMealCount || 0)
+const yearlyMealMinValue = computed(() => form.dailyMealCount || 1)
 const siretIsRequired = computed(() => form.hasSiret === "has-siret")
 const sirenIsRequired = computed(() => form.hasSiret === "no-siret")
 
@@ -270,10 +270,10 @@ const rules = {
   dailyMealCount: {
     required: requiredIf(dailyMealRequired),
     integer,
-    minValue: minValue(0),
+    minValue: minValue(1),
   },
   yearlyMealCount: { required, integer, minValue: minValue(yearlyMealMinValue) },
-  satelliteCanteensCount: { required: requiredIf(showSatelliteCanteensCount), integer, minValue: minValue(0) },
+  satelliteCanteensCount: { required: requiredIf(showSatelliteCanteensCount), integer, minValue: minValue(1) },
   centralProducerSiret: {
     required: requiredIf(showCentralProducerSiret),
     notSameSiret: helpers.withMessage(


### PR DESCRIPTION
## Description 

Corrige le validateur "vuelidate" qui avec "minValue", vérifie que la valeur est "égale ou supérieur à". Les utilisateurs pouvaient donc indiquer des valeurs égales à zéro. 