### PR TITLE
refactor(Cantines): Actions: pour les cantines satellites, regarder si la CC n'a pas déjà un bilan complet

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -1062,16 +1062,12 @@ class ActionableCanteensListView(ListAPIView):
         # annotate with action
         should_teledeclare = settings.ENABLE_TELEDECLARATION
         conditions = [
-            # FILL_CANTEEN_DATA
-            When(has_missing_data_query(), then=Value(Canteen.Actions.FILL_CANTEEN_DATA)),
-            # ADD_SATELLITES
             When(
                 (is_central_cuisine_query() & Q(satellite_canteens_count__gt=0) & Q(nb_satellites_in_db=None)),
                 then=Value(Canteen.Actions.ADD_SATELLITES),
             ),
             When(nb_satellites_in_db__lt=F("satellite_canteens_count"), then=Value(Canteen.Actions.ADD_SATELLITES)),
             When(nb_satellites_in_db__gt=F("satellite_canteens_count"), then=Value(Canteen.Actions.ADD_SATELLITES)),
-            # DIAGNOSTIC
             When(
                 Q(diagnostic_for_year=None) & Q(has_purchases_for_year=True),
                 then=Value(Canteen.Actions.PREFILL_DIAGNOSTIC),
@@ -1079,6 +1075,7 @@ class ActionableCanteensListView(ListAPIView):
             When(diagnostic_for_year=None, then=Value(Canteen.Actions.CREATE_DIAGNOSTIC)),
             When(has_complete_diagnostic_for_year=False, then=Value(Canteen.Actions.COMPLETE_DIAGNOSTIC)),
             When((is_central_cuisine_query() & Q(has_cc_mode=False)), then=Value(Canteen.Actions.COMPLETE_DIAGNOSTIC)),
+            When(has_missing_data_query(), then=Value(Canteen.Actions.FILL_CANTEEN_DATA)),
         ]
         if should_teledeclare:
             conditions.append(When(has_td=False, then=Value(Canteen.Actions.TELEDECLARE)))

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -1041,9 +1041,7 @@ class ActionableCanteensListView(ListAPIView):
         purchases_for_year = Purchase.objects.filter(canteen=OuterRef("pk"), date__year=year)
         user_canteens = user_canteens.annotate(has_purchases_for_year=Exists(purchases_for_year))
         # prep complete diag action
-        complete_diagnostics = Diagnostic.objects.filter(
-            Q(canteen=OuterRef("central_kitchen_id")) | Q(canteen=OuterRef("pk")), year=year, value_total_ht__gt=0
-        )
+        complete_diagnostics = diagnostics.filter(value_total_ht__gt=0)
         user_canteens = user_canteens.annotate(has_complete_diagnostic_for_year=Exists(Subquery(complete_diagnostics)))
         has_cc_mode = Diagnostic.objects.filter(
             pk=OuterRef("diagnostic_for_year"),


### PR DESCRIPTION
Encore des modifications dans `ActionableCanteensListView`

On gérait mal le cas des CSAT qui auraient déjà commencé un diag, et que leur CC aurait aussi fait un diag complet + TD.
On demandait aux CSAT de compléter leur diag, alors que c'était déjà bon.
- il fallait créer une query dédiée pour les `complete_diagnostics`

Je créerais des tests supplémentaires dans la PR suivante : #5161