### PR TITLE
refactor(API Recherche Entreprise): renvoyer aussi l'EPCI et la region

### DIFF
--- a/common/api/recherche_entreprises.py
+++ b/common/api/recherche_entreprises.py
@@ -68,6 +68,8 @@ def fetch_geo_data_from_siren(siren, response):
                 response["postalCode"] = etablissement["code_postal"]
                 response["city"] = etablissement["libelle_commune"]
                 response["department"] = etablissement["departement"]
+                response["region"] = etablissement["region"]
+                response["epci"] = etablissement["epci"]
                 return response
             except KeyError as e:
                 logger.error(
@@ -115,6 +117,9 @@ def fetch_geo_data_from_siret(siret, response):
                 response["cityInseeCode"] = etablissement["commune"]
                 response["postalCode"] = etablissement["code_postal"]
                 response["city"] = etablissement["libelle_commune"]
+                # response["department"] = etablissement["departement"]  # not in response
+                response["region"] = etablissement["region"]
+                response["epci"] = etablissement["epci"]
                 return response
             except KeyError as e:
                 logger.error(

--- a/common/api/recherche_entreprises.py
+++ b/common/api/recherche_entreprises.py
@@ -7,7 +7,7 @@ from common.utils import siret as utils_siret
 logger = logging.getLogger(__name__)
 
 
-RECHERCHE_ENTREPRISE_API_URL = "https://recherche-entreprises.api.gouv.fr/search"
+RECHERCHE_ENTREPRISES_API_URL = "https://recherche-entreprises.api.gouv.fr/search"
 DEFAULT_PARAMS = "etat_administratif=A&page=1&per_page=1"
 
 
@@ -57,7 +57,7 @@ def fetch_geo_data_from_siren(siren, response):
 
     response["siren"] = siren
     try:
-        api_response = requests.get(f"{RECHERCHE_ENTREPRISE_API_URL}?{DEFAULT_PARAMS}&q={siren}")
+        api_response = requests.get(f"{RECHERCHE_ENTREPRISES_API_URL}?{DEFAULT_PARAMS}&q={siren}")
         api_response.raise_for_status()
         result = validate_result(siren, api_response)
         if result:
@@ -107,7 +107,7 @@ def fetch_geo_data_from_siret(siret, response):
 
     response["siret"] = siret
     try:
-        api_response = requests.get(f"{RECHERCHE_ENTREPRISE_API_URL}?{DEFAULT_PARAMS}&q={siret}")
+        api_response = requests.get(f"{RECHERCHE_ENTREPRISES_API_URL}?{DEFAULT_PARAMS}&q={siret}")
         api_response.raise_for_status()
         result = validate_result(siret, api_response)
         if result:


### PR DESCRIPTION
l'API recherche entreprise renvoie pour le siège et les établissements des infos géo.
On se sert déjà du code postal et du code INSEE de la commune, ainsi que de son libellé.

Cette PR
- rend explicite le fait que cette API renvoi aussi le département (pour le siège seulement, pas pour les établissements), la région et le code EPCI
- fix une typo (s manquant)