### PR TITLE
refactor(Dates de campagnes): ajout des dates de correction pour la campagne de 2024

### DIFF
--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -16,8 +16,8 @@ from data.region_choices import Region
 year_data = now().year - 1
 mocked_campaign_dates = {
     year_data: {
-        "start_date": now().replace(month=1, day=1, hour=0, minute=0, second=0),
-        "end_date": now().replace(month=12, day=31, hour=23, minute=59, second=59),
+        "teledeclaration_start_date": now().replace(month=1, day=1, hour=0, minute=0, second=0),
+        "teledeclaration_end_date": now().replace(month=12, day=31, hour=23, minute=59, second=59),
     }
 }
 

--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -138,7 +138,7 @@ class TestCanteenStatsApi(APITestCase):
                 diag = DiagnosticFactory.create(canteen=canteen, **diagnostic_data)
                 Teledeclaration.create_from_diagnostic(diag, applicant=UserFactory.create())
 
-        with patch("macantine.utils.CAMPAIGN_DATES", mocked_campaign_dates):
+        with patch("data.models.diagnostic.CAMPAIGN_DATES", mocked_campaign_dates):
             response = self.client.get(reverse("canteen_statistics"), {"region": "01", "year": year_data})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -159,7 +159,7 @@ class TestCanteenStatsApi(APITestCase):
         self.assertEqual(sector_categories[Sector.Categories.SOCIAL], 0)
 
         # can also call without location info
-        with patch("macantine.utils.CAMPAIGN_DATES", mocked_campaign_dates):
+        with patch("data.models.diagnostic.CAMPAIGN_DATES", mocked_campaign_dates):
             response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -359,7 +359,7 @@ class TestCanteenStatsApi(APITestCase):
 
         self.assertEqual(appro_badge_qs.count(), 6)
 
-        with patch("macantine.utils.CAMPAIGN_DATES", mocked_campaign_dates):
+        with patch("data.models.diagnostic.CAMPAIGN_DATES", mocked_campaign_dates):
             response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
         body = response.json()
         # There are 3 canteens that do not meet criteria (including one for which the diag is not even created),
@@ -544,7 +544,7 @@ class TestCanteenStatsApi(APITestCase):
         )
         Teledeclaration.create_from_diagnostic(diag, applicant=UserFactory.create())
 
-        with patch("macantine.utils.CAMPAIGN_DATES", mocked_campaign_dates):
+        with patch("data.models.diagnostic.CAMPAIGN_DATES", mocked_campaign_dates):
             response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -39,8 +39,8 @@ class DiagnosticQuerySet(models.QuerySet):
         return self.filter(
             year=year,
             teledeclaration__creation_date__range=(
-                CAMPAIGN_DATES[year]["start_date"],
-                CAMPAIGN_DATES[year]["end_date"],
+                CAMPAIGN_DATES[year]["teledeclaration_start_date"],
+                CAMPAIGN_DATES[year]["teledeclaration_end_date"],
             ),
             teledeclaration__status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
         )
@@ -53,8 +53,8 @@ class DiagnosticQuerySet(models.QuerySet):
             .exclude(canteen__siret="")
             .exclude(
                 canteen__deletion_date__range=(
-                    CAMPAIGN_DATES[year]["start_date"],
-                    CAMPAIGN_DATES[year]["end_date"],
+                    CAMPAIGN_DATES[year]["teledeclaration_start_date"],
+                    CAMPAIGN_DATES[year]["teledeclaration_end_date"],
                 )
             )
         )

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -38,8 +38,8 @@ class TeledeclarationQuerySet(models.QuerySet):
         return self.filter(
             year=year,
             creation_date__range=(
-                CAMPAIGN_DATES[year]["start_date"],
-                CAMPAIGN_DATES[year]["end_date"],
+                CAMPAIGN_DATES[year]["teledeclaration_start_date"],
+                CAMPAIGN_DATES[year]["teledeclaration_end_date"],
             ),
             status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
         )
@@ -51,8 +51,8 @@ class TeledeclarationQuerySet(models.QuerySet):
             .filter(canteen_has_siret_or_siren_unite_legale_query())
             .exclude(
                 canteen__deletion_date__range=(
-                    CAMPAIGN_DATES[year]["start_date"],
-                    CAMPAIGN_DATES[year]["end_date"],
+                    CAMPAIGN_DATES[year]["teledeclaration_start_date"],
+                    CAMPAIGN_DATES[year]["teledeclaration_end_date"],
                 )
             )
         )

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -9,8 +9,8 @@ from data.models import Diagnostic, Teledeclaration
 year_data = now().year - 1
 mocked_campaign_dates = {
     year_data: {
-        "start_date": now().replace(month=1, day=1, hour=0, minute=0, second=0),
-        "end_date": now().replace(month=12, day=31, hour=23, minute=59, second=59),
+        "teledeclaration_start_date": now().replace(month=1, day=1, hour=0, minute=0, second=0),
+        "teledeclaration_end_date": now().replace(month=12, day=31, hour=23, minute=59, second=59),
     }
 }
 

--- a/data/tests/test_teledeclaration.py
+++ b/data/tests/test_teledeclaration.py
@@ -9,8 +9,8 @@ from data.models import Teledeclaration
 year_data = now().year - 1
 mocked_campaign_dates = {
     year_data: {
-        "start_date": now().replace(month=1, day=1, hour=0, minute=0, second=0),
-        "end_date": now().replace(month=12, day=31, hour=23, minute=59, second=59),
+        "teledeclaration_start_date": now().replace(month=1, day=1, hour=0, minute=0, second=0),
+        "teledeclaration_end_date": now().replace(month=12, day=31, hour=23, minute=59, second=59),
     }
 }
 

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -10,19 +10,23 @@ redis = r.from_url(settings.REDIS_URL, decode_responses=True)
 
 CAMPAIGN_DATES = {
     2021: {
-        "start_date": datetime(2022, 7, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "end_date": datetime(2022, 12, 5, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_start_date": datetime(2022, 7, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(2022, 12, 5, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
     2022: {
-        "start_date": datetime(2023, 2, 12, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "end_date": datetime(2023, 7, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_start_date": datetime(2023, 2, 12, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(2023, 7, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
     2023: {
-        "start_date": datetime(2024, 1, 8, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "end_date": datetime(2024, 6, 12, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_start_date": datetime(2024, 1, 8, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(2024, 6, 12, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "correction_start_date": datetime(2024, 6, 3, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "correction_end_date": datetime(2024, 6, 13, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
     2024: {
-        "start_date": datetime(2025, 1, 7, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "end_date": datetime(2025, 4, 7, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_start_date": datetime(2025, 1, 7, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(2025, 4, 7, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "correction_start_date": datetime(2025, 4, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "correction_end_date": datetime(2025, 5, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
 }


### PR DESCRIPTION
Modifications de `CAMPAIGN_DATES`
- renommer `start_date` en `teledeclaration_start_date` (pareil pour `end_date`)
- pour 2023 & 2024 : ajout de `correction_start_date` & `correction_end_date`