### PR TITLE
refactor(Cantines): Nouvelle querysets pour mieux documenter les règles concernant les cantines centrales & satellites

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -1020,10 +1020,7 @@ class ActionableCanteensListView(ListAPIView):
         # prep add satellites action
         # https://docs.djangoproject.com/en/4.1/ref/models/expressions/#using-aggregates-within-a-subquery-expression
         satellites = (
-            Canteen.objects.filter(
-                central_producer_siret=OuterRef("siret"),
-                production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
-            )
+            Canteen.objects.get_satellites(OuterRef("siret"))
             .order_by()
             .values("central_producer_siret")  # sets the groupBy for the aggregation
         )

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -1050,8 +1050,14 @@ class ActionableCanteensListView(ListAPIView):
                 (is_central_cuisine_query() & Q(satellite_canteens_count__gt=0) & Q(satellites_in_db_count=None)),
                 then=Value(Canteen.Actions.ADD_SATELLITES),
             ),
-            When(satellites_in_db_count__lt=F("satellite_canteens_count"), then=Value(Canteen.Actions.ADD_SATELLITES)),
-            When(satellites_in_db_count__gt=F("satellite_canteens_count"), then=Value(Canteen.Actions.ADD_SATELLITES)),
+            When(
+                is_central_cuisine_query() & Q(satellites_in_db_count__lt=F("satellite_canteens_count")),
+                then=Value(Canteen.Actions.ADD_SATELLITES),
+            ),
+            When(
+                is_central_cuisine_query() & Q(satellites_in_db_count__gt=F("satellite_canteens_count")),
+                then=Value(Canteen.Actions.ADD_SATELLITES),
+            ),
             When(
                 Q(diagnostic_for_year=None) & Q(has_purchases_for_year=True),
                 then=Value(Canteen.Actions.PREFILL_DIAGNOSTIC),

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -95,6 +95,9 @@ class CanteenQuerySet(SoftDeletionQuerySet):
             else self.exclude(publication_status=Canteen.PublicationStatus.PUBLISHED)
         )
 
+    def is_satellite(self):
+        return self.filter(is_satellite_query())
+
     def get_satellites(self, central_producer_siret):
         return self.filter(is_satellite_query(), central_producer_siret=central_producer_siret)
 
@@ -123,6 +126,12 @@ class CanteenManager(SoftDeletionManager):
 
     def publicly_hidden(self):
         return self.get_queryset().publicly_hidden()
+
+    def is_satellite(self):
+        return self.get_queryset().is_satellite()
+
+    def get_satellites(self, central_producer_siret):
+        return self.get_queryset().get_satellites(central_producer_siret)
 
     def has_missing_data(self):
         return self.get_queryset().has_missing_data()
@@ -171,38 +180,6 @@ class Canteen(SoftDeletionModel):
         TELEDECLARE = "40_teledeclare", "Télédéclarer"
         PUBLISH = "50_publish", "Publier"
         NOTHING = "95_nothing", "Rien à faire !"
-
-    class Sectors(models.TextChoices):
-        """
-        Restaurants des prisons administration True
-        Restaurants administratifs d’Etat (RA) administration True
-        Restaurants des armées / police / gendarmerie administration True
-        Etablissements publics d’Etat (EPA ou EPIC) administration True
-        Supérieur et Universitaire education True
-        Autres structures d’enseignement education True
-        Etablissements de la PJJ social True
-        Hôpitaux health False
-        Autres établissements de soins health False
-        Restaurants inter-administratifs d’État (RIA) administration True
-        Etablissements d’enseignement agricole education False
-        Autres établissements sociaux et médico-sociaux social False
-        Autres établissements de loisirs leisure False
-        Restaurants d’entreprises enterprise False
-        Restaurants inter-entreprises enterprise False
-        Restaurants administratifs des collectivités territoriales administration False
-        Secondaire collège education False
-        Ecole primaire (maternelle et élémentaire) education False
-        Cliniques health False
-        Secondaire lycée (hors agricole) education False
-        Crèche social False
-        Autres établissements non listés autres False
-        EHPAD / maisons de retraite / foyers de personnes âgées social False
-        IME / ITEP social False
-        ESAT / Etablissements spécialisés social False
-        Centre de vacances / sportif leisure False
-        """
-
-        ADMINISTRATION_PRISONS = "administration", "Restaurants des prisons"
 
     class Ministries(models.TextChoices):
         AFFAIRES_ETRANGERES = "affaires_etrangeres", "Affaires étrangères"

