### PR TITLE
improve(Télédéclaration): Améliorer encore le wording du badge indiquant que la cantine satellite n'a rien à faire

### DIFF
--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -28,7 +28,7 @@ const BADGE_LIST = [
     ],
   },
   {
-    body: "Données à compléter par votre livreur",
+    body: "En attente de la télédéclaration de votre livreur",
     mode: "WARNING",
     actions: ["90_nothing_satellite"],
   },


### PR DESCRIPTION
Suite et fin de #5191 & #5210

il manquait un dernier changement...