### PR TITLE
improve(Télédéclaration): Nouveau badge pour indiquer que la cantine satellite n'a rien à faire

### DIFF
--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -986,7 +986,6 @@ class TestCanteenApi(APITestCase):
             value_total_ht=1000,
             central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
         )
-        Teledeclaration.create_from_diagnostic(diagnostic, authenticate.user)
 
         DiagnosticFactory.create(
             year=2021,
@@ -994,10 +993,18 @@ class TestCanteenApi(APITestCase):
             value_total_ht=1200,
         )
 
+        # cc diagnostic not teledeclared
         response = self.client.get(reverse("list_actionable_canteens", kwargs={"year": 2021}))
         returned_canteens = response.json()["results"]
         satellite_action = next(x for x in returned_canteens if x["id"] == satellite.id)["action"]
-        self.assertEqual(satellite_action, "95_nothing")
+        self.assertEqual(satellite_action, "90_nothing_satellite")
+
+        # cc diagnostic teledeclared
+        Teledeclaration.create_from_diagnostic(diagnostic, authenticate.user)
+        response = self.client.get(reverse("list_actionable_canteens", kwargs={"year": 2021}))
+        returned_canteens = response.json()["results"]
+        satellite_action = next(x for x in returned_canteens if x["id"] == satellite.id)["action"]
+        self.assertEqual(satellite_action, "91_nothing_satellite_teledeclared")
 
     @authenticate
     def test_get_canteens_with_purchases_no_diagnostics_for_year(self):

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -203,6 +203,11 @@ class Canteen(SoftDeletionModel):
         FILL_CANTEEN_DATA = "35_fill_canteen_data", "Compléter les infos de la cantine"
         TELEDECLARE = "40_teledeclare", "Télédéclarer"
         PUBLISH = "50_publish", "Publier"
+        NOTHING_SATELLITE = "90_nothing_satellite", "Rien à faire (à compléter par votre livreur)"
+        NOTHING_SATELLITE_TELEDECLARED = (
+            "91_nothing_satellite_teledeclared",
+            "Rien à faire (télédéclaré par votre livreur)",
+        )
         NOTHING = "95_nothing", "Rien à faire !"
 
     class Ministries(models.TextChoices):

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -114,15 +114,15 @@
           <template v-slot:[`item.action`]="{ item }">
             <v-fade-transition>
               <div :key="`${item.id}_${item.action}`">
-                <div v-if="item.action === '95_nothing'" class="px-3">
-                  <v-icon small class="mr-2" color="green">$checkbox-circle-fill</v-icon>
-                  <span class="caption">Rien à faire !</span>
+                <div v-if="getActionDisplay(item.action) === 'button'" class="px-3">
+                  <v-icon small class="mr-2" color="green">{{ getActionIcon(item.action) }}</v-icon>
+                  <span class="caption">{{ getActionText(item.action) }}</span>
                 </div>
                 <v-btn small outlined color="primary" :to="actionLink(item)" @click="action(item)" v-else>
                   <v-icon small class="mr-2" color="primary">
-                    {{ actions[item.action] && actions[item.action].icon }}
+                    {{ getActionIcon(item.action) }}
                   </v-icon>
-                  {{ actions[item.action] && actions[item.action].display }}
+                  {{ getActionText(item.action) }}
                   <span class="d-sr-only">{{ item.userCanView ? "" : "de" }} {{ item.name }}</span>
                 </v-btn>
               </div>