--- a/data/signals.py
+++ b/data/signals.py
@@ -32,10 +32,7 @@ def update_satellites_siret(sender, instance, raw, using, update_fields, **kwarg
             logger.info(
                 f"SIRET change. Central kitchen {instance.id} ({instance.name}) changed its SIRET from {obj.siret} to {instance.siret}"
             )
-            satellites = Canteen.objects.filter(
-                central_producer_siret=obj.siret,
-                production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
-            ).only("id")
+            satellites = Canteen.objects.get_satellites(obj.siret).only("id")
             for satellite in satellites:
                 logger.info(
                     f"SIRET change. Satellite cantine {satellite.id} had its central_producer_siret changed automatically from {obj.siret} to {instance.siret}"

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -89,6 +89,35 @@ class TestCanteenVisibleQuerySet(TestCase):
         self.assertEqual(qs.first(), self.canteen_published_armee)
 
 
+class TestCanteenSatelliteQuerySet(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen_central_1 = CanteenFactory(
+            siret="75665621899905", production_type=Canteen.ProductionType.CENTRAL, satellite_canteens_count=2
+        )  # 1 missing
+        cls.canteen_central_2 = CanteenFactory(
+            siret="75665621899906", production_type=Canteen.ProductionType.CENTRAL, satellite_canteens_count=2
+        )
+        cls.canteen_on_site_central_1 = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=cls.canteen_central_1.siret
+        )
+        cls.canteen_on_site_central_2 = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=cls.canteen_central_2.siret
+        )
+        cls.canteen_on_site_central_2 = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=cls.canteen_central_2.siret
+        )
+
+    def test_is_satellite(self):
+        self.assertEqual(Canteen.objects.count(), 5)
+        self.assertEqual(Canteen.objects.is_satellite().count(), 3)
+
+    def test_get_satellites(self):
+        self.assertEqual(Canteen.objects.count(), 5)
+        self.assertEqual(Canteen.objects.get_satellites(self.canteen_central_1.siret).count(), 1)
+        self.assertEqual(Canteen.objects.get_satellites(self.canteen_central_2.siret).count(), 2)
+
+
 class TestCanteenSiretOrSirenUniteLegaleQuerySet(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -112,10 +112,57 @@ class TestCanteenSatelliteQuerySet(TestCase):
         self.assertEqual(Canteen.objects.count(), 5)
         self.assertEqual(Canteen.objects.is_satellite().count(), 3)
 
+    def test_annotate_with_central_kitchen_id(self):
+        self.assertEqual(Canteen.objects.count(), 5)
+        self.assertEqual(
+            Canteen.objects.annotate_with_central_kitchen_id()
+            .filter(id=self.canteen_on_site_central_1.id)
+            .first()
+            .central_kitchen_id,
+            self.canteen_central_1.id,
+        )
+        self.assertEqual(
+            Canteen.objects.annotate_with_central_kitchen_id()
+            .filter(id=self.canteen_on_site_central_2.id)
+            .first()
+            .central_kitchen_id,
+            self.canteen_central_2.id,
+        )
+        self.assertIsNone(
+            Canteen.objects.annotate_with_central_kitchen_id()
+            .filter(id=self.canteen_central_1.id)
+            .first()
+            .central_kitchen_id
+        )
+
     def test_get_satellites(self):
         self.assertEqual(Canteen.objects.count(), 5)
         self.assertEqual(Canteen.objects.get_satellites(self.canteen_central_1.siret).count(), 1)
         self.assertEqual(Canteen.objects.get_satellites(self.canteen_central_2.siret).count(), 2)
+
+    def test_annotate_with_satellites_in_db_count(self):
+        self.assertEqual(Canteen.objects.count(), 5)
+        self.assertEqual(
+            Canteen.objects.annotate_with_satellites_in_db_count()
+            .filter(id=self.canteen_central_1.id)
+            .first()
+            .satellites_in_db_count,
+            1,
+        )
+        self.assertEqual(
+            Canteen.objects.annotate_with_satellites_in_db_count()
+            .filter(id=self.canteen_central_2.id)
+            .first()
+            .satellites_in_db_count,
+            2,
+        )
+        self.assertEqual(
+            Canteen.objects.annotate_with_satellites_in_db_count()
+            .filter(id=self.canteen_on_site_central_1.id)
+            .first()
+            .satellites_in_db_count,
+            0,
+        )
 
 
 class TestCanteenSiretOrSirenUniteLegaleQuerySet(TestCase):


### PR DESCRIPTION
4 nouvelles queryset sur le modèle `Canteen`
- `is_satellite`
- `annotate_with_central_kitchen_id`
- `get_satellites(central_producer_siret)`
- `annotate_with_satellites_in_db_count`

Permet de simplifier le code dans ActionableCanteensListView