### PR TITLE
refactor(Tableau de bord): récupérer le badge à l'aide de l'API actionableCanteens (au lieu de le recalculer dans le frontend)

### DIFF
--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -1,11 +1,46 @@
 <template>
-  <DsfrBadge v-if="body" :mode="mode">
-    <p class="ma-0 pa-0 text-uppercase">{{ body }}</p>
+  <DsfrBadge v-if="badge" :mode="badge.mode">
+    <p class="ma-0 pa-0 text-uppercase">{{ badge.body }}</p>
   </DsfrBadge>
   <span v-else></span>
 </template>
+
 <script>
 import DsfrBadge from "@/components/DsfrBadge"
+
+const BADGE_LIST = [
+  {
+    // currentYear
+    body: "Année en cours",
+    mode: "INFO",
+    actions: [],
+  },
+  {
+    // missingData
+    body: "Données à compléter",
+    mode: "ERROR",
+    actions: [
+      "10_add_satellites",
+      "35_fill_canteen_data",
+      "18_prefill_diagnostic",
+      "20_create_diagnostic",
+      "30_complete_diagnostic",
+    ],
+  },
+  {
+    // readyToTeledeclare
+    body: "Bilan à télédéclarer",
+    mode: "ERROR",
+    actions: ["40_teledeclare"],
+  },
+  {
+    // hasActiveTeledeclaration
+    body: "Bilan télédéclaré",
+    mode: "SUCCESS",
+    actions: ["95_nothing"],
+  },
+]
+
 export default {
   name: "DataInfoBadge",
   components: { DsfrBadge },
@@ -26,20 +61,20 @@ export default {
       default: false,
       type: Boolean,
     },
+    canteenAction: {
+      type: String,
+      default: null,
+    },
   },
   computed: {
-    body() {
-      if (this.hasActiveTeledeclaration) return "Bilan télédéclaré"
-      if (this.currentYear) return "Année en cours"
-      if (this.missingData) return "Données à compléter"
-      if (this.readyToTeledeclare) return "Bilan à télédéclarer"
+    badge() {
+      if (this.currentYear) return BADGE_LIST[0]
+      if (this.canteenAction)
+        return BADGE_LIST.find((badge) => badge.actions && badge.actions.includes(this.canteenAction))
+      if (this.hasActiveTeledeclaration) return BADGE_LIST[3]
+      if (this.missingData) return BADGE_LIST[1]
+      if (this.readyToTeledeclare) return BADGE_LIST[2]
       return null
-    },
-    mode() {
-      if (this.hasActiveTeledeclaration) return "SUCCESS"
-      else if (this.currentYear) return "INFO"
-      else if (this.missingData || this.readyToTeledeclare) return "ERROR"
-      return "INFO"
     },
   },
 }

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -18,13 +18,6 @@
             :missingData="needsData"
             :readyToTeledeclare="readyToTeledeclare"
             :hasActiveTeledeclaration="hasActiveTeledeclaration"
-            class="mt-4"
-          />
-          <DataInfoBadge
-            :currentYear="isCurrentYear"
-            :missingData="needsData"
-            :readyToTeledeclare="readyToTeledeclare"
-            :hasActiveTeledeclaration="hasActiveTeledeclaration"
             :canteenAction="canteenAction"
             class="mt-4"
           />

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -20,6 +20,14 @@
             :hasActiveTeledeclaration="hasActiveTeledeclaration"
             class="mt-4"
           />
+          <DataInfoBadge
+            :currentYear="isCurrentYear"
+            :missingData="needsData"
+            :readyToTeledeclare="readyToTeledeclare"
+            :hasActiveTeledeclaration="hasActiveTeledeclaration"
+            :canteenAction="canteenAction"
+            class="mt-4"
+          />
           <hr aria-hidden="true" role="presentation" class="my-6" />
         </div>
         <ApproSegment
@@ -177,6 +185,7 @@ export default {
       allowedYears: years.map((year) => ({ text: year, value: year })),
       showTeledeclarationPreview: false,
       purchasesSummary: undefined,
+      canteenAction: null,
     }
   },
   computed: {
@@ -313,6 +322,16 @@ export default {
           })
       }
     },
+    fetchCanteenAction() {
+      fetch(`/api/v1/actionableCanteens/${this.canteen.id}/${this.year}`)
+        .then((response) => {
+          if (response.status < 200 || response.status >= 400) throw new Error(`Error encountered : ${response}`)
+          return response.json()
+        })
+        .then((canteen) => {
+          this.canteenAction = canteen.action
+        })
+    },
   },
   mounted() {
     if (this.$route.query?.year && this.diagnosticYears.indexOf(+this.$route.query.year) > -1) {
@@ -321,10 +340,14 @@ export default {
     }
   },
   watch: {
-    year() {
-      if (this.isCurrentYear && !this.purchasesSummary) {
-        this.fetchPurchasesSummary()
-      }
+    year: {
+      handler() {
+        this.fetchCanteenAction()
+        if (this.isCurrentYear && !this.purchasesSummary) {
+          this.fetchPurchasesSummary()
+        }
+      },
+      immediate: true,
     },
   },
 }


### PR DESCRIPTION
### Quoi

Sur la page "tableau de bord de sa cantine", changer la façon dont on affiche le badge.
- actuellement : recalculé par le frontend
- avec cette PR : utiliser l'endpoint API `/actionableCanteens` et ainsi récupérer la même action que dans la vue "tableau de bord mes cantines"

### Capture d'écran

![image](https://github.com/user-attachments/assets/b6c03601-72ca-40a2-a441-535e1b84a691)
 