### PR TITLE
refactor(API Decoupage Administratif): nouveau fichier pour centraliser les appels à cet API externe

### DIFF
--- a/api/views/statistics.py
+++ b/api/views/statistics.py
@@ -1,6 +1,5 @@
 import logging
 
-import requests
 from django.http import JsonResponse
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
@@ -8,6 +7,7 @@ from rest_framework.views import APIView
 
 from api.serializers import CanteenStatisticsSerializer
 from api.views.utils import camelize
+from common.api.decoupage_administratif import fetch_communes_from_epci
 from data.models import Canteen, Teledeclaration
 
 logger = logging.getLogger(__name__)
@@ -65,9 +65,8 @@ class CanteenStatisticsView(APIView):
     def _get_city_insee_codes(self, epcis):
         city_insee_codes = []
         for e in epcis:
-            response = requests.get(f"https://geo.api.gouv.fr/epcis/{e}/communes?fields=code", timeout=5)
-            response.raise_for_status()
-            city_insee_codes.extend(commune["code"] for commune in response.json())
+            response = fetch_communes_from_epci(e)
+            city_insee_codes.extend(commune["code"] for commune in response)
         return city_insee_codes
 
     def _filter_canteens(self, regions, departments, city_insee_codes, sectors):

--- a/common/api/decoupage_administratif.py
+++ b/common/api/decoupage_administratif.py
@@ -1,0 +1,27 @@
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+# DECOUPAGE_ADMINISTRATIF_DOCUMENTATION: https://geo.api.gouv.fr/decoupage-administratif
+DECOUPAGE_ADMINISTRATIF_API_URL = "https://geo.api.gouv.fr"
+
+
+def fetch_communes():
+    response = requests.get(f"{DECOUPAGE_ADMINISTRATIF_API_URL}/communes", timeout=50)
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_epcis():
+    response = requests.get(f"{DECOUPAGE_ADMINISTRATIF_API_URL}/epcis/?fields=nom", timeout=50)
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_communes_from_epci(epci):
+    response = requests.get(f"{DECOUPAGE_ADMINISTRATIF_API_URL}/epcis/{epci}/communes?fields=code", timeout=5)
+    response.raise_for_status()
+    return response.json()

--- a/macantine/etl/utils.py
+++ b/macantine/etl/utils.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import requests
 
+from common.api.decoupage_administratif import fetch_communes, fetch_epcis
 from data.models import Sector, Teledeclaration
 
 logger = logging.getLogger(__name__)
@@ -77,9 +78,7 @@ def map_communes_infos():
     commune_details = {}
     try:
         logger.info("Starting communes dl")
-        response_commune = requests.get("https://geo.api.gouv.fr/communes", timeout=50)
-        response_commune.raise_for_status()
-        communes = response_commune.json()
+        communes = fetch_communes()
         for commune in communes:
             commune_details[commune["code"]] = {}
             if "codeDepartement" in commune.keys():
@@ -97,9 +96,7 @@ def map_communes_infos():
 def map_epcis_code_name():
     try:
         epci_names = {}
-        response = requests.get("https://geo.api.gouv.fr/epcis/?fields=nom", timeout=50)
-        response.raise_for_status()
-        epcis = response.json()
+        epcis = fetch_epcis()
         for epci in epcis:
             epci_names[epci["code"]] = epci["nom"]
         return epci_names


### PR DESCRIPTION
Nouveau fichier `common/api/decoupage_administratif.py`

Pour gérer les appels API à https://geo.api.gouv.fr/decoupage-administratif