### PR TITLE
feat(DataGouv): méthode pour récupérer les PAT depuis l'API

### DIFF
--- a/common/api/datagouv.py
+++ b/common/api/datagouv.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 import os
 from datetime import date
@@ -9,6 +10,11 @@ logger = logging.getLogger(__name__)
 
 # DATAGOUV_DOCUMENTATION: https://www.data.gouv.fr/fr/dataservices/api-catalogue-des-donnees-ouvertes-data-gouv-fr/
 DATAGOUV_API_URL = "https://www.data.gouv.fr/api/1"
+
+# PAT (Projets Alimentaires Territoriaux): https://france-pat.fr/presentation-de-l-observatoire/
+PAT_DATAGOUV_DATASET_ID = "pat-projets-alimentaires-territoriaux-description"
+# PAT_DATAGOUV_RESOURCE_ID = "4f2a6bed-e9e3-48eb-aecc-85b08cb984f3"  # 20250224  # TODO: update twice a year
+PAT_DATAGOUV_RESOURCE_ID = "96606cae-0b3b-4910-9d8b-65e3dd7f1bda"  # 20250224 (ISO-8859-1)  # TODO: update twice a year
 
 
 def get_dataset(dataset_id):
@@ -71,3 +77,52 @@ def update_dataset_resources(dataset_id):
         logger.exception(e)
     except Exception as e:
         logger.exception(e)
+
+
+def map_pat_list_to_communes_insee_code():
+    """
+    Create a dict that maps insee codes with their pat
+    Input: a list of pat. 891;https://france-pat.fr/pat/redon-agglomeration/;"Programme Agricole et Alimentaire de Territoire de REDON Agglomération";;"Pays de la Loire, Bretagne";"Ille-et-Vilaine, Loire-Atlantique, Morbihan";;35145,56232,44185,56011,56216,56250,44067,35045,35268,35285,35064,35151,35219,56221,35236,56154,56239,35013,35237,56001,56223,44123,35328,44057,44092,56194,35294,44044,44128,56060,44007;...
+    Output: a dict with the commune's insee code as pivot. {"35145": {"pat": "891", "pat_lib": "Programme Agricole et Alimentaire de Territoire de REDON Agglomération"}}
+    """
+    pat_mapping = {}
+    try:
+        pat_list = []
+        pat_dataset_resource = get_dataset_resource(PAT_DATAGOUV_DATASET_ID, PAT_DATAGOUV_RESOURCE_ID)
+        response = requests.get(pat_dataset_resource["url"])
+        response.raise_for_status()
+        print(response.encoding)
+        reader = csv.DictReader(response.iter_lines(decode_unicode=True), delimiter=";")
+        pat_list = list(reader)
+        # with open(pat_dataset_resource["url"], "r", encoding="utf-8") as pat_csv_file:
+        #     pat_list = pat_csv_file.read().splitlines()
+        for pat in pat_list:
+            city_insee_code_list = [insee_code for insee_code in pat["communes_code_insee"].split(",") if insee_code]
+            for city_insee_code in city_insee_code_list:
+                if city_insee_code not in pat_mapping.keys():
+                    pat_mapping[city_insee_code] = []
+                pat_mapping[city_insee_code].append(
+                    {
+                        "pat": pat["id"],
+                        "pat_lib": pat["nom_administratif"],
+                    }
+                )
+            if len(city_insee_code_list) == 0:
+                logger.warning(f"PAT with no insee code : {pat['id']} : {pat['nom_administratif']}")
+        print(len(pat_list))
+        print(len(pat_mapping.keys()))
+        from collections import Counter
+
+        # Stats
+        print(Counter([len(pat_mapping[insee_code]) for insee_code in pat_mapping.keys()]))
+        # for city_insee_code in pat_mapping.keys():
+        #     # PAT with comma
+        #     if "," in pat_mapping[city_insee_code][0]["pat_lib"]:
+        #         print(f"Pat with comma : {city_insee_code} : {pat_mapping[city_insee_code]}")
+        #     # PAT with more than 2 communes
+        #     if len(pat_mapping[city_insee_code]) > 2:
+        #         print(f"Pat with more than 2 : {city_insee_code} : {pat_mapping[city_insee_code]}")
+
+    except requests.HTTPError as e:
+        logger.info(e)
+    # return pat_mapping

--- a/common/api/datagouv.py
+++ b/common/api/datagouv.py
@@ -12,9 +12,11 @@ logger = logging.getLogger(__name__)
 DATAGOUV_API_URL = "https://www.data.gouv.fr/api/1"
 
 # PAT (Projets Alimentaires Territoriaux): https://france-pat.fr/presentation-de-l-observatoire/
