### PR TITLE
improve(Pages du footer): homogénéise l'affichage des pages du footer

### DIFF
--- a/2024-frontend/src/css/global.css
+++ b/2024-frontend/src/css/global.css
@@ -26,6 +26,19 @@ address {
     padding-left: 0;
 }
 
+/* STICKY */
+.ma-cantine--sticky__container {
+    position: relative !important;
+    overflow: initial !important;
+}
+
+.ma-cantine--sticky__bottom {
+    position: sticky !important;
+    top: 90vh;
+    z-index: 1;
+}
+
+
 /* TABLE */
 @media (min-width: 768px) {
 

--- a/2024-frontend/src/layouts/LayoutOneColumn.vue
+++ b/2024-frontend/src/layouts/LayoutOneColumn.vue
@@ -1,12 +1,31 @@
 <script setup>
 import { useRoute } from "vue-router"
 const route = useRoute()
+
+const scrollTop = () => {
+  window.scrollTo(0, 0)
+}
 </script>
 
 <template>
-  <div class="fr-col-12 fr-col-lg-7 layout-one-column">
+  <div class="layout-one-column">
     <h1 class="fr-my-8w">{{ route.meta.title }}</h1>
-    <slot></slot>
+    <div class="fr-grid-row">
+      <div class="fr-col-12 fr-col-lg-7">
+        <slot></slot>
+      </div>
+      <div
+        class="ma-cantine--sticky__container fr-hidden fr-unhidden-lg fr-col-lg-5 fr-grid-row fr-grid-row--top fr-grid-row--right"
+      >
+        <DsfrButton
+          class="ma-cantine--sticky__bottom"
+          label="Retour en haut de page"
+          icon="fr-icon-arrow-up-line"
+          secondary
+          @click="scrollTop"
+        />
+      </div>
+    </div>
   </div>
 </template>
 

--- a/2024-frontend/src/layouts/LayoutOneColumn.vue
+++ b/2024-frontend/src/layouts/LayoutOneColumn.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="fr-col-12 fr-col-lg-7 layout-one-column">
+    <slot></slot>
+  </div>
+</template>
+
+<style lang="scss">
+.layout-one-column {
+  section {
+    margin-top: 2rem;
+  }
+}
+</style>

--- a/2024-frontend/src/layouts/LayoutOneColumn.vue
+++ b/2024-frontend/src/layouts/LayoutOneColumn.vue
@@ -1,5 +1,11 @@
+<script setup>
+import { useRoute } from "vue-router"
+const route = useRoute()
+</script>
+
 <template>
   <div class="fr-col-12 fr-col-lg-7 layout-one-column">
+    <h1 class="fr-my-8w">{{ route.meta.title }}</h1>
     <slot></slot>
   </div>
 </template>

--- a/2024-frontend/src/views/AccessibilityDeclaration.vue
+++ b/2024-frontend/src/views/AccessibilityDeclaration.vue
@@ -10,36 +10,41 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       Elle vise à présenter nos engagements en matière d'accessibilité numérique puis à définir le niveau de conformité
       de ce présent site à la réglementation et aux référentiels en vigueur.
     </p>
-    <h2>Qu'est-ce que l'accessibilité numérique ?</h2>
-    <p>
-      L'accessibilité numérique est un ensemble de règles et de bonnes pratiques qui couvrent notamment les aspects
-      fonctionnels, graphiques, techniques et éditoriaux.
-    </p>
-    <p>
-      Le suivi de ces règles et bonnes pratiques permet de s'assurer que les supports numériques (sites web,
-      applications mobiles, documents PDF, etc.) sont accessibles aux personnes en situation de handicap.
-    </p>
-    <p>
-      Un site accessible permet par exemple de :
-    </p>
-    <ul>
-      <li>
-        Personnaliser son affichage via le système d'exploitation et/ou le navigateur (agrandissement ou rétrécissement
-        des caractères, changement de la typographie, modification des couleurs, arrêt des animations, etc.).
-      </li>
-      <li>
-        Naviguer à l'aide de technologies d'assistance comme une synthèse vocale ou une plage braille.
-      </li>
-      <li>Naviguer sans utiliser la souris, avec le clavier uniquement, des contacteurs ou via un écran tactile.</li>
-      <li>Consulter les vidéos et les contenus audio à l'aide de sous-titres et/ou de transcriptions.</li>
-      <li>Etc.</li>
-    </ul>
-    <h2>Engagements d'accessibilité numérique</h2>
-    <p>
-      Le Ministère de l'Agriculture et de la Souveraineté alimentaire s'engage à rendre accessibles ses sites web
-      (internet, intranet et extranet), ses applications mobiles, ses progiciels et son mobilier urbain numérique
-      conformément à l'article 47 de la loi n°2005-102 du 11 février 2005.
-    </p>
+    <section>
+      <h2>Qu'est-ce que l'accessibilité numérique ?</h2>
+      <p>
+        L'accessibilité numérique est un ensemble de règles et de bonnes pratiques qui couvrent notamment les aspects
+        fonctionnels, graphiques, techniques et éditoriaux.
+      </p>
+      <p>
+        Le suivi de ces règles et bonnes pratiques permet de s'assurer que les supports numériques (sites web,
+        applications mobiles, documents PDF, etc.) sont accessibles aux personnes en situation de handicap.
+      </p>
+      <p>
+        Un site accessible permet par exemple de :
+      </p>
+      <ul>
+        <li>
+          Personnaliser son affichage via le système d'exploitation et/ou le navigateur (agrandissement ou
+          rétrécissement des caractères, changement de la typographie, modification des couleurs, arrêt des animations,
+          etc.).
+        </li>
+        <li>
+          Naviguer à l'aide de technologies d'assistance comme une synthèse vocale ou une plage braille.
+        </li>
+        <li>Naviguer sans utiliser la souris, avec le clavier uniquement, des contacteurs ou via un écran tactile.</li>
+        <li>Consulter les vidéos et les contenus audio à l'aide de sous-titres et/ou de transcriptions.</li>
+        <li>Etc.</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Engagements d'accessibilité numérique</h2>
+      <p>
+        Le Ministère de l'Agriculture et de la Souveraineté alimentaire s'engage à rendre accessibles ses sites web
+        (internet, intranet et extranet), ses applications mobiles, ses progiciels et son mobilier urbain numérique
+        conformément à l'article 47 de la loi n°2005-102 du 11 février 2005.
+      </p>
+    </section>
     <!-- TODO: complete after a11y meeting in september 2023
     <p>
       À cette fin, elle met en œuvre la stratégie et les actions suivantes :
@@ -53,192 +58,196 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       </li>
     </ul>
     -->
