### PR TITLE
fix(Metabase): Corriger la colonne objectif_zone_geo

### DIFF
--- a/macantine/etl/analysis.py
+++ b/macantine/etl/analysis.py
@@ -306,7 +306,7 @@ class ETL_ANALYSIS_TELEDECLARATIONS(ANALYSIS, etl.TELEDECLARATIONS):
         self.df["diagnostic_type"] = self.df["teledeclaration.diagnostic_type"].apply(get_diagnostic_type)
         # Add geo data
         self.df["nbre_cantines_region"] = self.df["canteen.region"].apply(get_nbre_cantines_region)
-        self.df["objectif_zone_geo"] = self.df["canteen.region"].apply(get_objectif_zone_geo)
+        self.df["objectif_zone_geo"] = self.df["canteen.department"].apply(get_objectif_zone_geo)
         # Combine columns
         self.df["teledeclaration.value_somme_egalim_avec_bio_ht"] = self.df.apply(get_egalim_avec_bio, axis=1)
         self.df["teledeclaration.value_somme_egalim_hors_bio_ht"] = self.df.apply(get_egalim_hors_bio, axis=1)


### PR DESCRIPTION
Il y a actuellement des erreurs sur la colonne `objectif_zone_geo`, dont le but est de caractériser la réglementation d'une une TD en fonction de sa zone géographique.
Actuellement, au lieu de spécifier : 
* France Métropolitaine
* DROM (Hors Mayotte)
* DROM (Mayotte)

nous n'avions que du France Métropolitaine, avec des DROM caractérisées telles que France Métropolitaine.
