### PR TITLE
fix(Télédéclaration): homogénéise les badges utilisés dans la page progression et la télédéclaration

### DIFF
--- a/frontend/src/components/KeyMeasureBadge.vue
+++ b/frontend/src/components/KeyMeasureBadge.vue
@@ -18,7 +18,7 @@ export default {
     id: String,
     diagnostic: Object,
     canteen: Object,
-    year: String,
+    year: Number,
   },
   computed: {
     isRequired() {
@@ -67,7 +67,7 @@ export default {
     hasCentralKitchenDeclared() {
       if (!this.isSatellite) return false
       const teledeclaredDiag = this.canteen.centralKitchenDiagnostics.filter((diagnostic) => {
-        const isCurrentYear = diagnostic.year == this.year
+        const isCurrentYear = diagnostic.year === this.year
         return isCurrentYear && diagnostic.isTeledeclared
       })
       return teledeclaredDiag.length > 0

--- a/frontend/src/views/DashboardManager/ApproSegment.vue
+++ b/frontend/src/views/DashboardManager/ApproSegment.vue
@@ -72,7 +72,7 @@
           class="py-0 ml-8"
           :canteen="canteen"
           :diagnostic="diagnostic"
-          :year="year"
+          :year="`${year}`"
           id="qualite-des-produits"
         />
       </v-card-text>

--- a/frontend/src/views/DashboardManager/ApproSegment.vue
+++ b/frontend/src/views/DashboardManager/ApproSegment.vue
@@ -23,7 +23,7 @@
         <KeyMeasureBadge
           class="py-0 ml-8"
           :canteen="canteen"
-          :diagnostic="diagnostic"
+          :diagnostic="canteenDiagnostic"
           :year="year"
           id="qualite-des-produits"
         />
@@ -80,7 +80,7 @@
         <KeyMeasureBadge
           class="py-0 ml-8"
           :canteen="canteen"
-          :diagnostic="diagnostic"
+          :diagnostic="canteenDiagnostic"
           :year="year"
           id="qualite-des-produits"
         />
@@ -174,6 +174,9 @@ export default {
     },
     year: {
       type: Number,
+    },
+    canteenDiagnostic: {
+      type: Object,
     },
   },
   data() {

--- a/frontend/src/views/DashboardManager/ApproSegment.vue
+++ b/frontend/src/views/DashboardManager/ApproSegment.vue
@@ -67,6 +67,15 @@
         </v-icon>
         <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
       </v-card-title>
+      <v-card-text v-if="!delegatedToCentralKitchen">
+        <KeyMeasureBadge
+          class="py-0 ml-8"
+          :canteen="canteen"
+          :diagnostic="diagnostic"
+          :year="year"
+          id="qualite-des-produits"
+        />
+      </v-card-text>
       <v-card-text v-if="level" :class="`mt-n4 pl-12 py-0 ${level.colorClass}`">
         <p class="mb-0 mt-2 fr-text-xs">
           NIVEAU :
@@ -134,11 +143,12 @@
 import { hasDiagnosticApproData, lastYear, hasStartedMeasureTunnel, applicableDiagnosticRules } from "@/utils"
 import Constants from "@/constants"
 import ApproGraph from "@/components/ApproGraph"
+import KeyMeasureBadge from "@/components/KeyMeasureBadge"
 import keyMeasures from "@/data/key-measures.json"
 
 export default {
   name: "ApproSegment",
-  components: { ApproGraph },
+  components: { ApproGraph, KeyMeasureBadge },
   props: {
     purchases: {
       type: Array,
@@ -206,6 +216,11 @@ export default {
     },
     bioPercent() {
       return this.rules.bioThreshold
+    },
+    delegatedToCentralKitchen() {
+      const isSatellite = this.canteen.productionType === "site_cooked_elsewhere"
+      const usesCentralDiag = isSatellite && this.diagnostic?.canteenId === this.canteen.centralKitchen?.id
+      return usesCentralDiag && this.diagnostic?.centralKitchenDiagnosticMode === "ALL"
     },
   },
 }

--- a/frontend/src/views/DashboardManager/ApproSegment.vue
+++ b/frontend/src/views/DashboardManager/ApproSegment.vue
@@ -19,6 +19,15 @@
         </v-icon>
         <h3 class="font-weight-bold fr-text">{{ keyMeasure.shortTitle }}</h3>
       </v-card-title>
+      <v-card-text>
+        <KeyMeasureBadge
+          class="py-0 ml-8"
+          :canteen="canteen"
+          :diagnostic="diagnostic"
+          :year="year"
+          id="qualite-des-produits"
+        />
+      </v-card-text>
       <v-card-text class="fill-height d-flex flex-column" style="position: relative;">
         <v-spacer />
         <v-card class="py-4 px-5" color="grey lighten-4">
@@ -67,12 +76,12 @@
         </v-icon>
         <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
       </v-card-title>
-      <v-card-text v-if="!delegatedToCentralKitchen">
+      <v-card-text>
         <KeyMeasureBadge
           class="py-0 ml-8"
           :canteen="canteen"
           :diagnostic="diagnostic"
-          :year="`${year}`"
+          :year="year"
           id="qualite-des-produits"
         />
       </v-card-text>
@@ -216,11 +225,6 @@ export default {
     },
     bioPercent() {
       return this.rules.bioThreshold
-    },
-    delegatedToCentralKitchen() {
-      const isSatellite = this.canteen.productionType === "site_cooked_elsewhere"
-      const usesCentralDiag = isSatellite && this.diagnostic?.canteenId === this.canteen.centralKitchen?.id
-      return usesCentralDiag && this.diagnostic?.centralKitchenDiagnosticMode === "ALL"
     },
   },
 }

--- a/frontend/src/views/DashboardManager/DiversificationCard.vue
+++ b/frontend/src/views/DashboardManager/DiversificationCard.vue
@@ -9,13 +9,7 @@
       </h3>
     </v-card-title>
     <v-card-text v-if="!delegatedToCentralKitchen">
-      <KeyMeasureBadge
-        class="py-0 ml-8"
-        :canteen="canteen"
-        :diagnostic="diagnostic"
-        :year="`${year}`"
-        :id="measureId"
-      />
+      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
     </v-card-text>
     <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">

--- a/frontend/src/views/DashboardManager/DiversificationCard.vue
+++ b/frontend/src/views/DashboardManager/DiversificationCard.vue
@@ -8,10 +8,10 @@
         {{ keyMeasure.shortTitle }}
       </h3>
     </v-card-title>
-    <v-card-text v-if="needsData">
-      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
+    <v-card-text v-if="!delegatedToCentralKitchen">
+      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
     </v-card-text>
-    <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
+    <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
         NIVEAU :
         <span class="font-weight-black">{{ level.text }}</span>
@@ -30,13 +30,13 @@
 
 <script>
 import Constants from "@/constants"
-import DataInfoBadge from "@/components/DataInfoBadge"
+import KeyMeasureBadge from "@/components/KeyMeasureBadge"
 import keyMeasures from "@/data/key-measures.json"
 import { hasStartedMeasureTunnel, applicableDiagnosticRules } from "@/utils"
 
 export default {
   name: "DiversificationCard",
-  components: { DataInfoBadge },
+  components: { KeyMeasureBadge },
   props: {
     diagnostic: {
       type: Object,
@@ -45,6 +45,7 @@ export default {
       type: Object,
       required: true,
     },
+    year: String,
   },
   data() {
     return {

--- a/frontend/src/views/DashboardManager/DiversificationCard.vue
+++ b/frontend/src/views/DashboardManager/DiversificationCard.vue
@@ -9,7 +9,13 @@
       </h3>
     </v-card-title>
     <v-card-text v-if="!delegatedToCentralKitchen">
-      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
+      <KeyMeasureBadge
+        class="py-0 ml-8"
+        :canteen="canteen"
+        :diagnostic="diagnostic"
+        :year="`${year}`"
+        :id="measureId"
+      />
     </v-card-text>
     <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -45,7 +51,7 @@ export default {
       type: Object,
       required: true,
     },
-    year: String,
+    year: Number,
   },
   data() {
     return {

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -55,7 +55,7 @@
             <NoPlasticCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="selectedYear" />
           </v-col>
           <v-col cols="12" md="6" class="pb-md-0 px-0 pl-md-3">
-            <InformationCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" />
+            <InformationCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="selectedYear" />
           </v-col>
         </v-row>
       </v-col>

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -47,16 +47,16 @@
             </v-btn>
           </div>
           <v-col cols="12" md="6" class="pt-md-0 px-0 pr-md-3">
-            <FoodWasteCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="selectedYear" />
+            <FoodWasteCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="year" />
           </v-col>
           <v-col cols="12" md="6" class="pt-md-0 px-0 pl-md-3">
-            <DiversificationCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="selectedYear" />
+            <DiversificationCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="year" />
           </v-col>
           <v-col cols="12" md="6" class="pb-md-0 px-0 pr-md-3">
-            <NoPlasticCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="selectedYear" />
+            <NoPlasticCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="year" />
           </v-col>
           <v-col cols="12" md="6" class="pb-md-0 px-0 pl-md-3">
-            <InformationCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="selectedYear" />
+            <InformationCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="year" />
           </v-col>
         </v-row>
       </v-col>

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -52,7 +52,7 @@
             <DiversificationCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="selectedYear" />
           </v-col>
           <v-col cols="12" md="6" class="pb-md-0 px-0 pr-md-3">
-            <NoPlasticCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" />
+            <NoPlasticCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="selectedYear" />
           </v-col>
           <v-col cols="12" md="6" class="pb-md-0 px-0 pl-md-3">
             <InformationCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" />

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -49,7 +49,7 @@
             <FoodWasteCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="selectedYear" />
           </v-col>
           <v-col cols="12" md="6" class="pt-md-0 px-0 pl-md-3">
-            <DiversificationCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" />
+            <DiversificationCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="selectedYear" />
           </v-col>
           <v-col cols="12" md="6" class="pb-md-0 px-0 pr-md-3">
             <NoPlasticCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" />

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -46,7 +46,7 @@
             </v-btn>
           </div>
           <v-col cols="12" md="6" class="pt-md-0 px-0 pr-md-3">
-            <FoodWasteCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" />
+            <FoodWasteCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" :year="selectedYear" />
           </v-col>
           <v-col cols="12" md="6" class="pt-md-0 px-0 pl-md-3">
             <DiversificationCard :diagnostic="otherMeasuresDiagnostic" :canteen="canteen" />

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -29,6 +29,7 @@
           :lastYearDiagnostic="lastYearDiagnostic"
           :canteen="canteen"
           :year="year"
+          :canteenDiagnostic="canteenDiagnostic"
         />
       </v-col>
       <v-col cols="12" md="8">

--- a/frontend/src/views/DashboardManager/FoodWasteCard.vue
+++ b/frontend/src/views/DashboardManager/FoodWasteCard.vue
@@ -7,13 +7,7 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="!delegatedToCentralKitchen">
-      <KeyMeasureBadge
-        class="py-0 ml-8"
-        :canteen="canteen"
-        :diagnostic="diagnostic"
-        :year="`${year}`"
-        :id="measureId"
-      />
+      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
     </v-card-text>
     <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">

--- a/frontend/src/views/DashboardManager/FoodWasteCard.vue
+++ b/frontend/src/views/DashboardManager/FoodWasteCard.vue
@@ -7,7 +7,13 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="!delegatedToCentralKitchen">
-      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
+      <KeyMeasureBadge
+        class="py-0 ml-8"
+        :canteen="canteen"
+        :diagnostic="diagnostic"
+        :year="`${year}`"
+        :id="measureId"
+      />
     </v-card-text>
     <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -43,7 +49,7 @@ export default {
       type: Object,
       required: true,
     },
-    year: String,
+    year: Number,
   },
   data() {
     return {

--- a/frontend/src/views/DashboardManager/FoodWasteCard.vue
+++ b/frontend/src/views/DashboardManager/FoodWasteCard.vue
@@ -6,10 +6,10 @@
       </v-icon>
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
-    <v-card-text v-if="needsData">
-      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
+    <v-card-text v-if="!delegatedToCentralKitchen">
+      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
     </v-card-text>
-    <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
+    <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
         NIVEAU :
         <span class="font-weight-black">{{ level.text }}</span>
@@ -28,13 +28,13 @@
 
 <script>
 import Constants from "@/constants"
-import DataInfoBadge from "@/components/DataInfoBadge"
+import KeyMeasureBadge from "@/components/KeyMeasureBadge"
 import keyMeasures from "@/data/key-measures.json"
 import { hasStartedMeasureTunnel } from "@/utils"
 
 export default {
   name: "FoodWasteCard",
-  components: { DataInfoBadge },
+  components: { KeyMeasureBadge },
   props: {
     diagnostic: {
       type: Object,
@@ -43,6 +43,7 @@ export default {
       type: Object,
       required: true,
     },
+    year: String,
   },
   data() {
     return {

--- a/frontend/src/views/DashboardManager/InformationCard.vue
+++ b/frontend/src/views/DashboardManager/InformationCard.vue
@@ -7,13 +7,7 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="!delegatedToCentralKitchen">
-      <KeyMeasureBadge
-        class="py-0 ml-8"
-        :canteen="canteen"
-        :diagnostic="diagnostic"
-        :year="`${year}`"
-        :id="measureId"
-      />
+      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
     </v-card-text>
     <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">

--- a/frontend/src/views/DashboardManager/InformationCard.vue
+++ b/frontend/src/views/DashboardManager/InformationCard.vue
@@ -7,7 +7,13 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="!delegatedToCentralKitchen">
-      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
+      <KeyMeasureBadge
+        class="py-0 ml-8"
+        :canteen="canteen"
+        :diagnostic="diagnostic"
+        :year="`${year}`"
+        :id="measureId"
+      />
     </v-card-text>
     <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -43,7 +49,7 @@ export default {
       type: Object,
       required: true,
     },
-    year: String,
+    year: Number,
   },
   data() {
     return {

--- a/frontend/src/views/DashboardManager/InformationCard.vue
+++ b/frontend/src/views/DashboardManager/InformationCard.vue
@@ -6,10 +6,10 @@
       </v-icon>
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
-    <v-card-text v-if="needsData">
-      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
+    <v-card-text v-if="!delegatedToCentralKitchen">
+      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
     </v-card-text>
-    <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
+    <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
         NIVEAU :
         <span class="font-weight-black">{{ level.text }}</span>
@@ -28,13 +28,13 @@
 
 <script>
 import Constants from "@/constants"
-import DataInfoBadge from "@/components/DataInfoBadge"
+import KeyMeasureBadge from "@/components/KeyMeasureBadge"
 import keyMeasures from "@/data/key-measures.json"
 import { hasStartedMeasureTunnel } from "@/utils"
 
 export default {
   name: "InformationCard",
-  components: { DataInfoBadge },
+  components: { KeyMeasureBadge },
   props: {
     diagnostic: {
       type: Object,
@@ -43,6 +43,7 @@ export default {
       type: Object,
       required: true,
     },
+    year: String,
   },
   data() {
     return {

--- a/frontend/src/views/DashboardManager/NoPlasticCard.vue
+++ b/frontend/src/views/DashboardManager/NoPlasticCard.vue
@@ -7,13 +7,7 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="!delegatedToCentralKitchen">
-      <KeyMeasureBadge
-        class="py-0 ml-8"
-        :canteen="canteen"
-        :diagnostic="diagnostic"
-        :year="`${year}`"
-        :id="measureId"
-      />
+      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
     </v-card-text>
     <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">

--- a/frontend/src/views/DashboardManager/NoPlasticCard.vue
+++ b/frontend/src/views/DashboardManager/NoPlasticCard.vue
@@ -7,7 +7,13 @@
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
     <v-card-text v-if="!delegatedToCentralKitchen">
-      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
+      <KeyMeasureBadge
+        class="py-0 ml-8"
+        :canteen="canteen"
+        :diagnostic="diagnostic"
+        :year="`${year}`"
+        :id="measureId"
+      />
     </v-card-text>
     <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
@@ -43,7 +49,7 @@ export default {
       type: Object,
       required: true,
     },
-    year: String,
+    year: Number,
   },
   data() {
     return {

--- a/frontend/src/views/DashboardManager/NoPlasticCard.vue
+++ b/frontend/src/views/DashboardManager/NoPlasticCard.vue
@@ -6,10 +6,10 @@
       </v-icon>
       <h3 class="fr-text font-weight-bold">{{ keyMeasure.shortTitle }}</h3>
     </v-card-title>
-    <v-card-text v-if="needsData">
-      <DataInfoBadge :missingData="true" class="py-0 ml-8" />
+    <v-card-text v-if="!delegatedToCentralKitchen">
+      <KeyMeasureBadge class="py-0 ml-8" :canteen="canteen" :diagnostic="diagnostic" :year="year" :id="measureId" />
     </v-card-text>
-    <v-card-text v-else-if="level" :class="`mt-n4 pl-12 ${level.colorClass}`">
+    <v-card-text v-if="!needsData && level" :class="`mt-n4 pl-12 ${level.colorClass}`">
       <p class="mb-0 mt-2 fr-text-xs">
         NIVEAU :
         <span class="font-weight-black">{{ level.text }}</span>
@@ -28,13 +28,13 @@
 
 <script>
 import Constants from "@/constants"
-import DataInfoBadge from "@/components/DataInfoBadge"
+import KeyMeasureBadge from "@/components/KeyMeasureBadge"
 import keyMeasures from "@/data/key-measures.json"
 import { hasStartedMeasureTunnel } from "@/utils"
 
 export default {
   name: "NoPlasticCard",
-  components: { DataInfoBadge },
+  components: { KeyMeasureBadge },
   props: {
     diagnostic: {
       type: Object,
@@ -43,6 +43,7 @@ export default {
       type: Object,
       required: true,
     },
+    year: String,
   },
   data() {
     return {


### PR DESCRIPTION
## Description

Suite du travail avec Raphael sur l'homogénéisation des badges #5186 #5185 .
On affiche maintenant les mêmes "sous-badges", soit les badges de progression de la TD, dans la page de la cantine.

## Prévisualisation 

| Avant | Après |
|--|--|
| <img width="1237" alt="Capture d’écran 2025-03-31 à 18 40 29" src="https://github.com/user-attachments/assets/b1b1fca0-a22c-4e79-9b46-3fe32f84f5e1" /> | <img width="1227" alt="Capture d’écran 2025-03-31 à 18 39 59" src="https://github.com/user-attachments/assets/b98dcdfb-8dd8-4a49-8e06-32d9ec8b4779" /> |