-    <h2>Déclaration de non-conformité au RGAA</h2>
-    <p>
-      Cette déclaration s'applique au site « ma-cantine.agriculture.gouv.fr ».
-    </p>
-    <h3>
-      État de conformité
-    </h3>
-    <p>
-      Ce présent site est partiellement conforme avec le RGAA (Référentiel Général d'Amélioration de l'Accessibilité) -
-      version 4.1.2 en raison des non-conformités énumérées ci-après.
-    </p>
-    <h3>
-      Résultats des tests
-    </h3>
-    <p>
-      L'audit de conformité au RGAA version 4.1.2 réalisé en juillet 2023 par la société Ideance révèle que, sur
-      l'échantillon, le taux de conformité global est de 37,9%. Puis, un contre audit réalisé en juillet 2024 par la
-      société Ideance révèle que, sur l'échantillon, le taux de conformité global est de 70,5%. (Obtenu en divisant le
-      nombre de critères conformes par le nombre de critères applicables.)
-    </p>
-    <h3>
-      Contenus non accessibles
-    </h3>
-    <h4>
-      Non-conformités
-    </h4>
-    <p>
-      Liste des critères non conformes :
-    </p>
-    <ul>
-      <li>
-        1.1 - Des images porteuses d'information n'ont pas d'alternative textuelle.
-      </li>
-      <li>1.2 - Des images décoratives ne sont pas ignorées par les technologies d'assistance.</li>
-      <li>3.1 - Des informations sont données uniquement par la couleur.</li>
-      <li>4.8 - Des médias non temporels ne possèdent pas d'alternative.</li>
-      <li>
-        4.12 - La consultation de médias non temporels n'est pas contrôlable par le clavier et tout dispositif de
-        pointage.
-      </li>
-      <li>4.13 - Des vidéos et des médias non temporels ne sont pas compatibles avec les technologies d'assistance.</li>
-      <li>7.1 - Des scripts ne sont pas compatibles avec les technologies d'assistance.</li>
-      <li>7.3 - Des scripts ne sont pas contrôlables par le clavier et par tout dispositif de pointage.</li>
-      <li>8.2 - Le code source généré n'est pas valide selon le type de document spécifié.</li>
-      <li>8.7 - Des changements de langue ne sont pas indiqués.</li>
-      <li>8.9 - Des balises sont utilisées uniquement à des fins de présentation.</li>
-      <li>10.7 - La prise de focus d'éléments interactifs n'est pas visible.</li>
-      <li>10.8 - Des contenus cachés n'ont pas vocation à être ignorés par les technologies d'assistance.</li>
-      <li>
-        10.11 - Des contenus ne peuvent pas être présentés sans avoir recours à un défilement horizontal pour une
-        fenêtre ayant une largeur de 320px.
-      </li>
-      <li>11.1 - Des champs de formulaire n'ont pas d'étiquette.</li>
-      <li>11.10 - Des contrôles de saisie ne sont pas utilisés de manière pertinente.</li>
-      <li>12.7 - Un lien d'évitement ou d'accès rapide à la zone de contenu principal est absent.</li>
-      <li>12.8 - L'ordre de tabulation n'est pas cohérent.</li>
-      <li>13.1 - Des limites de temps modifiant le contenu ne sont pas contrôlables.</li>
-      <li>13.3 - Des documents bureautiques en téléchargement ne possèdent pas de version accessible.</li>
-    </ul>
-    <h4>
-      Contenus non soumis à l'obligation d'accessibilité
-    </h4>
-    <p>
-      Le module de chat « crisp » a été exempté. Il n'a donc pas fait l'objet d'un audit complet et détaillé.
-    </p>
-    <p>
-      Il a toutefois été vérifié que sa présence n'empêche pas l'utilisation et la consultation du reste du site.
-    </p>
-    <p>
-      À noter également qu'il est en contrepartie possible de contacter « ma cantine » depuis le formulaire de contact
-      ainsi que par email à l'adresse suivante
-      <a href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
-      .
-    </p>
-    <h3>
-      Établissement de cette déclaration
-    </h3>
-    <p>
-      Cette déclaration a été établie le 27/07/2023 puis mise à jour le 07/08/2024 à la suite d'un contre audit.
-    </p>
-    <h4>
-      Technologies utilisées pour la réalisation du site
-    </h4>
-    <ul>
-      <li>
-        HTML5
-      </li>
-      <li>SVG</li>
-      <li>ARIA</li>
-      <li>CSS</li>
-      <li>JavaScript</li>
-    </ul>
-    <h4>
-      Environnement de test
-    </h4>
-    <p>
-      Les tests ont été effectués avec les combinaisons de navigateur web et lecteur d'écran suivantes :
-    </p>
-    <ul>
-      <li>Firefox 115 et NVDA 2023.1</li>
-      <li>Firefox 115 et JAWS 2022</li>
-      <li>Safari et VoiceOver (macOS 13.4)</li>
-      <li>Safari et VoiceOver (iOS 16.5)</li>
-    </ul>
-    <h4>
-      Outils pour évaluer l'accessibilité
-    </h4>
-    <ul>
-      <li>Pika (analyse de contraste)</li>
-      <li>Contrast Finder</li>
-      <li>Outils de développement Firefox</li>
-      <li>Web Developer (extension Firefox)</li>
-    </ul>
-    <h4>
-      Pages du site ayant fait l'objet de la vérification de conformité
-    </h4>
-    <ul>
-      <li><router-link :to="{ name: 'LandingPage' }">Accueil</router-link></li>
-      <li><router-link :to="{ name: 'DiagnosticPage' }">Auto évaluation</router-link></li>
-      <li><router-link :to="{ name: 'CanteensHome' }">Index des cantines</router-link></li>
-      <li><router-link :to="{ name: 'FAQ' }">FAQ</router-link></li>
-      <li>
-        <a href="https://ma-cantine.agriculture.gouv.fr/nos-cantines/14--Cantine%20de%20Misson/">
-          Exemple d'une fiche détaillée
-        </a>
-      </li>
-      <li><router-link :to="{ name: 'CommunityPage' }">Page entraide/communauté</router-link></li>
-      <li><router-link :to="{ name: 'ContactPage' }">Contact</router-link></li>
-      <li><router-link :to="{ name: 'LegalNotices' }">Mentions légales</router-link></li>
-      <li><a href="/s-identifier">Authentification</a></li>
-      <li><a href="/creer-mon-compte">Création d'un compte</a></li>
-      <li><router-link :to="{ name: 'SiteMap' }">Plan du site</router-link></li>
-      <li><router-link :to="{ name: 'AccessibilityDeclaration' }">Accessibilité</router-link></li>
-    </ul>
-    <h3>
-      Plan d'action
-    </h3>
-    <p>
-      Vous pouvez suivre notre progrès sur l'amélioration de nos non-confirmités sur
-      <a
-        href="https://github.com/betagouv/ma-cantine/issues?q=is%3Aissue+is%3Aopen+label%3Aa11y"
-        target="_blank"
-        rel="noopener external"
-        title="GitHub issues - ouvre une nouvelle fenêtre"
-      >
-        GitHub
-      </a>
-      .
-    </p>
-    <h3>
-      Retour d'information et contact
-    </h3>
-    <p>
-      Si vous n'arrivez pas à accéder à un contenu ou à un service de ce site, vous pouvez nous contacter via un des
-      moyens ci-dessous pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
-    </p>
-    <ul>
-      <li>
-        Envoyez-nous un message via notre
-        <router-link :to="{ name: 'ContactPage' }">formulaire de contact</router-link>
-        .
-      </li>
-      <li>
-        Écrivez-nous à l'adresse email :
+    <section>
+      <h2>Déclaration de non-conformité au RGAA</h2>
+      <p>
+        Cette déclaration s'applique au site « ma-cantine.agriculture.gouv.fr ».
+      </p>
+      <h3>
+        État de conformité
+      </h3>
+      <p>
+        Ce présent site est partiellement conforme avec le RGAA (Référentiel Général d'Amélioration de l'Accessibilité)
+        - version 4.1.2 en raison des non-conformités énumérées ci-après.
+      </p>
+      <h3>
+        Résultats des tests
+      </h3>
+      <p>
+        L'audit de conformité au RGAA version 4.1.2 réalisé en juillet 2023 par la société Ideance révèle que, sur
+        l'échantillon, le taux de conformité global est de 37,9%. Puis, un contre audit réalisé en juillet 2024 par la
+        société Ideance révèle que, sur l'échantillon, le taux de conformité global est de 70,5%. (Obtenu en divisant le
+        nombre de critères conformes par le nombre de critères applicables.)
+      </p>
+      <h3>
+        Contenus non accessibles
+      </h3>
+      <h4>
+        Non-conformités
+      </h4>
+      <p>
+        Liste des critères non conformes :
+      </p>
+      <ul>
+        <li>
+          1.1 - Des images porteuses d'information n'ont pas d'alternative textuelle.
+        </li>
+        <li>1.2 - Des images décoratives ne sont pas ignorées par les technologies d'assistance.</li>
+        <li>3.1 - Des informations sont données uniquement par la couleur.</li>
+        <li>4.8 - Des médias non temporels ne possèdent pas d'alternative.</li>
+        <li>
+          4.12 - La consultation de médias non temporels n'est pas contrôlable par le clavier et tout dispositif de
+          pointage.
+        </li>
+        <li>
+          4.13 - Des vidéos et des médias non temporels ne sont pas compatibles avec les technologies d'assistance.
+        </li>
+        <li>7.1 - Des scripts ne sont pas compatibles avec les technologies d'assistance.</li>
+        <li>7.3 - Des scripts ne sont pas contrôlables par le clavier et par tout dispositif de pointage.</li>
+        <li>8.2 - Le code source généré n'est pas valide selon le type de document spécifié.</li>
+        <li>8.7 - Des changements de langue ne sont pas indiqués.</li>
+        <li>8.9 - Des balises sont utilisées uniquement à des fins de présentation.</li>
+        <li>10.7 - La prise de focus d'éléments interactifs n'est pas visible.</li>
+        <li>10.8 - Des contenus cachés n'ont pas vocation à être ignorés par les technologies d'assistance.</li>
+        <li>
+          10.11 - Des contenus ne peuvent pas être présentés sans avoir recours à un défilement horizontal pour une
+          fenêtre ayant une largeur de 320px.
+        </li>
+        <li>11.1 - Des champs de formulaire n'ont pas d'étiquette.</li>
+        <li>11.10 - Des contrôles de saisie ne sont pas utilisés de manière pertinente.</li>
+        <li>12.7 - Un lien d'évitement ou d'accès rapide à la zone de contenu principal est absent.</li>
+        <li>12.8 - L'ordre de tabulation n'est pas cohérent.</li>
+        <li>13.1 - Des limites de temps modifiant le contenu ne sont pas contrôlables.</li>
+        <li>13.3 - Des documents bureautiques en téléchargement ne possèdent pas de version accessible.</li>
+      </ul>
+      <h4>
+        Contenus non soumis à l'obligation d'accessibilité
+      </h4>
+      <p>
+        Le module de chat « crisp » a été exempté. Il n'a donc pas fait l'objet d'un audit complet et détaillé.
+      </p>
+      <p>
+        Il a toutefois été vérifié que sa présence n'empêche pas l'utilisation et la consultation du reste du site.
+      </p>
+      <p>
+        À noter également qu'il est en contrepartie possible de contacter « ma cantine » depuis le formulaire de contact
+        ainsi que par email à l'adresse suivante
         <a href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
         .
-      </li>
-      <li>Écrivez-nous par voie postale à l'adresse suivante : 20 avenue de Ségur, 75007, Paris</li>
-    </ul>
-    <h3>
-      Voies de recours
-    </h3>
-    <p>
-      Cette procédure est à utiliser dans le cas suivant.
-    </p>
-    <p>
-      Vous avez signalé au responsable du site internet un défaut d'accessibilité qui vous empêche d'accéder à un
-      contenu ou à un des services et vous n'avez pas obtenu de réponse satisfaisante.
-    </p>
-    <ul>
-      <li>Écrire un message au Défenseur des droits.</li>
-      <li>Contacter le délégué du Défenseur des droits dans votre région.</li>
-      <li>
-        Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) à l'adresse suivante : Défenseur des droits
-        Libre réponse 71120 75342 Paris CEDEX 07
-      </li>
-    </ul>
+      </p>
+      <h3>
+        Établissement de cette déclaration
+      </h3>
+      <p>
+        Cette déclaration a été établie le 27/07/2023 puis mise à jour le 07/08/2024 à la suite d'un contre audit.
+      </p>
+      <h4>
+        Technologies utilisées pour la réalisation du site
+      </h4>
+      <ul>
+        <li>
+          HTML5
+        </li>
+        <li>SVG</li>
+        <li>ARIA</li>
+        <li>CSS</li>
+        <li>JavaScript</li>
+      </ul>
+      <h4>
+        Environnement de test
+      </h4>
+      <p>
+        Les tests ont été effectués avec les combinaisons de navigateur web et lecteur d'écran suivantes :
+      </p>
+      <ul>
+        <li>Firefox 115 et NVDA 2023.1</li>
+        <li>Firefox 115 et JAWS 2022</li>
+        <li>Safari et VoiceOver (macOS 13.4)</li>
+        <li>Safari et VoiceOver (iOS 16.5)</li>
+      </ul>
+      <h4>
+        Outils pour évaluer l'accessibilité
+      </h4>
+      <ul>
+        <li>Pika (analyse de contraste)</li>
+        <li>Contrast Finder</li>
+        <li>Outils de développement Firefox</li>
+        <li>Web Developer (extension Firefox)</li>
+      </ul>
+      <h4>
+        Pages du site ayant fait l'objet de la vérification de conformité
+      </h4>
+      <ul>
+        <li><router-link :to="{ name: 'LandingPage' }">Accueil</router-link></li>
+        <li><router-link :to="{ name: 'DiagnosticPage' }">Auto évaluation</router-link></li>
+        <li><router-link :to="{ name: 'CanteensHome' }">Index des cantines</router-link></li>
+        <li><router-link :to="{ name: 'FAQ' }">FAQ</router-link></li>
+        <li>
+          <a href="https://ma-cantine.agriculture.gouv.fr/nos-cantines/14--Cantine%20de%20Misson/">
+            Exemple d'une fiche détaillée
+          </a>
+        </li>
+        <li><router-link :to="{ name: 'CommunityPage' }">Page entraide/communauté</router-link></li>
+        <li><router-link :to="{ name: 'ContactPage' }">Contact</router-link></li>
+        <li><router-link :to="{ name: 'LegalNotices' }">Mentions légales</router-link></li>
+        <li><a href="/s-identifier">Authentification</a></li>
+        <li><a href="/creer-mon-compte">Création d'un compte</a></li>
+        <li><router-link :to="{ name: 'SiteMap' }">Plan du site</router-link></li>
+        <li><router-link :to="{ name: 'AccessibilityDeclaration' }">Accessibilité</router-link></li>
+      </ul>
+      <h3>
+        Plan d'action
+      </h3>
+      <p>
+        Vous pouvez suivre notre progrès sur l'amélioration de nos non-confirmités sur
+        <a
+          href="https://github.com/betagouv/ma-cantine/issues?q=is%3Aissue+is%3Aopen+label%3Aa11y"
+          target="_blank"
+          rel="noopener external"
+          title="GitHub issues - ouvre une nouvelle fenêtre"
+        >
+          GitHub
+        </a>
+        .
+      </p>
+      <h3>
+        Retour d'information et contact
+      </h3>
+      <p>
+        Si vous n'arrivez pas à accéder à un contenu ou à un service de ce site, vous pouvez nous contacter via un des
+        moyens ci-dessous pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
+      </p>
+      <ul>
+        <li>
+          Envoyez-nous un message via notre
+          <router-link :to="{ name: 'ContactPage' }">formulaire de contact</router-link>
+          .
+        </li>
+        <li>
+          Écrivez-nous à l'adresse email :
+          <a href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
+          .
+        </li>
+        <li>Écrivez-nous par voie postale à l'adresse suivante : 20 avenue de Ségur, 75007, Paris</li>
+      </ul>
+      <h3>
+        Voies de recours
+      </h3>
+      <p>
+        Cette procédure est à utiliser dans le cas suivant.
+      </p>
+      <p>
+        Vous avez signalé au responsable du site internet un défaut d'accessibilité qui vous empêche d'accéder à un
+        contenu ou à un des services et vous n'avez pas obtenu de réponse satisfaisante.
+      </p>
+      <ul>
+        <li>Écrire un message au Défenseur des droits.</li>
+        <li>Contacter le délégué du Défenseur des droits dans votre région.</li>
+        <li>
+          Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) à l'adresse suivante : Défenseur des
+          droits Libre réponse 71120 75342 Paris CEDEX 07
+        </li>
+      </ul>
+    </section>
   </LayoutOneColumn>
 </template>

