### PR TITLE
fix(Recherche): augmente le nombre de cantine renvoyées par page (3 -> 30)

### DIFF
--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -363,7 +363,7 @@ export default {
     const sectors = this.$store.state.sectors
     const user = this.$store.state.loggedUser
     return {
-      limit: 3,
+      limit: 30,
       departments: [],
       regions: [],
       sectors: [],

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -273,7 +273,7 @@
               :length="Math.ceil(publishedCanteenCount / limit)"
               :total-visible="5"
               v-if="publishedCanteenCount"
-              @input="pageChangedManually"
+              @input="scrollTop"
             />
           </div>
         </v-col>
@@ -778,9 +778,8 @@ export default {
     setLocation(location) {
       this.location = location
     },
-    pageChangedManually() {
-      // TODO: make this dependent on window height to avoid jumps for bigger screens
-      document.getElementById("filters-and-results").scrollIntoView({ behavior: "smooth" })
+    scrollTop() {
+      window.scrollTo(0, 0)
     },
   },
   watch: {


### PR DESCRIPTION
## Description

Lors d'une recherches les cantines étaient renvoyées par lot de 3, maintenant on passe à 30, qui était le nombre limite indiqué dans le code backend.

## Prévisualisation

|Avant|Après|
|--|--|
| <img width="603" alt="Capture d’écran 2025-05-12 à 16 00 06" src="https://github.com/user-attachments/assets/f34769ef-027b-49ea-b886-149cd1c17151" />| <img width="545" alt="Capture d’écran 2025-05-12 à 15 59 52" src="https://github.com/user-attachments/assets/27fed7d4-c151-484d-8484-59142ec275d9" /> |
