### PR TITLE
fix(ETL): Les valeurs yearly_meal_count vides des satelittes étaient remplacées par la valeur de la CC 

### DIFF
--- a/macantine/etl/analysis.py
+++ b/macantine/etl/analysis.py
@@ -136,19 +136,14 @@ class ETL_ANALYSIS_TELEDECLARATIONS(ANALYSIS, etl.EXTRACTOR):
                 nbre_satellites = len(row["tmp_satellites"]) + (
                     1 if row["production_type"] == Canteen.ProductionType.CENTRAL_SERVING else 0
                 )
-
                 for satellite in row["tmp_satellites"]:
                     satellite_row = row.copy()
-                    satellite_row.update(
-                        {
-                            "canteen_id": satellite["id"],
-                            "name": satellite["name"],
-                            "production_type": Canteen.ProductionType.ON_SITE_CENTRAL,
-                            "siret": satellite["siret"],
-                            "satellite_canteens_count": 0,
-                            "yearly_meal_count": satellite["yearly_meal_count"],
-                        }
-                    )
+                    satellite_row["canteen_id"] = satellite["id"]
+                    satellite_row["name"] = satellite["name"]
+                    satellite_row["production_type"] = Canteen.ProductionType.ON_SITE_CENTRAL
+                    satellite_row["siret"] = satellite["siret"]
+                    satellite_row["satellite_canteens_count"] = 0
+                    satellite_row["yearly_meal_count"] = satellite["yearly_meal_count"]
                     satellite_row = self.split_appro_values(satellite_row, nbre_satellites)
                     satellite_rows.append(satellite_row)
 

--- a/macantine/tests/test_etl_analysis.py
+++ b/macantine/tests/test_etl_analysis.py
@@ -431,7 +431,7 @@ class TestETLAnalysisTD(TestCase):
                         "id": 31,
                         "name": "SATELLITE 2",
                         "siret": "31930055500456",
-                        "yearly_meal_count": 80,
+                        "yearly_meal_count": None,
                     },
                 ],
             },
@@ -446,6 +446,7 @@ class TestETLAnalysisTD(TestCase):
         self.assertEqual(len(etl.df[etl.df.canteen_id == 3]), 1)  # Central kitchen filtered out
         self.assertEqual(etl.df[etl.df.canteen_id == 3].iloc[0].value_total_ht, 500)  # Appro value split
         self.assertEqual(etl.df[etl.df.canteen_id == 30].iloc[0].value_total_ht, 500)  # Appro value split
+        self.assertIs(pd.isna(etl.df[etl.df.canteen_id == 31].iloc[0].yearly_meal_count), True)
 
     def test_delete_duplicates_cc_csat_with_duplicates(self):
 


### PR DESCRIPTION
`update()` n'override pas la valeur si elle est nulle.