--- a/2024-frontend/src/views/AccessibilityDeclaration.vue
+++ b/2024-frontend/src/views/AccessibilityDeclaration.vue
@@ -4,13 +4,13 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
 
 <template>
   <LayoutOneColumn>
-    <h1 class="my-6 fr-h1">Déclaration d'accessibilité</h1>
+    <h1>Déclaration d'accessibilité</h1>
     <p>Cette page n'est pas une page d'aide.</p>
     <p>
       Elle vise à présenter nos engagements en matière d'accessibilité numérique puis à définir le niveau de conformité
       de ce présent site à la réglementation et aux référentiels en vigueur.
     </p>
-    <h2 class="fr-h2">Qu'est-ce que l'accessibilité numérique ?</h2>
+    <h2>Qu'est-ce que l'accessibilité numérique ?</h2>
     <p>
       L'accessibilité numérique est un ensemble de règles et de bonnes pratiques qui couvrent notamment les aspects
       fonctionnels, graphiques, techniques et éditoriaux.
@@ -34,7 +34,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       <li>Consulter les vidéos et les contenus audio à l'aide de sous-titres et/ou de transcriptions.</li>
       <li>Etc.</li>
     </ul>
-    <h2 class="fr-h2">Engagements d'accessibilité numérique</h2>
+    <h2>Engagements d'accessibilité numérique</h2>
     <p>
       Le Ministère de l'Agriculture et de la Souveraineté alimentaire s'engage à rendre accessibles ses sites web
       (internet, intranet et extranet), ses applications mobiles, ses progiciels et son mobilier urbain numérique
@@ -53,18 +53,18 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       </li>
     </ul>
     -->
-    <h2 class="fr-h2">Déclaration de non-conformité au RGAA</h2>
+    <h2>Déclaration de non-conformité au RGAA</h2>
     <p>
       Cette déclaration s'applique au site « ma-cantine.agriculture.gouv.fr ».
     </p>
-    <h3 class="fr-h3">
+    <h3>
       État de conformité
     </h3>
     <p>
       Ce présent site est partiellement conforme avec le RGAA (Référentiel Général d'Amélioration de l'Accessibilité) -
       version 4.1.2 en raison des non-conformités énumérées ci-après.
     </p>
-    <h3 class="fr-h3">
+    <h3>
       Résultats des tests
     </h3>
     <p>
@@ -73,10 +73,10 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       société Ideance révèle que, sur l'échantillon, le taux de conformité global est de 70,5%. (Obtenu en divisant le
       nombre de critères conformes par le nombre de critères applicables.)
     </p>
-    <h3 class="fr-h3">
+    <h3>
       Contenus non accessibles
     </h3>
-    <h4 class="fr-h4">
+    <h4>
       Non-conformités
     </h4>
     <p>
@@ -112,7 +112,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       <li>13.1 - Des limites de temps modifiant le contenu ne sont pas contrôlables.</li>
       <li>13.3 - Des documents bureautiques en téléchargement ne possèdent pas de version accessible.</li>
     </ul>
-    <h4 class="fr-h4">
+    <h4>
       Contenus non soumis à l'obligation d'accessibilité
     </h4>
     <p>
@@ -127,13 +127,13 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       <a href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
       .
     </p>
-    <h3 class="fr-h3">
+    <h3>
       Établissement de cette déclaration
     </h3>
     <p>
       Cette déclaration a été établie le 27/07/2023 puis mise à jour le 07/08/2024 à la suite d'un contre audit.
     </p>
-    <h4 class="fr-h4">
+    <h4>
       Technologies utilisées pour la réalisation du site
     </h4>
     <ul>
@@ -145,7 +145,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       <li>CSS</li>
       <li>JavaScript</li>
     </ul>
-    <h4 class="fr-h4">
+    <h4>
       Environnement de test
     </h4>
     <p>
@@ -157,7 +157,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       <li>Safari et VoiceOver (macOS 13.4)</li>
       <li>Safari et VoiceOver (iOS 16.5)</li>
     </ul>
-    <h4 class="fr-h4">
+    <h4>
       Outils pour évaluer l'accessibilité
     </h4>
     <ul>
@@ -166,7 +166,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       <li>Outils de développement Firefox</li>
       <li>Web Developer (extension Firefox)</li>
     </ul>
-    <h4 class="fr-h4">
+    <h4>
       Pages du site ayant fait l'objet de la vérification de conformité
     </h4>
     <ul>
@@ -187,7 +187,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       <li><router-link :to="{ name: 'SiteMap' }">Plan du site</router-link></li>
       <li><router-link :to="{ name: 'AccessibilityDeclaration' }">Accessibilité</router-link></li>
     </ul>
-    <h3 class="fr-h3">
+    <h3>
       Plan d'action
     </h3>
     <p>
@@ -202,7 +202,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       </a>
       .
     </p>
-    <h3 class="fr-h3">
+    <h3>
       Retour d'information et contact
     </h3>
     <p>
@@ -222,7 +222,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       </li>
       <li>Écrivez-nous par voie postale à l'adresse suivante : 20 avenue de Ségur, 75007, Paris</li>
     </ul>
-    <h3 class="fr-h3">
+    <h3>
       Voies de recours
     </h3>
     <p>

--- a/2024-frontend/src/views/AccessibilityDeclaration.vue
+++ b/2024-frontend/src/views/AccessibilityDeclaration.vue
@@ -4,7 +4,6 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
 
 <template>
   <LayoutOneColumn>
-    <h1>Déclaration d'accessibilité</h1>
     <p>Cette page n'est pas une page d'aide.</p>
     <p>
       Elle vise à présenter nos engagements en matière d'accessibilité numérique puis à définir le niveau de conformité

--- a/2024-frontend/src/views/AccessibilityDeclaration.vue
+++ b/2024-frontend/src/views/AccessibilityDeclaration.vue
@@ -1,5 +1,9 @@
+<script setup>
+import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
+</script>
+
 <template>
-  <div class="fr-col-12">
+  <LayoutOneColumn>
     <h1 class="my-6 fr-h1">Déclaration d'accessibilité</h1>
     <p>Cette page n'est pas une page d'aide.</p>
     <p>
@@ -236,5 +240,5 @@
         Libre réponse 71120 75342 Paris CEDEX 07
       </li>
     </ul>
-  </div>
+  </LayoutOneColumn>
 </template>

--- a/2024-frontend/src/views/CGU.vue
+++ b/2024-frontend/src/views/CGU.vue
@@ -1,5 +1,9 @@
+<script setup>
+import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
+</script>
+
 <template>
-  <div class="fr-col-12">
+  <LayoutOneColumn>
     <h1 class="fr-h1">
       Conditions générales d'utilisation de « ma cantine »
     </h1>
@@ -277,5 +281,5 @@
         .
       </li>
     </ul>
-  </div>
+  </LayoutOneColumn>
 </template>

--- a/2024-frontend/src/views/CGU.vue
+++ b/2024-frontend/src/views/CGU.vue
@@ -12,7 +12,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       L'utilisation du Service est gratuite et facultative sauf pour les déclarations obligatoires prévues par les
       dispositions du code rural et de la pêche maritime (articles L. 230-5 à L. 230-5-2 et R. 230-30-4).
     </p>
-    <h2 class="fr-h2">
+    <h2>
       1 - Présentation
     </h2>
     <p>
@@ -46,7 +46,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       </li>
     </ul>
 
-    <h2 class="fr-h2">2 – Définitions</h2>
+    <h2>2 – Définitions</h2>
     <p>« Visiteur » est toute personne qui consulte ou utilise le Service.</p>
     <p>« Gestionnaire » est toute personne qui ouvre un compte sur le Service.</p>
     <p>
@@ -58,9 +58,9 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       finalités.
     </p>
 
-    <h2 class="fr-h2">3 - Fonctionnalités</h2>
+    <h2>3 - Fonctionnalités</h2>
 
-    <h3 class="fr-h3">3.1 Visiteurs</h3>
+    <h3>3.1 Visiteurs</h3>
     <p>Tout Visiteur peut accéder au Service sans inscription.</p>
 
     <p>Le Visiteur peut :</p>
@@ -82,11 +82,11 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       </li>
     </ul>
 
-    <h3 class="fr-h3">3.2 Gestionnaire de RC</h3>
+    <h3>3.2 Gestionnaire de RC</h3>
 
     <p>En plus des fonctionnalités Visiteur, chaque Gestionnaire de cantine dispose des fonctionnalités suivantes :</p>
 
-    <h4 class="fr-h4">1) Création d’un compte gestionnaire</h4>
+    <h4>1) Création d’un compte gestionnaire</h4>
     <p>
       Tout gestionnaire RC crée un compte en saisissant ses nom, prénom, courrier électronique, numéro de téléphone, nom
       d’utilisateur et numéro de SIRET.
@@ -97,7 +97,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
     </p>
     <p>Tout gestionnaire peut supprimer son compte via les paramètres de son compte.</p>
 
-    <h4 class="fr-h4">2) Gestion des établissements de RC</h4>
+    <h4>2) Gestion des établissements de RC</h4>
     <p>
       Depuis son espace de gestion, le Gestionnaire peut ajouter d’autres établissements de RC soit en renseignant un
       numéro de SIRET propre à l’établissement, soit lorsqu’il ne dispose pas d’un tel numéro de SIRET en se rattachant
@@ -122,10 +122,10 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       en est faite notamment en matière de confidentialité des données.
     </p>
 
-    <h4 class="fr-h4">3) Positionner son établissement par rapport aux objectifs des lois EGalim</h4>
+    <h4>3) Positionner son établissement par rapport aux objectifs des lois EGalim</h4>
     <p>Chaque Gestionnaire peut comparer son établissement de RC par rapport aux objectifs des lois EGalim.</p>
 
-    <h4 class="fr-h4">4) Télédéclaration</h4>
+    <h4>4) Télédéclaration</h4>
     <p>
       Chaque Gestionnaire procède à ses télédéclarations selon les dispositions prévues par le code rural et de la pêche
       maritime et les lois EGalim.
@@ -139,7 +139,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       concerné.
     </p>
 
-    <h4 class="fr-h4">5) Référencement de mon établissement en ligne</h4>
+    <h4>5) Référencement de mon établissement en ligne</h4>
     <p>
       Dès lors qu’un établissement est créée sur la plateforme, ses informations administratives et ses taux EGalim sont
       visibles publiquement sur l’onglet « nos cantines publiées » et sur le site data.gouv.fr.
@@ -150,14 +150,14 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       alimentaire, diversification des protéines, substitution plastique, information convives).
     </p>
 
-    <h4 class="fr-h4">6) Outil de suivi de ses achats</h4>
+    <h4>6) Outil de suivi de ses achats</h4>
     <p>
       Les Gestionnaires peuvent ajouter leurs achats dans un tableau mis à disposition sur la plateforme. La complétion
       du tableau permet aux Gestionnaires de voir la répartition des achats en fonction des différentes familles de
       produit, ainsi que le pourcentage en lien avec les lois EGalim.
     </p>
 
