### PR TITLE
fix(Geo Bot): change la requête pour inclure les codes INSEE des arrondissements des villes de Paris, Lyon & Marseille

### DIFF
--- a/common/api/decoupage_administratif.py
+++ b/common/api/decoupage_administratif.py
@@ -10,7 +10,9 @@ DECOUPAGE_ADMINISTRATIF_API_URL = "https://geo.api.gouv.fr"
 
 
 def fetch_communes():
-    response = requests.get(f"{DECOUPAGE_ADMINISTRATIF_API_URL}/communes", timeout=50)
+    response = requests.get(
+        f"{DECOUPAGE_ADMINISTRATIF_API_URL}/communes?type=arrondissement-municipal,commune-actuelle", timeout=50
+    )
     response.raise_for_status()
     return response.json()
 


### PR DESCRIPTION
Il nous manquait les 45 arrondissements (Paris : 20 / Lyon : 9 / Marseille : 16) et leur code insee associés