### PR TITLE
improve(Geo Bot): Cantines: récupérer l'epci si il est manquant

### DIFF
--- a/common/api/recherche_entreprises.py
+++ b/common/api/recherche_entreprises.py
@@ -67,9 +67,9 @@ def fetch_geo_data_from_siren(siren, response):
                 response["cityInseeCode"] = etablissement["commune"]
                 response["postalCode"] = etablissement["code_postal"]
                 response["city"] = etablissement["libelle_commune"]
+                response["epci"] = etablissement["epci"]
                 response["department"] = etablissement["departement"]
                 response["region"] = etablissement["region"]
-                response["epci"] = etablissement["epci"]
                 return response
             except KeyError as e:
                 logger.error(
@@ -117,9 +117,9 @@ def fetch_geo_data_from_siret(siret, response):
                 response["cityInseeCode"] = etablissement["commune"]
                 response["postalCode"] = etablissement["code_postal"]
                 response["city"] = etablissement["libelle_commune"]
+                response["epci"] = etablissement["epci"]
                 # response["department"] = etablissement["departement"]  # not in response
                 response["region"] = etablissement["region"]
-                response["epci"] = etablissement["epci"]
                 return response
             except KeyError as e:
                 logger.error(

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -174,6 +174,12 @@ class CanteenQuerySet(SoftDeletionQuerySet):
     def has_siret_or_siren_unite_legale(self):
         return self.filter(has_siret_or_siren_unite_legale_query())
 
+    def has_postal_code_or_city_insee_code(self):
+        return self.filter(Q(postal_code__isnull=False) | Q(city_insee_code__isnull=False))
+
+    def has_city_insee_code_missing(self):
+        return self.filter(Q(city_insee_code__isnull=True) | Q(city_insee_code=""))
+
     def has_missing_data(self):
         return self.annotate_with_requires_line_ministry().filter(has_missing_data_query())
 
@@ -273,6 +279,12 @@ class CanteenManager(SoftDeletionManager):
 
     def annotate_with_td_for_year(self, year):
         return self.get_queryset().annotate_with_td_for_year(year)
+
+    def has_postal_code_or_city_insee_code(self):
+        return self.get_queryset().has_postal_code_or_city_insee_code()
+
+    def has_city_insee_code_missing(self):
+        return self.get_queryset().has_city_insee_code_missing()
 
     def has_missing_data(self):
         return self.get_queryset().has_missing_data()

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -258,7 +258,8 @@ def _update_canteen_geo_data(canteen, response):
             canteen.city_insee_code = response["cityInseeCode"]
             canteen.postal_code = response["postalCode"]
             canteen.city = response["city"]
-            canteen.epci = response["epci"]
+            if "epci" in response.keys():
+                canteen.epci = response["epci"]
             canteen.save()
             update_change_reason(canteen, "Données de localisation MAJ par bot, via SIRET")
             logger.info(f"Canteen info has been updated. Canteen name : {canteen.name}")


### PR DESCRIPTION
Suite à https://github.com/betagouv/ma-cantine/pull/5333 (nouveau champ Canteen.epci), on souhaite remplir ce champ 

On le récupère grâce à l'API Recherche Entreprises

Todo
- remplir aussi le libellé : on va le stocker grâce à #5349, il faudra faire tourner un autre cron
- ne plus se baser sur le postal_code