### PR TITLE
fix(Trouver une cantine): corrige le filtre par donnée d'approvisionnement

### DIFF
--- a/api/tests/test_public_canteen_previews.py
+++ b/api/tests/test_public_canteen_previews.py
@@ -434,6 +434,13 @@ class TestPublicCanteenSearchApi(APITestCase):
         guadeloupe_canteen = CanteenFactory.create(
             publication_status=Canteen.PublicationStatus.PUBLISHED, region=Region.guadeloupe, name="Guadeloupe"
         )
+        good_canteen_with_siren = CanteenFactory.create(
+            publication_status="published",
+            name="Siren",
+            region=Region.auvergne_rhone_alpes,
+            siret="",
+            siren_unite_legale="123456789",
+        )
 
         publication_year = date.today().year - 1
 
@@ -509,59 +516,75 @@ class TestPublicCanteenSearchApi(APITestCase):
             value_externality_performance_ht=None,
             value_egalim_others_ht=0,
         )
+        DiagnosticFactory.create(
+            canteen=good_canteen_with_siren,
+            year=publication_year,
+            value_total_ht=100,
+            value_bio_ht=30,
+            value_sustainable_ht=10,
+            value_externality_performance_ht=10,
+            value_egalim_others_ht=10,
+        )
+
         url = f"{reverse('published_canteens')}?min_portion_bio={0.2}"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
         self.assertIn("Satellite", result_names)
+        self.assertIn("Siren", result_names)
 
         url = f"{reverse('published_canteens')}?min_portion_combined={0.5}"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 5)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
         self.assertIn("Satellite", result_names)
+        self.assertIn("Siren", result_names)
         self.assertIn("Wasabi", result_names)
         self.assertIn("Umami", result_names)
 
         url = f"{reverse('published_canteens')}?min_portion_bio={0.1}&min_portion_combined={0.5}"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 4)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
         self.assertIn("Satellite", result_names)
+        self.assertIn("Siren", result_names)
         self.assertIn("Wasabi", result_names)
 
         url = f"{reverse('published_canteens')}?badge=appro"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 4)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
         self.assertIn("Satellite", result_names)
+        self.assertIn("Siren", result_names)
         self.assertIn("Guadeloupe", result_names)
 
         # if both badge and thresholds specified, return the results that match the most strict threshold
         url = f"{reverse('published_canteens')}?badge=appro&min_portion_combined={0.01}"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 4)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
         self.assertIn("Satellite", result_names)
+        self.assertIn("Siren", result_names)
         self.assertIn("Guadeloupe", result_names)
 
         url = f"{reverse('published_canteens')}?badge=appro&min_portion_combined={0.5}"
         response = self.client.get(url)
         results = response.json().get("results", [])
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 3)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
         self.assertIn("Satellite", result_names)
+        self.assertIn("Siren", result_names)
 
     def test_pagination_departments(self):
         CanteenFactory.create(publication_status="published", department="75", name="Shiso")

--- a/api/tests/test_public_canteen_previews.py
+++ b/api/tests/test_public_canteen_previews.py
@@ -441,6 +441,26 @@ class TestPublicCanteenSearchApi(APITestCase):
             siret="",
             siren_unite_legale="123456789",
         )
+        good_canteen_empty_siret = CanteenFactory.create(
+            publication_status="published",
+            name="Cantine avec bilan mais siret vide",
+            siret="",
+        )
+        good_canteen_siret_none = CanteenFactory.create(
+            publication_status="published", name="Cantine avec bilan mais siret null", siret=None
+        )
+        CanteenFactory.create(
+            publication_status="published",
+            name="Cantine sans bilan avec siret cuisine centrale vide",
+            siret="12345678937462",
+            central_producer_siret="",
+        )
+        CanteenFactory.create(
+            publication_status="published",
+            name="Cantine sans bilan avec siret cuisine centrale null",
+            siret="12345678937463",
+            central_producer_siret=None,
+        )
 
         publication_year = date.today().year - 1
 
@@ -525,6 +545,24 @@ class TestPublicCanteenSearchApi(APITestCase):
             value_externality_performance_ht=10,
             value_egalim_others_ht=10,
         )
+        DiagnosticFactory.create(
+            canteen=good_canteen_empty_siret,
+            year=publication_year,
+            value_total_ht=100,
+            value_bio_ht=1,
+            value_sustainable_ht=0,
+            value_externality_performance_ht=0,
+            value_egalim_others_ht=0,
+        )
+        DiagnosticFactory.create(
+            canteen=good_canteen_siret_none,
+            year=publication_year,
+            value_total_ht=100,
+            value_bio_ht=1,
+            value_sustainable_ht=0,
+            value_externality_performance_ht=0,
+            value_egalim_others_ht=0,
+        )
 
         url = f"{reverse('published_canteens')}?min_portion_bio={0.2}"
         response = self.client.get(url)
