### PR TITLE
fix(Gaspillage alimentaire): corrige condition pour une valeur vide

### DIFF
--- a/2024-frontend/src/components/EdibleChart.vue
+++ b/2024-frontend/src/components/EdibleChart.vue
@@ -4,7 +4,7 @@ import { formatNumber, getSum, getPercentage } from "@/utils"
 
 const props = defineProps(["measurement"])
 
-const isEmpty = (value) => value === "" || value === null
+const isEmpty = (value) => value === "" || value === null || value === undefined
 
 const measurementComputedValues = computed(() => {
   const m = props.measurement


### PR DESCRIPTION
Suite [#5385](https://github.com/betagouv/ma-cantine/pull/5385) 

Il manquait une valeur possible considérée comme "vide" pour le graphique comestible / non comestible.