### PR TITLE
refactor(API Adresse): gérer tous les appels à l'API dans un même fichier

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -50,7 +50,7 @@ from api.serializers import (
     SatelliteCanteenSerializer,
 )
 from api.views.utils import camelize, update_change_reason_with_auth
-from common.api.adresse import fetch_geo_data_from_api_entreprise_by_siret
+from common.api.adresse import fetch_geo_data_from_code
 from common.api.recherche_entreprises import (
     fetch_geo_data_from_siren,
     fetch_geo_data_from_siret,
@@ -466,7 +466,7 @@ class CanteenStatusBySiretView(APIView):
             city = response.get("city", None)
             postcode = response.get("postalCode", None)
             if city and postcode:
-                response = fetch_geo_data_from_api_entreprise_by_siret(response)
+                response = fetch_geo_data_from_code(response)
         return JsonResponse(response, status=status.HTTP_200_OK)
 
 

--- a/api/views/canteenimport.py
+++ b/api/views/canteenimport.py
@@ -17,7 +17,7 @@ from simple_history.utils import update_change_reason
 from api.permissions import IsAuthenticated
 from api.serializers import FullCanteenSerializer
 from common.api import validata
-from common.api.adresse import fetch_geo_data_by_csv
+from common.api.adresse import fetch_geo_data_from_code_csv
 from common.utils import file_import
 from common.utils.siret import normalise_siret
 from data.models import Canteen, ImportFailure, ImportType, Sector
@@ -236,7 +236,7 @@ class ImportCanteensView(APIView):
 
     def _update_location_data(self, locations_csv_str):
         try:
-            response = fetch_geo_data_by_csv(locations_csv_str)
+            response = fetch_geo_data_from_code_csv(locations_csv_str)
             for row in csv.reader(response.splitlines()):
                 if row[0] == "siret":
                     continue  # skip header

--- a/api/views/canteenimport.py
+++ b/api/views/canteenimport.py
@@ -3,7 +3,6 @@ import logging
 import re
 import time
 
-import requests
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
@@ -18,6 +17,7 @@ from simple_history.utils import update_change_reason
 from api.permissions import IsAuthenticated
 from api.serializers import FullCanteenSerializer
 from common.api import validata
+from common.api.adresse import fetch_geo_data_by_csv
 from common.utils import file_import
 from common.utils.siret import normalise_siret
 from data.models import Canteen, ImportFailure, ImportType, Sector
@@ -236,21 +236,8 @@ class ImportCanteensView(APIView):
 
     def _update_location_data(self, locations_csv_str):
         try:
-            # NB: max size of a csv file is 50 MB
-            response = requests.post(
-                "https://api-adresse.data.gouv.fr/search/csv/",
-                files={
-                    "data": ("locations.csv", locations_csv_str),
-                },
-                data={
-                    "postcode": "postcode",
-                    "citycode": "citycode",
-                    "result_columns": ["result_citycode", "result_postcode", "result_city", "result_context"],
-                },
-                timeout=4,
-            )
-            response.raise_for_status()  # Raise an exception if the request failed
-            for row in csv.reader(response.text.splitlines()):
+            response = fetch_geo_data_by_csv(locations_csv_str)
+            for row in csv.reader(response.splitlines()):
                 if row[0] == "siret":
                     continue  # skip header
                 if row[5] != "":  # city found, so rest of data is found

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -18,7 +18,7 @@ from simple_history.utils import update_change_reason
 
 from api.permissions import IsAuthenticated
 from api.serializers import FullCanteenSerializer
-from common.api.adresse import fetch_geo_data_by_csv
+from common.api.adresse import fetch_geo_data_from_code_csv
 from common.utils import file_import
 from common.utils.siret import normalise_siret
 from data.models import Canteen, ImportFailure, ImportType, Sector
@@ -289,7 +289,7 @@ class ImportDiagnosticsView(ABC, APIView):
 
     def _update_location_data(self, locations_csv_str):
         try:
-            response = fetch_geo_data_by_csv(locations_csv_str)
+            response = fetch_geo_data_from_code_csv(locations_csv_str)
             for row in csv.reader(response.splitlines()):
                 if row[0] == "siret":
                     continue  # skip header

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -5,7 +5,6 @@ import time
 from abc import ABC, abstractmethod
 from decimal import Decimal, InvalidOperation
 
-import requests
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
@@ -19,6 +18,7 @@ from simple_history.utils import update_change_reason
 
 from api.permissions import IsAuthenticated
 from api.serializers import FullCanteenSerializer
+from common.api.adresse import fetch_geo_data_by_csv
 from common.utils import file_import
 from common.utils.siret import normalise_siret
 from data.models import Canteen, ImportFailure, ImportType, Sector
@@ -289,21 +289,8 @@ class ImportDiagnosticsView(ABC, APIView):
 
     def _update_location_data(self, locations_csv_str):
         try:
-            # NB: max size of a csv file is 50 MB
-            response = requests.post(
-                "https://api-adresse.data.gouv.fr/search/csv/",
-                files={
-                    "data": ("locations.csv", locations_csv_str),
-                },
-                data={
-                    "postcode": "postcode",
-                    "citycode": "citycode",
-                    "result_columns": ["result_citycode", "result_postcode", "result_city", "result_context"],
-                },
-                timeout=4,
-            )
-            response.raise_for_status()  # Raise an exception if the request failed
-            for row in csv.reader(response.text.splitlines()):
+            response = fetch_geo_data_by_csv(locations_csv_str)
+            for row in csv.reader(response.splitlines()):
                 if row[0] == "siret":
                     continue  # skip header
                 if row[5] != "":  # city found, so rest of data is found

--- a/common/api/adresse.py
+++ b/common/api/adresse.py
@@ -46,3 +46,21 @@ def fetch_geo_data_from_api_entreprise_by_siret(response):
         logger.exception(f"Error completing location data with SIRET for city: {response['city']}")
         logger.exception(e)
     return response
+
+
+def fetch_geo_data_by_csv(csv_str, timeout=4):
+    # NB: max size of a csv file is 50 MB
+    response = requests.post(
+        ADRESSE_CSV_API_URL,
+        files={
+            "data": ("locations.csv", csv_str),
+        },
+        data={
+            "postcode": "postcode",
+            "citycode": "citycode",
+            "result_columns": ["result_citycode", "result_postcode", "result_city", "result_context"],
+        },
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.text

--- a/common/api/adresse.py
+++ b/common/api/adresse.py
@@ -7,12 +7,14 @@ from data.region_choices import Region
 logger = logging.getLogger(__name__)
 
 REGIONS_LIB = {i.label.split(" - ")[1]: i.value for i in Region}
+# ADRESSE_API_DOCUMENTATION: https://adresse.data.gouv.fr/outils/api-doc/adresse
+ADRESSE_API_URL = "https://api-adresse.data.gouv.fr/search"
 
 
 def fetch_geo_data_from_api_entreprise_by_siret(response):
     try:
         location_response = requests.get(
-            f"https://api-adresse.data.gouv.fr/search/?q={response['cityInseeCode']}&citycode={response['cityInseeCode']}&type=municipality&autocomplete=1"
+            f"{ADRESSE_API_URL}/?q={response['cityInseeCode']}&citycode={response['cityInseeCode']}&type=municipality&autocomplete=1"
         )
         if location_response.ok:
             location_response = location_response.json()

--- a/common/api/adresse.py
+++ b/common/api/adresse.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 REGIONS_LIB = {i.label.split(" - ")[1]: i.value for i in Region}
 # ADRESSE_API_DOCUMENTATION: https://adresse.data.gouv.fr/outils/api-doc/adresse
 ADRESSE_API_URL = "https://api-adresse.data.gouv.fr/search"
+ADRESSE_CSV_API_URL = "https://api-adresse.data.gouv.fr/search/csv"
 
 
 def fetch_geo_data_from_api_entreprise_by_siret(response):

--- a/common/api/adresse.py
+++ b/common/api/adresse.py
@@ -12,7 +12,7 @@ ADRESSE_API_URL = "https://api-adresse.data.gouv.fr/search"
 ADRESSE_CSV_API_URL = "https://api-adresse.data.gouv.fr/search/csv"
 
 
-def fetch_geo_data_from_api_entreprise_by_siret(response):
+def fetch_geo_data_from_code(response):
     try:
         location_response = requests.get(
             f"{ADRESSE_API_URL}/?q={response['cityInseeCode']}&citycode={response['cityInseeCode']}&type=municipality&autocomplete=1"
@@ -48,7 +48,7 @@ def fetch_geo_data_from_api_entreprise_by_siret(response):
     return response
 
 
-def fetch_geo_data_by_csv(csv_str, timeout=4):
+def fetch_geo_data_from_code_csv(csv_str, timeout=4):
     # NB: max size of a csv file is 50 MB
     response = requests.post(
         ADRESSE_CSV_API_URL,

--- a/macantine/management/commands/importcsv.py
+++ b/macantine/management/commands/importcsv.py
@@ -4,7 +4,7 @@ import logging
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError, transaction
 
-from common.api.adresse import fetch_geo_data_by_csv
+from common.api.adresse import fetch_geo_data_from_code_csv
 from data.models import Canteen, Diagnostic, ManagerInvitation
 
 logger = logging.getLogger(__name__)
@@ -143,7 +143,7 @@ class Command(BaseCommand):
     @staticmethod
     def _update_location_data(canteens, locations_csv_str):
         try:
-            response = fetch_geo_data_by_csv(locations_csv_str, timeout=100)
+            response = fetch_geo_data_from_code_csv(locations_csv_str, timeout=100)
             for row in csv.reader(response.splitlines()):
                 if row[0] == "siret":
                     continue  # skip header

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -15,7 +15,7 @@ from sib_api_v3_sdk.rest import ApiException
 
 import macantine.brevo as brevo
 from api.views.utils import update_change_reason
-from common.api.adresse import fetch_geo_data_by_csv
+from common.api.adresse import fetch_geo_data_from_code_csv
 from common.api.recherche_entreprises import fetch_geo_data_from_siret
 from data.models import Canteen, User
 
@@ -306,7 +306,7 @@ def fill_missing_geolocation_data_using_insee_code_or_postcode():
             continue
         try:
             location_csv_string = _get_location_csv_string(canteens)
-            response = fetch_geo_data_by_csv(location_csv_string, timeout=60)
+            response = fetch_geo_data_from_code_csv(location_csv_string, timeout=60)
             _fill_from_api_response(response, canteens)
         except requests.exceptions.HTTPError as e:
             logger.info(f"INSEE Geolocation Bot error: HTTPError\n{e}")


### PR DESCRIPTION
Nouveau fichier `common/api/adresse.py`

Pour gérer les appels à https://adresse.data.gouv.fr/outils/api-doc/adresse