### PR TITLE
refactor(Cantines): renommer 'complete' en 'filled' pour clarifier

### DIFF
--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -540,7 +540,7 @@ class TestDiagnosticsApi(APITestCase):
             daily_meal_count=12,
             city_insee_code="69123",
             economic_model=Canteen.EconomicModel.PUBLIC,
-            siret=None,  # this needs to be completed for the diag to be teledeclarable
+            siret=None,  # this needs to be filled for the diag to be teledeclarable
         )
         DiagnosticFactory.create(canteen=canteen_with_incomplete_data, year=last_year, value_total_ht=10000)
 

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -143,7 +143,7 @@ class DiagnosticsToTeledeclareListView(ListAPIView):
 
     def get_queryset(self):
         year = self.request.parser_context.get("kwargs").get("year")
-        canteens = DiagnosticsToTeledeclareListView._get_complete_canteens(self.request.user.canteens.all())
+        canteens = DiagnosticsToTeledeclareListView._get_canteens_filled(self.request.user.canteens.all())
         diagnostics_filled = Diagnostic.objects.is_filled().filter(
             year=year, canteen__in=canteens, diagnostic_type__isnull=False
         )
@@ -157,11 +157,11 @@ class DiagnosticsToTeledeclareListView(ListAPIView):
         return diagnostics_filled.exclude(id__in=teledeclared)
 
     @staticmethod
-    def _get_complete_canteens(canteens):
+    def _get_canteens_filled(canteens):
         # We use this method instead of the SQL based one in the views/canteen.py file because we
         # don't need all the actions. By doing this on Python we can return early without running
         # all SQL requests when not needed. We are also not interested exactly in the kind of
         # completeness, just wether or not the canteen can teledeclare.
         # Possible to have this method in the model
-        complete_canteens = [canteen for canteen in canteens if canteen.has_complete_data]
-        return complete_canteens
+        canteens_filled = [canteen for canteen in canteens if canteen.has_filled_data]
+        return canteens_filled

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -163,5 +163,5 @@ class DiagnosticsToTeledeclareListView(ListAPIView):
         # all SQL requests when not needed. We are also not interested exactly in the kind of
         # completeness, just wether or not the canteen can teledeclare.
         # Possible to have this method in the model
-        canteens_filled = [canteen for canteen in canteens if canteen.has_filled_data]
+        canteens_filled = [canteen for canteen in canteens if canteen.is_filled]
         return canteens_filled

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -171,7 +171,7 @@ class CanteenQuerySet(SoftDeletionQuerySet):
     def has_missing_data(self):
         return self.annotate_with_requires_line_ministry().filter(has_missing_data_query())
 
-    def has_filled_data(self):
+    def is_filled(self):
         return self.annotate_with_requires_line_ministry().exclude(has_missing_data_query())
 
     def annotate_with_action_for_year(self, year):
@@ -266,8 +266,8 @@ class CanteenManager(SoftDeletionManager):
     def has_missing_data(self):
         return self.get_queryset().has_missing_data()
 
-    def has_filled_data(self):
-        return self.get_queryset().has_filled_data()
+    def is_filled(self):
+        return self.get_queryset().is_filled()
 
     def annotate_with_action_for_year(self, year):
         return self.get_queryset().annotate_with_action_for_year(year)
@@ -563,9 +563,9 @@ class Canteen(SoftDeletionModel):
         return not self.managers.exists()
 
     @property
-    def has_filled_data(self) -> bool:
+    def is_filled(self) -> bool:
         # basic rules
