### PR TITLE
fix(Cantines): répare la commande qui remplit le champ declaration_donnees_YEAR (suite à la valeur par défaut à False) + ajout de tests

### DIFF
--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -6,7 +6,7 @@ from data.factories import (
     DiagnosticFactory,
     PurchaseFactory,
     SectorFactory,
-    TeledeclarationFactory,
+    UserFactory,
 )
 from data.models import Canteen, Diagnostic, Sector, Teledeclaration
 
@@ -196,30 +196,23 @@ class TestCanteenDiagnosticTeledeclarationQuerySet(TestCase):
             year=2024,
             value_total_ht=1000,
         )  # filled
-        TeledeclarationFactory(
-            canteen=canteen_with_diagnostic_cancelled,
-            diagnostic=diagnostic_filled,
-            year=2024,
-            status=Teledeclaration.TeledeclarationStatus.CANCELLED,
-        )
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            td_to_cancel = Teledeclaration.create_from_diagnostic(diagnostic_filled, applicant=UserFactory())
+            td_to_cancel.cancel()
         diagnostic_filled_and_submitted = DiagnosticFactory(
             canteen=canteen_with_diagnostic_submitted,
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
             year=2024,
             value_total_ht=1000,
         )  # filled & submitted
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            Teledeclaration.create_from_diagnostic(diagnostic_filled_and_submitted, applicant=UserFactory())
         DiagnosticFactory(
             canteen=canteen_with_diagnostic_submitted,
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
             year=2023,
             value_total_ht=None,
         )  # missing data
-        TeledeclarationFactory(
-            canteen=canteen_with_diagnostic_submitted,
-            diagnostic=diagnostic_filled_and_submitted,
-            year=2024,
-            status=Teledeclaration.TeledeclarationStatus.SUBMITTED,
-        )
 
     def test_annotate_with_diagnostic_for_year(self):
         self.assertEqual(Canteen.objects.count(), 3)

--- a/macantine/management/commands/fill_canteen_declaration_donnees_year_field.py
+++ b/macantine/management/commands/fill_canteen_declaration_donnees_year_field.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
         field_name = f"declaration_donnees_{year}"
 
         # Step 1: reset the field for all the canteens
-        Canteen.objects.all().update(**{field_name: None})
+        Canteen.objects.all().update(**{field_name: False})
 
         # Step 2: find the canteens that have a teledeclaration for the specified year
         teledeclarations = Teledeclaration.objects.submitted_for_year(year)
@@ -40,9 +40,8 @@ class Command(BaseCommand):
                 for satellite in td["declared_data"]["satellites"]:
                     canteens_with_teledeclarations.append(satellite["id"])
 
-        # Step 3: update the field for all the canteens
+        # Step 3: update the field
         Canteen.objects.filter(id__in=canteens_with_teledeclarations).update(**{field_name: True})
-        Canteen.objects.exclude(**{field_name: True}).update(**{field_name: False})
 
         # Done!
         logger.info(

--- a/macantine/tests/test_fill_canteen_declaration_donnees_year_field.py
+++ b/macantine/tests/test_fill_canteen_declaration_donnees_year_field.py
@@ -1,0 +1,48 @@
+from django.core.management import call_command
+from django.test import TestCase
+from freezegun import freeze_time
+
+from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
+from data.models import Canteen, Diagnostic, Teledeclaration
+
+
+class FillCanteenDeclarationDonneesYearFieldCommandTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen_with_diagnostic_cancelled = CanteenFactory()
+        cls.canteen_with_diagnostic_submitted = CanteenFactory(
+            siret="75665621899905", production_type=Canteen.ProductionType.CENTRAL, satellite_canteens_count=1
+        )
+        cls.canteen_satellite_with_central_diagnostic_submitted = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+            central_producer_siret=cls.canteen_with_diagnostic_submitted.siret,
+        )
+        diagnostic_filled = DiagnosticFactory(
+            canteen=cls.canteen_with_diagnostic_cancelled,
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+            year=2024,
+            value_total_ht=1000,
+        )  # filled
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            td_to_cancel = Teledeclaration.create_from_diagnostic(diagnostic_filled, applicant=UserFactory())
+            td_to_cancel.cancel()
+        diagnostic_filled_and_submitted = DiagnosticFactory(
+            canteen=cls.canteen_with_diagnostic_submitted,
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+            year=2024,
+            value_total_ht=1000,
+        )  # filled & submitted
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            Teledeclaration.create_from_diagnostic(diagnostic_filled_and_submitted, applicant=UserFactory())
+
+    def test_fill_canteen_declaration_donnees_year_field(self):
+        self.assertFalse(self.canteen_with_diagnostic_cancelled.declaration_donnees_2024)
+        self.assertFalse(self.canteen_with_diagnostic_submitted.declaration_donnees_2024)
+        self.assertFalse(self.canteen_satellite_with_central_diagnostic_submitted.declaration_donnees_2024)
+        call_command("fill_canteen_declaration_donnees_year_field", year=2024)
+        self.canteen_with_diagnostic_cancelled.refresh_from_db()
+        self.canteen_with_diagnostic_submitted.refresh_from_db()
+        self.canteen_satellite_with_central_diagnostic_submitted.refresh_from_db()
+        self.assertFalse(self.canteen_with_diagnostic_cancelled.declaration_donnees_2024)
+        self.assertTrue(self.canteen_with_diagnostic_submitted.declaration_donnees_2024)
+        self.assertTrue(self.canteen_satellite_with_central_diagnostic_submitted.declaration_donnees_2024)

--- a/macantine/tests/test_fill_missing_td_canteen_geolocation_data.py
+++ b/macantine/tests/test_fill_missing_td_canteen_geolocation_data.py
@@ -5,7 +5,7 @@ from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 from data.models import Teledeclaration
 
 
-class FixturesTest(TestCase):
+class FillMissingTDCanteenGeolocationDataCommandTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.canteen_with_geo_data = CanteenFactory.create(


### PR DESCRIPTION
On avait créé la commande dans #5450
Mais on a ensuite changé la valeur par défaut de ces champs à False dans #5519

On a oublié de faire la modif dans la commande

J'en ai profité pour rajouter des tests :pray: 