### PR TITLE
feat(Tableau de bord): affiche les badges dans le tableau de actions

### DIFF
--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -121,7 +121,14 @@
                   <v-icon small class="mr-2" color="green">{{ getActionIcon(item.action) }}</v-icon>
                   <span class="caption">{{ getActionText(item.action) }}</span>
                 </div>
-                <v-btn small outlined color="primary" :to="actionLink(item)" @click="action(item)" v-else>
+                <v-btn
+                  v-else-if="getActionDisplay(item.action) === 'button'"
+                  small
+                  outlined
+                  color="primary"
+                  :to="actionLink(item)"
+                  @click="action(item)"
+                >
                   <v-icon small class="mr-2" color="primary">
                     {{ getActionIcon(item.action) }}
                   </v-icon>
@@ -212,24 +219,16 @@ export default {
           display: "button",
         },
         "45_did_not_teledeclare": {
-          text: "Rien à faire !",
-          icon: "$checkbox-circle-fill",
-          display: "text",
+          display: "empty",
         },
         "90_nothing_satellite": {
-          text: "En attente de la télédéclaration de votre livreur",
-          icon: "$information-fill",
-          display: "text",
+          display: "empty",
         },
         "91_nothing_satellite_teledeclared": {
-          text: "Rien à faire ! (télédéclaré par votre livreur)",
-          icon: "$checkbox-circle-fill",
-          display: "text",
+          display: "empty",
         },
         "95_nothing": {
-          text: "Rien à faire !",
-          icon: "$checkbox-circle-fill",
-          display: "text",
+          display: "empty",
         },
       },
       canteenForTD: null,

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -112,7 +112,7 @@
             {{ typeDisplay[item.productionType] }}
           </template>
           <template v-slot:[`item.badge`]="{ item }">
-            <p>{{ item.action }}</p>
+            <DataInfoBadge :canteen-action="item.action" />
           </template>
           <template v-slot:[`item.action`]="{ item }">
             <v-fade-transition>
@@ -147,11 +147,12 @@
 
 <script>
 import TeledeclarationPreview from "@/components/TeledeclarationPreview"
+import DataInfoBadge from "@/components/DataInfoBadge"
 import { lastYear } from "@/utils"
 
 export default {
   name: "AnnualActionableCanteensTable",
-  components: { TeledeclarationPreview },
+  components: { TeledeclarationPreview, DataInfoBadge },
   data() {
     const year = lastYear()
     return {

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -111,6 +111,9 @@
           <template v-slot:[`item.productionType`]="{ item }">
             {{ typeDisplay[item.productionType] }}
           </template>
+          <template v-slot:[`item.badge`]="{ item }">
+            <p>{{ item.action }}</p>
+          </template>
           <template v-slot:[`item.action`]="{ item }">
             <v-fade-transition>
               <div :key="`${item.id}_${item.action}`">
@@ -167,6 +170,7 @@ export default {
         { text: "Nom", value: "name" },
         { text: "Siret ou Siren", value: "siret" },
         { text: "Type", value: "productionType" },
+        { text: "Statut", value: "badge" },
         { text: "Action", value: "action" },
       ],
       typeDisplay: {


### PR DESCRIPTION
## Description

Depuis la vue liste pour différencier les bilans non télédéclarés des télédéclarés qui seront ensuite modifiables : 
- on affiche le badge du bilan, 
- et simplifie la colonne action pour ne pas avoir de doublon dans le message

## Prévisualisation

Pendant la campagne de TD
|Avant|Après|
|--|--|
| <img width="1224" alt="Capture d’écran 2025-04-08 à 14 59 50" src="https://github.com/user-attachments/assets/86aacd03-7a52-41c2-a50f-3230f2414388" /> | <img width="1230" alt="Capture d’écran 2025-04-08 à 14 49 38" src="https://github.com/user-attachments/assets/bdf76ddb-9da6-46af-866f-c3b31625bc87" />|


Hors campagne de TD
|Avant|Après|
|--|--|
| <img width="1227" alt="Capture d’écran 2025-04-08 à 14 58 41" src="https://github.com/user-attachments/assets/749c160e-b8c1-4615-92e4-f477fd341e35" /> | <img width="1227" alt="Capture d’écran 2025-04-08 à 14 57 43" src="https://github.com/user-attachments/assets/0c299c2b-2240-45af-b14d-def3f2f2c6bf" />|


