### PR TITLE
improve(Cantines): nouveau badge 'Bilan non télédéclaré' pour indiquer que la cantine n'a pas TD (si en dehors des dates de campagne)

### DIFF
--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -226,6 +226,8 @@ class CanteenQuerySet(SoftDeletionQuerySet):
         ]
         if is_in_teledeclaration(year):
             conditions.append(When(has_td=False, then=Value(Canteen.Actions.TELEDECLARE)))
+        else:
+            conditions.append(When(has_td=False, then=Value(Canteen.Actions.DID_NOT_TELEDECLARE)))
         if not settings.PUBLISH_BY_DEFAULT:
             conditions.append(
                 When(publication_status=Canteen.PublicationStatus.DRAFT, then=Value(Canteen.Actions.PUBLISH))
@@ -311,6 +313,7 @@ class Canteen(SoftDeletionModel):
         FILL_DIAGNOSTIC = "30_fill_diagnostic", "Compléter le diagnostic"
         FILL_CANTEEN_DATA = "35_fill_canteen_data", "Compléter les infos de la cantine"
         TELEDECLARE = "40_teledeclare", "Télédéclarer"
+        DID_NOT_TELEDECLARE = "45_did_not_teledeclare", "Non télédéclaré"
         PUBLISH = "50_publish", "Publier"
         NOTHING_SATELLITE = "90_nothing_satellite", "En attente de la télédéclaration de votre livreur"
         NOTHING_SATELLITE_TELEDECLARED = (

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -20,6 +20,7 @@ from data.utils import (
     get_region,
     optimize_image,
 )
+from macantine.utils import is_in_teledeclaration
 
 from .softdeletionmodel import (
     SoftDeletionManager,
@@ -188,7 +189,6 @@ class CanteenQuerySet(SoftDeletionQuerySet):
         # prep TD action
         self = self.annotate_with_td_for_year(year)
         # annotate with action
-        should_teledeclare = settings.ENABLE_TELEDECLARATION
         conditions = [
             When(
                 (is_central_cuisine_query() & Q(satellite_canteens_count__gt=0) & Q(satellites_in_db_count=None)),
@@ -224,7 +224,7 @@ class CanteenQuerySet(SoftDeletionQuerySet):
             ),
             When(has_missing_data_query(), then=Value(Canteen.Actions.FILL_CANTEEN_DATA)),
         ]
-        if should_teledeclare:
+        if is_in_teledeclaration(year):
             conditions.append(When(has_td=False, then=Value(Canteen.Actions.TELEDECLARE)))
         if not settings.PUBLISH_BY_DEFAULT:
             conditions.append(

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -206,6 +206,11 @@ export default {
           icon: "$send-plane-fill",
           display: "button",
         },
+        "45_did_not_teledeclare": {
+          text: "Rien à faire !",
+          icon: "$checkbox-circle-fill",
+          display: "text",
+        },
         "90_nothing_satellite": {
           text: "En attente de la télédéclaration de votre livreur",
           icon: "$information-fill",

--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -33,6 +33,11 @@ const BADGE_LIST = [
     actions: ["90_nothing_satellite"],
   },
   {
+    body: "Bilan non télédéclaré",
+    mode: "ERROR",
+    actions: ["45_did_not_teledeclare"],
+  },
+  {
     // readyToTeledeclare
     body: "Bilan à télédéclarer",
     mode: "ERROR",


### PR DESCRIPTION
## Prévisualisation
|Dans la page de la télédéclaration| Sur le tableu de bord|
|--|--|
|<img width="686" alt="Capture d’écran 2025-04-08 à 10 30 28" src="https://github.com/user-attachments/assets/d7be6ccb-28d7-4910-9f1d-a50c754fb2f2" /> | <img width="1206" alt="Capture d’écran 2025-04-08 à 10 32 27" src="https://github.com/user-attachments/assets/c50573b7-ef38-4e08-825c-539060b5a403" /> |
