### PR TITLE
improve(Open Data): afficher le libellé complet du ministère de tutelle des cantines (au lieu du nom interne)

### DIFF
--- a/data/schemas/CHANGELOG_CANTINES.MD
+++ b/data/schemas/CHANGELOG_CANTINES.MD
@@ -2,6 +2,11 @@
 
 Tous les changements notables apportés aux jeux de données exposés sur data.gouv.fr vont être documentés ici.
 
+## 2025-05-12
+
+### Modification
+- La colonne 'line_ministry' renvoie maintenant le libellé complet du ministère de tutelle (au lieu du code interne)
+
 ## 2025-02-07
 
 ### Ajout
@@ -30,7 +35,6 @@ Tous les changements notables apportés aux jeux de données exposés sur data.g
 ### Ajout
 * Fichier au format parquet
 * Fichier au format xlsx
-
 
 ## 2024-02-07
 

--- a/data/schemas/CHANGELOG_CANTINES.MD
+++ b/data/schemas/CHANGELOG_CANTINES.MD
@@ -2,10 +2,10 @@
 
 Tous les changements notables apportés aux jeux de données exposés sur data.gouv.fr vont être documentés ici.
 
-## 2025-05-12
+## 2025-05-14
 
 ### Modification
-- La colonne 'line_ministry' renvoie maintenant le libellé complet du ministère de tutelle (au lieu du code interne)
+- La colonne 'line_ministry' renvoie maintenant le libellé complet du ministère de tutelle (au lieu de son nom interne)
 
 ## 2025-02-07
 

--- a/data/schemas/CHANGELOG_TELEDECLARATION.MD
+++ b/data/schemas/CHANGELOG_TELEDECLARATION.MD
@@ -2,6 +2,11 @@
 
 Tous les changements notables apportés aux jeux de données exposés sur data.gouv.fr vont être documentés ici.
 
+## 2025-05-14
+
+### Modification
+- La colonne 'canteen_line_ministry' renvoie maintenant le libellé complet du ministère de tutelle de la cantine (au lieu de son nom interne)
+
 ## 2024-04-03
 
 ### Ajouts
@@ -18,6 +23,5 @@ Tous les changements notables apportés aux jeux de données exposés sur data.g
 ## 2024-03-29
 
 ### Modification
-
 * Renommage des colonnes commençants pas 'cantine_' en 'canteen_'
 * Colonne 'canteen_sectors' : le format passe de `[{'id': 27, 'name': 'Secondaire lycée agricole', 'category': 'education', 'hasLineMinistry': False}, {'id': 87, 'name': 'Ecole primaire (maternelle et élémentaire)', 'category': 'education', 'hasLineMinistry': False}]` à `"[""Secondaire lycées agricole"", ""Ecole primaire (maternelle et élémentaire""]"` afin d'être compatible au format et alléger la colonne

