### PR TITLE
improve(Modifier mon établissement): ajoute un lien pour accéder à la page de suppression de l'établissement

### DIFF
--- a/2024-frontend/src/main.js
+++ b/2024-frontend/src/main.js
@@ -14,6 +14,7 @@ import WeatherWindyIcon from "mdi-icons/WeatherWindy"
 import BullhornIcon from "mdi-icons/Bullhorn"
 import LeafIcon from "mdi-icons/Leaf"
 import LoadingIcon from "mdi-icons/Loading"
+import DeleteIcon from "mdi-icons/Loading"
 // "This few lines of CSS will cause the icons to scale with any surrounding text, which can be helpful when you primarily style with CSS."
 // https://www.npmjs.com/package/vue-material-design-icons
 import "mdi-icons/styles.css"
@@ -51,6 +52,7 @@ app.component("mdi-offer", OfferIcon)
 app.component("mdi-weather-windy", WeatherWindyIcon)
 app.component("mdi-bullhorn", BullhornIcon)
 app.component("mdi-loading", LoadingIcon)
+app.component("mdi-delete", DeleteIcon)
 // TODO: get the remix icon of leaf-fill
 app.component("$leaf-fill", LeafIcon)
 

--- a/2024-frontend/src/router/vue2.js
+++ b/2024-frontend/src/router/vue2.js
@@ -91,6 +91,10 @@ const vue2routes = [
     path: "/importer-diagnostics/:importUrlSlug",
     name: "DiagnosticImportPage",
   },
+  {
+    path: "/modifier-ma-cantine/:canteenUrlComponent/supprimer",
+    name: "CanteenDeletion",
+  },
 ]
 
 export default vue2routes

--- a/2024-frontend/src/views/CanteenModification.vue
+++ b/2024-frontend/src/views/CanteenModification.vue
@@ -50,19 +50,19 @@ const goToCanteenPage = (id) => {
 <template>
   <section class="fr-grid-row fr-grid-row--bottom">
     <h1>{{ route.meta.title }}</h1>
+    <AppLoader v-if="loading" />
+    <CanteenEstablishmentForm
+      v-else-if="!loading && canteenData.id"
+      :establishment-data="canteenData"
+      :showCancelButton="true"
+      @sendForm="(payload) => saveCanteen(payload)"
+      @cancel="(id) => goToCanteenPage(canteenId)"
+    />
+    <p v-else>
+      Une erreur est survenue,
+      <AppLinkRouter :to="{ name: 'DashboardManager' }" title="revenir à la page précédente" />
+    </p>
   </section>
-  <AppLoader v-if="loading" />
-  <CanteenEstablishmentForm
-    v-else-if="!loading && canteenData.id"
-    :establishment-data="canteenData"
-    :showCancelButton="true"
-    @sendForm="(payload) => saveCanteen(payload)"
-    @cancel="(id) => goToCanteenPage(canteenId)"
-  />
-  <p v-else>
-    Une erreur est survenue,
-    <AppLinkRouter :to="{ name: 'DashboardManager' }" title="revenir à la page précédente" />
-  </p>
   <section class="fr-container fr-background-alt--red-marianne fr-p-3w fr-mt-2w fr-grid-row fr-grid-row--center">
     <div class="fr-col-12 fr-col-lg-7 fr-background-default--grey fr-p-2w fr-p-md-7w">
       <h2 class="fr-h5 fr-text-default--error">

--- a/2024-frontend/src/views/CanteenModification.vue
+++ b/2024-frontend/src/views/CanteenModification.vue
@@ -63,7 +63,7 @@ const goToCanteenPage = (id) => {
     Une erreur est survenue,
     <AppLinkRouter :to="{ name: 'DashboardManager' }" title="revenir à la page précédente" />
   </p>
-  <section class="fr-container fr-background-alt--red-marianne fr-p-3w fr-mt-2w fr-grid-row fr-grid-row--center">
+  <section class="fr-container fr-background-alt--red-marianne fr-p-3w fr-mt-2w">
     <div class="fr-col-12 fr-col-lg-7 fr-background-default--grey fr-p-2w fr-p-md-7w">
       <h2 class="fr-h5 fr-text-default--error">
         <span class="mdi mdi-delete"></span>

--- a/2024-frontend/src/views/CanteenModification.vue
+++ b/2024-frontend/src/views/CanteenModification.vue
@@ -63,4 +63,16 @@ const goToCanteenPage = (id) => {
     Une erreur est survenue,
     <AppLinkRouter :to="{ name: 'DashboardManager' }" title="revenir à la page précédente" />
   </p>
+  <section class="fr-container fr-background-alt--red-marianne fr-p-3w fr-mt-2w fr-grid-row fr-grid-row--center">
+    <div class="fr-col-12 fr-col-lg-7 fr-background-default--grey fr-p-2w fr-p-md-7w">
+      <h2 class="fr-h5 fr-text-default--error">
+        <span class="mdi mdi-delete"></span>
+        Supprimer cet établissement
+      </h2>
+      <p class="fr-mb-0">
+        Vous ne souhaitez plus faire apparaître cet établissement sur la plateforme ma-cantine, vous pouvez le supprimer
+        <AppLinkRouter :to="{ name: 'CanteenDeletion' }" title="en cliquant ici" />
+      </p>
+    </div>
+  </section>
 </template>

--- a/2024-frontend/src/views/CanteenModification.vue
+++ b/2024-frontend/src/views/CanteenModification.vue
@@ -63,7 +63,7 @@ const goToCanteenPage = (id) => {
     Une erreur est survenue,
     <AppLinkRouter :to="{ name: 'DashboardManager' }" title="revenir à la page précédente" />
   </p>
-  <section class="fr-container fr-background-alt--red-marianne fr-p-3w fr-mt-2w">
+  <section class="fr-container fr-background-alt--red-marianne fr-p-3w fr-mt-2w fr-grid-row fr-grid-row--center">
     <div class="fr-col-12 fr-col-lg-7 fr-background-default--grey fr-p-2w fr-p-md-7w">
       <h2 class="fr-h5 fr-text-default--error">
         <span class="mdi mdi-delete"></span>


### PR DESCRIPTION
## Description
Lors de la migration de la page, le bouton pour supprimer son établissement a été oublié. La suppression d'un établissement est une page spécifique, pour avoir un correctif rapide je propose de faire un simple encart qui redirige vers la page, et nous ferons dans un second temps la migration de la page suppression.

## Prévisualisation

| Vue 3 | Vue 2 |
|--|--|
| <img width="1273" alt="Capture d’écran 2025-03-27 à 11 39 09" src="https://github.com/user-attachments/assets/6d54e1cc-4b41-47dd-aebf-5dde10ae3262" /> | <img width="1253" alt="Capture d’écran 2025-03-27 à 11 40 46" src="https://github.com/user-attachments/assets/f764714e-372a-4abc-bf90-26858e5d63f4" /> |