### PR TITLE
refactor(Télédéclaration): récupérer le badge à l'aide de l'API actionableCanteens (au lieu de le recalculer dans le frontend)

### DIFF
--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -316,6 +316,7 @@ export default {
       }
     },
     fetchCanteenAction() {
+      if (!this.canteen || !this.year) return
       fetch(`/api/v1/actionableCanteens/${this.canteen.id}/${this.year}`)
         .then((response) => {
           if (response.status < 200 || response.status >= 400) throw new Error(`Error encountered : ${response}`)

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -497,6 +497,7 @@ export default {
             title: "Télédéclaration prise en compte",
             status: "success",
           })
+          this.fetchCanteenAction()
           this.updateFromServer(diagnostic)
           window.scrollTo(0, 0)
         })
@@ -518,6 +519,7 @@ export default {
           this.$store.dispatch("notify", {
             title: "Votre télédéclaration a bien été annulée",
           })
+          this.fetchCanteenAction()
           this.updateFromServer(diagnostic)
         })
         .catch((e) => this.$store.dispatch("notifyServerError", e))

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -8,14 +8,13 @@
     />
     <v-row align="end">
       <v-col cols="12" md="9" lg="10">
-        <DataInfoBadge v-if="hasActiveTeledeclaration" class="my-2" :hasActiveTeledeclaration="true" />
         <DataInfoBadge
-          v-else-if="inTeledeclarationCampaign"
           class="my-2"
-          :readyToTeledeclare="readyToTeledeclare"
+          :currentYear="+year === currentYear"
           :missingData="!readyToTeledeclare"
+          :readyToTeledeclare="readyToTeledeclare"
+          :hasActiveTeledeclaration="hasActiveTeledeclaration"
         />
-        <DataInfoBadge v-else-if="+year >= currentYear" class="my-2" :currentYear="+year === currentYear" />
         <ProductionTypeTag v-if="canteen" :canteen="canteen" class="ml-3" />
         <h1 class="fr-h3 mt-1 mb-2" v-if="canteen">{{ canteen.name }} : Télédéclaration</h1>
         <p class="mb-0">SIRET : {{ canteen.siret || "inconnu" }}</p>
@@ -38,8 +37,14 @@
     <v-row v-if="canteen" class="mt-5 mt-md-10">
       <v-col cols="12" md="3" lg="2" style="border-right: 1px solid #DDD;" class="fr-text-sm pt-1">
         <DsfrNativeSelect v-model="selectedYear" :items="yearOptions" class="mb-3 mt-2" />
+        <DataInfoBadge
+          class="my-2"
+          :currentYear="+year === currentYear"
+          :missingData="!readyToTeledeclare"
+          :readyToTeledeclare="readyToTeledeclare"
+          :hasActiveTeledeclaration="hasActiveTeledeclaration"
+        />
         <div v-if="hasActiveTeledeclaration">
-          <DataInfoBadge class="my-2" :hasActiveTeledeclaration="true" />
           <p>
             Votre bilan a été télédéclaré
             <b>{{ timeAgo(diagnostic.teledeclaration.creationDate, true) }}.</b>
@@ -78,7 +83,6 @@
           <p>Votre livreur des repas va faire le bilan pour votre établissement.</p>
         </div>
         <div v-else-if="inTeledeclarationCampaign">
-          <DataInfoBadge class="my-2" :readyToTeledeclare="readyToTeledeclare" :missingData="!readyToTeledeclare" />
           <div v-if="isSatelliteWithApproCentralDiagnostic">
             <p>Votre livreur des repas va déclarer les données d'approvisionnement pour votre établissement.</p>
             <p>Pour aller plus loin, vous pouvez télédéclarer les autres volets du bilan.</p>
@@ -122,7 +126,6 @@
           </v-btn>
         </div>
         <div v-else-if="+year >= currentYear">
-          <DataInfoBadge class="my-2" :currentYear="+year === currentYear" />
           <p>
             Vous pouvez commencer ce bilan et le télédéclarer pendant la campagne de télédéclaration en
             {{ +year + 1 }}.

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -43,6 +43,7 @@
           :missingData="!readyToTeledeclare"
           :readyToTeledeclare="readyToTeledeclare"
           :hasActiveTeledeclaration="hasActiveTeledeclaration"
+          :canteenAction="canteenAction"
           class="my-2"
         />
         <div v-if="hasActiveTeledeclaration">

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -425,6 +425,7 @@ export default {
         })
     },
     fetchCanteenAction() {
+      if (!this.canteen || !this.year) return
       fetch(`/api/v1/actionableCanteens/${this.canteen.id}/${this.year}`)
         .then((response) => {
           if (response.status < 200 || response.status >= 400) throw new Error(`Error encountered : ${response}`)
@@ -577,14 +578,12 @@ export default {
       if (this.$route.params.measure !== this.tabHeaders[this.tab].urlSlug)
         this.$router.push({ params: { measure: this.tabHeaders[this.tab].urlSlug } })
     },
-    year: {
-      handler() {
-        this.fetchCanteenAction()
-        this.assignDiagnostic()
-      },
-      immediate: true,
+    year() {
+      this.fetchCanteenAction()
+      this.assignDiagnostic()
     },
     canteen() {
+      this.fetchCanteenAction()
       this.assignDiagnostic()
     },
     $route() {


### PR DESCRIPTION
Suite de #5185

Cette fois-ci on fait l'intégration dans `MyProgress`