### PR TITLE
improve(Metabase): Cantines: ne plus renvoyer 'inconnu' quand le champ est vide (modele eco, type gestion, type prod, min tutelle)

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -713,35 +713,31 @@ class CanteenMetabaseSerializer(serializers.ModelSerializer):
     def get_nbre_repas_an(self, obj):
         return obj.yearly_meal_count
 
-    def get_modele_economique(self, obj):
-        if obj.economic_model:
-            return Canteen.EconomicModel(obj.economic_model).label
-        else:
-            return "inconnu"
-
-    def get_type_gestion(self, obj):
-        if obj.management_type:
-            return Canteen.ManagementType(obj.management_type).label
-        else:
-            return "inconnu"
-
-    def get_type_production(self, obj):
-        if obj.production_type:
-            return Canteen.ProductionType(obj.production_type).label
-        else:
-            return "inconnu"
-
     def get_nombre_satellites(self, obj):
         return obj.satellite_canteens_count
 
     def get_siret_cuisine_centrale(self, obj):
         return obj.central_producer_siret
 
+    def get_modele_economique(self, obj):
+        if obj.economic_model:
+            return Canteen.EconomicModel(obj.economic_model).label
+        return None
+
+    def get_type_gestion(self, obj):
+        if obj.management_type:
+            return Canteen.ManagementType(obj.management_type).label
+        return None
+
+    def get_type_production(self, obj):
+        if obj.production_type:
+            return Canteen.ProductionType(obj.production_type).label
+        return None
+
     def get_ministere_tutelle(self, obj):
         if obj.line_ministry:
             return Canteen.Ministries(obj.line_ministry).label
-        else:
-            return "inconnu"
+        return None
 
     def get_secteur(self, obj):
         sectors = [sector.name for sector in obj.sectors.all()]

--- a/macantine/etl/open_data.py
+++ b/macantine/etl/open_data.py
@@ -29,7 +29,7 @@ class OPEN_DATA(etl.TRANSFORMER_LOADER):
     def transform_canteen_choice_fields(self, prefix=""):
         # line_ministry
         self.df[prefix + "line_ministry"] = self.df[prefix + "line_ministry"].apply(
-            lambda x: Canteen.Ministries(x).label if (x in Canteen.Ministries) else ""
+            lambda x: Canteen.Ministries(x).label if (x in Canteen.Ministries) else None
         )
 
     def transform_canteen_geo_data(self, prefix=""):

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -33,6 +33,9 @@ class TestETLOpenData(TestCase):
             region_lib="Auvergne-Rhône-Alpes",
             sectors=[SectorFactory(name="School", category=Sector.Categories.EDUCATION)],
             line_ministry=Canteen.Ministries.AGRICULTURE,
+            management_type=Canteen.ManagementType.DIRECT,
+            production_type=Canteen.ProductionType.ON_SITE,
+            economic_model=Canteen.EconomicModel.PUBLIC,
             managers=[cls.canteen_manager],
         )
         cls.canteen_without_manager = CanteenFactory.create(siret="75665621899905")
@@ -176,19 +179,19 @@ class TestETLOpenData(TestCase):
         # Check the schema matching
         self.assertEqual(len(canteens.columns), len(schema_cols), "The columns should match the schema.")
 
-        # Checking that the geo data has been fetched from the city insee code
-        self.assertEqual(canteens[canteens.id == self.canteen.id].iloc[0]["epci"], "200040715")
+        canteen = canteens[canteens.id == self.canteen.id].iloc[0]
+        self.assertEqual(canteen["epci"], "200040715")
+        self.assertEqual(canteen["epci_lib"], "Grenoble-Alpes-Métropole")
+        self.assertEqual(canteen["line_ministry"], "Agriculture, Alimentation et Forêts")
+        self.assertEqual(canteen["management_type"], "direct")
+        self.assertEqual(canteen["production_type"], "site")
+        self.assertEqual(canteen["economic_model"], "public")
 
-        # Check that the names of the region and departments are fetched from the code
-        self.assertEqual(
-            canteens[canteens.id == self.canteen.id].iloc[0]["epci_lib"],
-            "Grenoble-Alpes-Métropole",
-        )
-
-        # Check that the choice fields have been transformed
-        self.assertEqual(
-            canteens[canteens.id == self.canteen.id].iloc[0]["line_ministry"], "Agriculture, Alimentation et Forêts"
-        )
+        canteen_without_manager = canteens[canteens.id == self.canteen_without_manager.id].iloc[0]
+        self.assertEqual(canteen_without_manager["line_ministry"], "")
+        self.assertEqual(canteen_without_manager["management_type"], None)
+        self.assertEqual(canteen_without_manager["production_type"], None)
+        self.assertEqual(canteen_without_manager["economic_model"], None)
 
     def test_active_on_ma_cantine(self, mock):
         mock.get(

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -126,7 +126,7 @@ class TestETLOpenData(TestCase):
         self.assertEqual(len(etl_td.get_dataset().columns), len(schema_cols), "The columns should match the schema")
 
         self.assertEqual(
-            etl_td.get_dataset().iloc[0]["canteen_line_ministry"], "", "The line_ministry should be an empty string"
+            etl_td.get_dataset().iloc[0]["canteen_line_ministry"], None, "The line_ministry should be empty"
         )
         self.assertEqual(
             etl_td.get_dataset().iloc[0]["canteen_sectors"], '"[]"', "The sectors should be an empty list"
@@ -188,7 +188,7 @@ class TestETLOpenData(TestCase):
         self.assertEqual(canteen["economic_model"], "public")
 
         canteen_without_manager = canteens[canteens.id == self.canteen_without_manager.id].iloc[0]
-        self.assertEqual(canteen_without_manager["line_ministry"], "")
+        self.assertEqual(canteen_without_manager["line_ministry"], None)
         self.assertEqual(canteen_without_manager["management_type"], None)
         self.assertEqual(canteen_without_manager["production_type"], None)
         self.assertEqual(canteen_without_manager["economic_model"], None)


### PR DESCRIPTION
Suite à #5329 et une discussion qui en a découlée

Lors de l'export Metabase des choice fields du modèle `Canteen` on met "inconnu" lorsque le champ est vide.
Cette PR propose de ne RIEN renvoyer à la place

Et j'ai ajouté des tests pour rendre plus explicite ce qui est renvoyé par ces choice fields (quand l'info est présente, et quand l'info est vide)