### PR TITLE
refactor(Tests): Ajouter explicitement le manager lors de l'appel à CanteenFactory

### DIFF
--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -352,7 +352,6 @@ class TestDiagnosticsApi(APITestCase):
         diagnostic.canteen.managers.add(authenticate.user)
 
         payload = {"year": 2020}
-
         response = self.client.patch(
             reverse(
                 "diagnostic_edition",
@@ -371,7 +370,6 @@ class TestDiagnosticsApi(APITestCase):
         diagnostic.canteen.managers.add(user)
 
         payload = {"year": 2020}
-
         self.client.credentials(Authorization=f"Bearer {token}")
         response = self.client.patch(
             reverse(

--- a/api/tests/test_import_diagnostics.py
+++ b/api/tests/test_import_diagnostics.py
@@ -185,8 +185,8 @@ class TestImportDiagnosticsAPI(APITestCase):
             city="Ma ville",
             postal_code="66666",
             department=Department.ardeche,
+            managers=[authenticate.user],
         )
-        canteen.managers.add(authenticate.user)
 
         address_api_text = "siret,citycode,postcode,result_citycode,result_postcode,result_city,result_context\n"
         address_api_text += '21340172201787,,11111,00000,11111,Ma ville,"01,Something,Other"\n'
@@ -214,8 +214,7 @@ class TestImportDiagnosticsAPI(APITestCase):
         No canteens will be created since any error cancels out the entire file
         """
         CanteenFactory.create(siret="21340172201787")
-        my_canteen = CanteenFactory.create(siret="73282932000074")
-        my_canteen.managers.add(authenticate.user)
+        CanteenFactory.create(siret="73282932000074", managers=[authenticate.user])
 
         file_path = "./api/tests/files/diagnostics/diagnostics_simple_good_different_canteens.csv"
         with open(file_path) as diag_file:
@@ -988,32 +987,32 @@ class TestImportDiagnosticsAPI(APITestCase):
         # In the file, cuisine_centrale_1 has three satellites. We will create two of them and verify that a
         # third one is added after the import
         cuisine_centrale_1 = CanteenFactory.create(
-            siret="29969025300230", production_type=Canteen.ProductionType.CENTRAL
+            siret="29969025300230", production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
         )
         satellite_1_1 = CanteenFactory.create(
             siret="38589540005962",
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             central_producer_siret="29969025300230",
+            managers=[authenticate.user],
         )
         satellite_1_3 = CanteenFactory.create(
             siret="27309825823572",
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             central_producer_siret="29969025300230",
+            managers=[authenticate.user],
         )
 
         # In the file, cuisine_centrale_2 has two satellites. We will create a different one of them and verify that a
         # it is removed from the list of satellites after the import
         cuisine_centrale_2 = CanteenFactory.create(
-            siret="96463820453707", production_type=Canteen.ProductionType.CENTRAL
+            siret="96463820453707", production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
         )
         satellite_to_remove = CanteenFactory.create(
             siret="44331934540185",
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             central_producer_siret="96463820453707",
+            managers=[authenticate.user],
         )
-
-        for canteen in (cuisine_centrale_1, satellite_1_1, satellite_1_3, cuisine_centrale_2, satellite_to_remove):
-            canteen.managers.add(authenticate.user)
 
         with open("./api/tests/files/diagnostics/diagnostics_complete_cc_good.csv") as diag_file:
             response = self.client.post(f"{reverse('import_cc_complete_diagnostics')}", {"file": diag_file})
@@ -1105,32 +1104,32 @@ class TestImportDiagnosticsAPI(APITestCase):
         # In the file, cuisine_centrale_1 has three satellites. We will create two of them and verify that a
         # third one is added after the import
         cuisine_centrale_1 = CanteenFactory.create(
-            siret="29969025300230", production_type=Canteen.ProductionType.CENTRAL
+            siret="29969025300230", production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
         )
         satellite_1_1 = CanteenFactory.create(
             siret="38589540005962",
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             central_producer_siret="29969025300230",
+            managers=[authenticate.user],
         )
         satellite_1_3 = CanteenFactory.create(
             siret="27309825823572",
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             central_producer_siret="29969025300230",
+            managers=[authenticate.user],
         )
 
         # In the file, cuisine_centrale_2 has two satellites. We will create a different one of them and verify that a
         # it is removed from the list of satellites after the import
         cuisine_centrale_2 = CanteenFactory.create(
-            siret="96463820453707", production_type=Canteen.ProductionType.CENTRAL
+            siret="96463820453707", production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
         )
         satellite_to_remove = CanteenFactory.create(
             siret="44331934540185",
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             central_producer_siret="96463820453707",
+            managers=[authenticate.user],
         )
-
-        for canteen in (cuisine_centrale_1, satellite_1_1, satellite_1_3, cuisine_centrale_2, satellite_to_remove):
-            canteen.managers.add(authenticate.user)
 
         with open("./api/tests/files/diagnostics/diagnostics_simple_cc_good.csv") as diag_file:
             response = self.client.post(f"{reverse('import_cc_diagnostics')}", {"file": diag_file})
@@ -1163,8 +1162,7 @@ class TestImportDiagnosticsAPI(APITestCase):
         If a diagnostic already exists for the canteen, update the diag and canteen
         with data in import file
         """
-        canteen = CanteenFactory.create(siret="21340172201787", name="Old name")
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(siret="21340172201787", name="Old name", managers=[authenticate.user])
         diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, value_total_ht=1, value_bio_ht=0.2)
 
         with open("./api/tests/files/diagnostics/diagnostics_simple_good_different_canteens.csv") as diag_file:
@@ -1184,8 +1182,7 @@ class TestImportDiagnosticsAPI(APITestCase):
         If a diagnostic with a valid TD already exists for the canteen, throw an error
         If the TD is cancelled, allow update
         """
-        canteen = CanteenFactory.create(siret="21340172201787", name="Old name")
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(siret="21340172201787", name="Old name", managers=[authenticate.user])
         diagnostic = DiagnosticFactory.create(canteen=canteen, year=2020, value_total_ht=1, value_bio_ht=0.2)
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, authenticate.user)
 
@@ -1222,8 +1219,7 @@ class TestImportDiagnosticsAPI(APITestCase):
         """
         Attempt to auto-detect file encodings: UTF-8
         """
-        canteen = CanteenFactory.create(siret="96463820453707", name="Initial name")
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(siret="96463820453707", name="Initial name", managers=[authenticate.user])
 
         with open("./api/tests/files/diagnostics/diagnostics_complete_good_encoding_utf-8.csv", "rb") as diag_file:
             response = self.client.post(f"{reverse('import_complete_diagnostics')}", {"file": diag_file})
@@ -1241,8 +1237,7 @@ class TestImportDiagnosticsAPI(APITestCase):
         """
         Attempt to auto-detect file encodings: UTF-16
         """
-        canteen = CanteenFactory.create(siret="96463820453707", name="Initial name")
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(siret="96463820453707", name="Initial name", managers=[authenticate.user])
 
         with open("./api/tests/files/diagnostics/diagnostics_simple_good_encoding_utf-16.csv", "rb") as diag_file:
             response = self.client.post(f"{reverse('import_complete_diagnostics')}", {"file": diag_file})
@@ -1260,8 +1255,7 @@ class TestImportDiagnosticsAPI(APITestCase):
         """
         Attempt to auto-detect file encodings: Windows 1252
         """
-        canteen = CanteenFactory.create(siret="96463820453707", name="Initial name")
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(siret="96463820453707", name="Initial name", managers=[authenticate.user])
 
         with open("./api/tests/files/diagnostics/diagnostics_simple_good_encoding_iso-8859-1.csv", "rb") as diag_file:
             response = self.client.post(f"{reverse('import_complete_diagnostics')}", {"file": diag_file})

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -220,8 +220,7 @@ class TestPurchaseImport(APITestCase):
         """
         A file should not be valid if doesn't contain a header
         """
-        canteen = CanteenFactory.create(siret="82399356058716")
-        canteen.managers.add(authenticate.user)
+        CanteenFactory.create(siret="82399356058716", managers=[authenticate.user])
         self.assertEqual(Purchase.objects.count(), 0)
 
         file_path = "./api/tests/files/achats/purchases_bad_no_header.csv"
@@ -243,8 +242,7 @@ class TestPurchaseImport(APITestCase):
         """
         A file should not be valid if doesn't contain a valid header
         """
-        canteen = CanteenFactory.create(siret="82399356058716")
-        canteen.managers.add(authenticate.user)
+        CanteenFactory.create(siret="82399356058716", managers=[authenticate.user])
         self.assertEqual(Purchase.objects.count(), 0)
 
         # wrong header
@@ -458,8 +456,7 @@ class TestPurchaseImport(APITestCase):
         This is a smoke test - purchase import reuses diagnostics import
         More tests are with the diagnostic import tests
         """
-        canteen = CanteenFactory.create(siret="82399356058716")
-        canteen.managers.add(authenticate.user)
+        CanteenFactory.create(siret="82399356058716", managers=[authenticate.user])
         self.assertEqual(Purchase.objects.count(), 0)
 
         file_path = "./api/tests/files/achats/purchases_good_encoding_iso-8859-1.csv"

--- a/api/tests/test_initial_data.py
+++ b/api/tests/test_initial_data.py
@@ -65,8 +65,7 @@ class TestInitialDataApi(APITestCase):
         to thoroughly test the other keys, just making sure they are present.
         The cantine previews should also be present in this case.
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         response = self.client.get(reverse("initial_data"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/tests/test_manager_invitations.py
+++ b/api/tests/test_manager_invitations.py
@@ -101,8 +101,7 @@ class TestManagerInvitationApi(APITestCase):
         If API called twice with the same data, only save once,
         and only send one email
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         payload = {"canteenId": canteen.id, "email": "test@example.com"}
         self.client.post(reverse("add_manager"), payload)
         response = self.client.post(reverse("add_manager"), payload)
@@ -120,10 +119,8 @@ class TestManagerInvitationApi(APITestCase):
         One email can be associated to more than one canteen,
         one canteen can be associated to more than one email
         """
-        canteen1 = CanteenFactory.create()
-        canteen2 = CanteenFactory.create()
-        canteen1.managers.add(authenticate.user)
-        canteen2.managers.add(authenticate.user)
+        canteen1 = CanteenFactory.create(managers=[authenticate.user])
+        canteen2 = CanteenFactory.create(managers=[authenticate.user])
 
         self.client.post(
             reverse("add_manager"),
@@ -152,8 +149,7 @@ class TestManagerInvitationApi(APITestCase):
         If the email matches an existing user, add the user to the canteen managers
         without going through invitations table. No email sent for now
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         other_user = UserFactory.create(email="test@example.com")
         payload = {"canteenId": canteen.id, "email": other_user.email}
 
@@ -178,12 +174,9 @@ class TestManagerInvitationApi(APITestCase):
         It should be possible to remove a given manager from a canteen
         """
         coworker = UserFactory.create()
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
-        canteen.managers.add(coworker)
+        canteen = CanteenFactory.create(managers=[authenticate.user, coworker])
 
         payload = {"canteenId": canteen.id, "email": coworker.email}
-
         response = self.client.post(reverse("remove_manager"), payload)
         body = response.json()
 
@@ -199,11 +192,9 @@ class TestManagerInvitationApi(APITestCase):
         respond 200 OK.
         """
         coworker = UserFactory.create()
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         payload = {"canteenId": canteen.id, "email": coworker.email}
-
         response = self.client.post(reverse("remove_manager"), payload)
         body = response.json()
 
@@ -218,8 +209,7 @@ class TestManagerInvitationApi(APITestCase):
         We should be able to remove a pending invitation
         """
         invitedManagerEmail = "invited-manager@example.com"
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         invitation = ManagerInvitationFactory.create(canteen=canteen, email=invitedManagerEmail)
 
         payload = {"canteenId": canteen.id, "email": invitedManagerEmail}
@@ -237,11 +227,10 @@ class TestManagerInvitationApi(APITestCase):
         """
         If the email does not match an existing user, we try with a case insensitive query
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         other_user = UserFactory.create(email="TEst@example.com")
-        payload = {"canteenId": canteen.id, "email": "test@example.com"}
 
+        payload = {"canteenId": canteen.id, "email": "test@example.com"}
         response = self.client.post(reverse("add_manager"), payload)
         body = response.json()
 
@@ -264,14 +253,12 @@ class TestManagerInvitationApi(APITestCase):
         If the email does not match an existing user, we try with a case insensitive query. If several
         users have a similar email with different cases, we don't proceed.
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         UserFactory.create(email="TEst@example.com")
         UserFactory.create(email="TEST@example.com")
         UserFactory.create(email="TesT@example.com")
 
         payload = {"canteenId": canteen.id, "email": "test@example.com"}
-
         response = self.client.post(reverse("add_manager"), payload)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/api/tests/test_publish_canteen.py
+++ b/api/tests/test_publish_canteen.py
@@ -28,8 +28,7 @@ class TestPublishCanteen(APITestCase):
         """
         Users can publish the canteens they manage and add additional notes
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         payload = {
             "publication_comments": "Hello, world!",
             "quality_comments": "Quality",
@@ -58,8 +57,9 @@ class TestPublishCanteen(APITestCase):
         Calling the unpublish endpoint moves canteens from published
         to draft, optionally updating comments
         """
-        canteen = CanteenFactory.create(publication_status="published")
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(
+            publication_status=Canteen.PublicationStatus.PUBLISHED, managers=[authenticate.user]
+        )
         response = self.client.post(
             reverse("unpublish_canteen", kwargs={"pk": canteen.id}),
             {"publication_comments": "Hello, world!"},
@@ -75,11 +75,13 @@ class TestPublishCanteen(APITestCase):
         """
         Given a list of canteen ids, publish those canteens and return list of successful publication ids
         """
-        canteen_1 = CanteenFactory.create(publication_status=Canteen.PublicationStatus.DRAFT)
+        canteen_1 = CanteenFactory.create(
+            publication_status=Canteen.PublicationStatus.DRAFT, managers=[authenticate.user]
+        )
         # doesn't matter initial state
-        canteen_2 = CanteenFactory.create(publication_status=Canteen.PublicationStatus.PUBLISHED)
-        for canteen in [canteen_1, canteen_2]:
-            canteen.managers.add(authenticate.user)
+        canteen_2 = CanteenFactory.create(
+            publication_status=Canteen.PublicationStatus.PUBLISHED, managers=[authenticate.user]
+        )
 
         payload = {"ids": [canteen_1.id, canteen_2.id]}
         response = self.client.post(reverse("publish_canteens"), payload, format="json")
@@ -135,8 +137,9 @@ class TestPublishCanteen(APITestCase):
         If there are some canteens that aren't managed by the current user, publish what can be published
         and return list of the canteens that are either non-existant or not managed by the user.
         """
-        canteen_1 = CanteenFactory.create(publication_status=Canteen.PublicationStatus.DRAFT)
-        canteen_1.managers.add(authenticate.user)
+        canteen_1 = CanteenFactory.create(
+            publication_status=Canteen.PublicationStatus.DRAFT, managers=[authenticate.user]
+        )
         canteen_2 = CanteenFactory.create(publication_status=Canteen.PublicationStatus.DRAFT)
 
         payload = {"ids": [canteen_1.id, canteen_2.id, 999]}
@@ -159,8 +162,9 @@ class TestPublishCanteen(APITestCase):
         """
         Calling the unpublish endpoint when we have moved to publish by default does nothing
         """
-        canteen = CanteenFactory.create(publication_status="published")
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(
+            publication_status=Canteen.PublicationStatus.PUBLISHED, managers=[authenticate.user]
+        )
         response = self.client.post(reverse("unpublish_canteen", kwargs={"pk": canteen.id}))
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/api/tests/test_published_canteens.py
+++ b/api/tests/test_published_canteens.py
@@ -26,8 +26,7 @@ class TestPublishedCanteenApi(APITestCase):
         """
         Users cannot modify canteen publication status with this endpoint
         """
-        canteen = CanteenFactory.create(city="Paris")
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(city="Paris", managers=[authenticate.user])
         payload = {
             "publication_status": "published",
         }
@@ -570,8 +569,9 @@ class TestPublishedCanteenClaimApi(APITestCase):
 
     @authenticate
     def test_undo_claim_canteen(self):
-        canteen = CanteenFactory.create(claimed_by=authenticate.user, has_been_claimed=True)
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(
+            claimed_by=authenticate.user, has_been_claimed=True, managers=[authenticate.user]
+        )
 
         response = self.client.post(reverse("undo_claim_canteen", kwargs={"canteen_pk": canteen.id}), None)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -583,8 +583,7 @@ class TestPublishedCanteenClaimApi(APITestCase):
     @authenticate
     def test_undo_claim_canteen_fails_if_not_original_claimer(self):
         other_user = UserFactory.create()
-        canteen = CanteenFactory.create(claimed_by=other_user, has_been_claimed=True)
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(claimed_by=other_user, has_been_claimed=True, managers=[authenticate.user])
 
         response = self.client.post(reverse("undo_claim_canteen", kwargs={"canteen_pk": canteen.id}), None)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/api/tests/test_relation_central_satellite.py
+++ b/api/tests/test_relation_central_satellite.py
@@ -21,27 +21,30 @@ class TestRelationCentralSatellite(APITestCase):
         producer for other canteens, return some data for those canteens
         """
         central_siret = "22730656663081"
-        central = CanteenFactory.create(siret=central_siret, production_type=Canteen.ProductionType.CENTRAL)
+        central = CanteenFactory.create(
+            siret=central_siret, production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
+        )
         school = SectorFactory.create(name="School")
         enterprise = SectorFactory.create(name="Enterprise")
         satellite_1 = CanteenFactory.create(
             central_producer_siret=central_siret,
             sectors=[school, enterprise],
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+            managers=[authenticate.user],
         )
         # although user does not have mgmt rights on this, can get same data
         satellite_2 = CanteenFactory.create(
-            central_producer_siret=central_siret, production_type=Canteen.ProductionType.ON_SITE_CENTRAL
+            central_producer_siret=central_siret,
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+            managers=[authenticate.user],
         )
         # the following canteen should not be returned
         CanteenFactory.create()
         # neither should this canteen which isn't the satellite production type
-        not_a_satellite = CanteenFactory.create(
+        CanteenFactory.create(
             central_producer_siret=central_siret,
             production_type=Canteen.ProductionType.ON_SITE,
         )
-        for canteen in [central, satellite_1, not_a_satellite]:
-            canteen.managers.add(authenticate.user)
 
         response = self.client.get(reverse("list_create_update_satellite", kwargs={"canteen_pk": central.id}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -66,11 +69,14 @@ class TestRelationCentralSatellite(APITestCase):
         satellites is returned with the satellite list
         """
         central_siret = "22730656663081"
-        central = CanteenFactory.create(siret=central_siret, production_type=Canteen.ProductionType.CENTRAL)
+        central = CanteenFactory.create(
+            siret=central_siret, production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
+        )
         satellite_1 = CanteenFactory.create(
             central_producer_siret=central_siret,
             publication_status=Canteen.PublicationStatus.DRAFT,
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+            managers=[authenticate.user],
         )
         # although user does not have mgmt rights on this, can get same data
         CanteenFactory.create(
@@ -80,8 +86,6 @@ class TestRelationCentralSatellite(APITestCase):
         )
         # the following canteen should not be returned
         CanteenFactory.create()
-        for canteen in [central, satellite_1]:
-            canteen.managers.add(authenticate.user)
 
         response = self.client.get(reverse("list_create_update_satellite", kwargs={"canteen_pk": central.id}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -115,12 +119,13 @@ class TestRelationCentralSatellite(APITestCase):
         When the endpoint is called, create new canteens, adding in some additional helpful information
         """
         central_siret = "08376514425566"
-        canteen = CanteenFactory.create(siret=central_siret, production_type=Canteen.ProductionType.CENTRAL)
-        canteen.managers.add(authenticate.user)
         second_manager = UserFactory.create()
-        canteen.managers.add(second_manager)
+        canteen = CanteenFactory.create(
+            siret=central_siret,
+            production_type=Canteen.ProductionType.CENTRAL,
+            managers=[authenticate.user, second_manager],
+        )
         # all the mgmt team of the cuisine centrale should be added to the satellite team
-
         satellite_siret = "38782537682311"
         school = SectorFactory.create(name="School")
         enterprise = SectorFactory.create(name="Enterprise")
@@ -159,8 +164,10 @@ class TestRelationCentralSatellite(APITestCase):
             siret=satellite_siret, production_type=Canteen.ProductionType.ON_SITE_CENTRAL
         )
         central_siret = "08376514425566"
-        canteen = CanteenFactory.create(siret=central_siret, production_type=Canteen.ProductionType.CENTRAL)
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(
+            siret=central_siret, production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
+        )
+
         request = {
             "name": existing_canteen.name,
             "siret": existing_canteen.siret,
@@ -183,8 +190,10 @@ class TestRelationCentralSatellite(APITestCase):
         satellite_siret = "89834106501485"
         existing_canteen = CanteenFactory.create(siret=satellite_siret, production_type=Canteen.ProductionType.ON_SITE)
         central_siret = "08376514425566"
-        canteen = CanteenFactory.create(siret=central_siret, production_type=Canteen.ProductionType.CENTRAL)
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(
+            siret=central_siret, production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
+        )
+
         request = {
             "name": existing_canteen.name,
             "siret": existing_canteen.siret,
@@ -207,8 +216,10 @@ class TestRelationCentralSatellite(APITestCase):
         existing_canteen = CanteenFactory.create(siret=satellite_siret, production_type=Canteen.ProductionType.ON_SITE)
         existing_canteen.managers.all().delete()
         central_siret = "08376514425566"
-        canteen = CanteenFactory.create(siret=central_siret, production_type=Canteen.ProductionType.CENTRAL)
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(
+            siret=central_siret, production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
+        )
+
         request = {
             "name": existing_canteen.name,
             "siret": existing_canteen.siret,
@@ -232,8 +243,10 @@ class TestRelationCentralSatellite(APITestCase):
             siret=satellite_siret, production_type=Canteen.ProductionType.ON_SITE, managers=[UserFactory.create()]
         )
         central_siret = "08376514425566"
-        canteen = CanteenFactory.create(siret=central_siret, production_type=Canteen.ProductionType.CENTRAL)
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(
+            siret=central_siret, production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
+        )
+
         request = {
             "name": existing_canteen.name,
             "siret": existing_canteen.siret,
@@ -260,8 +273,10 @@ class TestRelationCentralSatellite(APITestCase):
             central_producer_siret=existing_central_cuisine_siret,
         )
         central_siret = "08376514425566"
-        canteen = CanteenFactory.create(siret=central_siret, production_type=Canteen.ProductionType.CENTRAL)
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(
+            siret=central_siret, production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
+        )
+
         request = {
             "name": linked_canteen.name,
             "siret": linked_canteen.siret,
@@ -285,8 +300,10 @@ class TestRelationCentralSatellite(APITestCase):
             siret=satellite_siret, production_type=Canteen.ProductionType.CENTRAL
         )
         central_siret = "08376514425566"
-        canteen = CanteenFactory.create(siret=central_siret, production_type=Canteen.ProductionType.CENTRAL)
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(
+            siret=central_siret, production_type=Canteen.ProductionType.CENTRAL, managers=[authenticate.user]
+        )
+
         request = {
             "name": central_satellite_canteen.name,
             "siret": central_satellite_canteen.siret,
@@ -310,8 +327,10 @@ class TestRelationCentralSatellite(APITestCase):
             siret=satellite_siret, production_type=Canteen.ProductionType.ON_SITE
         )
         central_siret = "08376514425566"
-        canteen = CanteenFactory.create(siret=central_siret, production_type=Canteen.ProductionType.ON_SITE)
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(
+            siret=central_siret, production_type=Canteen.ProductionType.ON_SITE, managers=[authenticate.user]
+        )
+
         request = {
             "name": satellite_canteen.name,
             "siret": satellite_canteen.siret,
@@ -362,8 +381,9 @@ class TestRelationCentralSatellite(APITestCase):
         Should be able to remove satellites from a central kitchen
         """
         central_siret = "08376514425566"
-        central_kitchen = CanteenFactory.create(production_type=Canteen.ProductionType.CENTRAL, siret=central_siret)
-        central_kitchen.managers.add(authenticate.user)
+        central_kitchen = CanteenFactory.create(
+            production_type=Canteen.ProductionType.CENTRAL, siret=central_siret, managers=[authenticate.user]
+        )
         satellite = CanteenFactory.create(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central_kitchen.siret
         )
@@ -385,8 +405,9 @@ class TestRelationCentralSatellite(APITestCase):
         Removing a non-linked satellite from a central kitchen should be a transparent operation
         """
         central_siret = "08376514425566"
-        central_kitchen = CanteenFactory.create(production_type=Canteen.ProductionType.CENTRAL, siret=central_siret)
-        central_kitchen.managers.add(authenticate.user)
+        central_kitchen = CanteenFactory.create(
+            production_type=Canteen.ProductionType.CENTRAL, siret=central_siret, managers=[authenticate.user]
+        )
         unlinked_satellite_siret = "86891081916867"
 
         response = self.client.post(

--- a/api/tests/test_relation_central_satellite.py
+++ b/api/tests/test_relation_central_satellite.py
@@ -40,9 +40,8 @@ class TestRelationCentralSatellite(APITestCase):
             central_producer_siret=central_siret,
             production_type=Canteen.ProductionType.ON_SITE,
         )
-        user = authenticate.user
         for canteen in [central, satellite_1, not_a_satellite]:
-            canteen.managers.add(user)
+            canteen.managers.add(authenticate.user)
 
         response = self.client.get(reverse("list_create_update_satellite", kwargs={"canteen_pk": central.id}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -81,9 +80,8 @@ class TestRelationCentralSatellite(APITestCase):
         )
         # the following canteen should not be returned
         CanteenFactory.create()
-        user = authenticate.user
         for canteen in [central, satellite_1]:
-            canteen.managers.add(user)
+            canteen.managers.add(authenticate.user)
 
         response = self.client.get(reverse("list_create_update_satellite", kwargs={"canteen_pk": central.id}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -230,8 +228,9 @@ class TestRelationCentralSatellite(APITestCase):
         If the satellite already has managers, the CC managers do not get automatic access
         """
         satellite_siret = "89834106501485"
-        existing_canteen = CanteenFactory.create(siret=satellite_siret, production_type=Canteen.ProductionType.ON_SITE)
-        existing_canteen.managers.add(UserFactory.create())
+        existing_canteen = CanteenFactory.create(
+            siret=satellite_siret, production_type=Canteen.ProductionType.ON_SITE, managers=[UserFactory.create()]
+        )
         central_siret = "08376514425566"
         canteen = CanteenFactory.create(siret=central_siret, production_type=Canteen.ProductionType.CENTRAL)
         canteen.managers.add(authenticate.user)

--- a/api/tests/test_reservation_expe.py
+++ b/api/tests/test_reservation_expe.py
@@ -14,8 +14,7 @@ class TestReservationExpeApi(APITestCase):
         """
         Test that we can create a new reservation experiment for a canteen
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         payload = {
             "leader_email": "test@example.com",
@@ -76,8 +75,7 @@ class TestReservationExpeApi(APITestCase):
         """
         Shouldn't be able to create more than one reservation expe for a canteen
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         reservation_expe = ReservationExpeFactory.create(canteen=canteen, satisfaction=5)
 
         response = self.client.post(
@@ -93,8 +91,7 @@ class TestReservationExpeApi(APITestCase):
         """
         Test that we can get a reservation experiment for a canteen
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         ReservationExpeFactory.create(canteen=canteen, leader_email="test@example.com")
 
         response = self.client.get(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}))
@@ -128,8 +125,7 @@ class TestReservationExpeApi(APITestCase):
         """
         Test attempting to get a reservation expe that doesn't exist
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         response = self.client.get(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}))
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -139,8 +135,7 @@ class TestReservationExpeApi(APITestCase):
         """
         Test that we can update a reservation experiment for a canteen
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         reservation_expe = ReservationExpeFactory.create(
             canteen=canteen, leader_email="bad@example.com", satisfaction=1
         )
@@ -181,8 +176,7 @@ class TestReservationExpeApi(APITestCase):
         """
         Shouldn't be able to update a reservation expe if it doesn't exist
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         payload = {"leader_email": "bad@example.com"}
         response = self.client.patch(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}), payload)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -193,8 +187,7 @@ class TestReservationExpeApi(APITestCase):
         """
         Check that cannot update canteen on a reservation expe
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         reservation_expe = ReservationExpeFactory.create(canteen=canteen)
         payload = {"canteen": CanteenFactory.create().id}
         response = self.client.patch(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}), payload)
@@ -207,8 +200,7 @@ class TestReservationExpeApi(APITestCase):
         """
         Check that updates with bad data are rejected
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         reservation_expe = ReservationExpeFactory.create(canteen=canteen, satisfaction=3, avg_weight_not_served_t2=70)
 
         response = self.client.patch(

--- a/api/tests/test_resource_actions.py
+++ b/api/tests/test_resource_actions.py
@@ -17,8 +17,7 @@ class TestResourceActionsApi(APITestCase):
         cls.waste_action = WasteActionFactory()
         cls.user = UserFactory()
         cls.user_with_canteen = UserFactory()
-        cls.canteen = CanteenFactory()
-        cls.canteen.managers.add(cls.user_with_canteen)
+        cls.canteen = CanteenFactory(managers=[cls.user_with_canteen])
         cls.url = reverse("resource_action_create_or_update", kwargs={"resource_pk": cls.waste_action.id})
 
     def test_create_resource_action_error(self):
@@ -84,8 +83,9 @@ class TestCanteenResourceActionApi(APITestCase):
         cls.user = UserFactory()
         cls.user_with_canteen = UserFactory()
         cls.canteen = CanteenFactory(publication_status=Canteen.PublicationStatus.PUBLISHED)
-        cls.canteen_with_resource_action = CanteenFactory(publication_status=Canteen.PublicationStatus.PUBLISHED)
-        cls.canteen_with_resource_action.managers.add(cls.user_with_canteen)
+        cls.canteen_with_resource_action = CanteenFactory(
+            publication_status=Canteen.PublicationStatus.PUBLISHED, managers=[cls.user_with_canteen]
+        )
         ResourceActionFactory(resource=cls.waste_action_1, canteen=cls.canteen_with_resource_action, is_done=True)
         ResourceActionFactory(resource=cls.waste_action_2, canteen=cls.canteen_with_resource_action, is_favorite=True)
 

--- a/api/tests/test_signals.py
+++ b/api/tests/test_signals.py
@@ -34,8 +34,8 @@ class TestSignals(APITestCase):
         user, token = get_oauth2_token("canteen:write")
         diagnostic = DiagnosticFactory.create(year=2021)
         diagnostic.canteen.managers.add(user)
-        payload = {"diagnosticId": diagnostic.id}
 
+        payload = {"diagnosticId": diagnostic.id}
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
         response = self.client.post(reverse("teledeclaration_create"), payload)
         self.assertEqual(response.status_code, 403)

--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -560,13 +560,19 @@ class TestTeledeclarationCreateApi(APITestCase):
         ),
         cases = [
             {
-                "canteen": CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, siret="79300704800044"),
+                "canteen": CanteenFactory(
+                    production_type=Canteen.ProductionType.ON_SITE,
+                    siret="79300704800044",
+                    managers=[authenticate.user],
+                ),
                 "diagnostic": DiagnosticFactory.create(year=2021, value_total_ht=100),
                 "expected_teledeclaration_mode": "SITE",
             },
             {
                 "canteen": CanteenFactory(
-                    production_type=Canteen.ProductionType.ON_SITE_CENTRAL, siret="79300704800044"
+                    production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+                    siret="79300704800044",
+                    managers=[authenticate.user],
                 ),
                 "diagnostic": DiagnosticFactory.create(year=2021, value_total_ht=100),
                 "expected_teledeclaration_mode": "SITE",
@@ -576,12 +582,17 @@ class TestTeledeclarationCreateApi(APITestCase):
                     production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
                     siret="79300704800044",
                     central_producer_siret="18704793618411",
+                    managers=[authenticate.user],
                 ),
                 "diagnostic": DiagnosticFactory.create(year=2021),
                 "expected_teledeclaration_mode": "SATELLITE_WITHOUT_APPRO",
             },
             {
-                "canteen": CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, siret="79300704800044"),
+                "canteen": CanteenFactory(
+                    production_type=Canteen.ProductionType.CENTRAL,
+                    siret="79300704800044",
+                    managers=[authenticate.user],
+                ),
                 "diagnostic": DiagnosticFactory.create(
                     year=2021,
                     value_total_ht=100,
@@ -591,7 +602,9 @@ class TestTeledeclarationCreateApi(APITestCase):
             },
             {
                 "canteen": CanteenFactory(
-                    production_type=Canteen.ProductionType.CENTRAL_SERVING, siret="79300704800044"
+                    production_type=Canteen.ProductionType.CENTRAL_SERVING,
+                    siret="79300704800044",
+                    managers=[authenticate.user],
                 ),
                 "diagnostic": DiagnosticFactory.create(
                     year=2021,
@@ -605,8 +618,6 @@ class TestTeledeclarationCreateApi(APITestCase):
             canteen = case["canteen"]
             diagnostic = case["diagnostic"]
             expected_td_mode = case["expected_teledeclaration_mode"]
-
-            canteen.managers.add(authenticate.user)
             diagnostic.canteen = canteen
             diagnostic.save()
 

--- a/api/tests/test_vegetarian_expe.py
+++ b/api/tests/test_vegetarian_expe.py
@@ -14,8 +14,7 @@ class TestVegetarianExpeApi(APITestCase):
         """
         Test that we can create a new vegetarian experiment for a canteen
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         payload = {
             "vegetarianMenuPercentageT0": 0.32,
@@ -76,8 +75,7 @@ class TestVegetarianExpeApi(APITestCase):
         """
         Shouldn't be able to create more than one vegetarian expe for a canteen
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         vegetarian_expe = VegetarianExpeFactory.create(canteen=canteen, satisfaction_guests_t0=5)
 
         response = self.client.post(
@@ -93,8 +91,7 @@ class TestVegetarianExpeApi(APITestCase):
         """
         Test that we can get a vegetarian expe for a canteen
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         VegetarianExpeFactory.create(canteen=canteen, satisfaction_guests_t0=4)
 
         response = self.client.get(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}))
@@ -128,8 +125,7 @@ class TestVegetarianExpeApi(APITestCase):
         """
         Test attempting to get a vegetarian expe that doesn't exist
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         response = self.client.get(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}))
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -139,8 +135,7 @@ class TestVegetarianExpeApi(APITestCase):
         """
         Test that we can update a vegetarian experiment for a canteen
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         vegetarian_expe = VegetarianExpeFactory.create(canteen=canteen, satisfaction_guests_t0=1)
         payload = {"satisfactionGuestsT0": 3}
         response = self.client.patch(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), payload)
@@ -178,8 +173,7 @@ class TestVegetarianExpeApi(APITestCase):
         """
         Shouldn't be able to update a vegetarian expe if it doesn't exist
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         payload = {"satisfactionGuestsT0": 2}
         response = self.client.patch(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), payload)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -190,8 +184,7 @@ class TestVegetarianExpeApi(APITestCase):
         """
         Check that cannot update canteen on a reservation expe
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         vegetarian_expe = VegetarianExpeFactory.create(canteen=canteen)
         payload = {"canteen": CanteenFactory.create().id}
         response = self.client.patch(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), payload)
@@ -204,8 +197,7 @@ class TestVegetarianExpeApi(APITestCase):
         """
         Check that updates with bad data are rejected
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         vegetarian_expe = VegetarianExpeFactory.create(
             canteen=canteen, satisfaction_guests_t0=3, waste_vegetarian_not_served_t0=70
         )

--- a/api/tests/test_waste_measurements.py
+++ b/api/tests/test_waste_measurements.py
@@ -60,8 +60,7 @@ class TestWasteMeasurementsApi(APITestCase):
         When calling this API on a canteen that the user manages
         we expect a waste_measurement to be created
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         payload = {
             "period_start_date": "2024-08-01",
@@ -108,8 +107,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         Same start & end dates (Period of 1 day)
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         payload = {
             "period_start_date": "2024-08-01",
@@ -124,8 +122,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         Period start date and period end date must be given
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         payload = {}
 
@@ -142,8 +139,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         The period end date cannot be in the future
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         payload = {
             "period_start_date": "2024-08-01",
@@ -160,8 +156,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         The period start date must be before end date
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         payload = {
             "period_start_date": "2024-08-10",
@@ -180,8 +175,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         A new measurement cannot have a period that overlaps with an existing measurement
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         WasteMeasurementFactory.create(
             canteen=canteen, period_start_date=datetime.date(2024, 7, 1), period_end_date=datetime.date(2024, 7, 5)
         )
@@ -233,8 +227,7 @@ class TestWasteMeasurementsApi(APITestCase):
         WasteMeasurementFactory.create(
             period_start_date=datetime.date(2024, 7, 1), period_end_date=datetime.date(2024, 7, 5)
         )
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
 
         response = self.client.post(
             reverse("canteen_waste_measurements", kwargs={"canteen_pk": canteen.id}),
@@ -250,6 +243,7 @@ class TestWasteMeasurementsApi(APITestCase):
         Get 403 when trying to fetch waste measurements without being authenticated
         """
         canteen = CanteenFactory.create()
+
         response = self.client.get(reverse("canteen_waste_measurements", kwargs={"canteen_pk": canteen.id}))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -267,8 +261,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         Canteen managers can fetch all the waste measurements for a canteen in order of period start date descending
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         measurement_july = WasteMeasurementFactory.create(
             canteen=canteen, period_start_date=datetime.date(2024, 7, 1), period_end_date=datetime.date(2024, 7, 5)
         )
@@ -294,10 +287,11 @@ class TestWasteMeasurementsApi(APITestCase):
         measurement = WasteMeasurementFactory.create(
             period_start_date=datetime.date(2024, 8, 1), period_end_date=datetime.date(2024, 8, 5)
         )
-        canteen = measurement.canteen
-        canteen.managers.add(authenticate.user)
+        measurement.canteen.managers.add(authenticate.user)
 
-        response = self.client.get(reverse("canteen_waste_measurements", kwargs={"canteen_pk": canteen.id}))
+        response = self.client.get(
+            reverse("canteen_waste_measurements", kwargs={"canteen_pk": measurement.canteen.id})
+        )
         body = response.json()
 
         self.assertEqual(body[0]["daysInPeriod"], 5)
@@ -309,8 +303,7 @@ class TestWasteMeasurementsApi(APITestCase):
         This is done by taking dividing the total mass by period meal count and multiplying by canteen's
         yearly meal count
         """
-        canteen = CanteenFactory(yearly_meal_count=1000)
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory(yearly_meal_count=1000, managers=[authenticate.user])
         WasteMeasurementFactory.create(canteen=canteen, meal_count=10, total_mass=50)
 
         response = self.client.get(reverse("canteen_waste_measurements", kwargs={"canteen_pk": canteen.id}))
@@ -336,8 +329,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         Canteen managers can fetch the waste measurement of a canteen they manage
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         measurement = WasteMeasurementFactory.create(canteen=canteen)
 
         response = self.client.get(
@@ -353,8 +345,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         Canteen managers can edit the waste measurement of a canteen they manage
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         measurement = WasteMeasurementFactory.create(canteen=canteen, meal_count=100)
 
         payload = {"mealCount": 200}
@@ -372,8 +363,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         The period end date cannot be updated to be in the future
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         measurement = WasteMeasurementFactory.create(
             canteen=canteen, period_start_date="2024-08-01", period_end_date="2024-08-05"
         )
@@ -391,8 +381,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         The period start date must be before end date in update
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         measurement = WasteMeasurementFactory.create(
             canteen=canteen, period_start_date=datetime.date(2024, 8, 1), period_end_date=datetime.date(2024, 8, 5)
         )
@@ -420,8 +409,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         A measurement update cannot have a period that overlaps with an existing measurement
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         WasteMeasurementFactory.create(
             canteen=canteen, period_start_date=datetime.date(2024, 7, 1), period_end_date=datetime.date(2024, 7, 5)
         )
@@ -473,8 +461,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         The period dates cannot be removed
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         measurement = WasteMeasurementFactory.create(canteen=canteen)
 
         payload = {
@@ -499,8 +486,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         Given valid dates, it it possible to update the dates of a measurement even when the new dates "overlap" the existing ones
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         measurement = WasteMeasurementFactory.create(
             canteen=canteen, period_start_date=datetime.date(2024, 5, 1), period_end_date=datetime.date(2024, 5, 10)
         )
@@ -520,8 +506,7 @@ class TestWasteMeasurementsApi(APITestCase):
         """
         Canteen managers can fetch all the waste measurements for a canteen in a particular time period
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         measurement_july = WasteMeasurementFactory.create(
             canteen=canteen, period_start_date=datetime.date(2024, 7, 1), period_end_date=datetime.date(2024, 7, 5)
         )

--- a/data/tests/test_teledeclaration.py
+++ b/data/tests/test_teledeclaration.py
@@ -166,8 +166,7 @@ class TestTeledeclarationModelConstraintsTest(TestCase):
         If the diagnostic used for the teledeclaration is deleted, the teledeclaration
         should be cancelled
         """
-        canteen = CanteenFactory.create()
-        canteen.managers.add(authenticate.user)
+        canteen = CanteenFactory.create(managers=[authenticate.user])
         diagnostic = DiagnosticFactory.create(
             canteen=canteen, year=2021, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
         )

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -122,9 +122,7 @@ class TestETLOpenData(TestCase):
         self.assertEqual(etl_canteen.len_dataset(), 0, "There shoud be an empty dataframe")
 
         # Adding data in the db
-        canteen_1 = CanteenFactory.create(siret="98648424243607")
-        canteen_1.managers.add(UserFactory.create())
-
+        canteen_1 = CanteenFactory.create(siret="98648424243607", managers=[UserFactory.create()])
         canteen_2 = CanteenFactory.create(siret="98648424243607")  # Another canteen, but without a manager
         canteen_2.managers.clear()
 
@@ -190,9 +188,8 @@ class TestETLOpenData(TestCase):
         )
 
         # Adding data in the db
-        canteen_1 = CanteenFactory.create()
-        canteen_1.managers.add(UserFactory.create())
-        canteen_2 = CanteenFactory.create()
+        canteen_1 = CanteenFactory.create(managers=[UserFactory.create()])
+        canteen_2 = CanteenFactory.create()  # Another canteen, but without a manager
         canteen_2.managers.clear()
 
         etl_canteen = ETL_OPEN_DATA_CANTEEN()


### PR DESCRIPTION
Suite à https://github.com/betagouv/ma-cantine/pull/5264

`CanteenFactory` génère un nombre aléatoire (entre 1 et 2) managers.
A terme on enlèverait ce mécanisme. D'abord on rajoute explicitement quand c'est le cas dans les tests
- [x] enlever un maximum de `canteen.managers.add(user)`
- [x] enlever un maximum de `canteen.managers.add(authenticated.user)`