### PR TITLE
improve(Metabase): Cantines: afficher la valeur du ministère de tutelle (au lieu du champ en DB)

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -714,7 +714,10 @@ class CanteenMetabaseSerializer(serializers.ModelSerializer):
         return obj.central_producer_siret
 
     def get_ministere_tutelle(self, obj):
-        return obj.line_ministry
+        if obj.line_ministry:
+            return Canteen.Ministries(obj.line_ministry).label
+        else:
+            return "inconnu"
 
     def get_secteur(self, obj):
         sectors = [sector.name for sector in obj.sectors.all()]


### PR DESCRIPTION
Metabase : comme les champs `economic_model`, `management_type` & `production_type`
On souhaite afficher la valeur "complète" du champ `line_ministry` dans les exports