### PR TITLE
refactor(Télédéclaration): Script pour re-TD une liste de cantines pour une année donnée

### DIFF
--- a/macantine/management/commands/20250416_canteen_td_resubmit.py
+++ b/macantine/management/commands/20250416_canteen_td_resubmit.py
@@ -3,6 +3,9 @@ Why this script?
 We updated/fixed the data of some canteens after they teledeclared.
 To reflect the changes in the Teledeclaration objects, we need to cancel and re-submit these teledeclarations.
 
+How to run?
+python manage.py 20250416_canteen_td_resubmit --year 2024 --canteen-siret-list 12345678901234,23456789012345
+
 Ran on 2025-04-16 (Campaign for 2024)
 """
 
@@ -10,24 +13,44 @@ from django.core.management.base import BaseCommand
 
 from data.models import Canteen, Teledeclaration
 
-CANTEEN_SIRET_LIST = ["21380397600017"]
-YEAR = 2024
-
 
 class Command(BaseCommand):
     help = "Resubmit teledeclarations for a specified list of canteens"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--year",
+            dest="year",
+            type=int,
+            required=True,
+            help="Year of the teledeclaration campaign to process",
+        )
+        parser.add_argument(
+            "--canteen-siret-list",
+            dest="canteen_siret_list",
+            type=str,
+            required=True,
+            help="Comma-seperated list of canteen SIRETs to process",
+        )
+
     def handle(self, *args, **options):
         # init
+        print("Starting teledeclaration resubmit task")
         teledeclaration_resubmitted_count = 0
-        canteen_qs = Canteen.objects.filter(siret__in=CANTEEN_SIRET_LIST)
+        year = options["year"]
+        print("Year in input:", year)
+        canteen_siret_list = options["canteen_siret_list"].split(",")
+        print("SIRET in input list:", len(canteen_siret_list))
+
+        canteen_qs = Canteen.objects.filter(siret__in=canteen_siret_list)
+        print("Canteens found:", canteen_qs.count())
 
         # loop on each canteen
         for canteen in canteen_qs:
             # canteen must have submitted a TD during the campaign
-            canteen_td_submitted_for_year_qs = Teledeclaration.objects.filter(canteen=canteen).submitted_for_year(YEAR)
+            canteen_td_submitted_for_year_qs = Teledeclaration.objects.filter(canteen=canteen).submitted_for_year(year)
             if not canteen_td_submitted_for_year_qs.exists():
-                print(f"No teledeclaration for canteen {canteen.siret} for year {YEAR}")
+                print(f"No teledeclaration for canteen {canteen.siret} for year {year}")
                 continue  # skip canteen
             canteen_td_submitted_for_year = canteen_td_submitted_for_year_qs.first()
             # cancel TD
@@ -40,11 +63,9 @@ class Command(BaseCommand):
                 )
                 teledeclaration_resubmitted_count += 1
             except Exception as e:
-                print(f"Failed to resubmit teledeclaration for canteen {canteen.siret} for year {YEAR}")
+                print(f"Failed to resubmit teledeclaration for canteen {canteen.siret} for year {year}")
                 print(e)
                 continue
 
         print("Done!")
-        print("SIRET in input list:", len(CANTEEN_SIRET_LIST))
-        print("Canteen found", canteen_qs.count())
         print("Teledeclarations resubmitted:", teledeclaration_resubmitted_count)

--- a/macantine/management/commands/20250416_canteen_td_resubmit.py
+++ b/macantine/management/commands/20250416_canteen_td_resubmit.py
@@ -1,0 +1,50 @@
+"""
+Why this script?
+We updated/fixed the data of some canteens after they teledeclared.
+To reflect the changes in the Teledeclaration objects, we need to cancel and re-submit these teledeclarations.
+
+Ran on 2025-04-16 (Campaign for 2024)
+"""
+
+from django.core.management.base import BaseCommand
+
+from data.models import Canteen, Teledeclaration
+
+CANTEEN_SIRET_LIST = ["21380397600017"]
+YEAR = 2024
+
+
+class Command(BaseCommand):
+    help = "Resubmit teledeclarations for a specified list of canteens"
+
+    def handle(self, *args, **options):
+        # init
+        teledeclaration_resubmitted_count = 0
+        canteen_qs = Canteen.objects.filter(siret__in=CANTEEN_SIRET_LIST)
+
+        # loop on each canteen
+        for canteen in canteen_qs:
+            # canteen must have submitted a TD during the campaign
+            canteen_td_submitted_for_year_qs = Teledeclaration.objects.filter(canteen=canteen).submitted_for_year(YEAR)
+            if not canteen_td_submitted_for_year_qs.exists():
+                print(f"No teledeclaration for canteen {canteen.siret} for year {YEAR}")
+                continue  # skip canteen
+            canteen_td_submitted_for_year = canteen_td_submitted_for_year_qs.first()
+            # cancel TD
+            canteen_td_submitted_for_year.cancel()
+            # recreate TD
+            try:
+                Teledeclaration.create_from_diagnostic(
+                    diagnostic=canteen_td_submitted_for_year.diagnostic,
+                    applicant=canteen_td_submitted_for_year.applicant,
+                )
+                teledeclaration_resubmitted_count += 1
+            except Exception as e:
+                print(f"Failed to resubmit teledeclaration for canteen {canteen.siret} for year {YEAR}")
+                print(e)
+                continue
+
+        print("Done!")
+        print("SIRET in input list:", len(CANTEEN_SIRET_LIST))
+        print("Canteen found", canteen_qs.count())
+        print("Teledeclarations resubmitted:", teledeclaration_resubmitted_count)

--- a/macantine/management/commands/canteen_teledeclaration_resubmit.py
+++ b/macantine/management/commands/canteen_teledeclaration_resubmit.py
@@ -4,9 +4,9 @@ We updated/fixed the data of some canteens after they teledeclared.
 To reflect the changes in the Teledeclaration objects, we need to cancel and re-submit these teledeclarations.
 
 How to run?
-python manage.py 20250416_canteen_td_resubmit --year 2024 --canteen-siret-list 12345678901234,23456789012345
+python manage.py canteen_teledeclaration_resubmit --year 2024 --canteen-siret-list 12345678901234,23456789012345
 
-Ran on 2025-04-16 (Campaign for 2024)
+Ran on 2025-04-18 (Campaign for 2024)
 """
 
 from django.core.management.base import BaseCommand


### PR DESCRIPTION
### Quoi

Script qui permet, pour une liste de SIRET donné (et une année), de les re-télédéclarer
- il faut que ces cantines aient une TD de SUBMITTED pendant les dates de la campagne
- on les cancel, puis re-create

### Pourquoi

Voir https://www.notion.so/incubateur-masa/1a2de24614be810c8436d361b1b866d8?v=1a2de24614be818290f0000c3eddc9db&p=1d5de24614be802286f9c2028f801d7b&pm=s

### Note

Je l'ai mis en management commands (initialement dans le dossier `/script`, mais je n'ai pas accès à l'app (et les modèles) Django...)