### PR TITLE
refactor(Tests): enlever les warning '_date received a naive datetime'

### DIFF
--- a/data/fixtures/initial_data.json
+++ b/data/fixtures/initial_data.json
@@ -11,11 +11,11 @@
   {
     "fields": {
       "city": "Paris",
-      "creation_date": "2025-01-01",
+      "creation_date": "2025-01-01T00:00:00+00:00",
       "managers": [
         1
       ],
-      "modification_date": "2025-01-01",
+      "modification_date": "2025-01-01T00:00:00+00:00",
       "name": "Sample Canteen",
       "postal_code": "75001",
       "siret": "83014132100034",
@@ -27,8 +27,8 @@
   {
     "fields": {
       "category": "administration",
-      "creation_date": "2025-01-01",
-      "modification_date": "2025-01-01",
+      "creation_date": "2025-01-01T00:00:00+00:00",
+      "modification_date": "2025-01-01T00:00:00+00:00",
       "name": "Administration ma-cantine"
     },
     "model": "data.sector",
@@ -37,8 +37,8 @@
   {
     "fields": {
       "canteen": 1,
-      "creation_date": "2025-01-01",
-      "modification_date": "2025-01-01",
+      "creation_date": "2025-01-01T00:00:00+00:00",
+      "modification_date": "2025-01-01T00:00:00+00:00",
       "value_bio_ht": 200,
       "value_total_ht": 1000
     },


### PR DESCRIPTION
Fait disparaitre les messages suivants dans la CI

```
/home/runner/work/ma-cantine/ma-cantine/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1665: RuntimeWarning: DateTimeField Canteen.creation_date received a naive datetime (2025-01-01 00:00:00) while time zone support is active.
  warnings.warn(
/home/runner/work/ma-cantine/ma-cantine/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1665: RuntimeWarning: DateTimeField Canteen.modification_date received a naive datetime (2025-01-01 00:00:00) while time zone support is active.
  warnings.warn(
/home/runner/work/ma-cantine/ma-cantine/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1665: RuntimeWarning: DateTimeField Sector.creation_date received a naive datetime (2025-01-01 00:00:00) while time zone support is active.
  warnings.warn(
/home/runner/work/ma-cantine/ma-cantine/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1665: RuntimeWarning: DateTimeField Sector.modification_date received a naive datetime (2025-01-01 00:00:00) while time zone support is active.
  warnings.warn(
/home/runner/work/ma-cantine/ma-cantine/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1665: RuntimeWarning: DateTimeField Diagnostic.creation_date received a naive datetime (2025-01-01 00:00:00) while time zone support is active.
  warnings.warn(
/home/runner/work/ma-cantine/ma-cantine/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1665: RuntimeWarning: DateTimeField Diagnostic.modification_date received a naive datetime (2025-01-01 00:00:00) while time zone support is active.
  warnings.warn(
```