### PR TITLE
fix(Badge): change la couleur du badge "Bilan non télédéclaré" de rouge à gris

### DIFF
--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -1,5 +1,5 @@
 <template>
-  <DsfrBadge v-if="badge" :mode="badge.mode">
+  <DsfrBadge v-if="badge" :mode="badge.mode" :show-icon="badge.mode !== 'NEUTRAL'">
     <p class="ma-0 pa-0 text-uppercase">{{ badge.body }}</p>
   </DsfrBadge>
   <span v-else></span>

--- a/frontend/src/components/DataInfoBadge.vue
+++ b/frontend/src/components/DataInfoBadge.vue
@@ -34,7 +34,7 @@ const BADGE_LIST = [
   },
   {
     body: "Bilan non télédéclaré",
-    mode: "ERROR",
+    mode: "NEUTRAL",
     actions: ["45_did_not_teledeclare"],
   },
   {


### PR DESCRIPTION
## Description

Si le bilan n'a pas été télédéclaré malheureusement l'utilisateur n'a plus de moyen d'action, du coup le badge passe en "gris" et non "rouge".

## Prévisualisation

|Avant|Après|
|--|--|
| <img width="262" alt="Capture d’écran 2025-04-08 à 19 29 38" src="https://github.com/user-attachments/assets/c4b7552a-b975-4d26-b822-354db71e5238" /> | <img width="253" alt="Capture d’écran 2025-04-08 à 19 29 24" src="https://github.com/user-attachments/assets/82a94b5f-853d-49c6-8899-49f8a797da7b" /> |