### PR TITLE
refactor(Secteurs): bouge le filtrage SPE dans une queryset dédiée

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -6,7 +6,6 @@ from rest_framework import serializers
 from data.department_choices import get_lib_department_from_code
 from data.models import Canteen, CanteenImage, Diagnostic, Sector
 from data.region_choices import get_lib_region_from_code
-from macantine.etl.utils import SECTEURS_SPE
 
 from .diagnostic import (
     ApproDiagnosticSerializer,
@@ -737,7 +736,7 @@ class CanteenMetabaseSerializer(serializers.ModelSerializer):
         return ",".join(categories)
 
     def get_spe(self, obj):
-        if obj.sectors.filter(pk__in=SECTEURS_SPE):
+        if obj.sectors.is_spe().exists():
             return "Oui"
         else:
             return "Non"

--- a/data/models/sector.py
+++ b/data/models/sector.py
@@ -1,13 +1,23 @@
 from django.db import models
 
+# 26 : Administration : Etablissements publics d’Etat (EPA ou EPIC)
+# 24 : Administration : Restaurants des prisons
+# 23 : Administration : Restaurants administratifs d’Etat (RA)
+# 22 : Administration : Restaurants des armées / police / gendarmerie
+# 4 : Administration : Restaurants inter-administratifs d’Etat (RIA)
+# 2 : Education : Supérieur et Universitaire
+SECTEURS_SPE = [26, 24, 23, 22, 4, 2]
+
+
+class SectorQuerySet(models.QuerySet):
+    def is_spe(self):
+        return self.filter(id__in=SECTEURS_SPE)
+
 
 class Sector(models.Model):
     class Meta:
         verbose_name = "secteur d'activité"
         verbose_name_plural = "secteurs d'activité"
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
 
     class Categories(models.TextChoices):
         ADMINISTRATION = "administration", "Administration"
@@ -17,6 +27,11 @@ class Sector(models.Model):
         SOCIAL = "social", "Social / Médico-social"
         LEISURE = "leisure", "Loisirs"
         AUTRES = "autres", "Autres"
+
+    objects = models.Manager.from_queryset(SectorQuerySet)()
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
 
     name = models.TextField()
     category = models.CharField(

--- a/data/tests/test_sector.py
+++ b/data/tests/test_sector.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+
+from data.factories import SectorFactory
+from data.models import Sector
+
+
+class SectorQuerySetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.sector = SectorFactory(id=1)
+        cls.sector_spe = SectorFactory(id=2)  # based on the id
+
+    def test_is_spe(self):
+        self.assertEqual(Sector.objects.count(), 2)
+        self.assertEqual(Sector.objects.is_spe().count(), 1)

--- a/macantine/etl/utils.py
+++ b/macantine/etl/utils.py
@@ -9,16 +9,9 @@ import requests
 
 from common.api.decoupage_administratif import fetch_communes, fetch_epcis
 from data.models import Sector, Teledeclaration
+from data.models.sector import SECTEURS_SPE
 
 logger = logging.getLogger(__name__)
-
-# 26 : Administration : Etablissements publics d’Etat (EPA ou EPIC)
-# 24 : Administration : Restaurants des prisons
-# 23 : Administration : Restaurants administratifs d’Etat (RA)
-# 22 : Administration : Restaurants des armées / police / gendarmerie
-# 4 : Administration : Restaurants inter-administratifs d’Etat (RIA)
-# 2 : Education : Supérieur et Universitaire
-SECTEURS_SPE = [26, 24, 23, 22, 4, 2]
 
 
 def common_members(a, b):


### PR DESCRIPTION
Nouveau queryset `Sector.is_spe()` et bouge la logique métier dans le modèle (au lieu d'un utils)