@@ -177,32 +177,49 @@ export default {
       },
       actions: {
         "10_add_satellites": {
-          display: "Ajouter des satellites",
+          text: "Ajouter des satellites",
           icon: "$community-fill",
+          display: "button",
         },
         "18_prefill_diagnostic": {
-          display: "Créer le bilan " + year,
+          text: "Créer le bilan " + year,
           icon: "$add-circle-fill",
+          display: "button",
         },
         "20_create_diagnostic": {
-          display: "Créer le bilan " + year,
+          text: "Créer le bilan " + year,
           icon: "$add-circle-fill",
+          display: "button",
         },
         "30_complete_diagnostic": {
-          display: "Compléter le bilan " + year,
+          text: "Compléter le bilan " + year,
           icon: "$edit-box-fill",
+          display: "button",
         },
         "35_fill_canteen_data": {
-          display: "Compléter les infos de la cantine",
+          text: "Compléter les infos de la cantine",
           icon: "$building-fill",
+          display: "button",
         },
         "40_teledeclare": {
-          display: "Télédéclarer",
+          text: "Télédéclarer",
           icon: "$send-plane-fill",
+          display: "button",
+        },
+        "90_nothing_satellite": {
+          text: "Rien à faire ! (à compléter par votre livreur)",
+          icon: "$checkbox-circle-fill",
+          display: "text",
+        },
+        "91_nothing_satellite_teledeclared": {
+          text: "Rien à faire ! (télédéclaré par votre livreur)",
+          icon: "$checkbox-circle-fill",
+          display: "text",
         },
         "95_nothing": {
-          display: "Rien à faire !",
+          text: "Rien à faire !",
           icon: "$checkbox-circle-fill",
+          display: "text",
         },
       },
       canteenForTD: null,
@@ -293,6 +310,15 @@ export default {
         name: "DashboardManager",
         params: { canteenUrlComponent: this.$store.getters.getCanteenUrlComponent(canteen) },
       }
+    },
+    getActionText(action) {
+      return this.actions[action] && this.actions[action].text
+    },
+    getActionIcon(action) {
+      return this.actions[action] && this.actions[action].icon
+    },
+    getActionDisplay(action) {
+      return this.actions[action] && this.actions[action].display
     },
     actionLink(canteen) {
       if (canteen.action === "10_add_satellites") {

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -114,7 +114,7 @@
           <template v-slot:[`item.action`]="{ item }">
             <v-fade-transition>
               <div :key="`${item.id}_${item.action}`">
-                <div v-if="getActionDisplay(item.action) === 'button'" class="px-3">
+                <div v-if="getActionDisplay(item.action) === 'text'" class="px-3">
                   <v-icon small class="mr-2" color="green">{{ getActionIcon(item.action) }}</v-icon>
                   <span class="caption">{{ getActionText(item.action) }}</span>
                 </div>

--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -28,6 +28,11 @@ const BADGE_LIST = [
     ],
   },
   {
+    body: "Données à compléter par votre livreur",
+    mode: "NEUTRAL",
+    actions: ["90_nothing_satellite"],
+  },
+  {
     // readyToTeledeclare
     body: "Bilan à télédéclarer",
     mode: "ERROR",
@@ -37,7 +42,7 @@ const BADGE_LIST = [
     // hasActiveTeledeclaration
     body: "Bilan télédéclaré",
     mode: "SUCCESS",
-    actions: ["95_nothing"],
+    actions: ["91_nothing_satellite_teledeclared", "95_nothing"],
   },
 ]
 

--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -29,7 +29,7 @@ const BADGE_LIST = [
   },
   {
     body: "Données à compléter par votre livreur",
-    mode: "NEUTRAL",
+    mode: "WARNING",
     actions: ["90_nothing_satellite"],
   },
   {


### PR DESCRIPTION
### Quoi

En période de TD, mieux informer les cantines satellites qui ne peuvent pas TD (car leur cuisine centrale a indiqué qu'elle ferait tout le bilan à leur place)

### Comment

Backend : dans le annotate de `ActionableCanteensListView`, nouvelles actions 
- `90_nothing_satellite`
- `91_nothing_satellite_teledeclared`

Frontend : 
- Tableau action : nouvelles actions "Rien à faire ! (à compléter par votre livreur)" & "Rien à faire ! (télédéclaré par votre livreur)"
- DataInfoBadge : nouveau badge WARNING "Données à compléter par votre livreur"

### Capture d'écran

![Screenshot from 2025-04-01 10-30-52](https://github.com/user-attachments/assets/e8b460de-aa43-45ac-a9ce-e6a21fe61a22)
