### PR TITLE
fix(ETL): Corriger les valeurs alimentaires des satellites des cc central serving

### DIFF
--- a/macantine/etl/analysis.py
+++ b/macantine/etl/analysis.py
@@ -117,9 +117,6 @@ class ETL_ANALYSIS_TELEDECLARATIONS(ANALYSIS, etl.EXTRACTOR):
                     1 if row["production_type"] == Canteen.ProductionType.CENTRAL_SERVING else 0
                 )
 
-                if row["production_type"] == Canteen.ProductionType.CENTRAL_SERVING:
-                    self.df.loc[row["id"]] = self.split_appro_values(row, nbre_satellites)
-
                 for satellite in row["tmp_satellites"]:
                     satellite_row = row.copy()
                     satellite_row.update(
@@ -134,6 +131,9 @@ class ETL_ANALYSIS_TELEDECLARATIONS(ANALYSIS, etl.EXTRACTOR):
                     )
                     satellite_row = self.split_appro_values(satellite_row, nbre_satellites)
                     satellite_rows.append(satellite_row)
+
+                if row["production_type"] == Canteen.ProductionType.CENTRAL_SERVING:
+                    self.df.loc[row["id"]] = self.split_appro_values(row, nbre_satellites)
 
         # Append all new rows at once
         if satellite_rows:

--- a/macantine/tests/test_etl_analysis.py
+++ b/macantine/tests/test_etl_analysis.py
@@ -443,6 +443,7 @@ class TestETLAnalysisTD(TestCase):
         self.assertEqual(etl.df[etl.df.canteen_id == 20].iloc[0].value_total_ht, 500)  # Appro value split
         self.assertEqual(len(etl.df[etl.df.canteen_id == 3]), 1)  # Central kitchen filtered out
         self.assertEqual(etl.df[etl.df.canteen_id == 3].iloc[0].value_total_ht, 500)  # Appro value split
+        self.assertEqual(etl.df[etl.df.canteen_id == 30].iloc[0].value_total_ht, 500)  # Appro value split
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Les valeurs alimentaires des cuisines centrales de type `central_serving` étaient écrasaient avant que les celles des satellites puissent être calculées