### PR TITLE
refactor(Open Data): ajout de tests dans l'ETL

### DIFF
--- a/macantine/etl/open_data.py
+++ b/macantine/etl/open_data.py
@@ -20,7 +20,7 @@ class OPEN_DATA(etl.TRANSFORMER_LOADER):
     Abstract class implementing the specifity for open data export
     """
 
-    def transform_geo_data(self, prefix=""):
+    def transform_canteen_geo_data(self, prefix=""):
         logger.info("Start fetching communes details")
         communes_infos = macantine.etl.utils.map_communes_infos()
 
@@ -178,7 +178,7 @@ class ETL_OPEN_DATA_CANTEEN(etl.CANTEENS, OPEN_DATA):
 
         logger.info("Canteens : Fill geo name...")
         start = time.time()
-        self.transform_geo_data()
+        self.transform_canteen_geo_data()
         end = time.time()
         logger.info(f"Time spent on geo data : {end - start}")
 
@@ -263,7 +263,7 @@ class ETL_OPEN_DATA_TELEDECLARATIONS(etl.TELEDECLARATIONS, OPEN_DATA):
         logger.info("TD campagne : Transform sectors...")
         self.df["canteen_sectors"] = self.transform_sectors()
         logger.info("TD Campagne : Fill geo name...")
-        self.transform_geo_data(prefix="canteen_")
+        self.transform_canteen_geo_data(prefix="canteen_")
 
     def _flatten_declared_data(self):
         tmp_df = pd.json_normalize(self.df["declared_data"])

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -8,7 +8,7 @@ from django.test import TestCase, override_settings
 from freezegun import freeze_time
 
 from data.factories import CanteenFactory, DiagnosticFactory, SectorFactory, UserFactory
-from data.models import Teledeclaration
+from data.models import Sector, Teledeclaration
 from macantine.etl.open_data import (
     ETL_OPEN_DATA_CANTEEN,
     ETL_OPEN_DATA_TELEDECLARATIONS,
@@ -282,6 +282,15 @@ class TestETLOpenData(TestCase):
             len(canteens),
             "The new canteen should not appear as its specific sector has to remain private",
         )
+
+        # Testing the transformation of the sector name
+        canteen_with_sector = CanteenFactory.create(
+            sectors=[SectorFactory(name="School", category=Sector.Categories.EDUCATION)]
+        )
+        etl_canteen.extract_dataset()
+        etl_canteen.transform_dataset()
+        canteens = etl_canteen.get_dataset()
+        self.assertEqual(canteens[canteens.id == canteen_with_sector.id].iloc[0]["sectors"], '"[""School""]"')
 
     def test_map_communes_infos(self, mock):
         mock.get(

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -30,9 +30,7 @@ class TestETLOpenData(TestCase):
             sectors=[SectorFactory(name="School", category=Sector.Categories.EDUCATION)],
             managers=[cls.canteen_manager],
         )
-        cls.canteen_without_manager = CanteenFactory.create(
-            siret="75665621899905"
-        )  # Another canteen, but without a manager
+        cls.canteen_without_manager = CanteenFactory.create(siret="75665621899905")
         cls.canteen_without_manager.managers.clear()
 
     @freeze_time("2023-05-14")  # Faking time to mock creation_date


### PR DESCRIPTION
Vu que je commence à mettre le nez dans l'Open Data, je fait quelques améliorations sur les tests
- utilisation de setUpTestClass pour regrouper certaines créations de cantines en haut
- ajout de tests sur les secteurs
- renommé quelques fonctions pour clarifier