### PR TITLE
fix(Badge): ajoute le champ secteurs aux champs obligatoires pour télédéclarer

### DIFF
--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -1188,7 +1188,9 @@ class TestCanteenActionApi(APITestCase):
         """
         Check that this endpoint can return the summary for a specified canteen
         """
-        canteen = CanteenFactory.create(id=3, production_type=Canteen.ProductionType.ON_SITE)
+        canteen = CanteenFactory.create(
+            id=3, production_type=Canteen.ProductionType.ON_SITE, sectors=[SectorFactory.create()]
+        )
         canteen.managers.add(authenticate.user)
 
         response = self.client.get(reverse("retrieve_actionable_canteen", kwargs={"pk": 3, "year": 2021}))
@@ -1210,6 +1212,7 @@ class TestCanteenActionApi(APITestCase):
             siret="75665621899905",
             city_insee_code="69123",
             economic_model=Canteen.EconomicModel.PUBLIC,
+            sectors=[SectorFactory.create()],
         )
         last_year = 2024
         complete.managers.add(authenticate.user)
@@ -1242,6 +1245,7 @@ class TestCanteenActionApi(APITestCase):
             siret="75665621899905",
             city_insee_code="69123",
             economic_model=Canteen.EconomicModel.PUBLIC,
+            sectors=[SectorFactory.create()],
         )
         last_year = 2024
         complete.managers.add(authenticate.user)
@@ -1288,6 +1292,7 @@ class TestCanteenActionApi(APITestCase):
             siret="75665621899905",
             city_insee_code="69123",
             economic_model=Canteen.EconomicModel.PUBLIC,
+            sectors=[SectorFactory.create()],
         )
         canteen_did_not_td = CanteenFactory.create(
             id=3,
@@ -1299,6 +1304,7 @@ class TestCanteenActionApi(APITestCase):
             city_insee_code="69123",
             economic_model=Canteen.EconomicModel.PUBLIC,
             management_type=Canteen.ManagementType.DIRECT,
+            sectors=[SectorFactory.create()],
         )
         last_year = 2024
         for canteen in [canteen_td, canteen_did_not_td]:

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -63,6 +63,7 @@ def is_central_cuisine_query():
 
 def has_missing_data_query():
     return (
+        # basic rules
         Q(name=None)
         | Q(city_insee_code=None)
         | Q(city_insee_code="")
@@ -71,14 +72,16 @@ def has_missing_data_query():
         | Q(production_type=None)
         | Q(management_type=None)
         | Q(economic_model=None)
-        | Q(sectors=None)
+        # serving-specific rules
         | Q(is_serving_query()) & (Q(daily_meal_count=None) | Q(daily_meal_count=0))
+        # satellite-specific rules
         | (is_satellite_query() & (Q(central_producer_siret=None) | Q(central_producer_siret="")))
         | (is_satellite_query() & Q(central_producer_siret=F("siret")))
+        # cc-specific rules
         | (is_central_cuisine_query() & (Q(satellite_canteens_count=None) | Q(satellite_canteens_count=0)))
-        | (
-            Q(economic_model=Canteen.EconomicModel.PUBLIC) & Q(requires_line_ministry=True) & Q(line_ministry=None)
-        )  # with annotate_with_requires_line_ministry()
+        # sectors & line_ministry (with annotate_with_requires_line_ministry)
+        | Q(sectors=None)
+        | (Q(economic_model=Canteen.EconomicModel.PUBLIC) & Q(requires_line_ministry=True) & Q(line_ministry=None))
     )
 
 

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -71,6 +71,7 @@ def has_missing_data_query():
         | Q(production_type=None)
         | Q(management_type=None)
         | Q(economic_model=None)
+        | Q(sectors=None)
         | Q(is_serving_query()) & (Q(daily_meal_count=None) | Q(daily_meal_count=0))
         | (is_satellite_query() & (Q(central_producer_siret=None) | Q(central_producer_siret="")))
         | (is_satellite_query() & Q(central_producer_siret=F("siret")))

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -385,3 +385,14 @@ class TestCanteenCompletePropertyAndQuerySet(TestCase):
     def test_has_missing_data_queryset(self):
         self.assertEqual(Canteen.objects.count(), 8)
         self.assertEqual(Canteen.objects.has_missing_data().count(), 4)
+
+    def test_sectors_is_required_field(self):
+        for canteen in [
+            self.canteen_central,
+            self.canteen_central_serving,
+            self.canteen_on_site,
+            self.canteen_on_site_central,
+        ]:
+            canteen.sectors.clear()
+            canteen.save()
+            self.assertFalse(canteen.is_filled)

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -6,9 +6,10 @@ from data.factories import (
     CanteenFactory,
     DiagnosticFactory,
     PurchaseFactory,
+    SectorFactory,
     TeledeclarationFactory,
 )
