### PR TITLE
fix(GeoBot): Augmenter la valeur du Geolocation Bot Attempt

### DIFF
--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -240,7 +240,7 @@ def _get_candidate_canteens_for_code_geobot():
     candidate_canteens = (
         Canteen.objects.filter(Q(city=None) | Q(department=None) | Q(city_insee_code=None) | Q(postal_code=None))
         .filter(Q(postal_code__isnull=False) | Q(city_insee_code__isnull=False))
-        .filter(geolocation_bot_attempts__lt=10)
+        .filter(geolocation_bot_attempts__lt=20)
         .annotate(postal_code_len=Length("postal_code"))
         .annotate(city_insee_code_len=Length("city_insee_code"))
         .filter(Q(postal_code_len=5) | Q(city_insee_code_len=5))

--- a/macantine/tests/test_geolocation_bot.py
+++ b/macantine/tests/test_geolocation_bot.py
@@ -83,7 +83,7 @@ class TestGeolocationBot(TestCase):
             ),
         ]
         _ = [
-            CanteenFactory.create(city=None, geolocation_bot_attempts=10, postal_code="69003"),
+            CanteenFactory.create(city=None, geolocation_bot_attempts=20, postal_code="69003"),
             CanteenFactory.create(
                 city=None,
                 geolocation_bot_attempts=0,


### PR DESCRIPTION
Le geobot ne tourne plus pour ~1000 cantines car le geo bot a déjà tourné 10 fois sur ces cantines.
Fautes de logs, nous ne savons pas pourquoi le geo bot avait failé avec ces cantines.

Un test api sur l'un des codes insee nous montre que la requête aurait du fonctionner