### PR TITLE
fix(Badge menus végétariens): modification du calcul d'obtention du badge

### DIFF
--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -506,6 +506,12 @@ class Canteen(SoftDeletionModel):
             return True
 
     @property
+    def in_administration(self):
+        administration_sectors = Sector.objects.filter(category="administration")
+        if administration_sectors.count() and self.sectors.intersection(administration_sectors).exists():
+            return True
+
+    @property
     def lead_image(self):
         return self.images.first()
 

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1253,15 +1253,17 @@ class Diagnostic(models.Model):
 
     @property
     def diversification_badge(self) -> bool | None:
-        if self.vegetarian_weekly_recurrence == Diagnostic.VegetarianMenuFrequency.DAILY:
-            return True
-        elif self.vegetarian_weekly_recurrence in [
+        has_daily_frequency = self.vegetarian_weekly_recurrence == Diagnostic.VegetarianMenuFrequency.DAILY
+        has_weekly_or_more_frequency = self.vegetarian_weekly_recurrence in [
+            Diagnostic.VegetarianMenuFrequency.DAILY,
             Diagnostic.VegetarianMenuFrequency.MID,
             Diagnostic.VegetarianMenuFrequency.HIGH,
-        ]:
-            # if the canteen is in the education sector, it can have a lower recurrence
-            if self.canteen.in_education:
-                return True
+        ]
+        # Only the canteens is in the administration sector must have a daily frequency
+        if self.canteen.in_administration and has_daily_frequency:
+            return True
+        if not self.canteen.in_administration and has_weekly_or_more_frequency:
+            return True
         if self.tunnel_diversification:
             return False
 


### PR DESCRIPTION
## Description

Suite à un bug remonté par un utilisateur sur son secteur spécifique des crèches, la règle de calcul du badge pour le ménu végétarien a été modifiée :

|Avant|Après|
|-|-|
| <img width="790" alt="Capture d’écran 2025-03-25 à 17 07 22" src="https://github.com/user-attachments/assets/4db723b8-6fb1-49f0-babc-3b2e47079b98" /> | <img width="940" alt="Capture d’écran 2025-03-25 à 17 07 27" src="https://github.com/user-attachments/assets/06fb29b0-a857-4a05-8dcc-9477af3a73f6" /> |