### PR TITLE
improve(Recherche): réduit le temps de chargement de la page (30 -> 15) et indique aux utilisateurs une temporalité

### DIFF
--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -224,7 +224,7 @@
           </v-form>
         </v-col>
         <v-col id="results" cols="12" md="8" class="d-flex flex-column">
-          <div v-if="loading" class="d-flex align-center mt-8">
+          <div v-if="loading" class="d-flex align-center">
             <v-progress-circular indeterminate class="align-self-center" />
             <p class="mb-0 ml-4">Patience le chargement de la page peut prendre une dizaine de secondes</p>
           </div>

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -226,7 +226,7 @@
         <v-col id="results" cols="12" md="8" class="d-flex flex-column">
           <div v-if="loading" class="d-flex align-center">
             <v-progress-circular indeterminate class="align-self-center" />
-            <p class="mb-0 ml-4">Patience le chargement de la page peut prendre une dizaine de secondes</p>
+            <p class="mb-0 ml-4">Patience, le chargement de la page peut prendre une dizaine de secondes</p>
           </div>
           <div v-else class="d-flex flex-column" style="height: 100%;">
             <div class="d-flex">

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -366,7 +366,7 @@ export default {
     const sectors = this.$store.state.sectors
     const user = this.$store.state.loggedUser
     return {
-      limit: 30,
+      limit: 15,
       departments: [],
       regions: [],
       sectors: [],

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -224,7 +224,10 @@
           </v-form>
         </v-col>
         <v-col id="results" cols="12" md="8" class="d-flex flex-column">
-          <v-progress-circular v-if="loading" indeterminate class="mt-8 align-self-center" />
+          <div v-if="loading" class="d-flex align-center mt-8">
+            <v-progress-circular indeterminate class="align-self-center" />
+            <p class="mb-0 ml-4">Patience le chargement de la page peut prendre une dizaine de secondes</p>
+          </div>
           <div v-else class="d-flex flex-column" style="height: 100%;">
             <div class="d-flex">
               <ResultCount :count="publishedCanteenCount" class="fr-h6 mb-0" />


### PR DESCRIPTION
## Description

Suite [#5338](https://github.com/betagouv/ma-cantine/pull/5338)

Le temps de chargement de la page était trop long, supérieur à 10 secondes.
On renvient à un nombre de cantines à afficher plus petit et on affiche un message pour l'utilisateur

## Prévisualisation 

<img width="342" alt="Capture d’écran 2025-05-13 à 10 35 15" src="https://github.com/user-attachments/assets/0a9a81c9-5e6e-4640-8ec3-f35ef98fdbd8" />

<img width="1090" alt="Capture d’écran 2025-05-13 à 11 31 38" src="https://github.com/user-attachments/assets/247e5a87-3ff9-4a4e-be30-8a6b7e758508" />
