### PR TITLE
fix(ETL): Ne plus ecraser les valeurs égales à 0 par None pour les champs issus du declared data

### DIFF
--- a/api/serializers/teledeclaration.py
+++ b/api/serializers/teledeclaration.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from api.serializers.utils import float_or_none, match_sector_values
+from api.serializers.utils import match_sector_values, safe_to_float
 from data.department_choices import Department
 from data.models import Diagnostic, Teledeclaration
 from data.models.sector import Sector
@@ -278,19 +278,19 @@ class TeledeclarationAnalysisSerializer(serializers.ModelSerializer):
         return obj.value_egalim_others_ht_agg
 
     def get_value_meat_poultry_ht(self, obj):
-        return float_or_none(obj.diagnostic.value_meat_poultry_ht)
+        return safe_to_float(obj.diagnostic.value_meat_poultry_ht)
 
     def get_value_meat_poultry_france_ht(self, obj):
-        return float_or_none(obj.diagnostic.value_meat_poultry_france_ht)
+        return safe_to_float(obj.diagnostic.value_meat_poultry_france_ht)
 
     def get_value_meat_poultry_egalim_ht(self, obj):
-        return float_or_none(obj.diagnostic.value_meat_poultry_egalim_ht)
+        return safe_to_float(obj.diagnostic.value_meat_poultry_egalim_ht)
 
     def get_value_fish_ht(self, obj):
-        return float_or_none(obj.diagnostic.value_fish_ht)
+        return safe_to_float(obj.diagnostic.value_fish_ht)
 
     def get_value_fish_egalim_ht(self, obj):
-        return float_or_none(obj.diagnostic.value_fish_egalim_ht)
+        return safe_to_float(obj.diagnostic.value_fish_egalim_ht)
 
     def get_value_somme_egalim_avec_bio_ht(self, obj):
         return utils.sum_int_and_none([self.get_value_somme_egalim_hors_bio_ht(obj), self.get_value_bio_ht(obj)])

--- a/api/serializers/utils.py
+++ b/api/serializers/utils.py
@@ -164,8 +164,11 @@ COMPLETE_APPRO_FIELDS = (
 )
 
 
-def float_or_none(value):
-    return float(value) if value else None
+def safe_to_float(value):
+    try:
+        return float(value) if value is not None else None
+    except (ValueError, TypeError):
+        return None
 
 
 def match_sector_values(value):

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -1,0 +1,24 @@
+from rest_framework.test import APITestCase
+
+from api.serializers.utils import safe_to_float
+
+
+class TestUtils(APITestCase):
+
+    def test_safe_to_float(self):
+        test_cases = [
+            (None, None),
+            ("", None),
+            ("abc", None),
+            ("123", 123.0),
+            (123, 123.0),
+            (123.45, 123.45),
+            ([], None),
+            ({}, None),
+            (True, 1.0),
+            (False, 0.0),
+            ("  42.5  ", 42.5),
+        ]
+        for input_value, expected in test_cases:
+            result = safe_to_float(input_value)
+            self.assertEqual(result, expected, msg=f"Failed for input: {input_value!r}")


### PR DESCRIPTION
Les champs du declared_data étaient écrasés par None lorsqu'ils étaient égaux à 0 à cause d'une condition mal écrite.

Le même problème avait été corrigé pour les valeurs issues de l'éclatement des cuisines centrales - https://github.com/betagouv/ma-cantine/pull/5484