### PR TITLE
fix(Synthèse approvisionnement): la valeur bio est renseignée à vide au lieu de zéro

### DIFF
--- a/frontend/src/components/ApproGraph.vue
+++ b/frontend/src/components/ApproGraph.vue
@@ -153,8 +153,9 @@ export default {
     },
     bioPercentage() {
       const percentage =
-        Math.round(this.diagnostic.percentageValueBioHt * 100) ||
-        getPercentage(this.diagnostic.valueBioHt, this.diagnostic.valueTotalHt, true)
+        this.diagnostic.percentageValueBioHt >= 0
+          ? Math.round(this.diagnostic.percentageValueBioHt * 100)
+          : getPercentage(this.diagnostic.valueBioHt, this.diagnostic.valueTotalHt, true)
       return this.isTruthyOrZero(percentage) ? percentage : "—"
     },
     sustainablePercentage() {


### PR DESCRIPTION
## Description

Si dans le bilan le total de bio est égal à zéro il s'affiche avec un tiret et non le chiffre à certains endroits du site : 
- la page publique de la cantine
- le tableau de bord dans le cas d'une cuisine sat

## Prévisualisation
|Avant|Après|
|--|--|
| <img width="424" alt="Capture d’écran 2025-05-27 à 18 32 43" src="https://github.com/user-attachments/assets/a917f857-16a6-427e-96d3-7e6995baa736" /> | <img width="416" alt="Capture d’écran 2025-05-27 à 18 38 19" src="https://github.com/user-attachments/assets/dd3cdab0-3ba7-4209-964a-1c35963fbb13" /> |
| <img width="1001" alt="Capture d’écran 2025-05-27 à 18 32 36" src="https://github.com/user-attachments/assets/ad29714a-8e7d-4dc0-9ba1-a023332fb8ca" /> | <img width="994" alt="Capture d’écran 2025-05-27 à 18 38 53" src="https://github.com/user-attachments/assets/731fac52-da95-4bf9-9c25-ad4cc5691370" /> |
| <img width="1090" alt="Capture d’écran 2025-05-27 à 18 40 15" src="https://github.com/user-attachments/assets/4eb1221f-5b16-4db5-a6fb-90dd46699da3" /> | <img width="1073" alt="Capture d’écran 2025-05-27 à 18 39 27" src="https://github.com/user-attachments/assets/1064b867-204d-4166-a88f-8de651987abc" /> |