### PR TITLE
fix(Campagne de correction): ajout d'actions pour afficher la sidebar lors de la campagne correction

### DIFF
--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -368,7 +368,7 @@ export default {
       // During the correction campaign, we allow only canteens with an existing teledeclaration to do corrections
       // BUT the backend does not return CANCELLED teledeclarations
       // instead we look at the canteen's action
-      const correctionActions = ["40_teledeclare", "35_fill_canteen_data"]
+      const correctionActions = ["40_teledeclare", "35_fill_canteen_data", "30_fill_diagnostic", "10_add_satellites"]
       return this.inCorrectionCampaign && correctionActions.includes(this.canteenAction)
     },
     hasActiveTeledeclaration() {


### PR DESCRIPTION
## Description

Lors de la campagne de correction on se base sur les actions renvoyées par le back-end pour afficher ou non à l'utilisateur la sidebar avec le détail des volets EGalim à remplir. 

Il manquait des actions à la liste et cela empêchait l'affichage du bouton "télédéclarer" : 
- "10_add_satellites" : dans le cas où une cuisine centrale supprimait ses sats durant la campagne de correction
- "30_fill_diagnostic" : si la cantine n'avait pas de valeur total ht de renseigner (impossible car champ obligatoire en front) mais je l'ajoute pour la suite, quand on déplacera les vérification en back-end uniquement

## Prévisualisation

|Avant|Après|
|--|--|
| <img width="638" alt="Capture d’écran 2025-04-30 à 17 00 53" src="https://github.com/user-attachments/assets/69208923-d050-4afc-9d59-4b1236442e81" /> | <img width="632" alt="Capture d’écran 2025-04-30 à 17 01 28" src="https://github.com/user-attachments/assets/6ceada8a-a68d-4675-a1ec-9cfb72584245" /> |