### PR TITLE
refactor(Cantines): nouveau queryset pour savoir si il manque des infos

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -78,6 +78,7 @@ from data.models import (
     Sector,
     Teledeclaration,
 )
+from data.models.canteen import has_missing_data_query, is_central_cuisine_query
 from data.region_choices import Region
 
 logger = logging.getLogger(__name__)
@@ -1040,38 +1041,12 @@ class ActionableCanteensListView(ListAPIView):
         user_canteens = user_canteens.annotate(diagnostic_for_year=Subquery(diagnostics.values("id")[:1]))
         purchases_for_year = Purchase.objects.filter(canteen=OuterRef("pk"), date__year=year)
         user_canteens = user_canteens.annotate(has_purchases_for_year=Exists(purchases_for_year))
-        is_serving_query = (
-            Q(production_type=Canteen.ProductionType.CENTRAL_SERVING)
-            | Q(production_type=Canteen.ProductionType.ON_SITE)
-            | Q(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
-        )
-        is_satellite_query = Q(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
-        is_central_cuisine_query = Q(production_type=Canteen.ProductionType.CENTRAL) | Q(
-            production_type=Canteen.ProductionType.CENTRAL_SERVING
-        )
         # prep line ministry check
         canteen_sector_relation = apps.get_model(app_label="data", model_name="Canteen_sectors")
         has_sector_requiring_line_ministry = canteen_sector_relation.objects.filter(
             canteen=OuterRef("pk"), sector__has_line_ministry=True
         )
         user_canteens = user_canteens.annotate(requires_line_ministry=Exists(has_sector_requiring_line_ministry))
-        incomplete_canteen_data_query = (
-            Q(name=None)
-            | Q(city_insee_code=None)
-            | Q(city_insee_code="")
-            | Q(yearly_meal_count=None)
-            | Q(siret=None)
-            | Q(siret="")
-            | Q(production_type=None)
-            | Q(management_type=None)
-            | Q(economic_model=None)
-            | Q(is_serving_query) & Q(daily_meal_count=None)
-            | (is_satellite_query & (Q(central_producer_siret=None) | Q(central_producer_siret="")))
-            | (is_satellite_query & Q(central_producer_siret=F("siret")))
-            | (is_central_cuisine_query & Q(satellite_canteens_count=None))
-            | (Q(line_ministry=None) & Q(requires_line_ministry=True))
-        )
-
         # prep complete diag action
         complete_diagnostics = Diagnostic.objects.filter(pk=OuterRef("diagnostic_for_year"), value_total_ht__gt=0)
         user_canteens = user_canteens.annotate(has_complete_diag=Exists(Subquery(complete_diagnostics)))
@@ -1087,12 +1062,14 @@ class ActionableCanteensListView(ListAPIView):
             status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
         )
         user_canteens = user_canteens.annotate(has_td=Exists(Subquery(tds)))
+        incomplete_canteen_data_query = has_missing_data_query() | (
+            Q(line_ministry=None) & Q(requires_line_ministry=True)
+        )
         # annotate with action
-
         should_teledeclare = settings.ENABLE_TELEDECLARATION
         conditions = [
             When(
-                (is_central_cuisine_query & Q(satellite_canteens_count__gt=0) & Q(nb_satellites_in_db=None)),
+                (is_central_cuisine_query() & Q(satellite_canteens_count__gt=0) & Q(nb_satellites_in_db=None)),
                 then=Value(Canteen.Actions.ADD_SATELLITES),
             ),
             When(nb_satellites_in_db__lt=F("satellite_canteens_count"), then=Value(Canteen.Actions.ADD_SATELLITES)),
@@ -1103,7 +1080,7 @@ class ActionableCanteensListView(ListAPIView):
             ),
             When(diagnostic_for_year=None, then=Value(Canteen.Actions.CREATE_DIAGNOSTIC)),
             When(has_complete_diag=False, then=Value(Canteen.Actions.COMPLETE_DIAGNOSTIC)),
-            When((is_central_cuisine_query & Q(has_cc_mode=False)), then=Value(Canteen.Actions.COMPLETE_DIAGNOSTIC)),
+            When((is_central_cuisine_query() & Q(has_cc_mode=False)), then=Value(Canteen.Actions.COMPLETE_DIAGNOSTIC)),
             When(incomplete_canteen_data_query, then=Value(Canteen.Actions.FILL_CANTEEN_DATA)),
         ]
         if should_teledeclare:

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -65,10 +65,10 @@ def has_missing_data_query():
         | Q(production_type=None)
         | Q(management_type=None)
         | Q(economic_model=None)
-        | Q(is_serving_query()) & Q(daily_meal_count=None)
+        | Q(is_serving_query()) & (Q(daily_meal_count=None) | Q(daily_meal_count=0))
         | (is_satellite_query() & (Q(central_producer_siret=None) | Q(central_producer_siret="")))
         | (is_satellite_query() & Q(central_producer_siret=F("siret")))
-        | (is_central_cuisine_query() & Q(satellite_canteens_count=None))
+        | (is_central_cuisine_query() & (Q(satellite_canteens_count=None) | Q(satellite_canteens_count=0)))
         | Q(line_ministry=None) & Q(requires_line_ministry=True)  # with annotate_with_requires_line_ministry()
     )
 

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -89,8 +89,9 @@ class TestCanteenQueryset(TestCase):
         self.assertEqual(qs.first(), self.canteen_published_armee)
 
 
