### PR TITLE
fix(Télédéclaration): utilise la même fonction pour le calcul du badge "complété" des approvisionnements et le bouton "Télédéclarer"

### DIFF
--- a/frontend/src/components/KeyMeasureBadge.vue
+++ b/frontend/src/components/KeyMeasureBadge.vue
@@ -12,7 +12,12 @@
 <script>
 import DsfrBadge from "@/components/DsfrBadge"
 import keyMeasures from "@/data/key-measures.json"
-import { missingCanteenData, hasSatelliteInconsistency, hasStartedMeasureTunnel } from "@/utils"
+import {
+  missingCanteenData,
+  hasSatelliteInconsistency,
+  hasStartedMeasureTunnel,
+  diagnosticCanBeTeledeclared,
+} from "@/utils"
 
 export default {
   name: "KeyMeasureBadge",
@@ -27,7 +32,9 @@ export default {
       return this.id === "etablissement" || this.id === "qualite-des-produits"
     },
     isFilled() {
-      return this.id === "etablissement" ? this.verifyEstablishmentFilled() : this.verifyMeasureFilled()
+      if (this.id === "etablissement") return this.verifyEstablishmentFilled()
+      else if (this.id === "qualite-des-produits") return this.verifyApproFilled()
+      else return this.verifyMeasureFilled()
     },
     isWaitingCentralKitchen() {
       return this.isAppro && this.isSatellite && !this.isFilled
@@ -61,10 +68,12 @@ export default {
     verifyEstablishmentFilled() {
       return this.isCentralKitchen ? this.isCentralKitchenFilled : !this.missingCanteenData
     },
+    verifyApproFilled() {
+      return diagnosticCanBeTeledeclared(this.canteen, this.diagnostic) || this.hasCentralKitchenDeclared()
+    },
     verifyMeasureFilled() {
       const measure = keyMeasures.find((measure) => measure.id === this.id)
-      if (this.isAppro) return hasStartedMeasureTunnel(this.diagnostic, measure) || this.hasCentralKitchenDeclared()
-      else return hasStartedMeasureTunnel(this.diagnostic, measure)
+      return hasStartedMeasureTunnel(this.diagnostic, measure)
     },
     hasCentralKitchenDeclared() {
       if (!this.isSatellite) return false

--- a/frontend/src/components/KeyMeasureBadge.vue
+++ b/frontend/src/components/KeyMeasureBadge.vue
@@ -12,12 +12,7 @@
 <script>
 import DsfrBadge from "@/components/DsfrBadge"
 import keyMeasures from "@/data/key-measures.json"
-import {
-  missingCanteenData,
-  hasSatelliteInconsistency,
-  hasStartedMeasureTunnel,
-  diagnosticCanBeTeledeclared,
-} from "@/utils"
+import { missingCanteenData, hasSatelliteInconsistency, hasStartedMeasureTunnel, hasDiagnosticApproData } from "@/utils"
 
 export default {
   name: "KeyMeasureBadge",
@@ -69,7 +64,7 @@ export default {
       return this.isCentralKitchen ? this.isCentralKitchenFilled : !this.missingCanteenData
     },
     verifyApproFilled() {
-      return diagnosticCanBeTeledeclared(this.canteen, this.diagnostic) || this.hasCentralKitchenDeclared()
+      return this.diagnostic ? hasDiagnosticApproData(this.diagnostic) : this.hasCentralKitchenDeclared()
     },
     verifyMeasureFilled() {
       const measure = keyMeasures.find((measure) => measure.id === this.id)

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -127,7 +127,7 @@
           </ul>
           <v-btn
             color="primary"
-            :disabled="!readyToTeledeclare && !hasFinishedMeasureTunnel"
+            :disabled="!readyToTeledeclare"
             @click="showTeledeclarationPreview = true"
             class="mt-3"
           >
@@ -282,7 +282,6 @@ import {
   hasDiagnosticApproData,
   missingCanteenData,
   hasSatelliteInconsistency,
-  hasFinishedMeasureTunnel,
 } from "@/utils"
 import keyMeasures from "@/data/key-measures.json"
 import Constants from "@/constants"
@@ -396,9 +395,6 @@ export default {
     },
     missingDeclarationMode() {
       return this.isCentralKitchen && !this.diagnostic?.centralKitchenDiagnosticMode
-    },
-    hasFinishedMeasureTunnel() {
-      return this.diagnostic && hasFinishedMeasureTunnel(this.diagnostic)
     },
     isSatellite() {
       return this.canteen?.productionType === "site_cooked_elsewhere"


### PR DESCRIPTION
## Description

Le badge "complété" s'affichait dans le tunnel alors que l'utilisateur n'avait pas renseigné les champs obligatoires des approvisionnements. 

## Prévisualisation

|Avant| Après|
|--|--|
| <img width="804" alt="Capture d’écran 2025-04-03 à 15 40 50" src="https://github.com/user-attachments/assets/e081de30-83c6-4550-952c-401b986c6c72" /> | <img width="1180" alt="Capture d’écran 2025-04-03 à 15 46 45" src="https://github.com/user-attachments/assets/866f369f-4630-4691-a2e4-360f2122453d" /> |