### PR TITLE
fix(Teledeclaration): Corriger les valeurs aggrégées pour les TD simples

### DIFF
--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -271,7 +271,7 @@ class TestTeledeclarationApi(APITestCase):
             json_teledeclaration["communicates_on_food_quality"],
             diagnostic.communicates_on_food_quality,
         )
-        # Test the aggregated values, as it is a SIMPLE diag, the should match directly the non agg ones
+        # Test the aggregated values, as it is a SIMPLE diag, the value should match directly the non agg ones
         self.assertEqual(teledeclaration.value_bio_ht_agg, diagnostic.value_bio_ht)
 
     @override_settings(ENABLE_TELEDECLARATION=False)

--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -272,7 +272,7 @@ class TestTeledeclarationApi(APITestCase):
             diagnostic.communicates_on_food_quality,
         )
         # Test the aggregated values, as it is a SIMPLE diag, the should match directly the non agg ones
-        self.assertEqual(json_teledeclaration["value_bio_ht__agg"], diagnostic.value_bio_ht)
+        self.assertEqual(teledeclaration.value_bio_ht_agg, diagnostic.value_bio_ht)
 
     @override_settings(ENABLE_TELEDECLARATION=False)
     @freeze_time("2021-01-20")
@@ -484,7 +484,6 @@ class TestTeledeclarationApi(APITestCase):
             year=LAST_YEAR,
             diagnostic_type="COMPLETE",
             value_total_ht=1000,
-            value_bio_ht=20,
             value_sustainable_ht=None,
         )
         # Making sure we will aggregate
@@ -542,7 +541,7 @@ class TestTeledeclarationApi(APITestCase):
 
         # Checking the aggregation
         self.assertEqual(teledeclaration.value_total_ht, 1000)
-        self.assertEqual(teledeclaration.value_bio_ht_agg, 20)
+        self.assertEqual(teledeclaration.value_bio_ht_agg, 0)
         self.assertEqual(
             teledeclaration.value_sustainable_ht_agg,
             json_teledeclaration["value_boissons_label_rouge"]

--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -185,7 +185,7 @@ class TestTeledeclarationApi(APITestCase):
         canteen = CanteenFactory.create()
         canteen.managers.add(user)
         diagnostic = DiagnosticFactory.create(
-            value_externality_performance_ht=0, canteen=canteen, year=2020, diagnostic_type="SIMPLE"
+            value_externality_performance_ht=0, canteen=canteen, year=2020, diagnostic_type="SIMPLE", value_bio_ht=20
         )
         payload = {"diagnosticId": diagnostic.id}
         response = self.client.post(reverse("teledeclaration_create"), payload)
@@ -271,6 +271,8 @@ class TestTeledeclarationApi(APITestCase):
             json_teledeclaration["communicates_on_food_quality"],
             diagnostic.communicates_on_food_quality,
         )
+        # Test the aggregated values, as it is a SIMPLE diag, the should match directly the non agg ones
+        self.assertEqual(json_teledeclaration["value_bio_ht__agg"], diagnostic.value_bio_ht)
 
     @override_settings(ENABLE_TELEDECLARATION=False)
     @freeze_time("2021-01-20")
@@ -478,7 +480,12 @@ class TestTeledeclarationApi(APITestCase):
         canteen = CanteenFactory.create()
         canteen.managers.add(user)
         diagnostic = DiagnosticFactory.create(
-            canteen=canteen, year=LAST_YEAR, diagnostic_type="COMPLETE", value_total_ht=1000, value_sustainable_ht=None
+            canteen=canteen,
+            year=LAST_YEAR,
+            diagnostic_type="COMPLETE",
+            value_total_ht=1000,
+            value_bio_ht=20,
+            value_sustainable_ht=None,
         )
         # Making sure we will aggregate
         diagnostic.value_sustainable_ht = None
@@ -535,6 +542,7 @@ class TestTeledeclarationApi(APITestCase):
 
         # Checking the aggregation
         self.assertEqual(teledeclaration.value_total_ht, 1000)
+        self.assertEqual(teledeclaration.value_bio_ht_agg, 20)
         self.assertEqual(
             teledeclaration.value_sustainable_ht_agg,
             json_teledeclaration["value_boissons_label_rouge"]

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -286,7 +286,8 @@ class Teledeclaration(models.Model):
             json_fields["satellites"] = serialized_satellites
             json_fields["satellite_canteens_count"] = canteen.satellite_canteens_count
 
-        diagnostic.populate_simplified_diagnostic_values()
+        if diagnostic.diagnostic_type == Diagnostic.DiagnosticType.COMPLETE:
+            diagnostic.populate_simplified_diagnostic_values()
 
         return Teledeclaration.objects.create(
             applicant=applicant,


### PR DESCRIPTION
Les TD dont les valeurs agrégées erronées étaient les TD simples.
La méthode populate écrasaient des valeurs avec des champs n'existant pas dans la TD simple.

Si le fix est satisfaisant, il faudra encore faire tourner la migration (reverse puis normal)