### PR TITLE
refactor(Dates de campagnes): basculer les end dates sur 23:59 du jour d'avant

### DIFF
--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -18,7 +18,7 @@ def convert_date_string_to_datetime(date_string, time_start_or_end="start"):
         try:
             datetime_object = datetime.strptime(date_string, "%Y-%m-%d")
             if time_start_or_end == "end":
-                datetime_object = datetime_object.replace(hour=23, minute=59, second=59)
+                datetime_object = datetime_object.replace(hour=23, minute=59, second=59, microsecond=999999)
             datetime_object = datetime_object.replace(tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
             return datetime_object
         except ValueError:
@@ -29,35 +29,41 @@ def convert_date_string_to_datetime(date_string, time_start_or_end="start"):
 
 CAMPAIGN_DATES = {
     2021: {
-        "teledeclaration_start_date": datetime(2022, 7, 16, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "teledeclaration_end_date": datetime(2022, 12, 4, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_start_date": datetime(2022, 7, 16, 0, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(
+            2022, 12, 4, 23, 59, 59, 999999, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")
+        ),
     },
     2022: {
-        "teledeclaration_start_date": datetime(2023, 2, 12, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "teledeclaration_end_date": datetime(2023, 6, 30, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_start_date": datetime(2023, 2, 12, 0, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(
+            2023, 6, 30, 23, 59, 59, 999999, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")
+        ),
     },
     2023: {
-        "teledeclaration_start_date": datetime(2024, 1, 8, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "teledeclaration_end_date": datetime(2024, 6, 11, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "correction_start_date": datetime(2024, 6, 3, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "correction_end_date": datetime(2024, 6, 12, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_start_date": datetime(2024, 1, 8, 0, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(
+            2024, 6, 11, 23, 59, 59, 999999, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")
+        ),
+        "correction_start_date": datetime(2024, 6, 3, 0, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "correction_end_date": datetime(2024, 6, 12, 23, 59, 59, 999999, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
     2024: {
         "teledeclaration_start_date": (
             convert_date_string_to_datetime(settings.TELEDECLARATION_START_DATE)
-            or datetime(2025, 1, 7, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
+            or datetime(2025, 1, 7, 0, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
         ),
         "teledeclaration_end_date": (
             convert_date_string_to_datetime(settings.TELEDECLARATION_END_DATE, "end")
-            or datetime(2025, 4, 6, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
+            or datetime(2025, 4, 6, 23, 59, 59, 999999, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
         ),
         "correction_start_date": (
             convert_date_string_to_datetime(settings.CORRECTION_START_DATE)
-            or datetime(2025, 4, 16, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
+            or datetime(2025, 4, 16, 0, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
         ),
         "correction_end_date": (
             convert_date_string_to_datetime(settings.CORRECTION_END_DATE, "end")
-            or datetime(2025, 4, 30, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
+            or datetime(2025, 4, 30, 23, 59, 59, 999999, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
         ),
     },
     # Note: au moment d'ajouter une nouvelle année :

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -9,14 +9,19 @@ logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)
 
 
-def date_string_to_datetime(date_string):
+def date_string_to_datetime(date_string, start_or_end="start"):
     """
-    Input: 2025-01-07
+    Input: 2025-01-07, "start"
     Output: 2025-01-07 00:00:00+01:00
     """
     if date_string:
         try:
-            return datetime.strptime(date_string, "%Y-%m-%d").replace(tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
+            if start_or_end == "start":
+                return datetime.strptime(date_string, "%Y-%m-%d").replace(tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
+            elif start_or_end == "end":
+                return datetime.strptime(date_string, "%Y-%m-%d").replace(
+                    hour=23, minute=59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")
+                )
         except ValueError:
             logger.warning(f"Invalid date string format: {date_string}")
             return None
@@ -26,27 +31,27 @@ def date_string_to_datetime(date_string):
 CAMPAIGN_DATES = {
     2021: {
         "teledeclaration_start_date": datetime(2022, 7, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "teledeclaration_end_date": datetime(2022, 12, 5, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(2022, 12, 4, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
     2022: {
         "teledeclaration_start_date": datetime(2023, 2, 12, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "teledeclaration_end_date": datetime(2023, 7, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(2023, 6, 30, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
     2023: {
         "teledeclaration_start_date": datetime(2024, 1, 8, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "teledeclaration_end_date": datetime(2024, 6, 12, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(2024, 6, 11, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
         "correction_start_date": datetime(2024, 6, 3, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "correction_end_date": datetime(2024, 6, 13, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "correction_end_date": datetime(2024, 6, 12, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
     2024: {
-        "teledeclaration_start_date": date_string_to_datetime(settings.TELEDECLARATION_START_DATE)
+        "teledeclaration_start_date": date_string_to_datetime(settings.TELEDECLARATION_START_DATE, "start")
         or datetime(2025, 1, 7, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "teledeclaration_end_date": date_string_to_datetime(settings.TELEDECLARATION_END_DATE)
-        or datetime(2025, 4, 7, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "correction_start_date": date_string_to_datetime(settings.CORRECTION_START_DATE)
+        "teledeclaration_end_date": date_string_to_datetime(settings.TELEDECLARATION_END_DATE, "end")
+        or datetime(2025, 4, 6, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "correction_start_date": date_string_to_datetime(settings.CORRECTION_START_DATE, "start")
         or datetime(2025, 4, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "correction_end_date": date_string_to_datetime(settings.CORRECTION_END_DATE)
-        or datetime(2025, 5, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "correction_end_date": date_string_to_datetime(settings.CORRECTION_END_DATE, "end")
+        or datetime(2025, 4, 30, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
     # Note: au moment d'ajouter une nouvelle année :
     # - penser à y ajouter les settings (pour override)

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -9,19 +9,18 @@ logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)
 
 
-def date_string_to_datetime(date_string, start_or_end="start"):
+def convert_date_string_to_datetime(date_string, time_start_or_end="start"):
     """
     Input: 2025-01-07, "start"
     Output: 2025-01-07 00:00:00+01:00
     """
     if date_string:
         try:
-            if start_or_end == "start":
-                return datetime.strptime(date_string, "%Y-%m-%d").replace(tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
-            elif start_or_end == "end":
-                return datetime.strptime(date_string, "%Y-%m-%d").replace(
-                    hour=23, minute=59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")
-                )
+            datetime_object = datetime.strptime(date_string, "%Y-%m-%d")
+            if time_start_or_end == "end":
+                datetime_object = datetime_object.replace(hour=23, minute=59, second=59)
+            datetime_object = datetime_object.replace(tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
+            return datetime_object
         except ValueError:
             logger.warning(f"Invalid date string format: {date_string}")
             return None
@@ -30,28 +29,36 @@ def date_string_to_datetime(date_string, start_or_end="start"):
 
 CAMPAIGN_DATES = {
     2021: {
-        "teledeclaration_start_date": datetime(2022, 7, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "teledeclaration_end_date": datetime(2022, 12, 4, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_start_date": datetime(2022, 7, 16, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(2022, 12, 4, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
     2022: {
-        "teledeclaration_start_date": datetime(2023, 2, 12, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "teledeclaration_end_date": datetime(2023, 6, 30, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_start_date": datetime(2023, 2, 12, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(2023, 6, 30, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
     2023: {
-        "teledeclaration_start_date": datetime(2024, 1, 8, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "teledeclaration_end_date": datetime(2024, 6, 11, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "correction_start_date": datetime(2024, 6, 3, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "correction_end_date": datetime(2024, 6, 12, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_start_date": datetime(2024, 1, 8, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_end_date": datetime(2024, 6, 11, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "correction_start_date": datetime(2024, 6, 3, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "correction_end_date": datetime(2024, 6, 12, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
     },
     2024: {
-        "teledeclaration_start_date": date_string_to_datetime(settings.TELEDECLARATION_START_DATE, "start")
-        or datetime(2025, 1, 7, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "teledeclaration_end_date": date_string_to_datetime(settings.TELEDECLARATION_END_DATE, "end")
-        or datetime(2025, 4, 6, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "correction_start_date": date_string_to_datetime(settings.CORRECTION_START_DATE, "start")
-        or datetime(2025, 4, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
-        "correction_end_date": date_string_to_datetime(settings.CORRECTION_END_DATE, "end")
-        or datetime(2025, 4, 30, 23, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),
+        "teledeclaration_start_date": (
+            convert_date_string_to_datetime(settings.TELEDECLARATION_START_DATE)
+            or datetime(2025, 1, 7, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
+        ),
+        "teledeclaration_end_date": (
+            convert_date_string_to_datetime(settings.TELEDECLARATION_END_DATE, "end")
+            or datetime(2025, 4, 6, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
+        ),
+        "correction_start_date": (
+            convert_date_string_to_datetime(settings.CORRECTION_START_DATE)
+            or datetime(2025, 4, 16, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
+        ),
+        "correction_end_date": (
+            convert_date_string_to_datetime(settings.CORRECTION_END_DATE, "end")
+            or datetime(2025, 4, 30, 23, 59, 59, tzinfo=zoneinfo.ZoneInfo("Europe/Paris"))
+        ),
     },
     # Note: au moment d'ajouter une nouvelle année :
     # - penser à y ajouter les settings (pour override)


### PR DESCRIPTION
Suite de #5231 et l'ajout des variables d'env pour les campagnes de TD & Correction

Mieux gérer les start & end dates
- end dates finissent maintenant à 23h59
- transformer les env différemment si start ou end