### PR TITLE
feat(Tableau de bord): affiche dans la vue liste des cantines un message pour modifier son bilan

### DIFF
--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -286,6 +286,13 @@ export default {
     populateInitialParameters() {
       this.page = this.$route.query.cantinePage ? parseInt(this.$route.query.cantinePage) : 1
     },
+    fetchCampaignDates() {
+      fetch(`/api/v1/campaignDates/${this.year}`)
+        .then((response) => response.json())
+        .then((response) => {
+          this.canEditTeledeclaration = response.inTeledeclaration || response.inCorrection
+        })
+    },
     fetchCurrentPage() {
       let queryParam = `ordering=action&limit=${this.limit}&offset=${this.offset}`
       if (this.searchTerm) queryParam += `&search=${this.searchTerm}`

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -255,7 +255,7 @@ export default {
         },
         "95_nothing": {
           icon: "$edit-fill",
-          text: `Vous pouvez modifier votre télédéclaration jusqu'au ${endEditDate} (heure de Paris)`,
+          text: `En cas d'erreur, vous pouvez modifier vos données jusqu’au ${endEditDate} (heure de Paris)`,
           display: canEditTd ? "edit" : "empty",
         },
       }
@@ -363,8 +363,7 @@ export default {
         ? this.campaignDates.teledeclarationEndDate
         : this.campaignDates.correctionEndDate
       const prettyDate = new Date(date).toLocaleDateString("fr-FR", {
-        month: "numeric",
-        year: "numeric",
+        month: "long",
         day: "numeric",
       })
       return prettyDate

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -131,7 +131,7 @@
                   <span class="caption">{{ getActionText(item.action) }}</span>
                 </div>
                 <v-btn
-                  v-else-if="getActionDisplay(item.action) === 'button'"
+                  v-if="getActionDisplay(item.action) === 'button'"
                   small
                   outlined
                   color="primary"

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -212,6 +212,7 @@ export default {
   computed: {
     actions() {
       const canEditTd = this.campaignDates.inCorrection || this.campaignDates.inTeledeclaration
+      const endEditDate = this.getEndEditDate()
       return {
         "10_add_satellites": {
           text: "Ajouter des satellites",
@@ -254,7 +255,7 @@ export default {
         },
         "95_nothing": {
           icon: "$edit-fill",
-          text: "Vous pouvez modifier votre télédéclaration jusqu'à la fin de la campagne",
+          text: `Vous pouvez modifier votre télédéclaration jusqu'au ${endEditDate} (heure de Paris)`,
           display: canEditTd ? "edit" : "empty",
         },
       }
@@ -355,6 +356,18 @@ export default {
     },
     getActionDisplay(action) {
       return this.actions[action] && this.actions[action].display
+    },
+    getEndEditDate() {
+      if (!this.campaignDates.inTeledeclaration || this.campaignDates.inCorrection) return null
+      const date = this.campaignDates.inTeledeclaration
+        ? this.campaignDates.teledeclarationEndDate
+        : this.campaignDates.correctionEndDate
+      const prettyDate = new Date(date).toLocaleDateString("fr-FR", {
+        month: "numeric",
+        year: "numeric",
+        day: "numeric",
+      })
+      return prettyDate
     },
     actionLink(canteen) {
       if (canteen.action === "10_add_satellites") {

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -365,6 +365,7 @@ export default {
       const prettyDate = new Date(date).toLocaleDateString("fr-FR", {
         month: "long",
         day: "numeric",
+        year: "numeric",
       })
       return prettyDate
     },

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -117,14 +117,14 @@
           <template v-slot:[`item.action`]="{ item }">
             <v-fade-transition>
               <div :key="`${item.id}_${item.action}`">
-                <div v-if="getActionDisplay(item.action) === 'edit'" class="px-3">
+                <div v-if="getActionDisplay(item.action) === 'edit'">
                   <v-icon small class="mr-2" color="primary">{{ getActionIcon(item.action) }}</v-icon>
                   <span class="caption">
                     {{ getActionText(item.action) }}
                     <router-link :to="toTeledeclaration(item)">en cliquant ici</router-link>
                   </span>
                 </div>
-                <div v-if="getActionDisplay(item.action) === 'text'" class="px-3">
+                <div v-if="getActionDisplay(item.action) === 'text'">
                   <v-icon v-if="getActionIcon(item.action)" small class="mr-2" color="green">
                     {{ getActionIcon(item.action) }}
                   </v-icon>

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -490,6 +490,7 @@ export default {
   },
   mounted() {
     this.populateInitialParameters()
+    this.fetchCampaignDates()
     return this.fetchDiagnosticsToTeledeclare()
       .then(this.fetchCurrentPage)
       .then(this.addWatchers)

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -339,6 +339,15 @@ export default {
         params: { canteenUrlComponent: this.$store.getters.getCanteenUrlComponent(canteen) },
       }
     },
+    toTeledeclaration(canteen) {
+      return {
+        name: "MyProgress",
+        params: {
+          canteenUrlComponent: this.$store.getters.getCanteenUrlComponent(canteen),
+          year: this.year,
+        },
+      }
+    },
     getActionText(action) {
       return this.actions[action] && this.actions[action].text
     },

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -125,7 +125,9 @@
                   </span>
                 </div>
                 <div v-if="getActionDisplay(item.action) === 'text'" class="px-3">
-                  <v-icon small class="mr-2" color="green">{{ getActionIcon(item.action) }}</v-icon>
+                  <v-icon v-if="getActionIcon(item.action)" small class="mr-2" color="green">
+                    {{ getActionIcon(item.action) }}
+                  </v-icon>
                   <span class="caption">{{ getActionText(item.action) }}</span>
                 </div>
                 <v-btn
@@ -251,7 +253,8 @@ export default {
           display: "empty",
         },
         "91_nothing_satellite_teledeclared": {
-          display: "empty",
+          text: "Votre livreur des repas a déclaré le bilan pour votre établissement",
+          display: "text",
         },
         "95_nothing": {
           icon: "$edit-fill",

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -206,11 +206,12 @@ export default {
       tdSuccesses: [],
       tdFailures: [],
       tdLoading: false,
-      canEditTeledeclaration: false,
+      campaignDates: null,
     }
   },
   computed: {
     actions() {
+      const canEditTd = this.campaignDates.inCorrection || this.campaignDates.inTeledeclaration
       return {
         "10_add_satellites": {
           text: "Ajouter des satellites",
@@ -254,7 +255,7 @@ export default {
         "95_nothing": {
           icon: "$edit-fill",
           text: "Vous pouvez modifier votre télédéclaration jusqu'à la fin de la campagne",
-          display: this.canEditTeledeclaration ? "edit" : "empty",
+          display: canEditTd ? "edit" : "empty",
         },
       }
     },
@@ -296,9 +297,7 @@ export default {
     fetchCampaignDates() {
       fetch(`/api/v1/campaignDates/${this.year}`)
         .then((response) => response.json())
-        .then((response) => {
-          this.canEditTeledeclaration = response.inTeledeclaration || response.inCorrection
-        })
+        .then((response) => (this.campaignDates = response))
     },
     fetchCurrentPage() {
       let queryParam = `ordering=action&limit=${this.limit}&offset=${this.offset}`

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -187,24 +187,41 @@ export default {
         central: "Livreur des repas",
         central_serving: "Livreur, avec service sur place",
       },
-      actions: {
+      canteenForTD: null,
+      showTeledeclarationPreview: false,
+      showMultipleTeledeclarationPreview: false,
+      toDiagnose: [],
+      diagLoading: false,
+      diagSuccesses: [],
+      toTeledeclare: [],
+      tdIdx: 0,
+      toTeledeclareCount: null,
+      tdSuccesses: [],
+      tdFailures: [],
+      tdLoading: false,
+      canEditTeledeclaration: false,
+    }
+  },
+  computed: {
+    actions() {
+      return {
         "10_add_satellites": {
           text: "Ajouter des satellites",
           icon: "$community-fill",
           display: "button",
         },
         "18_prefill_diagnostic": {
-          text: "Créer le bilan " + year,
+          text: "Créer le bilan " + this.year,
           icon: "$add-circle-fill",
           display: "button",
         },
         "20_create_diagnostic": {
-          text: "Créer le bilan " + year,
+          text: "Créer le bilan " + this.year,
           icon: "$add-circle-fill",
           display: "button",
         },
         "30_fill_diagnostic": {
-          text: "Compléter le bilan " + year,
+          text: "Compléter le bilan " + this.year,
           icon: "$edit-box-fill",
           display: "button",
         },
@@ -228,24 +245,12 @@ export default {
           display: "empty",
         },
         "95_nothing": {
-          display: "empty",
+          icon: "$edit-fill",
+          text: "Vous pouvez modifier votre télédéclaration jusqu'à la fin de la campagne",
+          display: this.canEditTeledeclaration ? "edit" : "empty",
         },
-      },
-      canteenForTD: null,
-      showTeledeclarationPreview: false,
-      showMultipleTeledeclarationPreview: false,
-      toDiagnose: [],
-      diagLoading: false,
-      diagSuccesses: [],
-      toTeledeclare: [],
-      tdIdx: 0,
-      toTeledeclareCount: null,
-      tdSuccesses: [],
-      tdFailures: [],
-      tdLoading: false,
-    }
-  },
-  computed: {
+      }
+    },
     showPagination() {
       return this.canteenCount && this.canteenCount > this.limit
     },

--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -117,6 +117,13 @@
           <template v-slot:[`item.action`]="{ item }">
             <v-fade-transition>
               <div :key="`${item.id}_${item.action}`">
+                <div v-if="getActionDisplay(item.action) === 'edit'" class="px-3">
+                  <v-icon small class="mr-2" color="primary">{{ getActionIcon(item.action) }}</v-icon>
+                  <span class="caption">
+                    {{ getActionText(item.action) }}
+                    <router-link :to="toTeledeclaration(item)">en cliquant ici</router-link>
+                  </span>
+                </div>
                 <div v-if="getActionDisplay(item.action) === 'text'" class="px-3">
                   <v-icon small class="mr-2" color="green">{{ getActionIcon(item.action) }}</v-icon>
                   <span class="caption">{{ getActionText(item.action) }}</span>

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -62,7 +62,8 @@
             En cas d'erreur, vous pouvez modifier vos données
             <span v-if="campaignEndDate">
               jusqu’au
-              {{ campaignEndDate.toLocaleString("fr-FR", { month: "long", day: "numeric", year: "numeric" }) }}.
+              {{ campaignEndDate.toLocaleString("fr-FR", { month: "long", day: "numeric", year: "numeric" }) }} (heure
+              de Paris).
             </span>
             <span v-else>
               jusqu’à la fin de la campagne.


### PR DESCRIPTION
## Description

Lorsque la campagne de télédéclaration ou celle de correction est ouverte on affiche un message texte, avec un accès rapide au bilan pour le modifier. Pour la phrase de modification j'ai copié celle que l'on affichait dans la page "MyProgress", et du coup j'ai aussi copié le message que l'on affichait pour les cuisines satellites. J'en ai profité pour également spécifier le fuseau horaire.

## Prévisualisation 

| Pendant la campagne de TD | <img width="1238" alt="Capture d’écran 2025-04-08 à 16 25 58" src="https://github.com/user-attachments/assets/672ac280-677d-4830-955a-f12d1340db77" /> | 
|--|--|
| Pendant la campagne de correction | <img width="1232" alt="Capture d’écran 2025-04-08 à 16 23 04" src="https://github.com/user-attachments/assets/7c3c2ff5-9693-4525-802a-5b37ff204c18" /> |
| En dehors de ces campagnes | <img width="1231" alt="Capture d’écran 2025-04-08 à 16 22 10" src="https://github.com/user-attachments/assets/8f8ffc6a-cfe8-4515-b955-ee032a9f14b0" /> |