### PR TITLE
refactor(Dates de campagnes): Pas besoin de fournir l'année. Ajout de tests.

### DIFF
--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -418,7 +418,7 @@ class TeledeclarationCampaignDatesRetrieveView(APIView):
         campaign_dates_for_year = {
             "year": year,
             **CAMPAIGN_DATES[year],
-            "in_teledeclaration": is_in_teledeclaration(year),
-            "in_correction": is_in_correction(year),
+            "in_teledeclaration": is_in_teledeclaration(),
+            "in_correction": is_in_correction(),
         }
         return Response(campaign_dates_for_year)

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -224,7 +224,7 @@ class CanteenQuerySet(SoftDeletionQuerySet):
             ),
             When(has_missing_data_query(), then=Value(Canteen.Actions.FILL_CANTEEN_DATA)),
         ]
-        if is_in_teledeclaration(year):
+        if is_in_teledeclaration():
             conditions.append(When(has_td=False, then=Value(Canteen.Actions.TELEDECLARE)))
         else:
             conditions.append(When(has_td=False, then=Value(Canteen.Actions.DID_NOT_TELEDECLARE)))

--- a/macantine/tests/test_utils.py
+++ b/macantine/tests/test_utils.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+from freezegun import freeze_time
+
+from macantine.utils import (
+    is_in_correction,
+    is_in_teledeclaration,
+    is_in_teledeclaration_or_correction,
+)
+
+
+class TestCampaignDates(TestCase):
+    def test_campaign_in_2O25(self):
+        with freeze_time("2025-01-06"):  # before campaign
+            self.assertFalse(is_in_teledeclaration())
+            self.assertFalse(is_in_correction())
+            self.assertFalse(is_in_teledeclaration_or_correction())
+
+        with freeze_time("2025-01-07"):  # first day of campaign
+            self.assertTrue(is_in_teledeclaration())
+            self.assertFalse(is_in_correction())
+            self.assertTrue(is_in_teledeclaration_or_correction())
+
+        with freeze_time("2025-04-06"):  # last day of campaign
+            self.assertTrue(is_in_teledeclaration())
+            self.assertFalse(is_in_correction())
+            self.assertTrue(is_in_teledeclaration_or_correction())
+
+        with freeze_time("2025-04-07"):  # after campaign
+            self.assertFalse(is_in_teledeclaration())
+            self.assertFalse(is_in_correction())
+            self.assertFalse(is_in_teledeclaration_or_correction())
+
+        with freeze_time("2025-04-20"):  # middle of correction campaign
+            self.assertFalse(is_in_teledeclaration())
+            self.assertTrue(is_in_correction())
+            self.assertTrue(is_in_teledeclaration_or_correction())

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -75,7 +75,7 @@ CAMPAIGN_DATES = {
 
 def is_in_teledeclaration():
     """
-    Check if the current date is within the teledeclaration period for the given year.
+    Check if the current date is within the teledeclaration period.
     """
     now = timezone.now()
     now_campaign_year = now.year - 1
@@ -88,7 +88,7 @@ def is_in_teledeclaration():
 
 def is_in_correction():
     """
-    Check if the current date is within the correction period for the given year.
+    Check if the current date is within the correction period.
     """
     now = timezone.now()
     now_campaign_year = now.year - 1
@@ -102,6 +102,6 @@ def is_in_correction():
 
 def is_in_teledeclaration_or_correction():
     """
-    Check if the current date is within the teledeclaration or correction period for the given year.
+    Check if the current date is within the teledeclaration or correction period.
     """
     return is_in_teledeclaration() or is_in_correction()

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -73,26 +73,35 @@ CAMPAIGN_DATES = {
 }
 
 
-def is_in_teledeclaration(year):
+def is_in_teledeclaration():
     """
     Check if the current date is within the teledeclaration period for the given year.
     """
     now = timezone.now()
-    if year in CAMPAIGN_DATES:
-        start_date = CAMPAIGN_DATES[year]["teledeclaration_start_date"]
-        end_date = CAMPAIGN_DATES[year]["teledeclaration_end_date"]
+    now_campaign_year = now.year - 1
+    if now_campaign_year in CAMPAIGN_DATES:
+        start_date = CAMPAIGN_DATES[now_campaign_year]["teledeclaration_start_date"]
+        end_date = CAMPAIGN_DATES[now_campaign_year]["teledeclaration_end_date"]
         return start_date <= now <= end_date
     return False
 
 
-def is_in_correction(year):
+def is_in_correction():
     """
     Check if the current date is within the correction period for the given year.
     """
     now = timezone.now()
-    if year in CAMPAIGN_DATES:
-        if "correction_start_date" in CAMPAIGN_DATES[year]:
-            start_date = CAMPAIGN_DATES[year]["correction_start_date"]
-            end_date = CAMPAIGN_DATES[year]["correction_end_date"]
+    now_campaign_year = now.year - 1
+    if now_campaign_year in CAMPAIGN_DATES:
+        if "correction_start_date" in CAMPAIGN_DATES[now_campaign_year]:
+            start_date = CAMPAIGN_DATES[now_campaign_year]["correction_start_date"]
+            end_date = CAMPAIGN_DATES[now_campaign_year]["correction_end_date"]
             return start_date <= now <= end_date
     return False
+
+
+def is_in_teledeclaration_or_correction():
+    """
+    Check if the current date is within the teledeclaration or correction period for the given year.
+    """
+    return is_in_teledeclaration() or is_in_correction()


### PR DESCRIPTION
Dans #5238 & #5242 on a créé et commencé à se servir des méthodes `is_in_teledeclaration` & `is_in_correction`.

Quelques améliorations supplémentaires : 
- pas besoin de passer l'année, car cela dépend pour l'instant de `now`
- rajouté `is_in_teledeclaration_or_correction`
- rajouté des tests