### PR TITLE
improve(Télédéclaration): remplace les valeurs de 0 à null lors du remplissage automatique du bilan à partir des achats

### DIFF
--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/QualityTotalStep.vue
@@ -120,6 +120,13 @@ export default {
       if (this.totalFamiliesError) fields.push(...["valueMeatPoultryHt", "valueFishHt"])
       return fields
     },
+    purchasesSummaryWithNullValues() {
+      const purchases = { ...this.purchasesSummary }
+      Object.keys(purchases).forEach((key) => {
+        purchases[key] = purchases[key] === 0 ? null : purchases[key]
+      })
+      return purchases
+    },
   },
   methods: {
     updatePayload() {
@@ -190,7 +197,7 @@ export default {
       this.$nextTick(this.$refs.totalField.validate)
     },
     autofillWithPurchases() {
-      Object.assign(this.payload, { diagnosticType: "COMPLETE" }, this.purchasesSummary)
+      Object.assign(this.payload, { diagnosticType: "COMPLETE" }, this.purchasesSummaryWithNullValues)
       this.$emit("tunnel-autofill", {
         payload: this.payload,
         message: {


### PR DESCRIPTION
## Description

Lorsqu'un utilisateur rempli automatiquement sa télédéclaration si la sommes de ses achats est nulle dans une catégorie du diagnostic, la valeur est enregistrée à `0`, mais il est aussi possible d'avoir une valeur à `null`.