### PR TITLE
fix(Campagne de correction): ne pas afficher les boutons "télédéclarer" si aucun bilan n'a été déclaré

### DIFF
--- a/frontend/src/components/AnnualActionableCanteensTable.vue
+++ b/frontend/src/components/AnnualActionableCanteensTable.vue
@@ -164,7 +164,7 @@
 <script>
 import TeledeclarationPreview from "@/components/TeledeclarationPreview"
 import DataInfoBadge from "@/components/DataInfoBadge"
-import { lastYear } from "@/utils"
+import { lastYear, actionIsTeledeclare } from "@/utils"
 
 export default {
   name: "AnnualActionableCanteensTable",
@@ -405,7 +405,7 @@ export default {
       }
     },
     action(canteen) {
-      if (canteen.action === "40_teledeclare") {
+      if (actionIsTeledeclare(canteen.action)) {
         this.canteenForTD = canteen
         this.showTeledeclarationPreview = true
       }

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -680,6 +680,10 @@ export const readyToTeledeclare = (canteen, diagnostic, sectors) => {
   )
 }
 
+export const actionIsTeledeclare = (action) => {
+  return action === "40_teledeclare"
+}
+
 // for diagnostics created before the redesign launched in 2024, many null values
 // were interpreted as false. Since then, we ask for an explicit false value.
 export const diagnosticUsesNullAsFalse = (diagnostic) => {

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -91,7 +91,7 @@
       </v-card-actions>
     </v-card>
     <v-card
-      v-else-if="diagnosticCanBeTeledeclared"
+      v-else-if="diagnosticCanBeTeledeclared && actionIsTeledeclare"
       class="pa-6 pb-2 pb-sm-6 my-6 fr-text grey--text text--darken-3 text-center cta-block"
     >
       <div v-if="tunnelFilled">
@@ -144,6 +144,7 @@ import {
   hasSatelliteInconsistency,
   hasFinishedMeasureTunnel,
   actionIsTeledeclare,
+  diagnosticCanBeTeledeclared,
 } from "@/utils"
 import FoodWasteCard from "./FoodWasteCard"
 import DiversificationCard from "./DiversificationCard"
@@ -239,6 +240,9 @@ export default {
       )
     },
     diagnosticCanBeTeledeclared() {
+      return diagnosticCanBeTeledeclared(this.canteen, this.canteenDiagnostic)
+    },
+    actionIsTeledeclare() {
       return actionIsTeledeclare(this.canteenAction)
     },
     inTeledeclarationCampaign() {

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -143,6 +143,7 @@ import {
   missingCanteenData,
   hasSatelliteInconsistency,
   hasFinishedMeasureTunnel,
+  actionIsTeledeclare,
 } from "@/utils"
 import FoodWasteCard from "./FoodWasteCard"
 import DiversificationCard from "./DiversificationCard"
@@ -238,7 +239,7 @@ export default {
       )
     },
     diagnosticCanBeTeledeclared() {
-      return this.canteenAction === "40_teledeclare"
+      return actionIsTeledeclare(this.canteenAction)
     },
     inTeledeclarationCampaign() {
       return inTeledeclarationCampaign(this.year)

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -139,7 +139,6 @@ import {
   lastYear,
   customDiagnosticYears,
   readyToTeledeclare,
-  diagnosticCanBeTeledeclared,
   inTeledeclarationCampaign,
   missingCanteenData,
   hasSatelliteInconsistency,
@@ -239,7 +238,7 @@ export default {
       )
     },
     diagnosticCanBeTeledeclared() {
-      return diagnosticCanBeTeledeclared(this.canteen, this.canteenDiagnostic)
+      return this.canteenAction === "40_teledeclare"
     },
     inTeledeclarationCampaign() {
       return inTeledeclarationCampaign(this.year)

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -241,10 +241,7 @@
                     Données télédéclarées
                   </v-btn>
                   <v-btn
-                    v-else-if="
-                      readyToTeledeclare &&
-                        (inTeledeclarationCampaign || (inCorrectionCampaign && hasCancelledTeledeclaration))
-                    "
+                    v-else-if="readyToTeledeclare && actionIsTeledeclare"
                     color="primary"
                     @click="showTeledeclarationPreview = true"
                     class="fr-text font-weight-medium"
@@ -364,11 +361,14 @@ export default {
     mobileSelectItems() {
       return this.tabHeaders.map((x, index) => ({ text: x.text, value: index }))
     },
+    actionIsTeledeclare() {
+      return actionIsTeledeclare(this.canteenAction)
+    },
     hasCancelledTeledeclaration() {
       // During the correction campaign, we allow only canteens with an existing teledeclaration to do corrections
       // BUT the backend does not return CANCELLED teledeclarations
       // instead we look at the canteen's action
-      return actionIsTeledeclare(this.canteenAction)
+      return this.actionIsTeledeclare
     },
     hasActiveTeledeclaration() {
       return this.diagnostic?.teledeclaration?.status === "SUBMITTED"

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -288,6 +288,7 @@ import {
   hasDiagnosticApproData,
   missingCanteenData,
   hasSatelliteInconsistency,
+  actionIsTeledeclare,
 } from "@/utils"
 import keyMeasures from "@/data/key-measures.json"
 import Constants from "@/constants"
@@ -367,7 +368,7 @@ export default {
       // During the correction campaign, we allow only canteens with an existing teledeclaration to do corrections
       // BUT the backend does not return CANCELLED teledeclarations
       // instead we look at the canteen's action
-      return this.canteenAction === "40_teledeclare"
+      return actionIsTeledeclare(this.canteenAction)
     },
     hasActiveTeledeclaration() {
       return this.diagnostic?.teledeclaration?.status === "SUBMITTED"

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -241,7 +241,10 @@
                     Données télédéclarées
                   </v-btn>
                   <v-btn
-                    v-else-if="readyToTeledeclare"
+                    v-else-if="
+                      readyToTeledeclare &&
+                        (inTeledeclarationCampaign || (inCorrectionCampaign && hasCancelledTeledeclaration))
+                    "
                     color="primary"
                     @click="showTeledeclarationPreview = true"
                     class="fr-text font-weight-medium"


### PR DESCRIPTION
## Description

Lors de la campagne de correction, les boutons de télédéclaration doivent s'afficher uniquement si le bilan a été télédéclaré

## Prévisualisation 

|Si TD| Sans TD|
|--|--|
| <img width="1238" alt="Capture d’écran 2025-04-16 à 12 30 41" src="https://github.com/user-attachments/assets/df579d33-9bda-48d3-b8b4-8a7b77d6bc93" /> | <img width="1259" alt="Capture d’écran 2025-04-16 à 12 31 10" src="https://github.com/user-attachments/assets/f6fa55f9-0a66-41f9-acdf-dd0fe04d2336" /> |
| <img width="1039" alt="Capture d’écran 2025-04-16 à 12 33 33" src="https://github.com/user-attachments/assets/f94895da-1cc7-48f4-9f06-513f0afa3a6b" /> | <img width="1006" alt="Capture d’écran 2025-04-16 à 12 31 37" src="https://github.com/user-attachments/assets/b72d285f-1e3c-417f-a689-324837cbfcc8" /> | 