### PR TITLE
refactor(Celery): modifier la configuration pour avoir le nom de la tâche

### DIFF
--- a/macantine/celery.py
+++ b/macantine/celery.py
@@ -20,7 +20,7 @@ dotenv.load_dotenv()
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "macantine.settings")
 
 app = Celery("macantine", broker=os.getenv("REDIS_URL"), backend="django-db", include=["macantine.tasks"])
-app.worker_hijack_root_logger = False
+app.config_from_object(dict(worker_hijack_root_logger=False, result_extended=True))
 
 hourly = crontab(hour="*", minute=0, day_of_week="*")  # Every hour
 midnights = crontab(hour=0, minute=0, day_of_week="*")  # Every day at midnight


### PR DESCRIPTION
(bon toujours une galère je trouve la doc de Celery)

Dans l'admin je trouvais bizarre qu'on n'ait aucune info sur les tâches de lancées, alors qu'on a setup https://django-celery-results.readthedocs.io/en/latest/index.html

![image](https://github.com/user-attachments/assets/a1f8ae23-a12d-4466-b511-e28aeea6c879)

En regardant cette issue - https://github.com/celery/django-celery-results/issues/334 - j'ai l'impression qu'on lance mal la config.
Du coup j'ai rajouté un `result_extended=True` + basculé la config dans `config_from_object`

### Test sur staging

||Avant|Après|
|-|-|-|
|Liste|![image](https://github.com/user-attachments/assets/e9fd6ec4-bf0e-42ae-af82-449b53487fa2)|![image](https://github.com/user-attachments/assets/cf7c983e-bef4-44b3-b52e-a44f96f77051)|
|Details|![image](https://github.com/user-attachments/assets/6c027cf5-aac2-4068-8f3d-7554e472a747)|![image](https://github.com/user-attachments/assets/f981bba1-a5e5-44e5-8117-379622152c45)|