-from data.models import Canteen, Diagnostic, Teledeclaration
+from data.models import Canteen, Diagnostic, Sector, Teledeclaration
 
 
 class TestCanteenModel(TestCase):
@@ -297,12 +298,14 @@ class TestCanteenSiretOrSirenUniteLegaleQuerySet(TestCase):
 class TestCanteenCompletePropertyAndQuerySet(TestCase):
     @classmethod
     def setUpTestData(cls):
+        sector = SectorFactory.create(name="Sector", category=Sector.Categories.AUTRES)
         COMMON = {
             # CanteenFactory generates: name, city_insee_code, sectors
             "yearly_meal_count": 1000,
             "publication_status": Canteen.PublicationStatus.PUBLISHED,
             "management_type": Canteen.ManagementType.DIRECT,
             "economic_model": Canteen.EconomicModel.PUBLIC,
+            "sectors": [sector],
         }
         cls.canteen_central = CanteenFactory(
             **COMMON,

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -368,7 +368,7 @@ export default {
       // During the correction campaign, we allow only canteens with an existing teledeclaration to do corrections
       // BUT the backend does not return CANCELLED teledeclarations
       // instead we look at the canteen's action
-      const possibleActions = ["40_teledeclare", "35_fill_canteen_data", "30_fill_diagnostic"]
+      const possibleActions = ["40_teledeclare", "35_fill_canteen_data"]
       return possibleActions.includes(this.canteenAction)
     },
     hasActiveTeledeclaration() {

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -368,7 +368,8 @@ export default {
       // During the correction campaign, we allow only canteens with an existing teledeclaration to do corrections
       // BUT the backend does not return CANCELLED teledeclarations
       // instead we look at the canteen's action
-      return this.actionIsTeledeclare
+      const possibleActions = ["40_teledeclare", "35_fill_canteen_data", "30_fill_diagnostic"]
+      return possibleActions.includes(this.canteenAction)
     },
     hasActiveTeledeclaration() {
       return this.diagnostic?.teledeclaration?.status === "SUBMITTED"

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -89,7 +89,7 @@
             bilan pour votre établissement.
           </p>
         </div>
-        <div v-else-if="inTeledeclarationCampaign || (inCorrectionCampaign && hasCancelledTeledeclaration)">
+        <div v-else-if="inTeledeclarationCampaign || hasTeledeclarationToCorrect">
           <div v-if="isSatelliteWithApproCentralDiagnostic">
             <p>
               Votre livreur des repas
@@ -364,12 +364,12 @@ export default {
     actionIsTeledeclare() {
       return actionIsTeledeclare(this.canteenAction)
     },
-    hasCancelledTeledeclaration() {
+    hasTeledeclarationToCorrect() {
       // During the correction campaign, we allow only canteens with an existing teledeclaration to do corrections
       // BUT the backend does not return CANCELLED teledeclarations
       // instead we look at the canteen's action
-      const possibleActions = ["40_teledeclare", "35_fill_canteen_data"]
-      return possibleActions.includes(this.canteenAction)
+      const correctionActions = ["40_teledeclare", "35_fill_canteen_data"]
+      return this.inCorrectionCampaign && correctionActions.includes(this.canteenAction)
     },
     hasActiveTeledeclaration() {
       return this.diagnostic?.teledeclaration?.status === "SUBMITTED"


### PR DESCRIPTION
## Description

Pour télédéclarer son diagnostic en front on vérifie que le champ secteur est rempli. Cette vérification était manquante côté back, ce qui fait qu'on affichait un badge "Bilan à télédéclarer" au lieu de "Données à compléter".

## Prévisualisation
|Avant| Après|
|--|--|
| <img width="263" alt="Capture d’écran 2025-04-17 à 12 45 45" src="https://github.com/user-attachments/assets/548699d0-22f3-4df0-9fe8-e5ab28b22285" /> | <img width="207" alt="Capture d’écran 2025-04-17 à 14 26 26" src="https://github.com/user-attachments/assets/d9cd5203-af99-4056-ae97-8453e4addde2" /> |
| <img width="813" alt="Capture d’écran 2025-04-17 à 12 49 27" src="https://github.com/user-attachments/assets/b49762f9-71c6-489f-927c-0aa90111c84a" /> | <img width="1210" alt="Capture d’écran 2025-04-17 à 14 26 58" src="https://github.com/user-attachments/assets/67f57a03-5b5b-4543-9d8a-ce18f55860cc" /> |