### PR TITLE
improve(Télédéclaration): améliore les messages pour les cuisines satellites

### DIFF
--- a/frontend/src/components/KeyMeasureBadge.vue
+++ b/frontend/src/components/KeyMeasureBadge.vue
@@ -1,5 +1,8 @@
 <template>
-  <DsfrBadge v-if="isCompleted" :showIcon="false" mode="SUCCESS">Complété</DsfrBadge>
+  <DsfrBadge v-if="isCompleted && isAppro && isSatellite" :showIcon="false" mode="SUCCESS">
+    Complété (par livreur)
+  </DsfrBadge>
+  <DsfrBadge v-else-if="isCompleted" :showIcon="false" mode="SUCCESS">Complété</DsfrBadge>
   <DsfrBadge v-else-if="isWaitingCentralKitchen" :showIcon="false" mode="NEUTRAL">
     À compléter (par livreur)
   </DsfrBadge>

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -82,7 +82,10 @@
           </TeledeclarationCancelDialog>
         </div>
         <div v-else-if="isSatelliteWithCompleteCentralDiagnostic">
-          <p>Votre livreur des repas va faire le bilan pour votre établissement.</p>
+          <p v-if="isSatelliteWithCentralDiagnosticTeledeclared">
+            Votre livreur des repas a déclaré le bilan pour votre établissement.
+          </p>
+          <p v-else>Votre livreur des repas va déclarer le bilan pour votre établissement.</p>
         </div>
         <div v-else-if="inTeledeclarationCampaign">
           <div v-if="isSatelliteWithApproCentralDiagnostic">
@@ -401,6 +404,9 @@ export default {
     },
     isSatelliteWithApproCentralDiagnostic() {
       return this.isSatellite && this.centralDiagnostic?.centralKitchenDiagnosticMode === "APPRO"
+    },
+    isSatelliteWithCentralDiagnosticTeledeclared() {
+      return this.centralDiagnostic.isTeledeclared
     },
     yearOptions() {
       return this.years.map((year) => ({ text: year, value: year }))

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -82,17 +82,18 @@
           </TeledeclarationCancelDialog>
         </div>
         <div v-else-if="isSatelliteWithCompleteCentralDiagnostic">
-          <p v-if="isSatelliteWithCentralDiagnosticTeledeclared">
-            Votre livreur des repas a déclaré le bilan pour votre établissement.
+          <p>
+            Votre livreur des repas {{ isSatelliteWithCentralDiagnosticTeledeclared ? "a déclaré" : "va déclarer" }} le
+            bilan pour votre établissement.
           </p>
-          <p v-else>Votre livreur des repas va déclarer le bilan pour votre établissement.</p>
         </div>
         <div v-else-if="inTeledeclarationCampaign">
           <div v-if="isSatelliteWithApproCentralDiagnostic">
-            <p v-if="isSatelliteWithCentralDiagnosticTeledeclared">
-              Votre livreur des repas a déclaré les données d'approvisionnement pour votre établissement.
+            <p>
+              Votre livreur des repas
+              {{ isSatelliteWithCentralDiagnosticTeledeclared ? "a déclaré" : "va déclarer" }} les données
+              d'approvisionnement pour votre établissement.
             </p>
-            <p v-else>Votre livreur des repas va déclarer les données d'approvisionnement pour votre établissement.</p>
             <p>Pour aller plus loin, vous pouvez télédéclarer les autres volets du bilan.</p>
           </div>
           <ul class="progress-list">

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -89,7 +89,10 @@
         </div>
         <div v-else-if="inTeledeclarationCampaign">
           <div v-if="isSatelliteWithApproCentralDiagnostic">
-            <p>Votre livreur des repas va déclarer les données d'approvisionnement pour votre établissement.</p>
+            <p v-if="isSatelliteWithCentralDiagnosticTeledeclared">
+              Votre livreur des repas a déclaré les données d'approvisionnement pour votre établissement.
+            </p>
+            <p v-else>Votre livreur des repas va déclarer les données d'approvisionnement pour votre établissement.</p>
             <p>Pour aller plus loin, vous pouvez télédéclarer les autres volets du bilan.</p>
           </div>
           <ul class="progress-list">


### PR DESCRIPTION
## Description

Les gestionnaires de cantine satellite n'avaient pas de messages différenciés si leur cuisine centrale avaient télédéclaré ou non le bilan. Précision aussi sur le badge "complété" en précisant "par livreur".

## Prévisualisation 

|Avant | Après si non TD| Après si TD |
|--|--|--|
| <img width="1710" alt="Capture d’écran 2025-04-03 à 11 43 38" src="https://github.com/user-attachments/assets/65dafe11-7611-47cb-8fbd-3a5be8de8eb4" /> | <img width="1227" alt="Capture d’écran 2025-04-03 à 11 43 09" src="https://github.com/user-attachments/assets/bd5e08df-eee8-486c-9d19-21c26f63db8c" /> | <img width="1258" alt="Capture d’écran 2025-04-03 à 11 42 51" src="https://github.com/user-attachments/assets/18dca1f4-e9ba-47f9-ace5-79c3234cc5cd" /> |
| <img width="1710" alt="Capture d’écran 2025-04-03 à 11 43 33" src="https://github.com/user-attachments/assets/ebe33540-c673-483c-b0a9-fbfb8932f402" /> | <img width="1295" alt="Capture d’écran 2025-04-03 à 11 46 35" src="https://github.com/user-attachments/assets/97ac22de-e0a4-4094-bc47-05233b7b6faa" /> | <img width="1288" alt="Capture d’écran 2025-04-03 à 11 46 44" src="https://github.com/user-attachments/assets/8858ec0b-03af-4a34-9e0e-7c356724d0e2" /> |