--- a/data/schemas/export_opendata/schema_cantines.json
+++ b/data/schemas/export_opendata/schema_cantines.json
@@ -149,7 +149,7 @@
     },
     {
       "description": "Ministère de tutelle de la cantine, s'il y en a un",
-      "example": "Ministère de l'Education Nationale",
+      "example": "Éducation et Jeunesse",
       "name": "line_ministry",
       "title": "Ministère de tutelle",
       "type": "string"

--- a/data/schemas/export_opendata/schema_teledeclarations.json
+++ b/data/schemas/export_opendata/schema_teledeclarations.json
@@ -156,7 +156,7 @@
     },
     {
       "description": "Ministère de tutelle de la cantine, s'il y en a un",
-      "example": "Ministère de l'Education Nationale",
+      "example": "Éducation et Jeunesse",
       "name": "canteen_line_ministry",
       "title": "Ministère de tutelle",
       "type": "string"

--- a/macantine/etl/open_data.py
+++ b/macantine/etl/open_data.py
@@ -260,6 +260,8 @@ class ETL_OPEN_DATA_TELEDECLARATIONS(etl.TELEDECLARATIONS, OPEN_DATA):
         self._filter_by_ministry()
         logger.info("TD campagne : Filter errors...")
         self._filter_outsiders()
+        logger.info("TD campagne : Transform choice fields...")
+        self.transform_choice_fields(prefix="canteen_")
         logger.info("TD campagne : Transform sectors...")
         self.df["canteen_sectors"] = self.transform_sectors()
         logger.info("TD Campagne : Fill geo name...")

--- a/macantine/etl/open_data.py
+++ b/macantine/etl/open_data.py
@@ -20,6 +20,12 @@ class OPEN_DATA(etl.TRANSFORMER_LOADER):
     Abstract class implementing the specifity for open data export
     """
 
+    def transform_canteen_choice_fields(self, prefix=""):
+        # line_ministry
+        self.df[prefix + "line_ministry"] = self.df[prefix + "line_ministry"].apply(
+            lambda x: Canteen.Ministries(x).label if (x in Canteen.Ministries) else ""
+        )
+
     def transform_canteen_geo_data(self, prefix=""):
         logger.info("Start fetching communes details")
         communes_infos = macantine.etl.utils.map_communes_infos()
@@ -176,6 +182,9 @@ class ETL_OPEN_DATA_CANTEEN(etl.CANTEENS, OPEN_DATA):
         logger.info("Canteens : Clean dataset...")
         self._clean_dataset()
 
+        logger.info("Canteens : Transform choice fields...")
+        self.transform_canteen_choice_fields()
+
         logger.info("Canteens : Fill geo name...")
         start = time.time()
         self.transform_canteen_geo_data()
@@ -261,7 +270,7 @@ class ETL_OPEN_DATA_TELEDECLARATIONS(etl.TELEDECLARATIONS, OPEN_DATA):
         logger.info("TD campagne : Filter errors...")
         self._filter_outsiders()
         logger.info("TD campagne : Transform choice fields...")
-        self.transform_choice_fields(prefix="canteen_")
+        self.transform_canteen_choice_fields(prefix="canteen_")
         logger.info("TD campagne : Transform sectors...")
         self.df["canteen_sectors"] = self.transform_sectors()
         logger.info("TD Campagne : Fill geo name...")

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -28,6 +28,7 @@ class TestETLOpenData(TestCase):
             department="75",
             region="11",
             sectors=[SectorFactory(name="School", category=Sector.Categories.EDUCATION)],
+            line_ministry=Canteen.Ministries.AGRICULTURE,
             managers=[cls.canteen_manager],
         )
         cls.canteen_without_manager = CanteenFactory.create(siret="75665621899905")
@@ -175,6 +176,11 @@ class TestETLOpenData(TestCase):
         self.assertEqual(
             canteens[canteens.id == self.canteen.id].iloc[0]["epci_lib"],
             "CC Communauté Lesneven Côte des Légendes",
+        )
+
+        # Check that the choice fields have been transformed
+        self.assertEqual(
+            canteens[canteens.id == self.canteen.id].iloc[0]["line_ministry"], "Agriculture, Alimentation et Forêts"
         )
 
     def test_active_on_ma_cantine(self, mock):

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -119,6 +119,9 @@ class TestETLOpenData(TestCase):
         self.assertEqual(len(etl_td.get_dataset().columns), len(schema_cols), "The columns should match the schema")
 
         self.assertEqual(
+            etl_td.get_dataset().iloc[0]["canteen_line_ministry"], "", "The line_ministry should be an empty string"
+        )
+        self.assertEqual(
             etl_td.get_dataset().iloc[0]["canteen_sectors"], '"[]"', "The sectors should be an empty list"
         )
 


### PR DESCRIPTION
Similaire à #5329
- dans les datasets canteen & teledeclaration, on affiche le libellé complet au lieu du nom interne)
- ajout de tests
- modification des schéma
- ajout au changelog