### PR TITLE
refactor(Geo Bot): récupérer seulement le code Insee à partir du Siret

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,7 +51,7 @@
       "stopOnEntry": false,
       "python": "${workspaceFolder}/venv/bin/python",
       "program": "${workspaceFolder}/manage.py",
-      "args": ["fill_missing_geolocation_data_using_siret"],
+      "args": ["fill_missing_insee_code_using_siret"],
       "justMyCode": false,
       "django": true
     },

--- a/macantine/celery.py
+++ b/macantine/celery.py
@@ -47,8 +47,8 @@ app.conf.beat_schedule = {
         "task": "macantine.tasks.fill_missing_geolocation_data_using_insee_code",
         "schedule": nightly,
     },
-    "fill_missing_geolocation_data_using_siret": {
-        "task": "macantine.tasks.fill_missing_geolocation_data_using_siret",
+    "fill_missing_insee_code_using_siret": {
+        "task": "macantine.tasks.fill_missing_insee_code_using_siret",
         "schedule": hourly,
     },
     "delete_old_historical_records": {

--- a/macantine/management/commands/fill_missing_geolocation_data_using_siret.py
+++ b/macantine/management/commands/fill_missing_geolocation_data_using_siret.py
@@ -2,7 +2,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from macantine.tasks import fill_missing_geolocation_data_using_siret
+from macantine.tasks import fill_missing_insee_code_using_siret
 
 logger = logging.getLogger(__name__)
 
@@ -14,4 +14,4 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         logger.info("Start task : fill_missing_geolocation_data")
-        fill_missing_geolocation_data_using_siret()
+        fill_missing_insee_code_using_siret()

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -240,9 +240,6 @@ def _update_canteen_geo_data_from_siret(canteen, response):
     try:
         if "cityInseeCode" in response.keys():
             canteen.city_insee_code = response["cityInseeCode"]
-            # TODO: remove this, leave it to the other geo bot
-            canteen.postal_code = response["postalCode"]
-            canteen.city = response["city"]
             canteen.save()
             update_change_reason(canteen, "Données de localisation MAJ par bot, via SIRET")
             logger.info(f"Canteen info has been updated. Canteen name : {canteen.name}")

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -253,7 +253,7 @@ def fill_missing_geolocation_data_using_siret():
     """
     Input: Canteens with siret but no city_insee_code
     Processing: API Recherche Entreprises
-    Output: Fill canteen's city_insee_code, postal_code & city fields
+    Output: Fill canteen's city_insee_code field
     """
     candidate_canteens = _get_candidate_canteens_for_siret_geobot()
     logger.info(f"Siret Geolocation Bot: found {candidate_canteens.count()} canteens")

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -232,7 +232,7 @@ def _get_candidate_canteens_for_insee_code_geobot():
     )
 
 
-def _get_candidate_canteens_for_siret_geobot():
+def _get_candidate_canteens_for_siret_to_insee_code_bot():
     return Canteen.objects.has_siret().has_city_insee_code_missing().order_by("-creation_date")
 
 
@@ -249,14 +249,14 @@ def _update_canteen_geo_data_from_siret(canteen, response):
 
 
 @app.task()
-def fill_missing_geolocation_data_using_siret():
+def fill_missing_insee_code_using_siret():
     """
     Input: Canteens with siret but no city_insee_code
     Processing: API Recherche Entreprises
     Output: Fill canteen's city_insee_code field
     """
-    candidate_canteens = _get_candidate_canteens_for_siret_geobot()
-    logger.info(f"Siret Geolocation Bot: found {candidate_canteens.count()} canteens")
+    candidate_canteens = _get_candidate_canteens_for_siret_to_insee_code_bot()
+    logger.info(f"Siret to insee_code Bot: found {candidate_canteens.count()} canteens")
     counter = 0
 
     if len(candidate_canteens) == 0:
@@ -279,7 +279,7 @@ def fill_missing_geolocation_data_using_siret():
             time.sleep(60)
 
     result = f"Updated {counter}/{candidate_canteens.count()} canteens"
-    logger.info(f"Siret Geolocation Bot: {result}")
+    logger.info(f"Siret to insee_code Bot: {result}")
     return result
 
 

--- a/macantine/tests/test_geolocation_bot.py
+++ b/macantine/tests/test_geolocation_bot.py
@@ -248,4 +248,4 @@ class TestGeolocationBotUsingSiret(TestCase):
 
         canteen.refresh_from_db()
         self.assertEqual(canteen.city_insee_code, city_insee_code)
-        self.assertEqual(canteen.postal_code, code_postal)
+        self.assertEqual(canteen.postal_code, None)  # will be filled by the other geo bot

--- a/macantine/tests/test_geolocation_bot.py
+++ b/macantine/tests/test_geolocation_bot.py
@@ -171,7 +171,7 @@ class TestGeolocationBotUsingSiret(TestCase):
             CanteenFactory.create(city_insee_code=29890),
             CanteenFactory.create(city_insee_code=None, siret=None),
         ]
-        result = list(tasks._get_candidate_canteens_for_siret_geobot())
+        result = list(tasks._get_candidate_canteens_for_siret_to_insee_code_bot())
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].id, candidate_canteen.id)
 
@@ -244,8 +244,8 @@ class TestGeolocationBotUsingSiret(TestCase):
             status_code=200,
         )
 
-        tasks.fill_missing_geolocation_data_using_siret()
+        tasks.fill_missing_insee_code_using_siret()
 
         canteen.refresh_from_db()
         self.assertEqual(canteen.city_insee_code, city_insee_code)
-        self.assertEqual(canteen.postal_code, None)  # will be filled by the other geo bot
+        self.assertEqual(canteen.postal_code, None)  # will be filled by the geo bot


### PR DESCRIPTION
Ne plus dupliquer de logique entre les 2 geo bot
- le premier "Siret" s'occupe maintenant juste de remplir le Code Insee manquant
- le deuxième "Insee" fait tout le job