+# Note: data updated twice a year
+# Note: communes can belong to multiple PATs
 PAT_DATAGOUV_DATASET_ID = "pat-projets-alimentaires-territoriaux-description"
-# PAT_DATAGOUV_RESOURCE_ID = "4f2a6bed-e9e3-48eb-aecc-85b08cb984f3"  # 20250224  # TODO: update twice a year
-PAT_DATAGOUV_RESOURCE_ID = "96606cae-0b3b-4910-9d8b-65e3dd7f1bda"  # 20250224 (ISO-8859-1)  # TODO: update twice a year
+# PAT_DATAGOUV_RESOURCE_ID = "4f2a6bed-e9e3-48eb-aecc-85b08cb984f3"  # 20250224
+PAT_DATAGOUV_RESOURCE_ID = "96606cae-0b3b-4910-9d8b-65e3dd7f1bda"  # 20250224 (ISO-8859-1)
 
 
 def get_dataset(dataset_id):
@@ -81,9 +83,9 @@ def update_dataset_resources(dataset_id):
 
 def map_pat_list_to_communes_insee_code():
     """
-    Create a dict that maps insee codes with their pat
-    Input: a list of pat. 891;https://france-pat.fr/pat/redon-agglomeration/;"Programme Agricole et Alimentaire de Territoire de REDON Agglomération";;"Pays de la Loire, Bretagne";"Ille-et-Vilaine, Loire-Atlantique, Morbihan";;35145,56232,44185,56011,56216,56250,44067,35045,35268,35285,35064,35151,35219,56221,35236,56154,56239,35013,35237,56001,56223,44123,35328,44057,44092,56194,35294,44044,44128,56060,44007;...
-    Output: a dict with the commune's insee code as pivot. {"35145": {"pat": "891", "pat_lib": "Programme Agricole et Alimentaire de Territoire de REDON Agglomération"}}
+    Create a dict that maps Insee codes with their PAT
+    Input: a list of PAT. 891;https://france-pat.fr/pat/redon-agglomeration/;"Programme Agricole et Alimentaire de Territoire de REDON Agglomération";;"Pays de la Loire, Bretagne";"Ille-et-Vilaine, Loire-Atlantique, Morbihan";;35145,56232,44185,56011,56216,56250,44067,35045,35268,35285,35064,35151,35219,56221,35236,56154,56239,35013,35237,56001,56223,44123,35328,44057,44092,56194,35294,44044,44128,56060,44007;...
+    Output: a dict with the commune's insee code as pivot. {"35145": [{"pat": "891", "pat_lib": "Programme Agricole et Alimentaire de Territoire de REDON Agglomération"}]}
     """
     pat_mapping = {}
     try:
@@ -91,14 +93,13 @@ def map_pat_list_to_communes_insee_code():
         pat_dataset_resource = get_dataset_resource(PAT_DATAGOUV_DATASET_ID, PAT_DATAGOUV_RESOURCE_ID)
         response = requests.get(pat_dataset_resource["url"])
         response.raise_for_status()
-        print(response.encoding)
         reader = csv.DictReader(response.iter_lines(decode_unicode=True), delimiter=";")
         pat_list = list(reader)
-        # with open(pat_dataset_resource["url"], "r", encoding="utf-8") as pat_csv_file:
-        #     pat_list = pat_csv_file.read().splitlines()
         for pat in pat_list:
-            city_insee_code_list = [insee_code for insee_code in pat["communes_code_insee"].split(",") if insee_code]
-            for city_insee_code in city_insee_code_list:
+            pat_city_insee_code_list = [
+                insee_code for insee_code in pat["communes_code_insee"].split(",") if insee_code
+            ]
+            for city_insee_code in pat_city_insee_code_list:
                 if city_insee_code not in pat_mapping.keys():
                     pat_mapping[city_insee_code] = []
                 pat_mapping[city_insee_code].append(
@@ -107,22 +108,6 @@ def map_pat_list_to_communes_insee_code():
                         "pat_lib": pat["nom_administratif"],
                     }
                 )
