### PR TITLE
feat(Campagne de correction): création d'un bandeau dédié pour les campagnes de télédéclaration et de correction

### DIFF
--- a/frontend/src/views/ManagementPage/InformationBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationBanner.vue
@@ -66,6 +66,7 @@ export default {
       correctionStartDate: null,
       correctionEndDate: null,
       isCorrection: false,
+      isTeledeclaration: false,
     }
   },
   mounted() {

--- a/frontend/src/views/ManagementPage/InformationBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationBanner.vue
@@ -12,10 +12,16 @@
       </p>
     </div>
     <v-row class="mt-4 mb-0 mx-0 align-center">
-      <v-btn :to="{ name: 'PendingActions' }" color="primary" class="mb-5 mb-md-2 mr-4">
+      <v-btn v-if="isTeledeclaration" :to="{ name: 'PendingActions' }" color="primary" class="mb-5 mb-md-2 mr-4">
         Télédéclarer mes cantines
       </v-btn>
-      <v-btn :to="{ name: 'CommunityPage', hash: '#evenements' }" color="primary" outlined class="mb-5 mb-md-2 mr-4">
+      <v-btn
+        v-if="isTeledeclaration"
+        :to="{ name: 'CommunityPage', hash: '#evenements' }"
+        color="primary"
+        outlined
+        class="mb-5 mb-md-2 mr-4"
+      >
         Inscrivez-vous à nos derniers webinaires
       </v-btn>
       <p class="fr-text-sm mb-5 mb-md-2 mr-4">

--- a/frontend/src/views/ManagementPage/InformationBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationBanner.vue
@@ -44,11 +44,43 @@
 
 <script>
 import DsfrCallout from "@/components/DsfrCallout"
+import { lastYear } from "@/utils"
 
 export default {
   name: "InformationBanner",
   components: {
     DsfrCallout,
+  },
+  data() {
+    return {
+      year: lastYear(),
+      correctionStartDate: null,
+      correctionEndDate: null,
+      isCorrection: false,
+    }
+  },
+  mounted() {
+    // TODO : change for api
+    this.updateBanner({
+      isCorrection: true,
+      isTeledeclaration: false,
+      correctionEndDate: "2025-04-30 00:00:00+01:00",
+      correctionStartDate: "2025-04-16 00:00:00+01:00",
+    })
+  },
+  methods: {
+    updateBanner(infos) {
+      this.isCorrection = infos.isCorrection
+      this.isTeledeclaration = infos.isTeledeclaration
+      this.correctionStartDate = this.prettifyDate(infos.correctionStartDate)
+      this.correctionEndDate = this.prettifyDate(infos.correctionEndDate)
+    },
+    prettifyDate(date) {
+      const dateObject = new Date(date)
+      const day = dateObject.getDate()
+      const monthName = dateObject.toLocaleString("default", { month: "long" })
+      return `${day} ${monthName}`
+    },
   },
 }
 </script>

--- a/frontend/src/views/ManagementPage/InformationBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationBanner.vue
@@ -1,13 +1,16 @@
 <template>
   <DsfrCallout noIcon class="mt-2">
-    <h2 class="fr-text font-weight-bold mb-2 mt-2">
-      INFORMATION IMPORTANTE :
-    </h2>
-    <p class="mb-0">
-      La télédéclaration 2025 est exceptionnellement maintenue ouverte sur l'ensemble de la première semaine d'avril.
-      <br />
-      Les télédéclarations seront possibles jusqu’au dimanche 6 avril 2025 inclus.
-    </p>
+    <div v-if="isCorrection">
+      <h2 class="fr-text font-weight-bold mb-2 mt-2">
+        <span class="text-uppercase">Droit à l'erreur :</span>
+        du {{ correctionStartDate }} au {{ correctionEndDate }} {{ year + 1 }}
+      </h2>
+      <p class="mb-0">
+        Valable uniquement pour les établissements qui ont validé leur télé-déclaration. Depuis votre bilan, vous pouvez
+        corriger vos informations si besoin. Attention la télé-déclaration rectificative doit être déposée avant le
+        {{ correctionEndDate }}.
+      </p>
+    </div>
     <v-row class="mt-4 mb-0 mx-0 align-center">
       <v-btn :to="{ name: 'PendingActions' }" color="primary" class="mb-5 mb-md-2 mr-4">
         Télédéclarer mes cantines

--- a/frontend/src/views/ManagementPage/InformationBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationBanner.vue
@@ -1,6 +1,6 @@
 <template>
   <DsfrCallout noIcon class="mt-2">
-    <div v-if="isCorrection">
+    <div v-if="inCorrection">
       <h2 class="fr-text font-weight-bold mb-2 mt-2">
         <span class="text-uppercase">Droit à l'erreur :</span>
         du {{ correctionStartDate }} au {{ correctionEndDate }} {{ year + 1 }}
@@ -12,11 +12,11 @@
       </p>
     </div>
     <v-row class="mt-4 mb-0 mx-0 align-center">
-      <v-btn v-if="isTeledeclaration" :to="{ name: 'PendingActions' }" color="primary" class="mb-5 mb-md-2 mr-4">
+      <v-btn v-if="inTeledeclaration" :to="{ name: 'PendingActions' }" color="primary" class="mb-5 mb-md-2 mr-4">
         Télédéclarer mes cantines
       </v-btn>
       <v-btn
-        v-if="isTeledeclaration"
+        v-if="inTeledeclaration"
         :to="{ name: 'CommunityPage', hash: '#evenements' }"
         color="primary"
         outlined
@@ -65,23 +65,23 @@ export default {
       year: lastYear(),
       correctionStartDate: null,
       correctionEndDate: null,
-      isCorrection: false,
-      isTeledeclaration: false,
+      inCorrection: false,
+      inTeledeclaration: false,
     }
   },
   mounted() {
     // TODO : change for api
     this.updateBanner({
-      isCorrection: true,
-      isTeledeclaration: false,
+      inCorrection: true,
+      inTeledeclaration: false,
       correctionEndDate: "2025-04-30 00:00:00+01:00",
       correctionStartDate: "2025-04-16 00:00:00+01:00",
     })
   },
   methods: {
     updateBanner(infos) {
-      this.isCorrection = infos.isCorrection
-      this.isTeledeclaration = infos.isTeledeclaration
+      this.inCorrection = infos.inCorrection
+      this.inTeledeclaration = infos.inTeledeclaration
       this.correctionStartDate = this.prettifyDate(infos.correctionStartDate)
       this.correctionEndDate = this.prettifyDate(infos.correctionEndDate)
     },

--- a/frontend/src/views/ManagementPage/InformationBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationBanner.vue
@@ -1,27 +1,18 @@
 <template>
   <DsfrCallout noIcon class="mt-2">
-    <div v-if="inCorrection">
-      <h2 class="fr-text font-weight-bold mb-2 mt-2">
-        <span class="text-uppercase">Droit à l'erreur :</span>
-        du {{ correctionStartDate }} au {{ correctionEndDate }} {{ year + 1 }}
-      </h2>
-      <p class="mb-0">
-        Valable uniquement pour les établissements qui ont validé leur télé-déclaration. Depuis votre bilan, vous pouvez
-        corriger vos informations si besoin. Attention la télé-déclaration rectificative doit être déposée avant le
-        {{ correctionEndDate }}.
-      </p>
-    </div>
+    <h2 class="fr-text font-weight-bold mb-2 mt-2">
+      INFORMATION IMPORTANTE :
+    </h2>
+    <p class="mb-0">
+      La télédéclaration 2025 est exceptionnellement maintenue ouverte sur l'ensemble de la première semaine d'avril.
+      <br />
+      Les télédéclarations seront possibles jusqu’au dimanche 6 avril 2025 inclus.
+    </p>
     <v-row class="mt-4 mb-0 mx-0 align-center">
-      <v-btn v-if="inTeledeclaration" :to="{ name: 'PendingActions' }" color="primary" class="mb-5 mb-md-2 mr-4">
+      <v-btn :to="{ name: 'PendingActions' }" color="primary" class="mb-5 mb-md-2 mr-4">
         Télédéclarer mes cantines
       </v-btn>
-      <v-btn
-        v-if="inTeledeclaration"
-        :to="{ name: 'CommunityPage', hash: '#evenements' }"
-        color="primary"
-        outlined
-        class="mb-5 mb-md-2 mr-4"
-      >
+      <v-btn :to="{ name: 'CommunityPage', hash: '#evenements' }" color="primary" outlined class="mb-5 mb-md-2 mr-4">
         Inscrivez-vous à nos derniers webinaires
       </v-btn>
       <p class="fr-text-sm mb-5 mb-md-2 mr-4">
@@ -53,44 +44,11 @@
 
 <script>
 import DsfrCallout from "@/components/DsfrCallout"
-import { lastYear } from "@/utils"
 
 export default {
   name: "InformationBanner",
   components: {
     DsfrCallout,
-  },
-  data() {
-    return {
-      year: lastYear(),
-      correctionStartDate: null,
-      correctionEndDate: null,
-      inCorrection: false,
-      inTeledeclaration: false,
-    }
-  },
-  mounted() {
-    // TODO : change for api
-    this.updateBanner({
-      inCorrection: true,
-      inTeledeclaration: false,
-      correctionEndDate: "2025-04-30 00:00:00+01:00",
-      correctionStartDate: "2025-04-16 00:00:00+01:00",
-    })
-  },
-  methods: {
-    updateBanner(infos) {
-      this.inCorrection = infos.inCorrection
-      this.inTeledeclaration = infos.inTeledeclaration
-      this.correctionStartDate = this.prettifyDate(infos.correctionStartDate)
-      this.correctionEndDate = this.prettifyDate(infos.correctionEndDate)
-    },
-    prettifyDate(date) {
-      const dateObject = new Date(date)
-      const day = dateObject.getDate()
-      const monthName = dateObject.toLocaleString("default", { month: "long" })
-      return `${day} ${monthName}`
-    },
   },
 }
 </script>

--- a/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
@@ -1,5 +1,17 @@
 <template>
   <DsfrCallout v-if="inCorrection || inTeledeclaration" noIcon class="mt-2">
+    <div v-if="inTeledeclaration">
+      <h2 class="fr-text font-weight-bold mb-2 mt-2">
+        <span class="text-uppercase">Campagne de télédéclaration {{ year + 1 }} :</span>
+        du {{ teledeclarationStartDate }} au {{ teledeclarationEndDate }}
+      </h2>
+      <p class="mb-0">
+        Dans votre espace cantine, remplissez votre bilan sur les données d'achat {{ year }} et télédéclarez vos
+        données.
+        <br />
+        Pour rappel, selon l’arrêté ministériel du 14 septembre 2022, il est obligatoire de télédéclarer ses achats.
+      </p>
+    </div>
     <div v-if="inCorrection">
       <h2 class="fr-text font-weight-bold mb-2 mt-2">
         <span class="text-uppercase">Droit à l'erreur :</span>
@@ -63,6 +75,8 @@ export default {
   data() {
     return {
       year: lastYear(),
+      teledeclarationStartDate: null,
+      teledeclarationEndDate: null,
       correctionStartDate: null,
       correctionEndDate: null,
       inCorrection: false,
@@ -72,8 +86,10 @@ export default {
   mounted() {
     // TODO : change for api
     this.updateBanner({
-      inCorrection: true,
-      inTeledeclaration: false,
+      inCorrection: false,
+      inTeledeclaration: true,
+      teledeclarationStartDate: "2025-01-07",
+      teledeclarationEndDate: "2025-03-30",
       correctionEndDate: "2025-04-30 00:00:00+01:00",
       correctionStartDate: "2025-04-16 00:00:00+01:00",
     })
@@ -84,6 +100,8 @@ export default {
       this.inTeledeclaration = infos.inTeledeclaration
       this.correctionStartDate = this.prettifyDate(infos.correctionStartDate)
       this.correctionEndDate = this.prettifyDate(infos.correctionEndDate)
+      this.teledeclarationStartDate = this.prettifyDate(infos.teledeclarationStartDate)
+      this.teledeclarationEndDate = this.prettifyDate(infos.teledeclarationEndDate)
     },
     prettifyDate(date) {
       const dateObject = new Date(date)

--- a/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
@@ -1,0 +1,106 @@
+<template>
+  <DsfrCallout v-if="inCorrection || inTeledeclaration" noIcon class="mt-2">
+    <div v-if="inCorrection">
+      <h2 class="fr-text font-weight-bold mb-2 mt-2">
+        <span class="text-uppercase">Droit à l'erreur :</span>
+        du {{ correctionStartDate }} au {{ correctionEndDate }} {{ year + 1 }}
+      </h2>
+      <p class="mb-0">
+        Valable uniquement pour les établissements qui ont validé leur télé-déclaration. Depuis votre bilan, vous pouvez
+        corriger vos informations si besoin. Attention la télé-déclaration rectificative doit être déposée avant le
+        {{ correctionEndDate }}.
+      </p>
+    </div>
+    <v-row class="mt-4 mb-0 mx-0 align-center">
+      <v-btn v-if="inTeledeclaration" :to="{ name: 'PendingActions' }" color="primary" class="mb-5 mb-md-2 mr-4">
+        Télédéclarer mes cantines
+      </v-btn>
+      <v-btn
+        v-if="inTeledeclaration"
+        :to="{ name: 'CommunityPage', hash: '#evenements' }"
+        color="primary"
+        outlined
+        class="mb-5 mb-md-2 mr-4"
+      >
+        Inscrivez-vous à nos derniers webinaires
+      </v-btn>
+      <p class="fr-text-sm mb-5 mb-md-2 mr-4">
+        <a
+          href="https://894795896-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2F-MSCF7Mdc8yfeIjMxMZr%2Fuploads%2F85J5bYm9Nd4aFRJk1pvm%2FGuide_prise_en_main_ma_cantine_janv2025.pdf?alt=media"
+          target="_blank"
+          rel="noopener external"
+          title="Le guide de télédéclaration - ouvre une nouvelle fenêtre"
+          class="grey--text text--darken-4"
+        >
+          Le guide de télédéclaration
+          <v-icon small class="ml-2 grey--text text--darken-4">mdi-open-in-new</v-icon>
+        </a>
+      </p>
+      <p class="fr-text-sm mb-5 mb-md-2">
+        <a
+          href="/static/documents/Antiseche_donnees_dachat_ma_cantine_2025.pdf"
+          download
+          title="Comment saisir mes données d'achat"
+          class="grey--text text--darken-4"
+        >
+          Comment saisir mes données d'achat
+          <v-icon class="ml-2 grey--text text--darken-4 icon-small">$download-line</v-icon>
+        </a>
+      </p>
+    </v-row>
+  </DsfrCallout>
+</template>
+
+<script>
+import DsfrCallout from "@/components/DsfrCallout"
+import { lastYear } from "@/utils"
+
+export default {
+  name: "InformationBanner",
+  components: {
+    DsfrCallout,
+  },
+  data() {
+    return {
+      year: lastYear(),
+      correctionStartDate: null,
+      correctionEndDate: null,
+      inCorrection: false,
+      inTeledeclaration: false,
+    }
+  },
+  mounted() {
+    // TODO : change for api
+    this.updateBanner({
+      inCorrection: true,
+      inTeledeclaration: false,
+      correctionEndDate: "2025-04-30 00:00:00+01:00",
+      correctionStartDate: "2025-04-16 00:00:00+01:00",
+    })
+  },
+  methods: {
+    updateBanner(infos) {
+      this.inCorrection = infos.inCorrection
+      this.inTeledeclaration = infos.inTeledeclaration
+      this.correctionStartDate = this.prettifyDate(infos.correctionStartDate)
+      this.correctionEndDate = this.prettifyDate(infos.correctionEndDate)
+    },
+    prettifyDate(date) {
+      const dateObject = new Date(date)
+      const day = dateObject.getDate()
+      const monthName = dateObject.toLocaleString("default", { month: "long" })
+      return `${day} ${monthName}`
+    },
+  },
+}
+</script>
+
+<style scoped>
+.v-sheet--shaped {
+  border-radius: 26px 4px !important;
+}
+
+.icon-small {
+  width: 1rem;
+}
+</style>

--- a/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
@@ -56,7 +56,7 @@ import DsfrCallout from "@/components/DsfrCallout"
 import { lastYear } from "@/utils"
 
 export default {
-  name: "InformationBanner",
+  name: "InformationCampaignBanner",
   components: {
     DsfrCallout,
   },

--- a/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
@@ -104,9 +104,7 @@ export default {
     },
     prettifyDate(date) {
       const dateObject = new Date(date)
-      const day = dateObject.getDate()
-      const monthName = dateObject.toLocaleString("default", { month: "long" })
-      return `${day} ${monthName}`
+      return dateObject.toLocaleString("default", { month: "long", day: "numeric" })
     },
   },
 }

--- a/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
@@ -2,11 +2,11 @@
   <DsfrCallout v-if="inCorrection || inTeledeclaration" noIcon class="mt-2">
     <div v-if="inTeledeclaration">
       <h2 class="fr-text font-weight-bold mb-2 mt-2">
-        <span class="text-uppercase">Campagne de télédéclaration {{ year + 1 }} :</span>
+        <span class="text-uppercase">Campagne de télédéclaration {{ currentYear }} :</span>
         du {{ teledeclarationStartDate }} au {{ teledeclarationEndDate }}
       </h2>
       <p class="mb-0">
-        Dans votre espace cantine, remplissez votre bilan sur les données d'achat {{ year }} et télédéclarez vos
+        Dans votre espace cantine, remplissez votre bilan sur les données d'achat {{ lastYear }} et télédéclarez vos
         données.
         <br />
         Pour rappel, selon l’arrêté ministériel du 14 septembre 2022, il est obligatoire de télédéclarer ses achats.
@@ -15,7 +15,7 @@
     <div v-if="inCorrection">
       <h2 class="fr-text font-weight-bold mb-2 mt-2">
         <span class="text-uppercase">Droit à l'erreur :</span>
-        du {{ correctionStartDate }} au {{ correctionEndDate }} {{ year + 1 }}
+        du {{ correctionStartDate }} au {{ correctionEndDate }} {{ currentYear }}
       </h2>
       <p class="mb-0">
         Valable uniquement pour les établissements qui ont validé leur télé-déclaration. Depuis votre bilan, vous pouvez
@@ -72,9 +72,14 @@ export default {
   components: {
     DsfrCallout,
   },
+  computed: {
+    currentYear() {
+      return this.lastYear + 1
+    },
+  },
   data() {
     return {
-      year: lastYear(),
+      lastYear: lastYear(),
       teledeclarationStartDate: null,
       teledeclarationEndDate: null,
       correctionStartDate: null,

--- a/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
+++ b/frontend/src/views/ManagementPage/InformationCampaignBanner.vue
@@ -89,15 +89,9 @@ export default {
     }
   },
   mounted() {
-    // TODO : change for api
-    this.updateBanner({
-      inCorrection: false,
-      inTeledeclaration: true,
-      teledeclarationStartDate: "2025-01-07",
-      teledeclarationEndDate: "2025-03-30",
-      correctionEndDate: "2025-04-30 00:00:00+01:00",
-      correctionStartDate: "2025-04-16 00:00:00+01:00",
-    })
+    fetch(`/api/v1/campaignDates/${this.lastYear}`)
+      .then((response) => response.json())
+      .then((response) => this.updateBanner(response))
   },
   methods: {
     updateBanner(infos) {

--- a/frontend/src/views/ManagementPage/index.vue
+++ b/frontend/src/views/ManagementPage/index.vue
@@ -19,6 +19,7 @@
       </router-link>
     </p>
     <InformationBanner v-if="showInformationBanner" />
+    <CampaignInformationBanner />
     <div v-if="canteenCount > 0" class="mt-4">
       <SuccessBanner v-if="showSuccessBanner" />
       <ActionsBanner v-else />
@@ -93,6 +94,7 @@ import PageSatisfaction from "@/components/PageSatisfaction.vue"
 import DsfrSegmentedControl from "@/components/DsfrSegmentedControl"
 import UserTools from "./UserTools"
 import InformationBanner from "./InformationBanner"
+import CampaignInformationBanner from "./CampaignInformationBanner"
 import CanteenCreationDialog from "./CanteenCreationDialog"
 import ActionsBanner from "./ActionsBanner"
 import SuccessBanner from "./SuccessBanner"
@@ -111,6 +113,7 @@ export default {
     UserTools,
     PageSatisfaction,
     InformationBanner,
+    CampaignInformationBanner,
     ActionsBanner,
     SuccessBanner,
     CanteenCreationDialog,

--- a/frontend/src/views/ManagementPage/index.vue
+++ b/frontend/src/views/ManagementPage/index.vue
@@ -19,7 +19,7 @@
       </router-link>
     </p>
     <InformationBanner v-if="showInformationBanner" />
-    <CampaignInformationBanner />
+    <InformationCampaignBanner />
     <div v-if="canteenCount > 0" class="mt-4">
       <SuccessBanner v-if="showSuccessBanner" />
       <ActionsBanner v-else />
@@ -94,7 +94,7 @@ import PageSatisfaction from "@/components/PageSatisfaction.vue"
 import DsfrSegmentedControl from "@/components/DsfrSegmentedControl"
 import UserTools from "./UserTools"
 import InformationBanner from "./InformationBanner"
-import CampaignInformationBanner from "./CampaignInformationBanner"
+import InformationCampaignBanner from "./InformationCampaignBanner"
 import CanteenCreationDialog from "./CanteenCreationDialog"
 import ActionsBanner from "./ActionsBanner"
 import SuccessBanner from "./SuccessBanner"
@@ -113,7 +113,7 @@ export default {
     UserTools,
     PageSatisfaction,
     InformationBanner,
-    CampaignInformationBanner,
+    InformationCampaignBanner,
     ActionsBanner,
     SuccessBanner,
     CanteenCreationDialog,


### PR DESCRIPTION
## Description

Dans le tableau de bord on utilise un bandeau pour partager de l'information à nos utilisateurs. Dans le cadre de la campagne de télédéclaration, ou de correction un bandeau sera affiché automatiquement lors de cette dernière grâce au nouvel endpoint `campaignDates` (PR #5238)

## Prévisualisation

Exemple bandeau simple pour la correction
<img width="1230" alt="Capture d’écran 2025-04-07 à 17 07 08" src="https://github.com/user-attachments/assets/47ee2b56-5095-455c-a756-e9d87d345805" />

Exemple bandeau double
<img width="1227" alt="Capture d’écran 2025-04-07 à 17 21 05" src="https://github.com/user-attachments/assets/f83ef25e-8409-4883-848f-aa0e2fa5a222" />
