### PR TITLE
fix(Geo Bot): ajoute les Code INSEE des arrondissements des villes de Paris, Lyon & Marseille

### DIFF
--- a/common/api/tests/test_decoupage_administratif.py
+++ b/common/api/tests/test_decoupage_administratif.py
@@ -60,6 +60,101 @@ class TestDecoupageAdministratifAPI(unittest.TestCase):
         self.assertEqual(fetch_commune_detail("01003", communes_details, "city"), None)
         self.assertEqual(fetch_commune_detail("01003", communes_details, "epci"), None)
 
+    def test_map_communes_infos_with_arrondissements(self, mock):
+        mock.get(
+            f"{DECOUPAGE_ADMINISTRATIF_API_URL}/communes",
+            text=json.dumps(
+                [
+                    {
+                        "nom": "Paris",
+                        "code": "75056",
+                        "codeDepartement": "75",
+                        "siren": "217500016",
+                        "codeEpci": "200054781",
+                        "codeRegion": "11",
+                        "codesPostaux": [
+                            "75001",
+                            "75002",
+                            "75003",
+                            "75004",
+                            "75005",
+                            "75006",
+                            "75007",
+                            "75008",
+                            "75009",
+                            "75010",
+                            "75011",
+                            "75012",
+                            "75013",
+                            "75014",
+                            "75015",
+                            "75016",
+                            "75017",
+                            "75018",
+                            "75019",
+                            "75020",
+                            "75116",
+                        ],
+                        "population": 2113705,
+                    },
+                    {
+                        "nom": "Lyon",
+                        "code": "69123",
+                        "codeDepartement": "69",
+                        "siren": "216901231",
+                        "codeEpci": "200046977",
+                        "codeRegion": "84",
+                        "codesPostaux": [
+                            "69001",
+                            "69002",
+                            "69003",
+                            "69004",
+                            "69005",
+                            "69006",
+                            "69007",
+                            "69008",
+                            "69009",
+                        ],
+                        "population": 520774,
+                    },
+                    {
+                        "nom": "Marseille",
+                        "code": "13055",
+                        "codeDepartement": "13",
+                        "siren": "211300553",
+                        "codeEpci": "200054807",
+                        "codeRegion": "93",
+                        "codesPostaux": [
+                            "13001",
+                            "13002",
+                            "13003",
+                            "13004",
+                            "13005",
+                            "13006",
+                            "13007",
+                            "13008",
+                            "13009",
+                            "13010",
+                            "13011",
+                            "13012",
+                            "13013",
+                            "13014",
+                            "13015",
+                            "13016",
+                        ],
+                        "population": 877215,
+                    },
+                ]
+            ),
+        )
+
+        communes_details = map_communes_infos()
+        self.assertEqual(len(communes_details), 3 + 20 + 9 + 16)
+        self.assertEqual(communes_details["69123"]["city"], "Lyon")  # initial insee code
+        self.assertEqual(communes_details["69301"]["city"], "Lyon")  # enriched insee code
+        self.assertEqual(communes_details["69309"]["city"], "Lyon")
+        self.assertEqual(communes_details["69309"]["postal_code_list"], ["69009"])
+
     def test_map_epcis_code_name(self, mock):
         mock.get(
             f"{DECOUPAGE_ADMINISTRATIF_API_URL}/epcis?fields=nom",


### PR DESCRIPTION
Dans l'API Découpage Administratif - https://geo.api.gouv.fr/communes - il manque les codes insee des arrondissements