### PR TITLE
fix(Gaspillage alimentaire): le graphique "part de comestible" ne s'affiche pas si un des totaux mesuré est égale à zéro

### DIFF
--- a/2024-frontend/src/components/EdibleChart.vue
+++ b/2024-frontend/src/components/EdibleChart.vue
@@ -4,14 +4,16 @@ import { formatNumber, getSum, getPercentage } from "@/utils"
 
 const props = defineProps(["measurement"])
 
+const isEmpty = (value) => value === "" || value === null
+
 const measurementComputedValues = computed(() => {
   const m = props.measurement
   const edibleMass = [m.preparationEdibleMass, m.unservedEdibleMass, m.leftoversEdibleMass]
   const edibleTotalMass = getSum(edibleMass)
-  const edibleIsEmpty = edibleMass.every((value) => value === "" || value === null)
+  const edibleIsEmpty = edibleMass.every(isEmpty)
   const inedibleMass = [m.preparationInedibleMass, m.unservedInedibleMass, m.leftoversInedibleMass]
   const inedibleTotalMass = getSum(inedibleMass)
-  const inedibleIsEmpty = inedibleMass.every((value) => value === "" || value === null)
+  const inedibleIsEmpty = inedibleMass.every(isEmpty)
   return {
     edible: {
       totalMass: edibleTotalMass,

--- a/2024-frontend/src/components/EdibleChart.vue
+++ b/2024-frontend/src/components/EdibleChart.vue
@@ -6,16 +6,22 @@ const props = defineProps(["measurement"])
 
 const measurementComputedValues = computed(() => {
   const m = props.measurement
-  const edibleTotalMass = getSum([m.preparationEdibleMass, m.unservedEdibleMass, m.leftoversEdibleMass])
-  const inedibleTotalMass = getSum([m.preparationInedibleMass, m.unservedInedibleMass, m.leftoversInedibleMass])
+  const edibleMass = [m.preparationEdibleMass, m.unservedEdibleMass, m.leftoversEdibleMass]
+  const edibleTotalMass = getSum(edibleMass)
+  const edibleIsEmpty = edibleMass.every((value) => value === "" || value === null)
+  const inedibleMass = [m.preparationInedibleMass, m.unservedInedibleMass, m.leftoversInedibleMass]
+  const inedibleTotalMass = getSum(inedibleMass)
+  const inedibleIsEmpty = inedibleMass.every((value) => value === "" || value === null)
   return {
     edible: {
       totalMass: edibleTotalMass,
       percentage: getPercentage(edibleTotalMass, m.totalMass),
+      isEmpty: edibleIsEmpty,
     },
     inedible: {
       totalMass: inedibleTotalMass,
       percentage: getPercentage(inedibleTotalMass, m.totalMass),
+      isEmpty: inedibleIsEmpty,
     },
   }
 })

--- a/2024-frontend/src/components/EdibleChart.vue
+++ b/2024-frontend/src/components/EdibleChart.vue
@@ -37,7 +37,7 @@ const measurementChartValues = computed(() => {
 })
 
 const showChart = computed(
-  () => measurementComputedValues.value.edible.totalMass && measurementComputedValues.value.inedible.totalMass
+  () => !measurementComputedValues.value.edible.isEmpty && !measurementComputedValues.value.inedible.isEmpty
 )
 
 const displayOption = ref("chart")


### PR DESCRIPTION
## Description

Le graphique de synthèse pour visualiser la part de comestible ne s'affichait pas si le total d'une des catégorie comestible ou non-comestible était égale à zéro. Ce total à zéro était considéré comme "non-renseigné".

## Prévisualisation

|Avant|Après|
|--|--|
|<img width="1218" alt="Capture d’écran 2025-05-27 à 16 48 29" src="https://github.com/user-attachments/assets/c0af9cea-662e-4354-8e74-720cfc1d3a09" /> | <img width="1240" alt="Capture d’écran 2025-05-27 à 17 40 26" src="https://github.com/user-attachments/assets/efbfb8b6-854b-4828-bc45-55f13e0cfc8c" /> |