### PR TITLE
fix(Cantines): le champ line_ministry n'est pas obligatoire pour les établissements privés

### DIFF
--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -69,7 +69,9 @@ def has_missing_data_query():
         | (is_satellite_query() & (Q(central_producer_siret=None) | Q(central_producer_siret="")))
         | (is_satellite_query() & Q(central_producer_siret=F("siret")))
         | (is_central_cuisine_query() & (Q(satellite_canteens_count=None) | Q(satellite_canteens_count=0)))
-        | Q(line_ministry=None) & Q(requires_line_ministry=True)  # with annotate_with_requires_line_ministry()
+        | (
+            Q(economic_model=Canteen.EconomicModel.PUBLIC) & Q(requires_line_ministry=True) & Q(line_ministry=None)
+        )  # with annotate_with_requires_line_ministry()
     )
 
 


### PR DESCRIPTION
Suite de #5150, et en lien avec #5112

Il y avaient encore une règle à prendre en compte...

