### PR TITLE
refactor(Tests): enlever les warning 'min_value should be a Decimal instance'

### DIFF
--- a/data/models/reservationexpe.py
+++ b/data/models/reservationexpe.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
@@ -45,7 +47,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des excédents présentés aux convives et non servis ou non valorisés (g/ convive) sur 20 déjeuners successifs",
     )
     avg_weight_leftover_t0 = models.DecimalField(
@@ -53,7 +55,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des restes des assiettes exprimées (g/convive) sur 20 déjeuners successifs",
     )
     ratio_edible_non_edible_t0 = models.DecimalField(
@@ -61,7 +63,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=5,
         decimal_places=4,
-        validators=[MinValueValidator(0), MaxValueValidator(1)],
+        validators=[MinValueValidator(Decimal(0)), MaxValueValidator(Decimal(1))],
         verbose_name="Ratio de la part non comestible (g) rapportée à la part comestible (g)",
     )
     avg_weight_preparation_leftover_t0 = models.DecimalField(
@@ -69,7 +71,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des déchets alimentaires issus de la préparation (g/convive)",
     )
     avg_weight_bread_leftover_t0 = models.DecimalField(
@@ -77,7 +79,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des pains jetés sur 20 déjeuners successifs (g/convive)",
     )
     avg_attendance_from_evaluation_t0 = models.DecimalField(
@@ -85,7 +87,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Nombre moyen d'usagers à partir de l'évaluation",
     )
     solution_use_rate_t0 = models.DecimalField(
@@ -93,7 +95,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=5,
         decimal_places=4,
-        validators=[MinValueValidator(0), MaxValueValidator(1)],
+        validators=[MinValueValidator(Decimal(0)), MaxValueValidator(Decimal(1))],
         verbose_name="Taux d’utilisation de la solution de réservation",
     )
     comments_t0 = models.TextField(null=True, blank=True, verbose_name="Commentaires")
@@ -104,7 +106,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des excédents présentés aux convives et non servis ou non valorisés (g/ convive) sur 20 déjeuners successifs",
     )
     avg_weight_leftover_t1 = models.DecimalField(
@@ -112,7 +114,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des restes des assiettes exprimées (g/convive) sur 20 déjeuners successifs",
     )
     ratio_edible_non_edible_t1 = models.DecimalField(
@@ -120,7 +122,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=5,
         decimal_places=4,
-        validators=[MinValueValidator(0), MaxValueValidator(1)],
+        validators=[MinValueValidator(Decimal(0)), MaxValueValidator(Decimal(1))],
         verbose_name="Ratio de la part non comestible (g) rapportée à la part comestible (g)",
     )
     avg_weight_preparation_leftover_t1 = models.DecimalField(
@@ -128,7 +130,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des déchets alimentaires issus de la préparation (g/convive)",
     )
     avg_weight_bread_leftover_t1 = models.DecimalField(
@@ -136,7 +138,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des pains jetés sur 20 déjeuners successifs (g/convive)",
     )
     avg_attendance_from_evaluation_t1 = models.DecimalField(
@@ -144,7 +146,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Nombre moyen d'usagers à partir de l'évaluation",
     )
     solution_use_rate_t1 = models.DecimalField(
@@ -152,7 +154,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Taux d’utilisation de la solution de réservation",
     )
     comments_t1 = models.TextField(null=True, blank=True, verbose_name="Commentaires")
@@ -163,7 +165,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des excédents présentés aux convives et non servis ou non valorisés (g/ convive) sur 20 déjeuners successifs",
     )
     avg_weight_leftover_t2 = models.DecimalField(
@@ -171,7 +173,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des restes des assiettes exprimées (g/convive) sur 20 déjeuners successifs",
     )
     ratio_edible_non_edible_t2 = models.DecimalField(
@@ -179,7 +181,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=5,
         decimal_places=4,
-        validators=[MinValueValidator(0), MaxValueValidator(1)],
+        validators=[MinValueValidator(Decimal(0)), MaxValueValidator(Decimal(1))],
         verbose_name="Ratio de la part non comestible (g) rapportée à la part comestible (g)",
     )
     avg_weight_preparation_leftover_t2 = models.DecimalField(
@@ -187,7 +189,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des déchets alimentaires issus de la préparation (g/convive)",
     )
     avg_weight_bread_leftover_t2 = models.DecimalField(
@@ -195,7 +197,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Moyenne des pesées des pains jetés sur 20 déjeuners successifs (g/convive)",
     )
     avg_attendance_from_evaluation_t2 = models.DecimalField(
@@ -203,7 +205,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Nombre moyen d'usagers à partir de l'évaluation",
     )
     solution_use_rate_t2 = models.DecimalField(
@@ -211,21 +213,24 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Taux d’utilisation de la solution de réservation",
     )
     comments_t2 = models.TextField(null=True, blank=True, verbose_name="Commentaires")
 
     # T2 only questions
     satisfaction = models.IntegerField(
-        null=True, blank=True, verbose_name="Satisfaction", validators=[MinValueValidator(0), MaxValueValidator(5)]
+        null=True,
+        blank=True,
+        verbose_name="Satisfaction",
+        validators=[MinValueValidator(Decimal(0)), MaxValueValidator(Decimal(5))],
     )
     system_cost = models.DecimalField(
         null=True,
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Coût de la solution de réservation sur 3 ans",
     )
     participation_cost = models.DecimalField(
@@ -233,7 +238,7 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Coûts liés à la participation à l'expérimentation sur 3 ans",
     )
     participation_cost_details = models.TextField(
@@ -244,6 +249,6 @@ class ReservationExpe(models.Model):
         blank=True,
         max_digits=20,
         decimal_places=2,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
         verbose_name="Gains générés par l'évitement du gaspillage laimentaire en euros sur 3 ans",
     )


### PR DESCRIPTION
Fait disparaitre les messages suivants dans la CI

```
/home/runner/work/ma-cantine/ma-cantine/.venv/lib/python3.11/site-packages/rest_framework/fields.py:992: UserWarning: min_value should be a Decimal instance.
  warnings.warn("min_value should be a Decimal instance.")
/home/runner/work/ma-cantine/ma-cantine/.venv/lib/python3.11/site-packages/rest_framework/fields.py:990: UserWarning: max_value should be a Decimal instance.
  warnings.warn("max_value should be a Decimal instance.")
................................................................................../home/runner/work/ma-cantine/ma-cantine/.venv/lib/python3.11/site-packages/rest_framework/fields.py:990: UserWarning: max_value should be a Decimal instance.
  warnings.warn("max_value should be a Decimal instance.")
/home/runner/work/ma-cantine/ma-cantine/.venv/lib/python3.11/site-packages/rest_framework/fields.py:992: UserWarning: min_value should be a Decimal instance.
  warnings.warn("min_value should be a Decimal instance.")
```