-class TestCanteenProperty(TestCase):
-    def test_has_complete_data(self):
+class TestCanteenCompletePropertyAndQueryset(TestCase):
+    @classmethod
+    def setUpTestData(cls):
         COMMON = {
             # CanteenFactory generates: name, city_insee_code, sectors
             "yearly_meal_count": 1000,
@@ -98,61 +99,76 @@ class TestCanteenProperty(TestCase):
             "management_type": Canteen.ManagementType.DIRECT,
             "economic_model": Canteen.EconomicModel.PUBLIC,
         }
-        canteen_central = CanteenFactory(
+        cls.canteen_central = CanteenFactory(
             **COMMON,
             siret="75665621899905",
             production_type=Canteen.ProductionType.CENTRAL,
             satellite_canteens_count=1
         )
-        canteen_central_incomplete = CanteenFactory(
+        cls.canteen_central_incomplete = CanteenFactory(
             **COMMON,
             siret="75665621899905",
             production_type=Canteen.ProductionType.CENTRAL,
             satellite_canteens_count=0  # incomplete
         )
-        canteen_central_serving = CanteenFactory(
+        cls.canteen_central_serving = CanteenFactory(
             **COMMON,
             siret="75665621899905",
             production_type=Canteen.ProductionType.CENTRAL_SERVING,
             daily_meal_count=12,
             satellite_canteens_count=1
         )
-        canteen_central_serving_incomplete = CanteenFactory(
+        cls.canteen_central_serving_incomplete = CanteenFactory(
             **COMMON,
             siret="75665621899905",
             production_type=Canteen.ProductionType.CENTRAL_SERVING,
             daily_meal_count=0,  # incomplete
             satellite_canteens_count=1
         )
-        canteen_on_site = CanteenFactory(
+        cls.canteen_on_site = CanteenFactory(
             **COMMON, siret="96766910375238", production_type=Canteen.ProductionType.ON_SITE, daily_meal_count=12
         )
-        canteen_on_site_incomplete = CanteenFactory(
+        cls.canteen_on_site_incomplete = CanteenFactory(
             **COMMON,
             siret="96766910375238",
             production_type=Canteen.ProductionType.ON_SITE,
             daily_meal_count=0  # incomplete
         )
-        canteen_on_site_central = CanteenFactory(
+        cls.canteen_on_site_central = CanteenFactory(
             **COMMON,
             siret="96766910375238",
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             daily_meal_count=12,
             central_producer_siret="75665621899905"
         )
-        canteen_on_site_central_incomplete = CanteenFactory(
+        cls.canteen_on_site_central_incomplete = CanteenFactory(
             **COMMON,
             siret="96766910375238",
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             daily_meal_count=12,
             central_producer_siret=None  # incomplete
         )
-        for canteen in [canteen_central, canteen_central_serving, canteen_on_site, canteen_on_site_central]:
+
+    def test_has_complete_data_queryset(self):
+        self.assertEqual(Canteen.objects.count(), 8)
+        self.assertEqual(Canteen.objects.has_complete_data().count(), 4)
+
+    def test_has_complete_data_property(self):
+        for canteen in [
+            self.canteen_central,
+            self.canteen_central_serving,
+            self.canteen_on_site,
+            self.canteen_on_site_central,
+        ]:
             self.assertTrue(canteen.has_complete_data)
         for canteen in [
-            canteen_central_incomplete,
-            canteen_central_serving_incomplete,
-            canteen_on_site_incomplete,
-            canteen_on_site_central_incomplete,
+            self.canteen_central_incomplete,
+            self.canteen_central_serving_incomplete,
+            self.canteen_on_site_incomplete,
+            self.canteen_on_site_central_incomplete,
         ]:
             self.assertFalse(canteen.has_complete_data)
+
+    def test_has_missing_data_queryset(self):
+        self.assertEqual(Canteen.objects.count(), 8)
+        self.assertEqual(Canteen.objects.has_missing_data().count(), 4)

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -51,7 +51,7 @@ class TestCanteenModel(TestCase):
         self.assertEqual(qs.count(), 1, "Soft deleted canteens can be accessed in custom queryset")
 
 
-class TestCanteenQueryset(TestCase):
+class TestCanteenQuerySet(TestCase):
     @classmethod
     def setUpTestData(cls):
         CanteenFactory(line_ministry=None, publication_status=Canteen.PublicationStatus.PUBLISHED)
@@ -89,7 +89,7 @@ class TestCanteenQueryset(TestCase):
         self.assertEqual(qs.first(), self.canteen_published_armee)
 
 
-class TestCanteenCompletePropertyAndQueryset(TestCase):
+class TestCanteenCompletePropertyAndQuerySet(TestCase):
     @classmethod
     def setUpTestData(cls):
         COMMON = {


### PR DESCRIPTION
Similaire à #5148, et suite à des changements dans #5150

J'en profite pour bouger cette logique existante dans la view (`ActionableCanteensListView`) vers le modèle (`Canteen`)

Et j'ai rajouté des tests :tada: 

TODO (futur PR ?)
- gérer la logique siret/siren_unite_legale (similaire à #5125)