### PR TITLE
fix(Campagne de correction): corrige le nombre de télédéclarations en masse disponibles

### DIFF
--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -661,8 +661,7 @@ class TestDiagnosticsApi(APITestCase):
             canteen=canteen_with_correction, year=last_year, value_total_ht=10000
         )
         teledeclaration_cancelled = Teledeclaration.create_from_diagnostic(diag_cancelled, authenticate.user)
-        teledeclaration_cancelled.status = Teledeclaration.TeledeclarationStatus.CANCELLED
-        teledeclaration_cancelled.save()
+        teledeclaration_cancelled.cancel()
 
         # API : Force correction campaign without changing dates
         with patch("api.views.diagnostic.is_in_correction", lambda: True):

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -146,11 +146,11 @@ class DiagnosticsToTeledeclareListView(ListAPIView):
     def get_queryset(self):
         year = self.request.parser_context.get("kwargs").get("year")
         canteens = DiagnosticsToTeledeclareListView._get_canteens_filled(self.request.user.canteens.all())
-        has_teledeclaration_submitted = Teledeclaration.objects.filter(
-            diagnostic=OuterRef("pk"), status=Teledeclaration.TeledeclarationStatus.SUBMITTED, year=year
+        has_teledeclaration_submitted = (
+            Teledeclaration.objects.filter(diagnostic=OuterRef("pk")).in_year(year).submitted()
         )
-        has_teledeclaration_cancelled = Teledeclaration.objects.filter(
-            diagnostic=OuterRef("pk"), status=Teledeclaration.TeledeclarationStatus.CANCELLED, year=year
+        has_teledeclaration_cancelled = (
+            Teledeclaration.objects.filter(diagnostic=OuterRef("pk")).in_year(year).cancelled()
         )
         diagnostics_to_teledeclare = (
             Diagnostic.objects.is_filled()

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -3,6 +3,7 @@ import logging
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import IntegrityError
+from django.db.models import Exists, OuterRef
 from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
@@ -145,32 +146,25 @@ class DiagnosticsToTeledeclareListView(ListAPIView):
     def get_queryset(self):
         year = self.request.parser_context.get("kwargs").get("year")
         canteens = DiagnosticsToTeledeclareListView._get_canteens_filled(self.request.user.canteens.all())
-        diagnostics_filled = Diagnostic.objects.is_filled().filter(
-            year=year,
-            canteen__in=canteens,
-            diagnostic_type__isnull=False,
+        has_teledeclaration_submitted = Teledeclaration.objects.filter(
+            diagnostic=OuterRef("pk"), status=Teledeclaration.TeledeclarationStatus.SUBMITTED, year=year
         )
-        teledeclared = (
-            Teledeclaration.objects.filter(
-                diagnostic__in=diagnostics_filled, status=Teledeclaration.TeledeclarationStatus.SUBMITTED
-            )
-            .values_list("diagnostic__id", flat=True)
-            .distinct()
+        has_teledeclaration_cancelled = Teledeclaration.objects.filter(
+            diagnostic=OuterRef("pk"), status=Teledeclaration.TeledeclarationStatus.CANCELLED, year=year
+        )
+        diagnostics_to_teledeclare = (
+            Diagnostic.objects.is_filled()
+            .filter(year=year, canteen__in=canteens, diagnostic_type__isnull=False)
+            .annotate(has_teledeclaration_submitted=Exists(has_teledeclaration_submitted))
+            .annotate(has_teledeclaration_cancelled=Exists(has_teledeclaration_cancelled))
         )
 
-        diagnostics_to_deledeclare = diagnostics_filled.exclude(id__in=teledeclared)
+        diagnostics_to_teledeclare = diagnostics_to_teledeclare.exclude(has_teledeclaration_submitted=True)
 
         if is_in_correction():
-            cancelled = (
-                Teledeclaration.objects.filter(
-                    diagnostic__in=diagnostics_filled, status=Teledeclaration.TeledeclarationStatus.CANCELLED
-                )
-                .values_list("diagnostic__id", flat=True)
-                .distinct()
-            )
-            diagnostics_to_deledeclare = diagnostics_to_deledeclare.filter(id__in=cancelled)
+            diagnostics_to_teledeclare = diagnostics_to_teledeclare.filter(has_teledeclaration_cancelled=True)
 
-        return diagnostics_to_deledeclare
+        return diagnostics_to_teledeclare
 
     @staticmethod
     def _get_canteens_filled(canteens):

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -57,6 +57,9 @@ class TeledeclarationQuerySet(models.QuerySet):
     def submitted(self):
         return self.filter(status=Teledeclaration.TeledeclarationStatus.SUBMITTED)
 
+    def cancelled(self):
+        return self.filter(status=Teledeclaration.TeledeclarationStatus.CANCELLED)
+
     def aberrant_values(self):
         return self.exclude(meal_price__gt=20, value_total_ht__gt=1000000)
 


### PR DESCRIPTION
## Description

Lors de la campagne de correction le nombre de télédéclarations en masse disponible ne doit pas prendre en compte les diagnostiques non télédéclarés précédemment.

## Prévisualisation

|Avant| Après|
|--|--|
| <img width="1235" alt="Capture d’écran 2025-04-16 à 14 29 40" src="https://github.com/user-attachments/assets/69699756-65ba-4266-9c50-f2f117ff0a82" /> | <img width="1223" alt="Capture d’écran 2025-04-16 à 14 30 03" src="https://github.com/user-attachments/assets/ed436574-677e-4b74-8a97-206ba3debbe6" /> |