### PR TITLE
improve(Télédéclaration): prolonge la campagne de télédéclaration jusqu'au 6 avril

### DIFF
--- a/frontend/src/views/ManagementPage/InformationBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationBanner.vue
@@ -1,12 +1,12 @@
 <template>
   <DsfrCallout noIcon class="mt-2">
     <h2 class="fr-text font-weight-bold mb-2 mt-2">
-      CAMPAGNE DE TELEDECLARATION 2025 : Du 7 janvier au 31 mars
+      INFORMATION IMPORTANTE :
     </h2>
     <p class="mb-0">
-      Dans votre espace cantine, remplissez votre bilan sur les données d'achat 2024 et télédéclarez vos données.
+      Maintien ouvert exceptionnel de la campagne de télédéclaration 2025 sur l'ensemble de la première semaine d'avril.
       <br />
-      Pour rappel, selon l’arrêté ministériel du 14 septembre 2022, il est obligatoire de télédéclarer ses achats.
+      Les télédéclarations seront possibles jusqu’au dimanche 6 avril 2025 inclus.
     </p>
     <v-row class="mt-4 mb-0 mx-0 align-center">
       <v-btn :to="{ name: 'PendingActions' }" color="primary" class="mb-5 mb-md-2 mr-4">

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -23,6 +23,6 @@ CAMPAIGN_DATES = {
     },
     2024: {
         "start_date": datetime(2025, 1, 7, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "end_date": datetime(2025, 3, 31, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "end_date": datetime(2025, 4, 7, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
 }


### PR DESCRIPTION
## Description

Il a été décidé de prolonger la campagne de télédéclaration jusqu'au dimanche 6 avril. Comme cette date tombe un dimanche, nous allons "officiellement" couper la campagne le lundi 7 tôt le matin.

## Prévisualistion

|Avant|Après|
|--|--|
| <img width="1233" alt="Capture d’écran 2025-03-27 à 10 54 18" src="https://github.com/user-attachments/assets/f148f72c-1056-48a9-822a-c2d4322286c7" /> | <img width="1255" alt="Capture d’écran 2025-03-27 à 10 54 27" src="https://github.com/user-attachments/assets/07790e8e-6561-42af-924c-5b59076783f1" /> |