### PR TITLE
fix(Teledeclaration): Exclure les TD sans diag de la migration

### DIFF
--- a/data/migrations/0170_repopulate_fields_agg.py
+++ b/data/migrations/0170_repopulate_fields_agg.py
@@ -78,7 +78,7 @@ def total_label_rup(diagnostic):
 
 def populate_aggregated_food_fields(apps, schema_editor):
     Teledeclaration = apps.get_model('data', 'Teledeclaration')
-    teledeclarations = Teledeclaration.objects.select_related('diagnostic').all()
+    teledeclarations = Teledeclaration.objects.select_related('diagnostic').filter(diagnostic__isnull=False)
     if teledeclarations:
         for td in teledeclarations:
             diag = td.diagnostic


### PR DESCRIPTION
fix de #5212

Corrige l'erreur
```
File "/home/bas/app_3184e7ca-d443-43f1-9c3d-200aadc9319a/data/migrations/0170_repopulate_fields_agg.py", line 85, in populate_aggregated_food_fields
AttributeError: 'NoneType' object has no attribute 'value_total_ht'
```