### PR TITLE
refactor(Achats): source de création: enlève une property obsolète

### DIFF
--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -27,13 +27,11 @@ class PurchaseSerializer(serializers.ModelSerializer):
             "local_definition",
             "import_source",
             "creation_source",
-            "created_by_import",
         )
         read_only_fields = (
             "id",
             "creation_date",
             "modification_date",
-            "created_by_import",
         )
 
     def create(self, validated_data):

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -133,7 +133,3 @@ class Purchase(SoftDeletionModel):
             except Exception:
                 pass
         return ", ".join(valid_characteristics) if valid_characteristics else None
-
-    @property
-    def created_by_import(self):
-        return bool(self.import_source) and self.import_source != "Duplication"

--- a/frontend/src/views/DashboardManager/PurchasesWidget.vue
+++ b/frontend/src/views/DashboardManager/PurchasesWidget.vue
@@ -98,7 +98,7 @@ export default {
     },
     purchaseDataSourceString() {
       if (!this.purchases.length) return
-      return this.purchases[0].createdByImport ? "import en masse" : "ajout manuel"
+      return this.purchases[0].creationSource === "APP" ? "ajout manuel" : "import en masse"
     },
     purchasesDelegated() {
       return this.canteen.productionType === "site_cooked_elsewhere"


### PR DESCRIPTION
Suite de #5293 & #5321

Achats: plus besoin de la property `created_by_import`, on utilise `creation_source` à la place