-    <h2 class="fr-h2">4 - Traitement des données personnelles</h2>
+    <h2>4 - Traitement des données personnelles</h2>
     <p>
       Le Service ne collecte que les données strictement nécessaires à sa mise en œuvre. Les données collectées incluent
       également des données à caractère personnel. Pour plus d’informations sur le traitement des données à caractère
@@ -166,7 +166,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       .
     </p>
 
-    <h2 class="fr-h2">5 – Inscription à l’infolettre</h2>
+    <h2>5 – Inscription à l’infolettre</h2>
     <p>La création d’un compte implique l’inscription automatique à l’infolettre « ma cantine ».</p>
     <p>
       Cette inscription est révocable à tout moment, soit en vous désabonnant à réception du courriel, ou en nous
@@ -174,7 +174,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       <a rel="noopener" href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
     </p>
 
-    <h2 class="fr-h2">6 - Statistiques et diffusion sur data.gouv.fr</h2>
+    <h2>6 - Statistiques et diffusion sur data.gouv.fr</h2>
     <p>Les données récoltées dans le cadre du téléservice servent au pilotage de la politique publique.</p>
     <p>
       Conformément aux dispositions des articles L. 230-5-1 et R. 230-30-4 du Code rural, les données recueillies par
@@ -187,9 +187,9 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       plateforme sur le site de data.gouv.fr
     </p>
 
-    <h2 class="fr-h2">7 - Engagements et responsabilité</h2>
+    <h2>7 - Engagements et responsabilité</h2>
 
-    <h3 class="fr-h3">Visiteur</h3>
+    <h3>Visiteur</h3>
     <p>
       Le Visiteur s’engage à respecter les présentes CGU et leurs éventuelles modifications ainsi que la législation en
       vigueur.
@@ -206,7 +206,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       poursuites devant les juridictions compétentes.
     </p>
 
-    <h3 class="fr-h3">Gestionnaire</h3>
+    <h3>Gestionnaire</h3>
 
     <p>
       Le titulaire d’un compte s’engage à respecter les présentes CGU ainsi que leurs éventuelles modifications ou de
@@ -230,7 +230,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       déposer que les seuls documents et informations demandées par le Service.
     </p>
 
-    <h3 class="fr-h3">L’Editeur</h3>
+    <h3>L’Editeur</h3>
 
     <p>
       Le Service est développé conformément à l’état de l’art. Toutefois, il n’est pas garanti qu’il soit exempt
@@ -248,13 +248,13 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       qui pourraient être engagées à son encontre.
     </p>
 
-    <h2 class="fr-h2">8 – Code source</h2>
+    <h2>8 – Code source</h2>
     <p>
       Le Service a été développé sous licence MIT, le code est disponible à l’adresse suivante :
       <a rel="noopener" href="https://github.com/betagouv/ma-cantine">https://github.com/betagouv/ma-cantine</a>
     </p>
 
-    <h2 class="fr-h2">9 – Modification et évolution du Service</h2>
+    <h2>9 – Modification et évolution du Service</h2>
     <p>
       Les termes des présentes conditions d’utilisation peuvent être modifiés ou complétés à tout moment, sans préavis,
       en fonction des modifications apportées au Service, de l’évolution de la législation ou pour tout autre motif jugé
@@ -265,7 +265,7 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       régulièrement à cette rubrique pour vérifier les conditions générales en vigueur.
     </p>
 
-    <h2 class="fr-h2">10 - Nous contacter</h2>
+    <h2>10 - Nous contacter</h2>
     <ul>
       <li>
         Difficultés techniques :

--- a/2024-frontend/src/views/CGU.vue
+++ b/2024-frontend/src/views/CGU.vue
@@ -4,9 +4,6 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
 
 <template>
   <LayoutOneColumn>
-    <h1 class="fr-h1">
-      Conditions générales d'utilisation de « ma cantine »
-    </h1>
     <p>
       Les présentes conditions d’utilisation (CGU) sont mises en œuvre conformément à l’article L. 112-9 du code des
       relations entre le public et l’administration. Elles s’imposent de plein droit aux Visiteurs avec ou sans compte.

--- a/2024-frontend/src/views/CGU.vue
+++ b/2024-frontend/src/views/CGU.vue
@@ -12,271 +12,286 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
       L'utilisation du Service est gratuite et facultative sauf pour les déclarations obligatoires prévues par les
       dispositions du code rural et de la pêche maritime (articles L. 230-5 à L. 230-5-2 et R. 230-30-4).
     </p>
-    <h2>
-      1 - Présentation
-    </h2>
-    <p>
-      « ma cantine » (ci-après dénommé « le Service ») est un téléservice mis en œuvre par le ministère de l’Agriculture
-      et de la Souveraineté Alimentaire (Direction générale à l’alimentation) en lien avec la Direction
-      interministérielle du numérique.
-    </p>
-    <p>
-      Le Service est destiné à accompagner au mieux les acteurs de la restauration collective (ci-après abrégé « RC »)
-      dans leur offre aux consommateurs et usagers pour une alimentation de qualité, saine et durable.
-    </p>
-    <p>Le Service est une plateforme numérique permettant :</p>
-    <ul>
-      <li>une meilleure connaissance des lois EGalim via une description détaillée et pédagogique des mesures,</li>
-      <li>
-        un aperçu de l'état des lieux des cantines ayant partagé leurs données pour connaître leur positionnement et
-        éventuellement fomenter des échanges entre elles et avec leurs convives,
-      </li>
-      <li>
-        une option d'auto-diagnostic pour les acteurs de la restauration collective afin de s'auto-évaluer et accéder à
-        des ressources pour s'améliorer,
-      </li>
-      <li>
-        de créez un PDF à afficher ou à envoyer par mail à aux convives pour les informer sur les initiatives et la
-        composition des repas servis.
-      </li>
-      <li>
-        de télédéclarer au ministère de l’Agriculture et de la Souveraineté Alimentaire les données annuelles d’achat
-        dans les conditions prévues par le code rural et de la pêche maritime (articles L. 230-5 à L. 230-5-2 et R.
-        230-30-4).
-      </li>
-    </ul>
+    <section>
+      <h2>
+        1 - Présentation
+      </h2>
+      <p>
+        « ma cantine » (ci-après dénommé « le Service ») est un téléservice mis en œuvre par le ministère de
+        l’Agriculture et de la Souveraineté Alimentaire (Direction générale à l’alimentation) en lien avec la Direction
+        interministérielle du numérique.
+      </p>
+      <p>
+        Le Service est destiné à accompagner au mieux les acteurs de la restauration collective (ci-après abrégé « RC »)
+        dans leur offre aux consommateurs et usagers pour une alimentation de qualité, saine et durable.
+      </p>
+      <p>Le Service est une plateforme numérique permettant :</p>
+      <ul>
+        <li>une meilleure connaissance des lois EGalim via une description détaillée et pédagogique des mesures,</li>
+        <li>
+          un aperçu de l'état des lieux des cantines ayant partagé leurs données pour connaître leur positionnement et
+          éventuellement fomenter des échanges entre elles et avec leurs convives,
+        </li>
+        <li>
+          une option d'auto-diagnostic pour les acteurs de la restauration collective afin de s'auto-évaluer et accéder
+          à des ressources pour s'améliorer,
+        </li>
+        <li>
+          de créez un PDF à afficher ou à envoyer par mail à aux convives pour les informer sur les initiatives et la
+          composition des repas servis.
+        </li>
+        <li>
+          de télédéclarer au ministère de l’Agriculture et de la Souveraineté Alimentaire les données annuelles d’achat
+          dans les conditions prévues par le code rural et de la pêche maritime (articles L. 230-5 à L. 230-5-2 et R.
+          230-30-4).
+        </li>
+      </ul>
+    </section>
 
-    <h2>2 – Définitions</h2>
-    <p>« Visiteur » est toute personne qui consulte ou utilise le Service.</p>
-    <p>« Gestionnaire » est toute personne qui ouvre un compte sur le Service.</p>
-    <p>
-      « L’Editeur » de la plateforme »ma cantine » est la Direction générale de l’alimentation du ministère de
-      l’Agriculture et de la Souveraineté Alimentaire.
-    </p>
-    <p>
-      Le « Service » correspond aux fonctionnalités offertes par la plateforme « ma cantine » pour répondre à ses
-      finalités.
-    </p>
+    <section>
+      <h2>2 – Définitions</h2>
+      <p>« Visiteur » est toute personne qui consulte ou utilise le Service.</p>
+      <p>« Gestionnaire » est toute personne qui ouvre un compte sur le Service.</p>
+      <p>
+        « L’Editeur » de la plateforme »ma cantine » est la Direction générale de l’alimentation du ministère de
+        l’Agriculture et de la Souveraineté Alimentaire.
+      </p>
+      <p>
+        Le « Service » correspond aux fonctionnalités offertes par la plateforme « ma cantine » pour répondre à ses
+        finalités.
+      </p>
+    </section>
 
-    <h2>3 - Fonctionnalités</h2>
+    <section>
+      <h2>3 - Fonctionnalités</h2>
 
-    <h3>3.1 Visiteurs</h3>
-    <p>Tout Visiteur peut accéder au Service sans inscription.</p>
+      <h3>3.1 Visiteurs</h3>
+      <p>Tout Visiteur peut accéder au Service sans inscription.</p>
 
-    <p>Le Visiteur peut :</p>
-    <ul>
-      <li>Prendre connaissance d’informations pédagogiques sur les objectifs et mesures des lois EGalims.</li>
-      <li>
-        Accéder aux informations télédéclarées dans le Services par les Gestionnaires de RC au regard des objectifs
-        fixés par les lois EGalim. Il dispose soit d’un filtre par numéro de SIRET, soit d’un filtre géographique et par
-        type d’EPCI et secteur d’activité.
-      </li>
-      <li>Simuler une évaluation d’un établissement de RC selon les objectifs fixés par les lois EGalim.</li>
-      <li>
-        Signaler l’absence d’un établissement de restauration collective (saisie d’une adresse mail, d’un nom et prénom
-        à titre facultatif et un champ libre).
-      </li>
-      <li>
-        S’inscrire à l’infolettre en saisissant son adresse électronique (un lien de désinscription est accessible dans
-        chaque infolettre).
-      </li>
-    </ul>
+      <p>Le Visiteur peut :</p>
+      <ul>
+        <li>Prendre connaissance d’informations pédagogiques sur les objectifs et mesures des lois EGalims.</li>
+        <li>
+          Accéder aux informations télédéclarées dans le Services par les Gestionnaires de RC au regard des objectifs
+          fixés par les lois EGalim. Il dispose soit d’un filtre par numéro de SIRET, soit d’un filtre géographique et
+          par type d’EPCI et secteur d’activité.
+        </li>
+        <li>Simuler une évaluation d’un établissement de RC selon les objectifs fixés par les lois EGalim.</li>
+        <li>
+          Signaler l’absence d’un établissement de restauration collective (saisie d’une adresse mail, d’un nom et
+          prénom à titre facultatif et un champ libre).
+        </li>
+        <li>
+          S’inscrire à l’infolettre en saisissant son adresse électronique (un lien de désinscription est accessible
+          dans chaque infolettre).
+        </li>
+      </ul>
 
-    <h3>3.2 Gestionnaire de RC</h3>
+      <h3>3.2 Gestionnaire de RC</h3>
 
