### PR TITLE
fix(Campagne de correction): autoriser les cantines qui ont fait une correction à re-télédéclarer

### DIFF
--- a/frontend/src/components/TeledeclarationCancelDialog.vue
+++ b/frontend/src/components/TeledeclarationCancelDialog.vue
@@ -13,7 +13,7 @@
       <v-card-text>
         <p class="mb-0">
           L’action de correction annule la télédéclaration déjà en place pour vous permettre de modifier les valeurs de
-          votre choix. Les informations sont pré-remplis avec vos dernières données. Une fois corrigé, vous devez
+          votre choix. Les informations sont pré-remplis avec vos dernières données. Une fois corrigée, vous devez
           soumettre de nouveau votre télédéclaration conformément à l'arrêté du 14 septembre 2022.
         </p>
       </v-card-text>

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -36,6 +36,7 @@
       </v-col>
     </v-row>
     <v-row v-if="canteen" class="mt-5 mt-md-10">
+      <!-- Sidebar -->
       <v-col cols="12" md="3" lg="2" style="border-right: 1px solid #DDD;" class="fr-text-sm pt-1">
         <DsfrNativeSelect v-model="selectedYear" :items="yearOptions" class="mb-3 mt-2" />
         <DataInfoBadge
@@ -88,7 +89,7 @@
             bilan pour votre établissement.
           </p>
         </div>
-        <div v-else-if="inTeledeclarationCampaign">
+        <div v-else-if="inTeledeclarationCampaign || (inCorrectionCampaign && hasCancelledTeledeclaration)">
           <div v-if="isSatelliteWithApproCentralDiagnostic">
             <p>
               Votre livreur des repas
@@ -149,6 +150,7 @@
           <router-link :to="{ name: 'ContactPage' }" class="grey--text text--darken-4">Contactez-nous</router-link>
         </p>
       </v-col>
+      <!-- Diagnostic tabs -->
       <v-col cols="12" md="9" lg="10">
         <v-card v-if="isCentralKitchen" class="pa-6 mb-4 mr-1" style="background: #f5f5fe">
           <v-radio-group
@@ -357,6 +359,12 @@ export default {
     },
     mobileSelectItems() {
       return this.tabHeaders.map((x, index) => ({ text: x.text, value: index }))
+    },
+    hasCancelledTeledeclaration() {
+      // During the correction campaign, we allow only canteens with an existing teledeclaration to do corrections
+      // BUT the backend does not return CANCELLED teledeclarations
+      // instead we look at the canteen's action
+      return this.canteenAction === "40_teledeclare"
     },
     hasActiveTeledeclaration() {
       return this.diagnostic?.teledeclaration?.status === "SUBMITTED"


### PR DESCRIPTION
### Quoi

Grâce à la PR précédente - #5268 - on a maintenant l'info si, durant la campagne de correction, la cantine a le droit de corriger/recréer sa télédéclaration.

### Captures d'écran

||Avant|Après|
|-|-|-|
|Avant d'annuler|![image](https://github.com/user-attachments/assets/ac408df0-3d12-45ae-bbe2-914c8c274075)|aucun changement|
|Après avoir annulée sa TD|![image](https://github.com/user-attachments/assets/a063be82-96de-4212-a123-370c3b04ddde)|![image](https://github.com/user-attachments/assets/888d1582-5cbd-4862-b540-fd909f344422)|