-            if len(city_insee_code_list) == 0:
-                logger.warning(f"PAT with no insee code : {pat['id']} : {pat['nom_administratif']}")
-        print(len(pat_list))
-        print(len(pat_mapping.keys()))
-        from collections import Counter
-
-        # Stats
-        print(Counter([len(pat_mapping[insee_code]) for insee_code in pat_mapping.keys()]))
-        # for city_insee_code in pat_mapping.keys():
-        #     # PAT with comma
-        #     if "," in pat_mapping[city_insee_code][0]["pat_lib"]:
-        #         print(f"Pat with comma : {city_insee_code} : {pat_mapping[city_insee_code]}")
-        #     # PAT with more than 2 communes
-        #     if len(pat_mapping[city_insee_code]) > 2:
-        #         print(f"Pat with more than 2 : {city_insee_code} : {pat_mapping[city_insee_code]}")
-
     except requests.HTTPError as e:
         logger.info(e)
-    # return pat_mapping
+    return pat_mapping

--- a/common/api/tests/test_datagouv.py
+++ b/common/api/tests/test_datagouv.py
@@ -1,0 +1,44 @@
+import json
+import unittest
+
+import requests_mock
+
+from common.api.datagouv import (
+    DATAGOUV_API_URL,
+    PAT_DATAGOUV_DATASET_ID,
+    PAT_DATAGOUV_RESOURCE_ID,
+    map_pat_list_to_communes_insee_code,
+)
+
+
+@requests_mock.Mocker()
+class TestDataGouvAPI(unittest.TestCase):
+    def test_map_pat_list_to_communes_insee_code(self, mock):
+        mock.get(
+            f"{DATAGOUV_API_URL}/datasets/{PAT_DATAGOUV_DATASET_ID}/resources/{PAT_DATAGOUV_RESOURCE_ID}",
+            text=json.dumps(
+                {
+                    "id": "96606cae-0b3b-4910-9d8b-65e3dd7f1bda",
+                    "title": "pats-20250224-win1252.csv",
+                    "url": "https://static.data.gouv.fr/resources/pat-projets-alimentaires-territoriaux-description/20250224-103639/pats-20250224-win1252.csv",
+                }
+            ),
+        )
+        pat_csv_text = (
+            "id;lien_vers_la_fiche_pat;nom_administratif;nom_usuel;regions;departement;epci;communes_code_insee\n"
+        )
+        pat_csv_text += '891;https://france-pat.fr/pat/redon-agglomeration/;"Programme Agricole et Alimentaire de Territoire de REDON Agglomération";;"Pays de la Loire, Bretagne";"Ille-et-Vilaine, Loire-Atlantique, Morbihan";;35145,56232,44185,56011,56216,56250,44067,35045,35268,35285,35064,35151,35219,56221,35236,56154,56239,35013,35237,56001,56223,44123,35328,44057,44092,56194,35294,44044,44128,56060,44007\n'
+        pat_csv_text += '1263;https://france-pat.fr/pat/pat-du-bassin-de-bourg-en-bresse/;"PAT du Bassin de Bourg-en-Bresse";"PAT Grand Bourg Agglomération : Relocaliser la valeur ajoutée sur le territoire";Auvergne-Rhône-Alpes;Ain;;01230,01212,01364,01367,01163,01029,01147,01296,01108,01232,01124,01128,01388,01380,01433,01196,01040,01406,01127,01321,01391,01445,01236,01432,01229,01266,01309,01038,01387,01346,01024,01375,01140,01115,01301,01125,01408,01177,01195,01259,01429,01065,01344,01264,01385,01150,01053,01447,01072,01317,01369,01184,01254,01245,01336,01289,01405,01069,01422,01211,01197,01374,01425,01106,01151,01145,01451,01241,01350,01139,01437,01130,01095,01426\n'
+        mock.get(
+            "https://static.data.gouv.fr/resources/pat-projets-alimentaires-territoriaux-description/20250224-103639/pats-20250224-win1252.csv",
+            text=pat_csv_text,
+        )
+
+        pat_list_to_communes_insee_code = map_pat_list_to_communes_insee_code()
+        self.assertEqual(len(pat_list_to_communes_insee_code), 105)
+        self.assertIn("35145", pat_list_to_communes_insee_code)
+        self.assertEqual(pat_list_to_communes_insee_code["35145"][0]["pat"], "891")
+        self.assertEqual(
+            pat_list_to_communes_insee_code["35145"][0]["pat_lib"],
+            "Programme Agricole et Alimentaire de Territoire de REDON Agglomération",
+        )


### PR DESCRIPTION
Ajout d'une méthode dans `datagouv.py` pour récupérer le dernier CSV contenant la liste des PAT (grâce à #5363) + transformer cette liste en mapping par commune insee code + ajout d'un test
