### PR TITLE
improve(Télédéclaration): autoriser la TD pendant la campagne de correction (seulement si une TD a été créé pendant la campagne de TD)

### DIFF
--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -78,6 +78,15 @@ class TeledeclarationCreateView(APIView):
             if user not in diagnostic.canteen.managers.all():
                 raise PermissionDenied()
 
+            # extra rule for correction campaign
+            # only allow to "edit" a teledeclaration
+            # (a teledeclaration must exist during the teledeclaration campaign)
+            if is_in_correction():
+                if not Teledeclaration.objects.for_year(last_year).filter(canteen=diagnostic.canteen).exists():
+                    raise PermissionDenied(
+                        "La campagne de correction est réservée aux cantines qui ont télédéclaré durant la campagne de télédéclaration."
+                    )
+
             try:
                 Teledeclaration.validate_diagnostic(diagnostic)
             except DjangoValidationError as e:
@@ -135,6 +144,15 @@ class TeledeclarationCancelView(APIView):
 
             if request.user not in teledeclaration.canteen.managers.all():
                 raise PermissionDenied()
+
+            # extra rule for correction campaign
+            # only allow to "edit" a teledeclaration
+            # (a teledeclaration must exist during the teledeclaration campaign)
+            if is_in_correction():
+                if not Teledeclaration.objects.for_year(last_year).filter(canteen=teledeclaration.canteen).exists():
+                    raise PermissionDenied(
+                        "La campagne de correction est réservée aux cantines qui ont télédéclaré durant la campagne de télédéclaration."
+                    )
 
             teledeclaration.status = Teledeclaration.TeledeclarationStatus.CANCELLED
             teledeclaration.save()

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -33,15 +33,20 @@ class CustomJSONEncoder(DjangoJSONEncoder):
 
 
 class TeledeclarationQuerySet(models.QuerySet):
-    def submitted_for_year(self, year):
+    def submitted(self):
+        return self.filter(status=Teledeclaration.TeledeclarationStatus.SUBMITTED)
+
+    def for_year(self, year):
         return self.filter(
             year=year,
             creation_date__range=(
                 CAMPAIGN_DATES[year]["teledeclaration_start_date"],
                 CAMPAIGN_DATES[year]["teledeclaration_end_date"],
             ),
-            status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
         )
+
+    def submitted_for_year(self, year):
+        return self.submitted().for_year(year)
 
     def canteen_for_stat(self, year):
         return (


### PR DESCRIPTION
Suite de #5253

Cette fois-ci on rajoute la logique dédiée à la campagne de correction
- on autorise le create & cancel de TD
- seulement si une TD pour cette cantine a été créé pendant la campagne de TD qui a précédé (même année)

TODO : quid de `Teledeclaration.validate_diagnostic(diagnostic)` ?