### PR TITLE
refactor(Diagnostic): Nouveau queryset is_filled. Renommer 'completed' par 'filled' pour clarifier

### DIFF
--- a/api/serializers/statistics.py
+++ b/api/serializers/statistics.py
@@ -26,7 +26,7 @@ class CanteenStatisticsSerializer(serializers.Serializer):
     def calculate_statistics(canteens, diagnostics):
         data = {"canteen_count": canteens.count(), "diagnostics_count": diagnostics.count()}
 
-        agg = diagnostics.filter(value_total_ht__gt=0).aggregate(
+        agg = diagnostics.is_filled().aggregate(
             Sum("value_bio_ht", default=0),
             Sum("value_total_ht", default=0),
             Sum("value_sustainable_ht", default=0),

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -703,7 +703,7 @@ class TestCanteenApi(APITestCase):
             economic_model=Canteen.EconomicModel.PUBLIC,
         )
         # complete diag
-        needs_to_complete_diag = CanteenFactory.create(
+        needs_to_fill_diag = CanteenFactory.create(
             production_type=Canteen.ProductionType.ON_SITE,
             publication_status=Canteen.PublicationStatus.DRAFT,
             management_type=Canteen.ManagementType.DIRECT,
@@ -750,7 +750,7 @@ class TestCanteenApi(APITestCase):
         for canteen in [
             needs_last_year_diag,
             complete,
-            needs_to_complete_diag,
+            needs_to_fill_diag,
             needs_diagnostic_mode,
             needs_to_publish,
             needs_td,
@@ -764,9 +764,9 @@ class TestCanteenApi(APITestCase):
         td_diag = DiagnosticFactory.create(year=last_year, canteen=complete, value_total_ht=1000)
         Teledeclaration.create_from_diagnostic(td_diag, authenticate.user)
 
-        DiagnosticFactory.create(year=last_year, canteen=needs_to_complete_diag, value_total_ht=None)
+        DiagnosticFactory.create(year=last_year, canteen=needs_to_fill_diag, value_total_ht=None)
         # make sure the endpoint only looks at diagnostics of the year requested
-        DiagnosticFactory.create(year=last_year - 1, canteen=needs_to_complete_diag, value_total_ht=1000)
+        DiagnosticFactory.create(year=last_year - 1, canteen=needs_to_fill_diag, value_total_ht=1000)
 
         DiagnosticFactory.create(
             year=last_year, canteen=needs_diagnostic_mode, central_kitchen_diagnostic_mode=None, value_total_ht=100
@@ -798,8 +798,8 @@ class TestCanteenApi(APITestCase):
         expected_actions = [
             (needs_additional_satellites, "10_add_satellites"),
             (needs_last_year_diag, "20_create_diagnostic"),
-            (needs_to_complete_diag, "30_complete_diagnostic"),
-            (needs_diagnostic_mode, "30_complete_diagnostic"),
+            (needs_to_fill_diag, "30_fill_diagnostic"),
+            (needs_diagnostic_mode, "30_fill_diagnostic"),
             (needs_td, "40_teledeclare"),
             (needs_to_publish, "50_publish"),
             (complete, "95_nothing"),

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -211,7 +211,7 @@ def filter_by_diagnostic_params(queryset, query_params):
     appro_badge_requested = badge == "appro"
     if bio or combined or appro_badge_requested:
         publication_year = date.today().year - 1
-        qs_diag = Diagnostic.objects.filter(year=publication_year, value_total_ht__gt=0)
+        qs_diag = Diagnostic.objects.is_filled().filter(year=publication_year)
         if bio or appro_badge_requested:
             qs_diag = qs_diag.annotate(
                 bio_share=Cast(Sum("value_bio_ht", default=0) / Sum("value_total_ht"), FloatField())

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -144,17 +144,17 @@ class DiagnosticsToTeledeclareListView(ListAPIView):
     def get_queryset(self):
         year = self.request.parser_context.get("kwargs").get("year")
         canteens = DiagnosticsToTeledeclareListView._get_complete_canteens(self.request.user.canteens.all())
-        complete_diagnostics = Diagnostic.objects.filter(
-            year=year, canteen__in=canteens, value_total_ht__gt=0, diagnostic_type__isnull=False
+        diagnostics_filled = Diagnostic.objects.is_filled().filter(
+            year=year, canteen__in=canteens, diagnostic_type__isnull=False
         )
         teledeclared = (
             Teledeclaration.objects.filter(
-                diagnostic__in=complete_diagnostics, status=Teledeclaration.TeledeclarationStatus.SUBMITTED
+                diagnostic__in=diagnostics_filled, status=Teledeclaration.TeledeclarationStatus.SUBMITTED
             )
             .values_list("diagnostic__id", flat=True)
             .distinct()
         )
-        return complete_diagnostics.exclude(id__in=teledeclared)
+        return diagnostics_filled.exclude(id__in=teledeclared)
 
     @staticmethod
     def _get_complete_canteens(canteens):

--- a/common/utils/badges.py
+++ b/common/utils/badges.py
@@ -11,7 +11,7 @@ def badges_for_queryset(diagnostic_year_queryset):
     appro_total = diagnostic_year_queryset
     appro_total = diagnostic_year_queryset.count()
     if appro_total:
-        appro_share_query = diagnostic_year_queryset.filter(value_total_ht__gt=0)
+        appro_share_query = diagnostic_year_queryset.is_filled()
         appro_share_query = appro_share_query.annotate(
             bio_share=Cast(
                 Sum("value_bio_ht", default=0) / Sum("value_total_ht"),

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -29,8 +29,8 @@ def canteen_has_siret_or_siren_unite_legale_query():
 
 
 class DiagnosticQuerySet(models.QuerySet):
-    """
-    Fetching the diagnostics for wich the data has been validated for stats"""
+    def is_filled(self):
+        return self.filter(value_total_ht__gt=0)
 
     def td_submitted_for_year(self, year):
         year = int(year)

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -231,19 +231,19 @@ class TestCanteenDiagnosticTeledeclarationQuerySet(TestCase):
         )
         self.assertEqual(
             Canteen.objects.annotate_with_diagnostic_for_year(2024)
-            .filter(has_complete_diagnostic_for_year=True)
+            .filter(has_diagnostic_filled_for_year=True)
             .count(),
             1,
         )
         self.assertEqual(
             Canteen.objects.annotate_with_diagnostic_for_year(2023)
-            .filter(has_complete_diagnostic_for_year=True)
+            .filter(has_diagnostic_filled_for_year=True)
             .count(),
             0,
         )
         self.assertEqual(
             Canteen.objects.annotate_with_diagnostic_for_year(2022)
-            .filter(has_complete_diagnostic_for_year=True)
+            .filter(has_diagnostic_filled_for_year=True)
             .count(),
             0,
         )

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -69,8 +69,19 @@ class DiagnosticQuerySetTest(TestCase):
         )
         Teledeclaration.create_from_diagnostic(self.deleted_canteen_diagnostic, applicant=UserFactory.create())
 
+    def test_is_filled(self):
+        valid_canteen_empty_diagnostic = Diagnostic.objects.create(
+            year=year_data - 1, canteen=self.valid_canteen_1, value_total_ht=None
+        )
+        self.assertEqual(Diagnostic.objects.count(), 5 + 1)
+        diagnostics = Diagnostic.objects.is_filled()
+        self.assertEqual(diagnostics.count(), 5)
+        self.assertIn(self.valid_canteen_diagnostic_1, diagnostics)
+        self.assertNotIn(valid_canteen_empty_diagnostic, diagnostics)
+
     def test_td_submitted_for_year(self):
         with patch("data.models.diagnostic.CAMPAIGN_DATES", mocked_campaign_dates):
+            self.assertEqual(Diagnostic.objects.filter(year=year_data).count(), 5)
             diagnostics = Diagnostic.objects.td_submitted_for_year(year_data)
         self.assertEqual(diagnostics.count(), 5)
         self.assertIn(self.valid_canteen_diagnostic_1, diagnostics)
@@ -79,6 +90,7 @@ class DiagnosticQuerySetTest(TestCase):
 
     def test_for_stat(self):
         with patch("data.models.diagnostic.CAMPAIGN_DATES", mocked_campaign_dates):
+            self.assertEqual(Diagnostic.objects.filter(year=year_data).count(), 5)
             diagnostics = Diagnostic.objects.for_stat(year_data)
         self.assertEqual(diagnostics.count(), 3)
         self.assertIn(self.valid_canteen_diagnostic_1, diagnostics)

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -191,7 +191,7 @@ export default {
           icon: "$add-circle-fill",
           display: "button",
         },
-        "30_complete_diagnostic": {
+        "30_fill_diagnostic": {
           text: "Compléter le bilan " + year,
           icon: "$edit-box-fill",
           display: "button",

--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -24,7 +24,7 @@ const BADGE_LIST = [
       "35_fill_canteen_data",
       "18_prefill_diagnostic",
       "20_create_diagnostic",
-      "30_complete_diagnostic",
+      "30_fill_diagnostic",
     ],
   },
   {


### PR DESCRIPTION
### Quoi

Tentative de clarifier les wording entre complete & filled, pour le modèle `Diagnostic`
- nouveau queryset `is_filled` + tests
- renomme les occurences de "complete_diag" en "filled_diag"
