### PR TITLE
fix(Tableau de bord): Vue actions: répare l'occurence de doublons

### DIFF
--- a/api/filters/utils.py
+++ b/api/filters/utils.py
@@ -22,6 +22,7 @@ class MaCantineOrderingFilter(filters.OrderingFilter):
         if ordering:
             ordering = map(make_f_object, ordering)
             queryset = queryset.order_by(*ordering)
+            queryset = queryset.distinct()  # to solve issues with duplicate/missing results
 
         return queryset
 


### PR DESCRIPTION
### Quoi

Dans la vue TDB > Actions, quand l'utilisateur a beaucoup de cantines et doit paginer, il y avait des cantines doublons d'une page à l'autre (et surtout des cantines manquantes).

### Comment

Vu qu'on fait un order sur `action` qui est un champ annotated, rajouter un `distinct` semble résoudre le bidule !

### Captures d'écran

(en réduisant le nombre de cantines par page à 3)

||Avant|Après|
|-|-|-|
|Page 1|![image](https://github.com/user-attachments/assets/044b8036-92fa-4787-92d2-8de96574460a)|![image](https://github.com/user-attachments/assets/69204fe1-0c2a-4656-851c-3e36ebd10ec2)|
|Page 2|![image](https://github.com/user-attachments/assets/719adf96-075a-4d79-983e-5b67631042ef)|![image](https://github.com/user-attachments/assets/1e36deff-52a0-4102-9b88-749c7929a390)|