-    <p>En plus des fonctionnalités Visiteur, chaque Gestionnaire de cantine dispose des fonctionnalités suivantes :</p>
+      <p>
+        En plus des fonctionnalités Visiteur, chaque Gestionnaire de cantine dispose des fonctionnalités suivantes :
+      </p>
 
-    <h4>1) Création d’un compte gestionnaire</h4>
-    <p>
-      Tout gestionnaire RC crée un compte en saisissant ses nom, prénom, courrier électronique, numéro de téléphone, nom
-      d’utilisateur et numéro de SIRET.
-    </p>
-    <p>
-      En accédant aux paramètres de son compte, le gestionnaire peut ajouter une photo de profil ainsi que via des
-      onglets déroulants préciser ses fonctions et la façon dont il a eu connaissance du Service.
-    </p>
-    <p>Tout gestionnaire peut supprimer son compte via les paramètres de son compte.</p>
+      <h4>1) Création d’un compte gestionnaire</h4>
+      <p>
+        Tout gestionnaire RC crée un compte en saisissant ses nom, prénom, courrier électronique, numéro de téléphone,
+        nom d’utilisateur et numéro de SIRET.
+      </p>
+      <p>
+        En accédant aux paramètres de son compte, le gestionnaire peut ajouter une photo de profil ainsi que via des
+        onglets déroulants préciser ses fonctions et la façon dont il a eu connaissance du Service.
+      </p>
+      <p>Tout gestionnaire peut supprimer son compte via les paramètres de son compte.</p>
 
-    <h4>2) Gestion des établissements de RC</h4>
-    <p>
-      Depuis son espace de gestion, le Gestionnaire peut ajouter d’autres établissements de RC soit en renseignant un
-      numéro de SIRET propre à l’établissement, soit lorsqu’il ne dispose pas d’un tel numéro de SIRET en se rattachant
-      à l’unité légale de tutelle dont il relève qui dispose d’un numéro de SIRET.
-    </p>
-    <p>
-      Un Gestionnaire peut se rattacher à une unité légale à condition :
-    </p>
-    <ul>
-      <li>de ne pas dupliquer un établissement déjà existant dans le Service,</li>
-      <li>de se rattacher à une unité légale qui exerce la tutelle de son établissement.</li>
-    </ul>
-    <p>
-      En cas de doute, l’Editeur peut prendre contact avec le Gestionnaire concerné et se réserve le droit de supprimer
-      tout établissement qui méconnaitrait ces conditions. Le Gestionnaire peut également inviter d’autres Gestionnaires
-      associés sur le ou les mêmes établissements en saisissant une adresse électronique. Chaque gestionnaire associé
-      reçoit un courrier électronique pour valider son compte ou refuser l’invitation en contactant le support technique
-      de ma cantine.
-    </p>
-    <p>
-      Le Gestionnaire est seul responsable de l’envoi des invitations, des accès qu’il attribue et de l’utilisation qui
-      en est faite notamment en matière de confidentialité des données.
-    </p>
+      <h4>2) Gestion des établissements de RC</h4>
+      <p>
+        Depuis son espace de gestion, le Gestionnaire peut ajouter d’autres établissements de RC soit en renseignant un
+        numéro de SIRET propre à l’établissement, soit lorsqu’il ne dispose pas d’un tel numéro de SIRET en se
+        rattachant à l’unité légale de tutelle dont il relève qui dispose d’un numéro de SIRET.
+      </p>
+      <p>
+        Un Gestionnaire peut se rattacher à une unité légale à condition :
+      </p>
+      <ul>
+        <li>de ne pas dupliquer un établissement déjà existant dans le Service,</li>
+        <li>de se rattacher à une unité légale qui exerce la tutelle de son établissement.</li>
+      </ul>
+      <p>
+        En cas de doute, l’Editeur peut prendre contact avec le Gestionnaire concerné et se réserve le droit de
+        supprimer tout établissement qui méconnaitrait ces conditions. Le Gestionnaire peut également inviter d’autres
+        Gestionnaires associés sur le ou les mêmes établissements en saisissant une adresse électronique. Chaque
+        gestionnaire associé reçoit un courrier électronique pour valider son compte ou refuser l’invitation en
+        contactant le support technique de ma cantine.
+      </p>
+      <p>
+        Le Gestionnaire est seul responsable de l’envoi des invitations, des accès qu’il attribue et de l’utilisation
+        qui en est faite notamment en matière de confidentialité des données.
+      </p>
 
-    <h4>3) Positionner son établissement par rapport aux objectifs des lois EGalim</h4>
-    <p>Chaque Gestionnaire peut comparer son établissement de RC par rapport aux objectifs des lois EGalim.</p>
+      <h4>3) Positionner son établissement par rapport aux objectifs des lois EGalim</h4>
+      <p>Chaque Gestionnaire peut comparer son établissement de RC par rapport aux objectifs des lois EGalim.</p>
 
-    <h4>4) Télédéclaration</h4>
-    <p>
-      Chaque Gestionnaire procède à ses télédéclarations selon les dispositions prévues par le code rural et de la pêche
-      maritime et les lois EGalim.
-    </p>
-    <p>
-      Le Service peut solliciter des informations complémentaires sur la gestion des établissements de RC afin de
-      consolider les données télédéclarées ou d’obtenir d’autres jeux de données.
-    </p>
-    <p>
-      Une fois les données saisies et validées par l’un des Gestionnaires, la télédéclaration engage l’établissement
-      concerné.
-    </p>
+      <h4>4) Télédéclaration</h4>
+      <p>
+        Chaque Gestionnaire procède à ses télédéclarations selon les dispositions prévues par le code rural et de la
+        pêche maritime et les lois EGalim.
+      </p>
+      <p>
+        Le Service peut solliciter des informations complémentaires sur la gestion des établissements de RC afin de
+        consolider les données télédéclarées ou d’obtenir d’autres jeux de données.
+      </p>
+      <p>
+        Une fois les données saisies et validées par l’un des Gestionnaires, la télédéclaration engage l’établissement
+        concerné.
+      </p>
 
-    <h4>5) Référencement de mon établissement en ligne</h4>
-    <p>
-      Dès lors qu’un établissement est créée sur la plateforme, ses informations administratives et ses taux EGalim sont
-      visibles publiquement sur l’onglet « nos cantines publiées » et sur le site data.gouv.fr.
-    </p>
-    <p>
-      Les informations transmises dans le cadre des campagnes de télédéclaration annuelles affichées sont notamment :
-      les pourcentages des taux EGalim et les données qualitatives sur les autres volets des lois EGalim (gaspillage
-      alimentaire, diversification des protéines, substitution plastique, information convives).
-    </p>
+      <h4>5) Référencement de mon établissement en ligne</h4>
+      <p>
+        Dès lors qu’un établissement est créée sur la plateforme, ses informations administratives et ses taux EGalim
+        sont visibles publiquement sur l’onglet « nos cantines publiées » et sur le site data.gouv.fr.
+      </p>
+      <p>
+        Les informations transmises dans le cadre des campagnes de télédéclaration annuelles affichées sont notamment :
+        les pourcentages des taux EGalim et les données qualitatives sur les autres volets des lois EGalim (gaspillage
+        alimentaire, diversification des protéines, substitution plastique, information convives).
+      </p>
 
-    <h4>6) Outil de suivi de ses achats</h4>
-    <p>
-      Les Gestionnaires peuvent ajouter leurs achats dans un tableau mis à disposition sur la plateforme. La complétion
-      du tableau permet aux Gestionnaires de voir la répartition des achats en fonction des différentes familles de
-      produit, ainsi que le pourcentage en lien avec les lois EGalim.
-    </p>
+      <h4>6) Outil de suivi de ses achats</h4>
+      <p>
+        Les Gestionnaires peuvent ajouter leurs achats dans un tableau mis à disposition sur la plateforme. La
+        complétion du tableau permet aux Gestionnaires de voir la répartition des achats en fonction des différentes
+        familles de produit, ainsi que le pourcentage en lien avec les lois EGalim.
+      </p>
+    </section>
 
-    <h2>4 - Traitement des données personnelles</h2>
-    <p>
-      Le Service ne collecte que les données strictement nécessaires à sa mise en œuvre. Les données collectées incluent
-      également des données à caractère personnel. Pour plus d’informations sur le traitement des données à caractère
-      personnel le Visiteur est invité à se référer à la
-      <router-link :to="{ name: 'PersonalData' }">données personnelles</router-link>
-      .
-    </p>
-
-    <h2>5 – Inscription à l’infolettre</h2>
-    <p>La création d’un compte implique l’inscription automatique à l’infolettre « ma cantine ».</p>
-    <p>
-      Cette inscription est révocable à tout moment, soit en vous désabonnant à réception du courriel, ou en nous
-      notifiant votre refus à l’adresse suivante :
-      <a rel="noopener" href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
-    </p>
-
-    <h2>6 - Statistiques et diffusion sur data.gouv.fr</h2>
-    <p>Les données récoltées dans le cadre du téléservice servent au pilotage de la politique publique.</p>
-    <p>
-      Conformément aux dispositions des articles L. 230-5-1 et R. 230-30-4 du Code rural, les données recueillies par
-      l’intermédiaire de la plateforme permettent de réaliser un bilan de la mise en œuvre du dispositif qui est adressé
-      notamment au Parlement.
-    </p>
-    <p>
-      En outre, conformément aux dispositions du Livre III du Code des relations entre le public et l'administration, la
-      plateforme diffuse des informations publiques relatives aux données collectées et au suivi de l'usage de la
-      plateforme sur le site de data.gouv.fr
-    </p>
-
-    <h2>7 - Engagements et responsabilité</h2>
-
-    <h3>Visiteur</h3>
-    <p>
-      Le Visiteur s’engage à respecter les présentes CGU et leurs éventuelles modifications ainsi que la législation en
-      vigueur.
-    </p>
-    <p>
-      Le Visiteur s’engage dans les champs libres à ne communiquer aucune donnée à caractère personnel le concernant ou
-      concernant des tiers en particulier des données sensibles (ex : santé, opinions politiques, syndicales,
-      philosophiques). Il s’engage à ne pas tenir de propos injurieux, diffamatoires, pornographiques et plus
-      globalement contraire à la loi.
-    </p>
-    <p>
-      En cas de violation d'une ou de plusieurs dispositions des CGU ou de tout autre document incorporé aux présentes
-      par référence, l’Editeur se réserve le droit de prendre toutes mesures utiles et, en particulier, d’engager des
-      poursuites devant les juridictions compétentes.
-    </p>
-
-    <h3>Gestionnaire</h3>
-
-    <p>
-      Le titulaire d’un compte s’engage à respecter les présentes CGU ainsi que leurs éventuelles modifications ou de
-      tout autre document incorporé aux présentes par référence. Il respecte également la législation en vigueur.
-    </p>
-    <p>
-      Le titulaire d’un compte est responsable de la conservation de ses identifiant et mot de passe. Il s'interdit donc
-      de les divulguer à quiconque.
-    </p>
-    <p>
-      Il est rappelé que toute personne procédant à une fausse déclaration pour elle-même ou pour autrui s’expose,
-      notamment, aux sanctions prévues à l’article 441-1 du code pénal, prévoyant des peines pouvant aller jusqu’à trois
-      ans d’emprisonnement et 45 000 euros d’amendes.
-    </p>
-    <p>
-      L’Editeur se réserve, le cas échéant, le droit de prendre toutes mesures utiles et, en particulier, d’engager des
-      poursuites devant les juridictions compétentes.
-    </p>
-    <p>
-      Les données télédéclarées relèvent du contrôle et de la responsabilité de son titulaire. Ce dernier s’engage à ne
-      déposer que les seuls documents et informations demandées par le Service.
-    </p>
-
-    <h3>L’Editeur</h3>
-
-    <p>
-      Le Service est développé conformément à l’état de l’art. Toutefois, il n’est pas garanti qu’il soit exempt
-      d’anomalies ou d'erreurs. Le Service est donc mis à disposition sans garantie sur sa disponibilité et ses
-      performances.
-    </p>
-    <p>
-      A ce titre, l’Editeur ne peut être tenu responsable des pertes et/ou préjudices, de quelque nature qu’ils soient,
-      qui pourraient être causés à la suite d’un dysfonctionnement ou une indisponibilité du Service. De telles
-      situations n'ouvriront droit à aucune compensation ou indemnité d’aucune nature dont financière.
-    </p>
-    <p>
-      Dans l'hypothèse où le Visiteur ne s'acquitte pas de ses engagements, l’Editeur se réserve le droit de suspendre
-      ou résilier le Service pour ce Visiteur sans préjudice des éventuelles actions en responsabilité pénale et civile
-      qui pourraient être engagées à son encontre.
-    </p>
-
-    <h2>8 – Code source</h2>
-    <p>
-      Le Service a été développé sous licence MIT, le code est disponible à l’adresse suivante :
-      <a rel="noopener" href="https://github.com/betagouv/ma-cantine">https://github.com/betagouv/ma-cantine</a>
-    </p>
-
-    <h2>9 – Modification et évolution du Service</h2>
-    <p>
-      Les termes des présentes conditions d’utilisation peuvent être modifiés ou complétés à tout moment, sans préavis,
-      en fonction des modifications apportées au Service, de l’évolution de la législation ou pour tout autre motif jugé
-      nécessaire.
-    </p>
-    <p>
-      Ces modifications et mises à jour s’imposent de plein droit au Visiteur qui doit, en conséquence, se référer
-      régulièrement à cette rubrique pour vérifier les conditions générales en vigueur.
-    </p>
-
-    <h2>10 - Nous contacter</h2>
-    <ul>
-      <li>
-        Difficultés techniques :
-        <a rel="noopener" href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
+    <section>
+      <h2>4 - Traitement des données personnelles</h2>
+      <p>
+        Le Service ne collecte que les données strictement nécessaires à sa mise en œuvre. Les données collectées
+        incluent également des données à caractère personnel. Pour plus d’informations sur le traitement des données à
+        caractère personnel le Visiteur est invité à se référer à la
+        <router-link :to="{ name: 'PersonalData' }">données personnelles</router-link>
         .
