### PR TITLE
fix(Foire aux questions): corrige erreur lors du build dû à l'asset introuvable par vite

### DIFF
--- a/2024-frontend/src/views/FAQ.vue
+++ b/2024-frontend/src/views/FAQ.vue
@@ -5,6 +5,7 @@ import AppNeedHelp from "@/components/AppNeedHelp.vue"
 import AppLinkRouter from "@/components/AppLinkRouter.vue"
 
 const route = useRoute()
+const readingDoodleIllustration = "/static/images/doodles-dsfr/primary/ReadingDoodle.png"
 </script>
 
 <template>
@@ -31,7 +32,7 @@ const route = useRoute()
       </DsfrAccordionsGroup>
     </div>
     <div class="fr-hidden fr-unhidden-lg fr-col-4 fr-grid-row fr-grid-row--right ma-cantine--sticky">
-      <img src="/static/images/doodles-dsfr/primary/ReadingDoodle.png" class="faq__illustration" />
+      <img :src="readingDoodleIllustration" class="faq__illustration" />
     </div>
   </section>
   <AppNeedHelp badge="Une suggestion" title="Vous ne trouvez pas ce que vous cherchez ?">


### PR DESCRIPTION
Suite à #5228

## Description

Lors du build si Vite ne trouve pas un des fichiers, il se met en erreur et arrête de construire le front. Comme l'image est servie par les statics il faut rendre cette url dynamique avec une variable.