@@ -585,6 +623,16 @@ class TestPublicCanteenSearchApi(APITestCase):
         self.assertIn("Shiso", result_names)
         self.assertIn("Satellite", result_names)
         self.assertIn("Siren", result_names)
+
+        url = f"{reverse('published_canteens')}?min_portion_bio={0.001}"
+        response = self.client.get(url)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 7)
+        result_names = list(map(lambda x: x.get("name"), results))
+        self.assertIn("Cantine avec bilan mais siret vide", result_names)
+        self.assertIn("Cantine avec bilan mais siret null", result_names)
+        self.assertNotIn("Cantine sans bilan avec siret cuisine centrale vide", result_names)
+        self.assertNotIn("Cantine sans bilan avec siret cuisine centrale null", result_names)
 
     def test_pagination_departments(self):
         CanteenFactory.create(publication_status="published", department="75", name="Shiso")

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -59,7 +59,7 @@ from common.utils import send_mail
 from data.department_choices import Department
 from data.models import Canteen, Diagnostic, ManagerInvitation, Sector
 from data.region_choices import Region
-from data.utils import CreationSource
+from data.utils import CreationSource, has_charfield_missing_query
 
 logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)
@@ -249,7 +249,7 @@ def filter_by_diagnostic_params(queryset, query_params):
                 )
             ).distinct()
         canteen_ids = qs_diag.values_list("canteen", flat=True)
-        canteen_sirets = qs_diag.exclude(Q(canteen__siret="") | Q(canteen__siret__isnull=True)).values_list(
+        canteen_sirets = qs_diag.exclude(has_charfield_missing_query("canteen__siret")).values_list(
             "canteen__siret", flat=True
         )
         queryset = queryset.exclude(redacted_appro_years__contains=[publication_year])

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -249,7 +249,9 @@ def filter_by_diagnostic_params(queryset, query_params):
                 )
             ).distinct()
         canteen_ids = qs_diag.values_list("canteen", flat=True)
-        canteen_sirets = qs_diag.values_list("canteen__siret", flat=True)
+        canteen_sirets = qs_diag.exclude(Q(canteen__siret="") | Q(canteen__siret__isnull=True)).values_list(
+            "canteen__siret", flat=True
+        )
         queryset = queryset.exclude(redacted_appro_years__contains=[publication_year])
         return queryset.filter(Q(id__in=canteen_ids) | Q(central_producer_siret__in=canteen_sirets))
     return queryset

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -139,7 +139,7 @@
                         'active-filter-label': !!filters.min_portion_bio.value || !!filters.min_portion_combined.value,
                       }"
                     >
-                      Dans les assiettes, part minimum de...
+                      En {{ lastYear }} la part minimum de...
                     </legend>
                     <div class="d-flex mt-1">
                       <DsfrTextField
@@ -321,7 +321,7 @@
 import PublishedCanteenCard from "./PublishedCanteenCard"
 import jsonDepartments from "@/departments.json"
 import jsonRegions from "@/regions.json"
-import { getObjectDiff, sectorsSelectList } from "@/utils"
+import { getObjectDiff, sectorsSelectList, lastYear } from "@/utils"
 import validators from "@/validators"
 import Constants from "@/constants"
 import badges from "@/badges"
@@ -374,6 +374,7 @@ export default {
       publishedCanteenCount: null,
       page: null,
       searchTerm: null,
+      lastYear: lastYear(),
       filters: {
         department: {
           param: "departement",


### PR DESCRIPTION
## Description

Lorsque l'on utilisait le filtre pour trouver une cantine en fonction de sont score bio, cela nous renvoyait des cantines fausses, par exemple : 
- des cantines sans bilan pour l'année recherchée, 
- des cantines avec un score de bio inférieur à la valeur recherchée. 

Ce bug venait du filtre par numéro SIRET de la cuisine centrale : 
- ce filtre est basé sur une liste de SIRET dont les bilans avait été filtrés comme valide pour le filtre, 
- sauf que dans ces bilans on pouvait avoir une cantine avec un SIRET vide. 
- cette valeur "vide" se retrouvait alors dans la liste des valeurs autorisées pour les `central_producer_siret`, 
- soit la valeur par défaut des cantines sites. 

Une cuisine sans bilan pour l'année n-1, était exclue au début de la fonction grâce au filtre par année mais était inclue à nouveau à la fin de la fonction en autorisant toute cuisine avec un valeur vide pour le siret du livreur de repas.

## Prévisualisation

|Avant|Après|
|--|--|
| <img width="383" alt="Capture d’écran 2025-06-05 à 21 57 22" src="https://github.com/user-attachments/assets/7c2a5c63-46e7-4313-ab67-513f7852e2d6" /> | <img width="377" alt="Capture d’écran 2025-06-05 à 21 57 57" src="https://github.com/user-attachments/assets/62dda545-3eb0-4e65-bc46-5e38b2f1fd34" /> |