-      </li>
-      <li>
-        Problèmes liés à la procédure :
+      </p>
+
+      <h2>5 – Inscription à l’infolettre</h2>
+      <p>La création d’un compte implique l’inscription automatique à l’infolettre « ma cantine ».</p>
+      <p>
+        Cette inscription est révocable à tout moment, soit en vous désabonnant à réception du courriel, ou en nous
+        notifiant votre refus à l’adresse suivante :
         <a rel="noopener" href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
-        .
-      </li>
-    </ul>
+      </p>
+
+      <h2>6 - Statistiques et diffusion sur data.gouv.fr</h2>
+      <p>Les données récoltées dans le cadre du téléservice servent au pilotage de la politique publique.</p>
+      <p>
+        Conformément aux dispositions des articles L. 230-5-1 et R. 230-30-4 du Code rural, les données recueillies par
+        l’intermédiaire de la plateforme permettent de réaliser un bilan de la mise en œuvre du dispositif qui est
+        adressé notamment au Parlement.
+      </p>
+      <p>
+        En outre, conformément aux dispositions du Livre III du Code des relations entre le public et l'administration,
+        la plateforme diffuse des informations publiques relatives aux données collectées et au suivi de l'usage de la
+        plateforme sur le site de data.gouv.fr
+      </p>
+    </section>
+
+    <section>
+      <h2>7 - Engagements et responsabilité</h2>
+      <h3>Visiteur</h3>
+      <p>
+        Le Visiteur s’engage à respecter les présentes CGU et leurs éventuelles modifications ainsi que la législation
+        en vigueur.
+      </p>
+      <p>
+        Le Visiteur s’engage dans les champs libres à ne communiquer aucune donnée à caractère personnel le concernant
+        ou concernant des tiers en particulier des données sensibles (ex : santé, opinions politiques, syndicales,
+        philosophiques). Il s’engage à ne pas tenir de propos injurieux, diffamatoires, pornographiques et plus
+        globalement contraire à la loi.
+      </p>
+      <p>
+        En cas de violation d'une ou de plusieurs dispositions des CGU ou de tout autre document incorporé aux présentes
+        par référence, l’Editeur se réserve le droit de prendre toutes mesures utiles et, en particulier, d’engager des
+        poursuites devant les juridictions compétentes.
+      </p>
+
+      <h3>Gestionnaire</h3>
+      <p>
+        Le titulaire d’un compte s’engage à respecter les présentes CGU ainsi que leurs éventuelles modifications ou de
+        tout autre document incorporé aux présentes par référence. Il respecte également la législation en vigueur.
+      </p>
+      <p>
+        Le titulaire d’un compte est responsable de la conservation de ses identifiant et mot de passe. Il s'interdit
+        donc de les divulguer à quiconque.
+      </p>
+      <p>
+        Il est rappelé que toute personne procédant à une fausse déclaration pour elle-même ou pour autrui s’expose,
+        notamment, aux sanctions prévues à l’article 441-1 du code pénal, prévoyant des peines pouvant aller jusqu’à
+        trois ans d’emprisonnement et 45 000 euros d’amendes.
+      </p>
+      <p>
+        L’Editeur se réserve, le cas échéant, le droit de prendre toutes mesures utiles et, en particulier, d’engager
+        des poursuites devant les juridictions compétentes.
+      </p>
+      <p>
+        Les données télédéclarées relèvent du contrôle et de la responsabilité de son titulaire. Ce dernier s’engage à
+        ne déposer que les seuls documents et informations demandées par le Service.
+      </p>
+
+      <h3>L’Editeur</h3>
+      <p>
+        Le Service est développé conformément à l’état de l’art. Toutefois, il n’est pas garanti qu’il soit exempt
+        d’anomalies ou d'erreurs. Le Service est donc mis à disposition sans garantie sur sa disponibilité et ses
+        performances.
+      </p>
+      <p>
+        A ce titre, l’Editeur ne peut être tenu responsable des pertes et/ou préjudices, de quelque nature qu’ils
+        soient, qui pourraient être causés à la suite d’un dysfonctionnement ou une indisponibilité du Service. De
+        telles situations n'ouvriront droit à aucune compensation ou indemnité d’aucune nature dont financière.
+      </p>
+      <p>
+        Dans l'hypothèse où le Visiteur ne s'acquitte pas de ses engagements, l’Editeur se réserve le droit de suspendre
+        ou résilier le Service pour ce Visiteur sans préjudice des éventuelles actions en responsabilité pénale et
+        civile qui pourraient être engagées à son encontre.
+      </p>
+    </section>
+
+    <section>
+      <h2>8 – Code source</h2>
+      <p>
+        Le Service a été développé sous licence MIT, le code est disponible à l’adresse suivante :
+        <a rel="noopener" href="https://github.com/betagouv/ma-cantine">https://github.com/betagouv/ma-cantine</a>
+      </p>
+    </section>
+
+    <section>
+      <h2>9 – Modification et évolution du Service</h2>
+      <p>
+        Les termes des présentes conditions d’utilisation peuvent être modifiés ou complétés à tout moment, sans
+        préavis, en fonction des modifications apportées au Service, de l’évolution de la législation ou pour tout autre
+        motif jugé nécessaire.
+      </p>
+      <p>
+        Ces modifications et mises à jour s’imposent de plein droit au Visiteur qui doit, en conséquence, se référer
+        régulièrement à cette rubrique pour vérifier les conditions générales en vigueur.
+      </p>
+    </section>
+
+    <section>
+      <h2>10 - Nous contacter</h2>
+      <ul>
+        <li>
+          Difficultés techniques :
+          <a rel="noopener" href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
+          .
+        </li>
+        <li>
+          Problèmes liés à la procédure :
+          <a rel="noopener" href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
+          .
+        </li>
+      </ul>
+    </section>
   </LayoutOneColumn>
 </template>

--- a/2024-frontend/src/views/LegalNotices.vue
+++ b/2024-frontend/src/views/LegalNotices.vue
@@ -1,5 +1,9 @@
+<script setup>
+import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
+</script>
+
 <template>
-  <div class="fr-col-12">
+  <LayoutOneColumn>
     <h1>Mentions légales</h1>
     <section>
       <h2>Éditeur de la Plateforme</h2>
@@ -78,5 +82,5 @@
         .
       </p>
     </section>
-  </div>
+  </LayoutOneColumn>
 </template>

--- a/2024-frontend/src/views/LegalNotices.vue
+++ b/2024-frontend/src/views/LegalNotices.vue
@@ -4,7 +4,6 @@ import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
 
 <template>
   <LayoutOneColumn>
-    <h1>Mentions légales</h1>
     <section>
       <h2>Éditeur de la Plateforme</h2>
       <p>

--- a/2024-frontend/src/views/PersonalData.vue
+++ b/2024-frontend/src/views/PersonalData.vue
@@ -1,11 +1,9 @@
 <script setup>
 import { onMounted } from "vue"
-import { useRoute } from "vue-router"
+import { showContent } from "@/services/matomo.js"
 import AppRawHTML from "@/components/AppRawHTML.vue"
 import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
-import { showContent } from "@/services/matomo.js"
 
-const route = useRoute()
 const linkCleverCloud =
   '<a href="https://www.clever-cloud.com/fr/conditions-generales-dutilisation/accord-de-traitement-des-donnees/"target="_blank">Lien vers le DPA</a>'
 
