### PR TITLE
improve(Admin): ajoute les liens des cantines satellites depuis la page de la cuisine centrale

### DIFF
--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -175,7 +175,8 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         satellites_list = ""
         for satellite in obj.satellites:
             satellites_list = (
-                satellites_list + f"<a href='/admin/data/canteen/{satellite.id}/change'>{satellite.name}</a><br/>"
+                satellites_list
+                + f"<a href='/admin/data/canteen/{satellite.id}/change'>{satellite.name} - {satellite.siret_or_siren_unite_legale}</a><br/>"
             )
         return format_html(satellites_list)
 

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -174,10 +174,7 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
     def satellites_display(self, obj):
         satellites_list = ""
         for satellite in obj.satellites:
-            satellites_list = (
-                satellites_list
-                + f"<a href='/admin/data/canteen/{satellite.id}/change'>{satellite.name} - {satellite.siret_or_siren_unite_legale}</a><br/>"
-            )
+            satellites_list += f"<a href='/admin/data/canteen/{satellite.id}/change'>{satellite.name} - {satellite.siret_or_siren_unite_legale}</a><br/>"
         return format_html(satellites_list)
 
     def source_des_données(self, obj):

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -122,6 +122,8 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         "siret_or_siren_unite_legale_display",
         "city",
         "télédéclarée",
+        "central_producer_siret",
+        "production_type",
         "creation_date",
         "modification_date",
         "source_des_données",
@@ -143,11 +145,7 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         "department",
         "import_source",
     )
-    search_fields = (
-        "name",
-        "siret",
-        "siren_unite_legale",
-    )
+    search_fields = ("name", "siret", "siren_unite_legale", "central_producer_siret")
 
     def save_model(self, request, obj, form, change):
         if not change:

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib import admin
 from django.utils import timezone
+from django.utils.html import format_html
 
 from data.models import Canteen, Teledeclaration
 from data.utils import CreationSource
@@ -74,6 +75,7 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         "daily_meal_count",
         "yearly_meal_count",
         "satellite_canteens_count",
+        "satellites_display",
         "economic_model",
         "sectors",
         "line_ministry",
@@ -113,6 +115,7 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         "creation_mtm_medium",
         "claimed_by",
         "has_been_claimed",
+        "satellites_display",
     )
     list_display = (
         "name",
@@ -168,6 +171,15 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
     @admin.display(description="Visible au public")
     def publication_status_display(self, obj):
         return dict(Canteen.PublicationStatus.choices).get(obj.publication_status_display_to_public)
+
+    @admin.display(description="Cantines satellites")
+    def satellites_display(self, obj):
+        satellites_list = ""
+        for satellite in obj.satellites:
+            satellites_list = (
+                satellites_list + f"<a href='/admin/data/canteen/{satellite.id}/change'>{satellite.name}</a><br/>"
+            )
+        return format_html(satellites_list)
 
     def source_des_données(self, obj):
         return obj.import_source


### PR DESCRIPTION
## Description

Ajoute un lien vers la page des cantines satellites depuis la page admin des cuisines centrales.
Ajoute aussi la recherche via le siret du livreur de repas depuis la page liste.

## Prévisualisation

|Avant|Après|
|--|--|
| <img width="521" alt="Capture d’écran 2025-06-23 à 19 40 05" src="https://github.com/user-attachments/assets/ec9a480a-00d7-4a1b-8a48-64aad1d0420f" /> | <img width="497" alt="Capture d’écran 2025-06-23 à 19 42 27" src="https://github.com/user-attachments/assets/ddd5cf19-7855-4646-8ba2-7bf9f8e2d15f" /> |
| <img width="805" alt="Capture d’écran 2025-06-23 à 19 41 53" src="https://github.com/user-attachments/assets/00d4f9b9-22ff-45dd-8ec0-c957477d0ed0" /> | <img width="713" alt="Capture d’écran 2025-06-23 à 19 41 24" src="https://github.com/user-attachments/assets/5c60ad85-91dc-4e8b-baad-ee47d40d0c40" /> |