-        has_filled_data = (
+        is_filled = (
             bool(self.name)
             and bool(self.city_insee_code)
             and bool(self.yearly_meal_count)
@@ -575,25 +575,25 @@ class Canteen(SoftDeletionModel):
             and bool(self.economic_model)
         )
         # serving-specific rules
-        if has_filled_data and self.is_serving:
-            has_filled_data = bool(self.daily_meal_count)
+        if is_filled and self.is_serving:
+            is_filled = bool(self.daily_meal_count)
         # satellite-specific rules
-        if has_filled_data and self.is_satellite:
-            has_filled_data = bool(self.central_producer_siret and self.central_producer_siret != self.siret)
+        if is_filled and self.is_satellite:
+            is_filled = bool(self.central_producer_siret and self.central_producer_siret != self.siret)
         # cc-specific rules
-        if has_filled_data and self.is_central_cuisine:
-            has_filled_data = bool(self.satellite_canteens_count)
+        if is_filled and self.is_central_cuisine:
+            is_filled = bool(self.satellite_canteens_count)
             # We check again to avoid useless DB hits
-            if has_filled_data:
-                has_filled_data = (
+            if is_filled:
+                is_filled = (
                     Canteen.objects.filter(central_producer_siret=self.siret).count() == self.satellite_canteens_count
                 )
         # sectors & line_ministry
-        if has_filled_data:
-            has_filled_data = self.sectors.exists()
-        if has_filled_data and self.sectors.filter(has_line_ministry=True).exists():
-            has_filled_data = bool(self.line_ministry)
-        return has_filled_data
+        if is_filled:
+            is_filled = self.sectors.exists()
+        if is_filled and self.sectors.filter(has_line_ministry=True).exists():
+            is_filled = bool(self.line_ministry)
+        return is_filled
 
     def has_diagnostic_for_year(self, year):
         has_diagnostics = self.diagnostic_set.filter(year=year).exists()

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -339,25 +339,25 @@ class TestCanteenCompletePropertyAndQuerySet(TestCase):
             central_producer_siret=None  # incomplete
         )
 
-    def test_has_filled_data_queryset(self):
+    def test_is_filled_queryset(self):
         self.assertEqual(Canteen.objects.count(), 8)
-        self.assertEqual(Canteen.objects.has_filled_data().count(), 4)
+        self.assertEqual(Canteen.objects.is_filled().count(), 4)
 
-    def test_has_filled_data_property(self):
+    def test_is_filled_property(self):
         for canteen in [
             self.canteen_central,
             self.canteen_central_serving,
             self.canteen_on_site,
             self.canteen_on_site_central,
         ]:
-            self.assertTrue(canteen.has_filled_data)
+            self.assertTrue(canteen.is_filled)
         for canteen in [
             self.canteen_central_incomplete,
             self.canteen_central_serving_incomplete,
             self.canteen_on_site_incomplete,
             self.canteen_on_site_central_incomplete,
         ]:
-            self.assertFalse(canteen.has_filled_data)
+            self.assertFalse(canteen.is_filled)
 
     def test_has_missing_data_queryset(self):
         self.assertEqual(Canteen.objects.count(), 8)

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -339,25 +339,25 @@ class TestCanteenCompletePropertyAndQuerySet(TestCase):
             central_producer_siret=None  # incomplete
         )
 
-    def test_has_complete_data_queryset(self):
+    def test_has_filled_data_queryset(self):
         self.assertEqual(Canteen.objects.count(), 8)
-        self.assertEqual(Canteen.objects.has_complete_data().count(), 4)
+        self.assertEqual(Canteen.objects.has_filled_data().count(), 4)
 
-    def test_has_complete_data_property(self):
+    def test_has_filled_data_property(self):
         for canteen in [
             self.canteen_central,
             self.canteen_central_serving,
             self.canteen_on_site,
             self.canteen_on_site_central,
         ]:
-            self.assertTrue(canteen.has_complete_data)
+            self.assertTrue(canteen.has_filled_data)
         for canteen in [
             self.canteen_central_incomplete,
             self.canteen_central_serving_incomplete,
             self.canteen_on_site_incomplete,
             self.canteen_on_site_central_incomplete,
         ]:
-            self.assertFalse(canteen.has_complete_data)
+            self.assertFalse(canteen.has_filled_data)
 
     def test_has_missing_data_queryset(self):
         self.assertEqual(Canteen.objects.count(), 8)


### PR DESCRIPTION
Suite de #5216

On fait les même changements (renommer "complete" en "filled"), cette fois-ci pour le modèle `Canteen`