### PR TITLE
feat(Campagne de correction): affiche le bouton de modification si la campagne de correction est ouverte

### DIFF
--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -70,7 +70,7 @@
           </p>
           <TeledeclarationCancelDialog
             v-model="cancelDialog"
-            v-if="inTeledeclarationCampaign"
+            v-if="inTeledeclarationCampaign || inCorrectionCampaign"
             @cancel="cancelTeledeclaration"
             :diagnostic="diagnostic"
           >

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -58,7 +58,7 @@
             target="_blank"
             class="mr-4"
           />
-          <p v-if="inTeledeclarationCampaign">
+          <p v-if="inTeledeclarationCampaign || inCorrectionCampaign">
             En cas d'erreur, vous pouvez modifier vos données
             <span v-if="campaignEndDate">
               jusqu’au

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -366,6 +366,10 @@ export default {
     inTeledeclarationCampaign() {
       return window.ENABLE_TELEDECLARATION && +this.year === lastYear()
     },
+    inCorrectionCampaign() {
+      // TODO remplir via api
+      return true
+    },
     campaignEndDate() {
       if (this.inTeledeclarationCampaign) return new Date(window.TELEDECLARATION_END_DATE)
       else if (this.inCorrectionCampaign) return new Date("2025-12-31")

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -321,7 +321,6 @@ export default {
       centralKitchenDiagnosticModes: Constants.CentralKitchenDiagnosticModes,
       centralKitchenDiagnosticMode: null,
       cancelDialog: false,
-      campaignEndDate: window.TELEDECLARATION_END_DATE ? new Date(window.TELEDECLARATION_END_DATE) : null,
       showTeledeclarationPreview: false,
       approId: "qualite-des-produits",
       establishmentId,
@@ -366,6 +365,11 @@ export default {
     },
     inTeledeclarationCampaign() {
       return window.ENABLE_TELEDECLARATION && +this.year === lastYear()
+    },
+    campaignEndDate() {
+      if (this.inTeledeclarationCampaign) return new Date(window.TELEDECLARATION_END_DATE)
+      else if (this.inCorrectionCampaign) return new Date("2025-12-31")
+      else return null
     },
     readyToTeledeclare() {
       return readyToTeledeclare(this.canteen, this.diagnostic, this.$store.state.sectors)


### PR DESCRIPTION
## Description

Affiche le bouton "Corriger ma télédéclaration" si la campagne de correction est ouverte à partir de l'endpoint `campaignDates` (PR #5238)

## Prévisualisation 

/!\ Ne pas se fier au badge "Bilan télédéclaré" il est buggy

Pendant la campagne de TD
|a télédéclaré| n'a pas télédéclaré|
|--|--|
|<img width="615" alt="Capture d’écran 2025-04-07 à 20 05 57" src="https://github.com/user-attachments/assets/14881277-3f37-46e5-8777-9866144cdede" />| <img width="571" alt="Capture d’écran 2025-04-07 à 20 07 12" src="https://github.com/user-attachments/assets/5a75943d-8f71-47a1-884b-c055cdaf7878" />|

Pendant la campagne de correction
|a télédéclaré| n'a pas télédéclaré|Année précédente|
|--|--|--|
|<img width="574" alt="Capture d’écran 2025-04-07 à 20 01 46" src="https://github.com/user-attachments/assets/cea6578e-6c34-4ba6-b328-3151ee91f4b3" /> |<img width="527" alt="Capture d’écran 2025-04-07 à 20 01 57" src="https://github.com/user-attachments/assets/f05d7d96-99b5-435b-8aef-dd6414b8e8e8" />|<img width="387" alt="Capture d’écran 2025-04-07 à 20 11 14" src="https://github.com/user-attachments/assets/fcfb7725-90e4-4eb9-998f-f286f78a59d8" />