@@ -16,7 +14,6 @@ onMounted(() => {
 
 <template>
   <LayoutOneColumn>
-    <h1>{{ route.meta.title }}</h1>
     <section>
       <h2>
         1 - Qui est responsable de traitement ?

--- a/2024-frontend/src/views/PersonalData.vue
+++ b/2024-frontend/src/views/PersonalData.vue
@@ -2,6 +2,7 @@
 import { onMounted } from "vue"
 import { useRoute } from "vue-router"
 import AppRawHTML from "@/components/AppRawHTML.vue"
+import LayoutOneColumn from "@/layouts/LayoutOneColumn.vue"
 import { showContent } from "@/services/matomo.js"
 
 const route = useRoute()
@@ -14,297 +15,301 @@ onMounted(() => {
 </script>
 
 <template>
-  <h1>{{ route.meta.title }}</h1>
-  <section>
-    <h2>
-      1 - Qui est responsable de traitement ?
-    </h2>
-    <p>
-      Le responsable de l’utilisation des données est la Direction générale de l’alimentation du ministère de
-      l’agriculture et de la souveraineté alimentaire, représentée par Madame Maud FAIPOUX, Directrice générale de
-      l’Alimention.
-    </p>
-  </section>
-  <section>
-    <h2>
-      2 - Pourquoi traitons-nous ces données ?
-    </h2>
-    <p>
-      « ma cantine » traite des données à caractère personnel pour accompagner au mieux les acteurs de la restauration
-      collective dans leur offre aux consommateurs pour une alimentation de qualité, saine et durable.
-    </p>
-    <p>
-      Cette plateforme permet ainsi :
-    </p>
-    <ul>
-      <li>
-        Une meilleure connaissance des lois EGalim via une description détaillée et pédagogique des mesures&nbsp;;
-      </li>
-      <li>
-        Un aperçu de l'état des lieux des cantines ayant partagé leurs données pour connaître leur positionnement et
-        éventuellement fomenter des échanges entre elles et avec leurs convives&nbsp;;
-      </li>
-      <li>
-        Une option d'auto-diagnostic pour les acteurs de la restauration collective afin de s'auto-évaluer et accéder à
-        des ressources pour s'améliorer&nbsp;;
-      </li>
-      <li>
-        De créer un PDF à afficher ou à envoyer par mail à aux convives pour les informer sur les initiatives et la
-        composition des repas servis&nbsp;;
-      </li>
-      <li>
-        De répondre à leurs obligations réglementaires de télédéclaration de leurs données d’achat, à l’administration,
-        lors des campagnes officielles annuelles.
-      </li>
-    </ul>
-    <p>L’autodiagnostic sur « ma cantine » est disponible sans création de compte.</p>
-  </section>
-  <section>
-    <h2>3 - Quelles sont les données que nous traitons ?</h2>
-    <p>
-      Ma Cantine traite les données à caractère personnel suivantes :
-    </p>
-    <DsfrTable
-      :headers="['Type de données', 'Description des données']"
-      :rows="[
-        {
-          rowData: [
-            'Création de compte',
-            'Certaines données sont obligatoires pour la création du compte : nom, prénom, nom d\'utilisateur, adresse électronique et numéro de téléphone. L’utilisateur doit également fournir un ensemble de données relatives à l’établissement concerné (SIRET, nombre de repas, nom de la cantine, ville, type de structure, mode de gestion etc…), qui ne sont pas considérées comme des données à caractère personnel.',
-          ],
-        },
-        {
-          rowData: [
-            'Contact',
-            'Sont collectées lors de la prise de contact avec les cantines l’adresse-mail et, de manière facultative, le prénom et le nom de la personne.',
-          ],
-        },
-        {
-          rowData: [
-            'Inscription à une infolettre (newsletter)',
-            'Adresse électronique de la personne qui souhaite recevoir l’infolettre.',
-          ],
-        },
-        {
-          rowData: ['Cookies', 'Traceurs destinés à améliorer la navigation sur la plateforme.'],
-        },
-      ]"
-    />
-  </section>
+  <LayoutOneColumn>
+    <h1>{{ route.meta.title }}</h1>
+    <section>
+      <h2>
+        1 - Qui est responsable de traitement ?
+      </h2>
+      <p>
+        Le responsable de l’utilisation des données est la Direction générale de l’alimentation du ministère de
+        l’agriculture et de la souveraineté alimentaire, représentée par Madame Maud FAIPOUX, Directrice générale de
+        l’Alimention.
+      </p>
+    </section>
+    <section>
+      <h2>
+        2 - Pourquoi traitons-nous ces données ?
+      </h2>
+      <p>
+        « ma cantine » traite des données à caractère personnel pour accompagner au mieux les acteurs de la restauration
+        collective dans leur offre aux consommateurs pour une alimentation de qualité, saine et durable.
+      </p>
+      <p>
+        Cette plateforme permet ainsi :
+      </p>
+      <ul>
+        <li>
+          Une meilleure connaissance des lois EGalim via une description détaillée et pédagogique des mesures&nbsp;;
+        </li>
+        <li>
+          Un aperçu de l'état des lieux des cantines ayant partagé leurs données pour connaître leur positionnement et
+          éventuellement fomenter des échanges entre elles et avec leurs convives&nbsp;;
+        </li>
+        <li>
+          Une option d'auto-diagnostic pour les acteurs de la restauration collective afin de s'auto-évaluer et accéder
+          à des ressources pour s'améliorer&nbsp;;
+        </li>
+        <li>
+          De créer un PDF à afficher ou à envoyer par mail à aux convives pour les informer sur les initiatives et la
+          composition des repas servis&nbsp;;
+        </li>
+        <li>
+          De répondre à leurs obligations réglementaires de télédéclaration de leurs données d’achat, à
+          l’administration, lors des campagnes officielles annuelles.
+        </li>
+      </ul>
+      <p>L’autodiagnostic sur « ma cantine » est disponible sans création de compte.</p>
+    </section>
+    <section>
+      <h2>3 - Quelles sont les données que nous traitons ?</h2>
+      <p>
+        Ma Cantine traite les données à caractère personnel suivantes :
+      </p>
+      <DsfrTable
+        :headers="['Type de données', 'Description des données']"
+        :rows="[
+          {
+            rowData: [
+              'Création de compte',
+              'Certaines données sont obligatoires pour la création du compte : nom, prénom, nom d\'utilisateur, adresse électronique et numéro de téléphone. L’utilisateur doit également fournir un ensemble de données relatives à l’établissement concerné (SIRET, nombre de repas, nom de la cantine, ville, type de structure, mode de gestion etc…), qui ne sont pas considérées comme des données à caractère personnel.',
+            ],
+          },
+          {
+            rowData: [
+              'Contact',
+              'Sont collectées lors de la prise de contact avec les cantines l’adresse-mail et, de manière facultative, le prénom et le nom de la personne.',
+            ],
+          },
+          {
+            rowData: [
+              'Inscription à une infolettre (newsletter)',
+              'Adresse électronique de la personne qui souhaite recevoir l’infolettre.',
+            ],
+          },
+          {
+            rowData: ['Cookies', 'Traceurs destinés à améliorer la navigation sur la plateforme.'],
+          },
+        ]"
+      />
+    </section>
 
-  <section>
-    <h2>4 - Qu’est-ce qui nous autorise à traiter ces données ?</h2>
-    <p>
-      « ma cantine » traite des données à caractère personnel en se basant sur :
-    </p>
-    <ul>
-      <li>
-        L’exécution d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le
-        responsable de traitement au sens de l’article 6-1 e du RPGD.
-      </li>
-      <li>
-        Cette mission d’intérêt public consiste en la mise en œuvre des obligations prévues par les articles L. 230-5 à
-        L. 230-5-2 du code rural et de la pêche maritime mais également des articles R. 230-30-4 du même code et de
-        l’arrêté du 14 septembre 2022 fixant les modalités de transmission par les gestionnaires de restaurants
-        collectifs des données nécessaires à l'établissement du bilan statistique annuel mentionné au V de l'article L.
-        230-5-1 du code rural et de la pêche maritime.
-      </li>
-    </ul>
-  </section>
+    <section>
+      <h2>4 - Qu’est-ce qui nous autorise à traiter ces données ?</h2>
+      <p>
+        « ma cantine » traite des données à caractère personnel en se basant sur :
+      </p>
+      <ul>
+        <li>
+          L’exécution d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi
+          le responsable de traitement au sens de l’article 6-1 e du RPGD.
+        </li>
+        <li>
+          Cette mission d’intérêt public consiste en la mise en œuvre des obligations prévues par les articles L. 230-5
+          à L. 230-5-2 du code rural et de la pêche maritime mais également des articles R. 230-30-4 du même code et de
+          l’arrêté du 14 septembre 2022 fixant les modalités de transmission par les gestionnaires de restaurants
+          collectifs des données nécessaires à l'établissement du bilan statistique annuel mentionné au V de l'article
+          L. 230-5-1 du code rural et de la pêche maritime.
+        </li>
+      </ul>
+    </section>
 
-  <section>
-    <h2>5 - Pendant combien de temps conservons-nous ces données ?</h2>
+    <section>
+      <h2>5 - Pendant combien de temps conservons-nous ces données ?</h2>
 
-    <DsfrTable
-      :headers="['Type de données', 'Durée de la conservation']"
-      :rows="[
-        {
-          rowData: [
-            'Données relatives à la création d’un compte',
-            '4 ans à compter de la dernière utilisation du compte',
-          ],
-        },
-        { rowData: ['Données de contact', '4 ans à compter de la dernière prise de contact'] },
-        {
-          rowData: [
-            'Données relatives à l’inscription à l’infolettre',
-            'Jusqu’à la suppression du compte ou retrait du consentement',
-          ],
-        },
-        { rowData: ['Cookies', 'Jusqu’au retrait du consentement ou 13 mois à compter du dépôt'] },
-      ]"
-    />
-  </section>
+      <DsfrTable
+        :headers="['Type de données', 'Durée de la conservation']"
+        :rows="[
+          {
+            rowData: [
+              'Données relatives à la création d’un compte',
+              '4 ans à compter de la dernière utilisation du compte',
+            ],
+          },
+          { rowData: ['Données de contact', '4 ans à compter de la dernière prise de contact'] },
+          {
+            rowData: [
+              'Données relatives à l’inscription à l’infolettre',
+              'Jusqu’à la suppression du compte ou retrait du consentement',
+            ],
+          },
+          { rowData: ['Cookies', 'Jusqu’au retrait du consentement ou 13 mois à compter du dépôt'] },
+        ]"
+      />
+    </section>
 
