### PR TITLE
fix(Cantine): affiche toutes années dans le comparateur "qualité des produits"

### DIFF
--- a/frontend/src/components/MultiYearSummaryStatistics.vue
+++ b/frontend/src/components/MultiYearSummaryStatistics.vue
@@ -44,7 +44,7 @@
 <script>
 import VueApexCharts from "vue-apexcharts"
 import DsfrAccordion from "@/components/DsfrAccordion"
-import { getPercentage, hasDiagnosticApproData, getSustainableTotal, regionDisplayName } from "@/utils"
+import { getPercentage, getSustainableTotal, hasApproGraphData, regionDisplayName } from "@/utils"
 
 const VALUE_DESCRIPTION = "Pourcentage d'achats"
 const BIO = "Bio"
@@ -73,7 +73,7 @@ export default {
     const completedDiagnostics = []
     const thisYear = new Date().getFullYear()
     diagArray.forEach((d) => {
-      if (hasDiagnosticApproData(d)) {
+      if (hasApproGraphData(d)) {
         completedDiagnostics.push(d)
         years.push(`${d.year}${d.year >= thisYear ? " (provisionnel)" : ""}`)
       }

--- a/frontend/src/components/MultiYearSummaryStatistics.vue
+++ b/frontend/src/components/MultiYearSummaryStatistics.vue
@@ -44,7 +44,7 @@
 <script>
 import VueApexCharts from "vue-apexcharts"
 import DsfrAccordion from "@/components/DsfrAccordion"
-import { getPercentage, hasApproGraphData, getSustainableTotal, regionDisplayName } from "@/utils"
+import { getPercentage, getSustainableTotal, regionDisplayName } from "@/utils"
 
 const VALUE_DESCRIPTION = "Pourcentage d'achats"
 const BIO = "Bio"
@@ -73,10 +73,8 @@ export default {
     const completedDiagnostics = []
     const thisYear = new Date().getFullYear()
     diagArray.forEach((d) => {
-      if (hasApproGraphData(d)) {
-        completedDiagnostics.push(d)
-        years.push(`${d.year}${d.year >= thisYear ? " (provisionnel)" : ""}`)
-      }
+      completedDiagnostics.push(d)
+      years.push(`${d.year}${d.year >= thisYear ? " (provisionnel)" : ""}`)
     })
     return {
       years,

--- a/frontend/src/components/MultiYearSummaryStatistics.vue
+++ b/frontend/src/components/MultiYearSummaryStatistics.vue
@@ -77,8 +77,8 @@ export default {
       years.push(`${d.year}${d.year >= thisYear ? " (provisionnel)" : ""}`)
     })
     return {
-      years,
-      completedDiagnostics,
+      years: years.reverse(),
+      completedDiagnostics: completedDiagnostics.reverse(),
     }
   },
   computed: {

--- a/frontend/src/components/MultiYearSummaryStatistics.vue
+++ b/frontend/src/components/MultiYearSummaryStatistics.vue
@@ -44,7 +44,7 @@
 <script>
 import VueApexCharts from "vue-apexcharts"
 import DsfrAccordion from "@/components/DsfrAccordion"
-import { getPercentage, getSustainableTotal, hasApproGraphData, regionDisplayName } from "@/utils"
+import { getPercentage, hasApproGraphData, getSustainableTotal, regionDisplayName } from "@/utils"
 
 const VALUE_DESCRIPTION = "Pourcentage d'achats"
 const BIO = "Bio"


### PR DESCRIPTION
## Description 
Les données de certaines années des diagnostics ne s'affichaient pas dans le comparateur, suite à un bug de la fonction qui vérifie si les données sont complètes.

## Solution
Dans une logique de simplification de l'app, on affiche toujours dans le comparateur les années des diagnostics sans vérifier les valeurs. Et si la valeur est vide / nulle la colonne est à zéro.

## Prévisualisation 
|Avant | Après|
|--|--|
| <img width="739" alt="Capture d’écran 2025-03-25 à 14 16 59" src="https://github.com/user-attachments/assets/8c2a20b6-0022-4c31-8217-a9aff03bc30f" /> |  <img width="695" alt="Capture d’écran 2025-03-25 à 14 18 05" src="https://github.com/user-attachments/assets/fab41d76-bbbd-4a1a-8328-c5cabe4a4434" /> |