### PR TITLE
refactor(Télédéclaration): enlève le check doublonné sur l'unicité de la TD par cantine et par année

### DIFF
--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -273,6 +273,7 @@ class TestTeledeclarationCreateApi(APITestCase):
         payload = {"diagnosticId": diagnostic.id}
         response = self.client.post(reverse("teledeclaration_create"), payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data[0], "Il existe déjà une télédéclaration en cours pour cette année")
 
     @freeze_time("2022-08-30")  # during the 2021 campaign
     @authenticate

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -233,21 +233,7 @@ class Teledeclaration(models.Model):
             pass
 
     def clean(self):
-        self.validate_uniqueness()
         return super().clean()
-
-    def validate_uniqueness(self):
-        """
-        Verify there is only one submitted declaration per year/canteen
-        at any given time.
-        """
-        if self.status == self.TeledeclarationStatus.SUBMITTED:
-            duplicates = Teledeclaration.objects.filter(
-                canteen=self.canteen, year=self.year, status=self.status
-            ).exclude(id=self.id)
-            message = "Il existe déjà une télédéclaration en cours pour cette année"
-            if duplicates.count() > 0:
-                raise ValidationError({"year": message})
 
     @staticmethod
     def should_use_central_kitchen_appro(diagnostic):

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -232,9 +232,6 @@ class Teledeclaration(models.Model):
         except Exception:
             pass
 
-    def clean(self):
-        return super().clean()
-
     @staticmethod
     def should_use_central_kitchen_appro(diagnostic):
         is_satellite = diagnostic.canteen.production_type == Canteen.ProductionType.ON_SITE_CENTRAL


### PR DESCRIPTION
Il y a déjà un check dans les `constraints`.
Pas besoin d'avoir la même chose (avec appels à la DB) dans le `clean`.