### PR TITLE
fix(Badge): Corrige les erreurs d'affichage du badge NEUTRAL

### DIFF
--- a/frontend/src/components/DsfrBadge.vue
+++ b/frontend/src/components/DsfrBadge.vue
@@ -53,7 +53,9 @@ export default {
           color: "rgb(24, 117, 60)",
           icon: "$checkbox-fill",
         },
-        NEUTRAL: {},
+        NEUTRAL: {
+          color: "rgb(0, 0, 0)",
+        },
       },
     }
   },


### PR DESCRIPTION
Dans #5186 on avait créé un nouveau type de style "NEUTRAL"
Mais j'avais des erreurs d'affichage, le texte restait parfois (tout le temps ?) rouge (ou vert, ca dépendait de quelle couleur il était avant ^^) d'une page à une autre.

Je force ici la couleur à noir

### Captures d'écran

||Avant|Après|
|-|-|-|
|AnnualActionableCanteensTable|![image](https://github.com/user-attachments/assets/1aec2aa9-d856-4470-875d-dcf7346e42a8)|aucun changement|
|MyProgress|![image](https://github.com/user-attachments/assets/7284195b-9c22-445c-9564-60156e7f7280)|![image](https://github.com/user-attachments/assets/9daba1f6-94d2-4242-93c3-4f345935eb77)|