### PR TITLE
improve(Django): Préparer la migration vers Django 5.1 en corrigeant les éléments dépréciés

### DIFF
--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -567,7 +567,7 @@ class Canteen(SoftDeletionModel):
         verbose_name="Source de création de la cantine",
     )
 
-    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
+    def save(self, **kwargs):
         # cleanup some fields
         if self.siret:
             self.siret = utils_siret.normalise_siret(self.siret)
@@ -578,7 +578,7 @@ class Canteen(SoftDeletionModel):
             self.logo = optimize_image(self.logo, self.logo.name, max_image_size)
         if self.department:
             self.region = self._get_region()
-        super().save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)
+        super().save(**kwargs)
 
     @property
     def url_slug(self):
@@ -821,6 +821,6 @@ class CanteenImage(models.Model):
         verbose_name="texte alternatif pour les utilisateurs qui voient pas l'image",
     )
 
-    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
+    def save(self, **kwargs):
         self.image = optimize_image(self.image, self.image.name)
-        super().save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)
+        super().save(**kwargs)

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -578,7 +578,7 @@ class Canteen(SoftDeletionModel):
             self.logo = optimize_image(self.logo, self.logo.name, max_image_size)
         if self.department:
             self.region = self._get_region()
-        super().save(force_insert, force_update, using, update_fields)
+        super().save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)
 
     @property
     def url_slug(self):
@@ -823,4 +823,4 @@ class CanteenImage(models.Model):
 
     def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         self.image = optimize_image(self.image, self.image.name)
-        super().save(force_insert, force_update, using, update_fields)
+        super().save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)

--- a/data/models/partner.py
+++ b/data/models/partner.py
@@ -109,7 +109,7 @@ class Partner(models.Model):
         max_image_size = 1600
         if self.image:
             self.image = optimize_image(self.image, self.image.name, max_image_size)
-        super().save(force_insert, force_update, using, update_fields)
+        super().save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)
 
     def __str__(self):
         return f'Partenaire "{self.name}"'

--- a/data/models/partner.py
+++ b/data/models/partner.py
@@ -105,11 +105,11 @@ class Partner(models.Model):
     def url_path(self):
         return f"/acteurs-de-l-eco-systeme/{self.url_slug}"
 
-    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
+    def save(self, **kwargs):
         max_image_size = 1600
         if self.image:
             self.image = optimize_image(self.image, self.image.name, max_image_size)
-        super().save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)
+        super().save(**kwargs)
 
     def __str__(self):
         return f'Partenaire "{self.name}"'

--- a/data/models/user.py
+++ b/data/models/user.py
@@ -136,7 +136,7 @@ class User(AbstractUser):
         max_avatar_size = 640
         if self.avatar:
             self.avatar = optimize_image(self.avatar, self.avatar.name, max_avatar_size)
-        super().save(force_insert, force_update, using, update_fields)
+        super().save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)
 
     def __str__(self):
         return f"{self.get_full_name()} ({self.username})"

--- a/data/models/user.py
+++ b/data/models/user.py
@@ -132,11 +132,11 @@ class User(AbstractUser):
         verbose_name="Nombre d'établissements gérés par l'utilisateur",
     )
 
-    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
+    def save(self, **kwargs):
         max_avatar_size = 640
         if self.avatar:
             self.avatar = optimize_image(self.avatar, self.avatar.name, max_avatar_size)
-        super().save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)
+        super().save(**kwargs)
 
     def __str__(self):
         return f"{self.get_full_name()} ({self.username})"

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 import dotenv  # noqa
 import sentry_sdk
-from botocore.client import Config as BotoConfig
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -240,10 +239,6 @@ if default_file_storage == "storages.backends.s3.S3Storage":
     AWS_STORAGE_BUCKET_NAME = os.getenv("CELLAR_BUCKET_NAME")
     AWS_LOCATION = "media"
     AWS_QUERYSTRING_AUTH = False
-    AWS_S3_CLIENT_CONFIG = BotoConfig(
-        request_checksum_calculation="when_required",
-        response_checksum_validation="when_required",
-    )
 
 MEDIA_ROOT = os.getenv("MEDIA_ROOT", os.path.join(BASE_DIR, "media"))
 MEDIA_URL = "/media/"

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import dotenv  # noqa
 import sentry_sdk
+from botocore.client import Config as BotoConfig
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -221,18 +222,32 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static/")
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Media and file storage
-AWS_ACCESS_KEY_ID = os.getenv("CELLAR_KEY")
-AWS_SECRET_ACCESS_KEY = os.getenv("CELLAR_SECRET")
-AWS_S3_ENDPOINT_URL = os.getenv("CELLAR_HOST")
-AWS_STORAGE_BUCKET_NAME = os.getenv("CELLAR_BUCKET_NAME")
-AWS_LOCATION = "media"
-AWS_QUERYSTRING_AUTH = False
+default_file_storage = os.getenv("DEFAULT_FILE_STORAGE")
 
-DEFAULT_FILE_STORAGE = os.getenv("DEFAULT_FILE_STORAGE")
+STORAGES = {
+    "default": {
+        "BACKEND": default_file_storage,
+    },
+    "staticfiles": {
+        "BACKEND": os.getenv("STATICFILES_STORAGE"),
+    },
+}
+
+if default_file_storage == "storages.backends.s3.S3Storage":
+    AWS_ACCESS_KEY_ID = os.getenv("CELLAR_KEY")
+    AWS_SECRET_ACCESS_KEY = os.getenv("CELLAR_SECRET")
+    AWS_S3_ENDPOINT_URL = os.getenv("CELLAR_HOST")
+    AWS_STORAGE_BUCKET_NAME = os.getenv("CELLAR_BUCKET_NAME")
+    AWS_LOCATION = "media"
+    AWS_QUERYSTRING_AUTH = False
+    AWS_S3_CLIENT_CONFIG = BotoConfig(
+        request_checksum_calculation="when_required",
+        response_checksum_validation="when_required",
+    )
+
 MEDIA_ROOT = os.getenv("MEDIA_ROOT", os.path.join(BASE_DIR, "media"))
 MEDIA_URL = "/media/"
 
-STATICFILES_STORAGE = os.getenv("STATICFILES_STORAGE")
 SESSION_COOKIE_AGE = 31536000
 SESSION_COOKIE_SECURE = os.getenv("SECURE") == "True"
 SESSION_COOKIE_HTTPONLY = True


### PR DESCRIPTION
Résout #4394 et doit permettre la migration vers Django 5.1

3 éléments avaient été mis en avant par Helen :
* Support for passing encoded JSON string literals to JSONField and associated lookups and expressions is removed : -> **je n'ai trouvé aucun filter utilisant du JSON brute** :heavy_check_mark: 
* The DEFAULT_FILE_STORAGE and STATICFILES_STORAGE settings is removed :heavy_check_mark: 
* Passing positional arguments to [Model.save()](https://docs.djangoproject.com/en/5.1/ref/models/instances/#django.db.models.Model.save) and [Model.asave()](https://docs.djangoproject.com/en/5.1/ref/models/instances/#django.db.models.Model.asave) is deprecated in favor of keyword-only arguments. (pour nous il y a super(Canteen, self).save(force_insert, force_update, using, update_fields) dans deux endroits de data/models/canteen.py, dans partner, dans user) :heavy_check_mark: 

