### PR TITLE
improve(Admin): améliore la recherche dans la page des cantines

### DIFF
--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -151,7 +151,7 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         "siren_unite_legale__istartswith",
         "central_producer_siret__istartswith",
     )
-    search_help_text = 'La recherche est faite sur les champs : nom de la cantine, siret, siren de l'unité légale, siret de la cuisine centrale.'
+    search_help_text = "La recherche est faite sur les champs : nom de la cantine, siret, siren de l'unité légale, siret de la cuisine centrale."
 
     def save_model(self, request, obj, form, change):
         if not change:


### PR DESCRIPTION
## Description

Durcie la recherche par siret ou siren en ne retournant que les établissements "qui commencent par" et non "qui contiennent" pour plus facilement retrouver une cantine si nous n'avons pas le siret exacte.

## Prévisualisation

|Avant|Après|
|--|--|
| <img width="641" alt="Capture d’écran 2025-06-24 à 17 46 39" src="https://github.com/user-attachments/assets/c089c326-373a-457a-a935-e634317a7a00" /> | <img width="947" alt="Capture d’écran 2025-06-24 à 17 47 02" src="https://github.com/user-attachments/assets/125d0d3c-9238-49e2-926e-08ccfb921c46" /> |

