### PR TITLE
fix(ETL): Enlever la TD d'un satellite en cas de doublon avec cuisine centrale

### DIFF
--- a/macantine/etl/analysis.py
+++ b/macantine/etl/analysis.py
@@ -111,12 +111,9 @@ class ETL_ANALYSIS_TELEDECLARATIONS(ANALYSIS, etl.EXTRACTOR):
         Remove duplicate rows for central kitchens and their satellites based on unique identifiers.
         Keep the row where production type is central kitchen if duplicates exist.
         """
-        if "canteen_id" in self.df.columns and "production_type" in self.df.columns:
+        if "canteen_id" in self.df.columns and "genere_par_cuisine_centrale" in self.df.columns:
             self.df = self.df.sort_values(
-                by=["production_type"],
-                key=lambda col: col.map(
-                    lambda x: x in [Canteen.ProductionType.CENTRAL, Canteen.ProductionType.CENTRAL_SERVING]
-                ),
+                by=["genere_par_cuisine_centrale"],
                 ascending=False,
             )
             self.df = self.df.drop_duplicates(subset=["canteen_id", "year"], keep="first")

--- a/macantine/tests/test_etl_analysis.py
+++ b/macantine/tests/test_etl_analysis.py
@@ -486,19 +486,20 @@ class TestETLAnalysisTD(TestCase):
         etl_instance = ETL_ANALYSIS_TELEDECLARATIONS()
         etl_instance.df = pd.DataFrame(
             {
+                "id": [10, 20, 30],
                 "canteen_id": [1, 1, 2],
                 "year": [2023, 2023, 2023],
-                "production_type": [
-                    Canteen.ProductionType.CENTRAL,
-                    Canteen.ProductionType.ON_SITE_CENTRAL,
-                    Canteen.ProductionType.ON_SITE_CENTRAL,
+                "genere_par_cuisine_centrale": [
+                    True,
+                    False,
+                    True,
                 ],
                 "other_column": [10, 20, 30],
             }
         )
         etl_instance.delete_duplicates_cc_csat()
         assert len(etl_instance.df) == 2
-        assert etl_instance.df.iloc[0]["production_type"] == Canteen.ProductionType.CENTRAL
+        assert etl_instance.df.iloc[0]["id"] == 10
 
     def test_delete_duplicates_cc_csat_no_duplicates(self):
         etl_instance = ETL_ANALYSIS_TELEDECLARATIONS()
@@ -506,7 +507,7 @@ class TestETLAnalysisTD(TestCase):
             {
                 "canteen_id": [1, 2],
                 "year": [2023, 2023],
-                "production_type": [Canteen.ProductionType.CENTRAL, Canteen.ProductionType.ON_SITE_CENTRAL],
+                "genere_par_cuisine_centrale": [False, True],
                 "other_column": [10, 20],
             }
         )


### PR DESCRIPTION
Changer colonne de tri pour enlever la TD du sat en cas de doublon.

La colonne PRODUCTION_TYPE ne permet pas de différencier les doublons car après le split des cuisines centrales, tous les doublons ont la valeur `SATELLITE`