### PR TITLE
perf(API Stats): mettre en place un cache pour accélérer la réponse

### DIFF
--- a/api/views/statistics.py
+++ b/api/views/statistics.py
@@ -1,6 +1,8 @@
 import logging
 
 from django.http import JsonResponse
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.views import APIView
@@ -61,6 +63,7 @@ class CanteenStatisticsView(APIView):
             ),
         ]
     )
+    @method_decorator(cache_page(60 * 60 * 24))  # Cache for 24 hours
     def get(self, request):
         """
         Get statistical summary of canteens and teledeclarations, filtered by query parameters.


### PR DESCRIPTION
Avec Django, il est possible de configurer un mécanisme de cache, à la maille "endpoint"

https://docs.djangoproject.com/en/5.2/topics/cache

Le cache par défaut est "local-memory". à discuter si l'on veut plutôt utiliser un stockage en DB, ou encore Redis.