### PR TITLE
improve(ETL): Ajout des champs declaration_campagne_YEAR dans TD analysis

### DIFF
--- a/api/serializers/teledeclaration.py
+++ b/api/serializers/teledeclaration.py
@@ -50,6 +50,10 @@ class TeledeclarationAnalysisSerializer(serializers.ModelSerializer):
     line_ministry = serializers.SerializerMethodField()
     spe = serializers.SerializerMethodField()
     genere_par_cuisine_centrale = serializers.SerializerMethodField()
+    declaration_donnees_2021 = serializers.SerializerMethodField()
+    declaration_donnees_2022 = serializers.SerializerMethodField()
+    declaration_donnees_2023 = serializers.SerializerMethodField()
+    declaration_donnees_2024 = serializers.SerializerMethodField()
 
     # Data related to the appro
     value_bio_ht = serializers.SerializerMethodField()
@@ -116,6 +120,10 @@ class TeledeclarationAnalysisSerializer(serializers.ModelSerializer):
             "objectif_zone_geo",
             "line_ministry",
             "spe",
+            "declaration_donnees_2021",
+            "declaration_donnees_2022",
+            "declaration_donnees_2023",
+            "declaration_donnees_2024",
             "year",
             "status",
             "applicant_id",
@@ -268,6 +276,18 @@ class TeledeclarationAnalysisSerializer(serializers.ModelSerializer):
     def get_spe(self, obj):
         line_ministry = self.get_line_ministry(obj)
         return "Oui" if line_ministry else "Non"
+
+    def get_declaration_donnees_2021(self, obj):
+        return obj.canteen.declaration_donnees_2021
+
+    def get_declaration_donnees_2022(self, obj):
+        return obj.canteen.declaration_donnees_2022
+
+    def get_declaration_donnees_2023(self, obj):
+        return obj.canteen.declaration_donnees_2023
+
+    def get_declaration_donnees_2024(self, obj):
+        return obj.canteen.declaration_donnees_2024
 
     def get_value_bio_ht(self, obj):
         return obj.value_bio_ht_agg

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -110,7 +110,7 @@ class TeledeclarationQuerySet(models.QuerySet):
         results = self.none()
         for year in years:
             results = results | self.valid_td_by_year(year)
-        return results.select_related("diagnostic")
+        return results.select_related("canteen", "diagnostic")
 
     def publicly_visible(self):
         return self.exclude(canteen__line_ministry=Canteen.Ministries.ARMEE)

--- a/data/schemas/export_analysis/schema_teledeclarations.json
+++ b/data/schemas/export_analysis/schema_teledeclarations.json
@@ -74,11 +74,6 @@
       "type": "integer"
     },
     {
-      "description": "Spécifie si les données ont été déclarées par une cuisine centrale",
-      "name": "genere_par_cuisine_centrale",
-      "type": "boolean"
-    },
-    {
       "name": "departement",
       "type": "string"
     },
@@ -123,6 +118,35 @@
       "name": "spe",
       "title": "Service Public Ecoresponsable",
       "type": "string"
+    },
+    {
+      "description": "Spécifie si les données ont été déclarées par une cuisine centrale",
+      "name": "genere_par_cuisine_centrale",
+      "type": "boolean"
+    },
+    {
+      "example": "true",
+      "name": "declaration_donnees_2021",
+      "title": "A déclaré en 2022 ses données de 2021",
+      "type": "boolean"
+    },
+    {
+      "example": "true",
+      "name": "declaration_donnees_2022",
+      "title": "A déclaré en 2023 ses données de 2022",
+      "type": "boolean"
+    },
+    {
+      "example": "true",
+      "name": "declaration_donnees_2023",
+      "title": "A déclaré en 2024 ses données de 2023",
+      "type": "boolean"
+    },
+    {
+      "example": "true",
+      "name": "declaration_donnees_2024",
+      "title": "A déclaré en 2025 ses données de 2024",
+      "type": "boolean"
     },
     {
       "name": "email",


### PR DESCRIPTION
Utilisation des champs de l'objet Canteen.
C'est la seule fois qu'on utilise directement la foreign key de Canteen dans le serializer TD Analysis