### PR TITLE
refactor(Télédéclaration): créer une méthode dédiée pour annuler une TD

### DIFF
--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -1256,8 +1256,7 @@ class TestCanteenActionApi(APITestCase):
         self.assertEqual(body["action"], "95_nothing")
 
         # cancel the teledeclaration
-        teledeclaration.status = Teledeclaration.TeledeclarationStatus.CANCELLED
-        teledeclaration.save()
+        teledeclaration.cancel()
 
         response = self.client.get(reverse("retrieve_actionable_canteen", kwargs={"pk": 2, "year": last_year}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/tests/test_import_diagnostics.py
+++ b/api/tests/test_import_diagnostics.py
@@ -1205,8 +1205,7 @@ class TestImportDiagnosticsAPI(APITestCase):
         self.assertEqual(diagnostic.value_total_ht, 1)
 
         # now test cancelled TD
-        teledeclaration.status = Teledeclaration.TeledeclarationStatus.CANCELLED
-        teledeclaration.save()
+        teledeclaration.cancel()
         with open("./api/tests/files/diagnostics/diagnostics_simple_good_different_canteens.csv") as diag_file:
             response = self.client.post(reverse("import_diagnostics"), {"file": diag_file})
 

--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -154,8 +154,8 @@ class TeledeclarationCancelView(APIView):
                         "La campagne de correction est réservée aux cantines qui ont télédéclaré durant la campagne de télédéclaration."
                     )
 
-            teledeclaration.status = Teledeclaration.TeledeclarationStatus.CANCELLED
-            teledeclaration.save()
+            # all the checks avec passed, we can cancel the teledeclaration
+            teledeclaration.cancel()
 
             data = FullDiagnosticSerializer(teledeclaration.diagnostic).data
             return JsonResponse(camelize(data), status=status.HTTP_200_OK)

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -33,7 +33,7 @@ class CustomJSONEncoder(DjangoJSONEncoder):
 
 
 class TeledeclarationQuerySet(models.QuerySet):
-    
+
     def submitted(self):
         return self.filter(status=Teledeclaration.TeledeclarationStatus.SUBMITTED)
 
@@ -210,8 +210,7 @@ class Teledeclaration(models.Model):
     def cancel_teledeclaration(sender, instance, **kwargs):
         try:
             teledeclaration = Teledeclaration.objects.get(diagnostic=instance)
-            teledeclaration.status = Teledeclaration.TeledeclarationStatus.CANCELLED
-            teledeclaration.save()
+            teledeclaration.cancel()
         except Exception:
             pass
 
@@ -374,6 +373,13 @@ class Teledeclaration(models.Model):
                 return Teledeclaration.TeledeclarationMode.CENTRAL_APPRO
 
         return Teledeclaration.TeledeclarationMode.SITE
+
+    def cancel(self):
+        """
+        Cancel the teledeclaration.
+        """
+        self.status = Teledeclaration.TeledeclarationStatus.CANCELLED
+        self.save()
 
     def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         self.full_clean()

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -44,8 +44,7 @@ class TestETLOpenData(TestCase):
         applicant = UserFactory.create()
         diagnostic = DiagnosticFactory.create(canteen=canteen, year=2022, diagnostic_type=None)
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, applicant)
-        teledeclaration.status = Teledeclaration.TeledeclarationStatus.CANCELLED
-        teledeclaration.save()
+        teledeclaration.cancel()
 
         etl_td = ETL_OPEN_DATA_TELEDECLARATIONS(2022)
         etl_td.extract_dataset()


### PR DESCRIPTION
Avant de me lancer dans le script qui "cancel puis re-submit" certaines TD, j'en profite pour refactorer le code dédiée à la partie "cancel"

Je bouge la logique (même courte ^^) dans le modèle