### PR TITLE
refactor(Cantines): rajouter des champs dans CanteenActionsSerializer

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -476,28 +476,37 @@ class ManagingTeamSerializer(serializers.ModelSerializer):
 
 class CanteenActionsSerializer(serializers.ModelSerializer):
     # TODO: is it worth moving the job of fetching the specific diag required to the front?
+    sectors = serializers.PrimaryKeyRelatedField(many=True, queryset=Sector.objects.all(), required=False)
+    publication_status = serializers.CharField(read_only=True, source="publication_status_display_to_public")
+    lead_image = CanteenImageSerializer()
     diagnostics = FullDiagnosticSerializer(many=True, read_only=True, source="diagnostic_set")
     action = serializers.CharField(allow_null=True)
-    sectors = serializers.PrimaryKeyRelatedField(many=True, queryset=Sector.objects.all(), required=False)
 
     class Meta:
         model = Canteen
         fields = (
             "id",
             "name",
-            "siret",
-            "siren_unite_legale",
             "city",
-            "production_type",
+            "city_insee_code",
+            "department",
+            "region",
+            "postal_code",
+            "sectors",  # M2M
+            "line_ministry",
             "daily_meal_count",
             "yearly_meal_count",
-            "management_type",
-            "sectors",
-            "line_ministry",
             "satellite_canteens_count",
+            "siret",
+            "siren_unite_legale",
             "central_producer_siret",
-            "action",
-            "diagnostics",
+            "management_type",
+            "production_type",
+            "economic_model",
+            "publication_status",  # property
+            "lead_image",  # M2O
+            "diagnostics",  # M2O
+            "action",  # annotate
         )
         read_only_fields = fields
 


### PR DESCRIPTION
Suite à https://github.com/betagouv/ma-cantine/pull/5248, on a changé l'endpoint pour afficher les cantines dans le tableau de bord des utilisateurs. Mais il manquait des infos dans le nouveau. 
- Avant : `/canteenSummaries` (CanteenSummarySerializer)
- Après : `/actionableCanteens` (CanteenActionsSerializer)
  - rajouté city_insee_code, department, region, postal_code, publication_status, economic_model, lead_image
  - réorganisé un peu l'ordre des champs pour matcher avec le modèle