### PR TITLE
refactor(Cantines): Actions: gère les cantines sans siret

### DIFF
--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -36,6 +36,10 @@ def list_properties(queryset, property):
     return list(queryset.values_list(property, flat=True))
 
 
+def has_siret_or_siren_unite_legale_query():
+    return Q(siret__isnull=False) | Q(siren_unite_legale__isnull=False)
+
+
 def is_serving_query():
     return Q(
         production_type__in=[
@@ -60,8 +64,7 @@ def has_missing_data_query():
         | Q(city_insee_code=None)
         | Q(city_insee_code="")
         | Q(yearly_meal_count=None)
-        | Q(siret=None)
-        | Q(siret="")
+        | Q(~has_siret_or_siren_unite_legale_query())
         | Q(production_type=None)
         | Q(management_type=None)
         | Q(economic_model=None)

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -121,6 +121,7 @@ class TestCanteenCompletePropertyAndQuerySet(TestCase):
         cls.canteen_central_serving_incomplete = CanteenFactory(
             **COMMON,
             siret=None,  # incomplete
+            siren_unite_legale=None,
             production_type=Canteen.ProductionType.CENTRAL_SERVING,
             daily_meal_count=12,
             satellite_canteens_count=1

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -120,13 +120,17 @@ class TestCanteenCompletePropertyAndQuerySet(TestCase):
         )
         cls.canteen_central_serving_incomplete = CanteenFactory(
             **COMMON,
-            siret="75665621899905",
+            siret=None,  # incomplete
             production_type=Canteen.ProductionType.CENTRAL_SERVING,
-            daily_meal_count=0,  # incomplete
+            daily_meal_count=12,
             satellite_canteens_count=1
         )
         cls.canteen_on_site = CanteenFactory(
-            **COMMON, siret="96766910375238", production_type=Canteen.ProductionType.ON_SITE, daily_meal_count=12
+            **COMMON,
+            siret=None,
+            siren_unite_legale="967669103",  # complete
+            production_type=Canteen.ProductionType.ON_SITE,
+            daily_meal_count=12
         )
         cls.canteen_on_site_incomplete = CanteenFactory(
             **COMMON,


### PR DESCRIPTION
Suite aux modifications sur ce même queryset (voir https://github.com/betagouv/ma-cantine/pull/5155)
Et à l'ajout du nouveau champ `siren_unite_legale` (voir https://github.com/betagouv/ma-cantine/pull/5082)

Une cantine sans `siret`, mais avec un `siren_unite_legale`, doit être considérée comme avec ses infos complétées !