-  <section>
-    <h2>6 - Quels droits avez-vous ?</h2>
-    <p>Vous disposez :</p>
-    <ul>
-      <li>D’un droit d’information et d’un droit d’accès à vos données&nbsp;;</li>
-      <li>D’un droit de rectification&nbsp;;</li>
-      <li>D’un droit d’opposition&nbsp;;</li>
-      <li>D’un droit à la limitation du traitement.</li>
-    </ul>
-    <p>
-      Pour les exercer, contactez-nous :
-    </p>
-    <ul>
-      <li>
-        par voie électronique à :
-        <a href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
-      </li>
-      <li>
-        par voie postale à :
-        <address>
-          MINISTÈRE DE L’AGRICULTURE
-          <br />
-          Direction Générale de l’Alimentation
-          <br />
-          251 Rue de Vaugirard, 75015 Paris
-        </address>
-      </li>
-    </ul>
-    <p>
-      Puisque ce sont des droits personnels, nous ne traiterons votre demande que si nous sommes en mesure de vous
-      identifier. Dans le cas où nous ne parvenons pas à vous identifier, nous pouvons être amenés à vous demander une
-      preuve de votre identité.
-    </p>
-    <p>
-      Pour vous aider dans votre démarche, vous trouverez un modèle de courrier élaboré par la CNIL ici :
-      <a href="https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces" target="_blank">
-        https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces
-      </a>
-    </p>
-    <p>
-      Nous nous engageons à vous répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la
-      réception de votre demande.
-    </p>
-  </section>
-
-  <section>
-    <h2>7 - Qui va avoir accès à ces données ?</h2>
-    <p>
-      Les accès aux données sont strictement encadrés et juridiquement justifiés. Les personnes suivantes vont avoir
-      accès aux données :
-    </p>
-    <DsfrTable
-      :headers="['Données', 'Destinataires']"
-      :rows="[
-        {
-          rowData: [
-            'Données relatives à la création d’un compte et données de contact',
-            'Agents publics habilités du ministère de l’agriculture et de la souveraineté alimentaire',
-          ],
-        },
-      ]"
-    />
-  </section>
-
-  <section>
-    <h2>8 - Quelles mesures de sécurité mettons-nous en place ?</h2>
-    <p>Nous mettons en place plusieurs mesures pour sécuriser les données :</p>
-    <ul>
-      <li>Stockage des données en base de données&nbsp;;</li>
-      <li>Cloisonnement des données&nbsp;;</li>
-      <li>Mesures de traçabilité&nbsp;;</li>
-      <li>Surveillance&nbsp;;</li>
-      <li>Protection contre les virus, malwares et logiciels espions&nbsp;;</li>
-      <li>Protection des réseaux&nbsp;;</li>
-      <li>Sauvegarde&nbsp;;</li>
-      <li>Mesures restrictives limitant l’accès physiques aux données à caractère personnel.</li>
-    </ul>
-  </section>
-
-  <section>
-    <h2>9 - Qui nous aide à traiter les données ?</h2>
-    <p>
-      Certaines des données sont envoyées à d’autres acteurs, appelés “sous-traitants de données”, pour qu’ils nous
-      aident à les manipuler. Nous nous assurons qu’ils respectent strictement le RGPD et qu’ils apportent des garanties
-      suffisantes en matière de sécurité.
-    </p>
-    <DsfrTable
-      :headers="['Sous-traitant', 'Pays destinataire', 'Traitement réalisé', 'Garanties']"
-      :rows="[{ rowData: ['Clever Cloud', 'France', 'Hébergement', { component: AppRawHTML, html: linkCleverCloud }] }]"
-    />
-  </section>
-
-  <section>
-    <h2 id="cookies">10 - Cookies</h2>
-    <p>
-      Un cookie est un fichier déposé sur votre terminal lors de la visite d’un site. Il a pour but de collecter des
-      informations relatives à votre navigation et de vous adresser des services adaptés à votre terminal (ordinateur,
-      mobile ou tablette).
-    </p>
-    <p>
-      En application de l’article 5(3) de la directive 2002/58/CE modifiée concernant le traitement des données à
-      caractère personnel et la protection de la vie privée dans le secteur des communications électroniques, transposée
-      à l’article 82 de la loi n° 78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, les
-      traceurs ou cookies suivent deux régimes distincts.
-    </p>
-    <p>
-      Les cookies strictement nécessaires au service ou ayant pour finalité exclusive de faciliter la communication par
-      voie électronique sont dispensés de consentement préalable au titre de l’article 82 de la loi n° 78-17 du 6
-      janvier 1978.
-    </p>
-    <p>
-      Les cookies n’étant pas strictement nécessaires au service ou n’ayant pas pour finalité exclusive de faciliter la
-      communication par voie électronique doivent être consenti par l’utilisateur.
-    </p>
-    <p>
-      Ce consentement de la personne concernée pour une ou plusieurs finalités spécifiques constitue une base légale au
-      sens du RGPD et doit être entendu au sens de l'article 6-1 a) du RGPD et à la libre circulation des données.
-    </p>
-    <p>Cookies recensés sur Ma Cantine :</p>
-    <DsfrTable
-      :headers="['Site', 'Description', 'Autorisation']"
-      :rows="[
-        {
-          rowData: [
-            'Matomo',
-            'Cookie de mesure d’audience, dans sa version exemptée de consentement préalable, telle que validée par la CNIL.',
-            {
-              component: AppRawHTML,
-              html: '<div id=\'matomo-opt-out\'></div>',
-            },
-          ],
-        },
-        {
-          rowData: [
-            'Crisp',
-            'Chatbot qui permet d’interagir avec les équipes de Ma Cantine pour toutes questions concernant la plateforme.',
-            'Toujours actif.',
-          ],
-        },
-      ]"
-    />
-    <p>
-      À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en
-      utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer
-      11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
-    </p>
-    <p>
-      Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et
-      des Libertés (CNIL) :
-    </p>
-    <ul>
-      <li>
-        <a
-          href="https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi"
-          target="_blank"
-          title="Cookies & traceurs : que dit la loi ? - ouvre une nouvelle fenêtre"
-        >
-          Cookies & traceurs : que dit la loi ?
+    <section>
+      <h2>6 - Quels droits avez-vous ?</h2>
+      <p>Vous disposez :</p>
+      <ul>
+        <li>D’un droit d’information et d’un droit d’accès à vos données&nbsp;;</li>
+        <li>D’un droit de rectification&nbsp;;</li>
+        <li>D’un droit d’opposition&nbsp;;</li>
+        <li>D’un droit à la limitation du traitement.</li>
+      </ul>
+      <p>
+        Pour les exercer, contactez-nous :
+      </p>
+      <ul>
+        <li>
+          par voie électronique à :
+          <a href="mailto:support-egalim@beta.gouv.fr">support-egalim@beta.gouv.fr</a>
+        </li>
+        <li>
+          par voie postale à :
+          <address>
+            MINISTÈRE DE L’AGRICULTURE
+            <br />
+            Direction Générale de l’Alimentation
+            <br />
+            251 Rue de Vaugirard, 75015 Paris
+          </address>
+        </li>
+      </ul>
+      <p>
+        Puisque ce sont des droits personnels, nous ne traiterons votre demande que si nous sommes en mesure de vous
+        identifier. Dans le cas où nous ne parvenons pas à vous identifier, nous pouvons être amenés à vous demander une
+        preuve de votre identité.
+      </p>
+      <p>
+        Pour vous aider dans votre démarche, vous trouverez un modèle de courrier élaboré par la CNIL ici :
+        <a href="https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces" target="_blank">
+          https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces
         </a>
-      </li>
-      <li>
-        <a
-          href="https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser"
-          target="_blank"
-          title="Cookies : les outils pour les maîtriser - ouvre une nouvelle fenêtre"
-        >
-          Cookies : les outils pour les maîtriser
-        </a>
-      </li>
-    </ul>
-  </section>
+      </p>
+      <p>
+        Nous nous engageons à vous répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la
+        réception de votre demande.
+      </p>
+    </section>
+
+    <section>
+      <h2>7 - Qui va avoir accès à ces données ?</h2>
+      <p>
+        Les accès aux données sont strictement encadrés et juridiquement justifiés. Les personnes suivantes vont avoir
+        accès aux données :
+      </p>
+      <DsfrTable
+        :headers="['Données', 'Destinataires']"
+        :rows="[
+          {
+            rowData: [
+              'Données relatives à la création d’un compte et données de contact',
+              'Agents publics habilités du ministère de l’agriculture et de la souveraineté alimentaire',
+            ],
+          },
+        ]"
+      />
+    </section>
+
+    <section>
+      <h2>8 - Quelles mesures de sécurité mettons-nous en place ?</h2>
+      <p>Nous mettons en place plusieurs mesures pour sécuriser les données :</p>
+      <ul>
+        <li>Stockage des données en base de données&nbsp;;</li>
+        <li>Cloisonnement des données&nbsp;;</li>
+        <li>Mesures de traçabilité&nbsp;;</li>
+        <li>Surveillance&nbsp;;</li>
+        <li>Protection contre les virus, malwares et logiciels espions&nbsp;;</li>
+        <li>Protection des réseaux&nbsp;;</li>
+        <li>Sauvegarde&nbsp;;</li>
+        <li>Mesures restrictives limitant l’accès physiques aux données à caractère personnel.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>9 - Qui nous aide à traiter les données ?</h2>
+      <p>
+        Certaines des données sont envoyées à d’autres acteurs, appelés “sous-traitants de données”, pour qu’ils nous
+        aident à les manipuler. Nous nous assurons qu’ils respectent strictement le RGPD et qu’ils apportent des
+        garanties suffisantes en matière de sécurité.
+      </p>
+      <DsfrTable
+        :headers="['Sous-traitant', 'Pays destinataire', 'Traitement réalisé', 'Garanties']"
+        :rows="[
+          { rowData: ['Clever Cloud', 'France', 'Hébergement', { component: AppRawHTML, html: linkCleverCloud }] },
+        ]"
+      />
+    </section>
+
+    <section>
+      <h2 id="cookies">10 - Cookies</h2>
+      <p>
+        Un cookie est un fichier déposé sur votre terminal lors de la visite d’un site. Il a pour but de collecter des
+        informations relatives à votre navigation et de vous adresser des services adaptés à votre terminal (ordinateur,
+        mobile ou tablette).
+      </p>
+      <p>
+        En application de l’article 5(3) de la directive 2002/58/CE modifiée concernant le traitement des données à
+        caractère personnel et la protection de la vie privée dans le secteur des communications électroniques,
+        transposée à l’article 82 de la loi n° 78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux
+        libertés, les traceurs ou cookies suivent deux régimes distincts.
+      </p>
+      <p>
+        Les cookies strictement nécessaires au service ou ayant pour finalité exclusive de faciliter la communication
+        par voie électronique sont dispensés de consentement préalable au titre de l’article 82 de la loi n° 78-17 du 6
+        janvier 1978.
+      </p>
+      <p>
+        Les cookies n’étant pas strictement nécessaires au service ou n’ayant pas pour finalité exclusive de faciliter
+        la communication par voie électronique doivent être consenti par l’utilisateur.
+      </p>
+      <p>
+        Ce consentement de la personne concernée pour une ou plusieurs finalités spécifiques constitue une base légale
+        au sens du RGPD et doit être entendu au sens de l'article 6-1 a) du RGPD et à la libre circulation des données.
+      </p>
+      <p>Cookies recensés sur Ma Cantine :</p>
+      <DsfrTable
+        :headers="['Site', 'Description', 'Autorisation']"
+        :rows="[
+          {
+            rowData: [
+              'Matomo',
+              'Cookie de mesure d’audience, dans sa version exemptée de consentement préalable, telle que validée par la CNIL.',
+              {
+                component: AppRawHTML,
+                html: '<div id=\'matomo-opt-out\'></div>',
+              },
+            ],
+          },
+          {
+            rowData: [
+              'Crisp',
+              'Chatbot qui permet d’interagir avec les équipes de Ma Cantine pour toutes questions concernant la plateforme.',
+              'Toujours actif.',
+            ],
+          },
+        ]"
+      />
+      <p>
+        À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en
+        utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer
+        11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
+      </p>
+      <p>
+        Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique
+        et des Libertés (CNIL) :
+      </p>
+      <ul>
+        <li>
+          <a
+            href="https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi"
+            target="_blank"
+            title="Cookies & traceurs : que dit la loi ? - ouvre une nouvelle fenêtre"
+          >
+            Cookies & traceurs : que dit la loi ?
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser"
+            target="_blank"
+            title="Cookies : les outils pour les maîtriser - ouvre une nouvelle fenêtre"
+          >
+            Cookies : les outils pour les maîtriser
+          </a>
+        </li>
+      </ul>
+    </section>
+  </LayoutOneColumn>
 </template>


### PR DESCRIPTION
## Description

Création d'un layout pour homogénéiser l'affichage des pages type "légales" :
- amélioration des espaces
- tous les titres sont dynamiques basés sur le router
- amélioration de la sémantique en ajoutant des sections
- suppression de classes CSS inutiles
- ajout d'un bouton pour retourner rapidement en haut de la page

## Prévisualisation

|Avant|Après|
|--|--|
| ![Screenshot 2025-05-30 at 15-40-56 Conditions générales d'utilisation - ma cantine](https://github.com/user-attachments/assets/8f26149e-9d8e-4ab7-8b1c-4cf3c5debf8e) | ![Screenshot 2025-05-30 at 15-40-06 Conditions générales d'utilisation - ma cantine](https://github.com/user-attachments/assets/dce0ff61-edde-4ebb-999a-ba1594feab4b) |