### PR TITLE
improve(Admin): facilite la suppression d'un lien cantine - gestionnaire

### DIFF
--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -175,8 +175,10 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
 
 class CanteenInline(admin.TabularInline):
     model = Canteen.managers.through
-    readonly_fields = ("active",)
-    fields = ("canteen",)
+    readonly_fields = (
+        "canteen",
+        "active",
+    )
     extra = 0
     verbose_name_plural = "Cantines gérées"
 

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -184,7 +184,7 @@ class CanteenInline(admin.TabularInline):
 
     @admin.display(description="Gestionnaire")
     def help(self, obj):
-        return "Pour vous supprimer des gestionnaire de la cantine cochez la case."
+        return "Pour retirer le gestionnaire de la cantine cochez la case, puis sauvegardez la modification."
 
     @admin.display(description="Est active")
     def active(self, obj):

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -175,15 +175,16 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
 
 class CanteenInline(admin.TabularInline):
     model = Canteen.managers.through
-    readonly_fields = (
-        "canteen",
-        "active",
-    )
+    readonly_fields = ("canteen", "active", "help")
     extra = 0
     verbose_name_plural = "Cantines gérées"
 
     def has_add_permission(self, request, obj):
         return True
+
+    @admin.display(description="Gestionnaire")
+    def help(self, obj):
+        return "Pour vous supprimer des gestionnaire de la cantine cochez la case."
 
     @admin.display(description="Est active")
     def active(self, obj):

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -182,5 +182,6 @@ class CanteenInline(admin.TabularInline):
     def has_add_permission(self, request, obj):
         return False
 
+    @admin.display(description="Est active")
     def active(self, obj):
         return "🗑️ Supprimée par l'utilisateur" if obj.canteen.deletion_date else "✔️"

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -175,12 +175,13 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
 
 class CanteenInline(admin.TabularInline):
     model = Canteen.managers.through
-    readonly_fields = ("canteen", "active")
+    readonly_fields = ("active",)
+    fields = ("canteen",)
     extra = 0
     verbose_name_plural = "Cantines gérées"
 
     def has_add_permission(self, request, obj):
-        return False
+        return True
 
     @admin.display(description="Est active")
     def active(self, obj):


### PR DESCRIPTION
## Description

Améliorer la compréhension du module pour se supprimer / s'ajouter rapidement de liste des gestionnaires d'une cantine depuis la page de l'utilisateur dans l'admin.

## Prévisualisation

|Avant|Après|
|--|--|
| <img width="1354" alt="Capture d’écran 2025-06-24 à 17 02 46" src="https://github.com/user-attachments/assets/e82f4270-48ab-4ac5-ad48-cf014fc3b753" /> | <img width="1353" alt="Capture d’écran 2025-06-24 à 17 02 32" src="https://github.com/user-attachments/assets/06c92d07-0ca4-4ae3-8a70-a7b7c02d9829" /> |