### PR TITLE
feat(Cantines): nouveau queryset pour filtrer par année de création (à la date de fin de la campagne)

### DIFF
--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -22,7 +22,7 @@ from data.utils import (
     has_charfield_missing_query,
     optimize_image,
 )
-from macantine.utils import is_in_correction, is_in_teledeclaration
+from macantine.utils import CAMPAIGN_DATES, is_in_correction, is_in_teledeclaration
 
 from .softdeletionmodel import (
     SoftDeletionManager,
@@ -92,6 +92,9 @@ class CanteenQuerySet(SoftDeletionQuerySet):
 
     def publicly_hidden(self):
         return self.filter(line_ministry=Canteen.Ministries.ARMEE)
+
+    def created_before_year_campaign_end_date(self, year):
+        return self.filter(creation_date__lte=CAMPAIGN_DATES[year]["teledeclaration_end_date"])
 
     def is_satellite(self):
         return self.filter(is_satellite_query())
@@ -259,6 +262,9 @@ class CanteenManager(SoftDeletionManager):
 
     def publicly_hidden(self):
         return self.get_queryset().publicly_hidden()
+
+    def created_before_year_campaign_end_date(self, year):
+        return self.get_queryset().created_before_year_campaign_end_date(year)
 
     def is_satellite(self):
         return self.get_queryset().is_satellite()

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -94,7 +94,11 @@ class CanteenQuerySet(SoftDeletionQuerySet):
         return self.filter(line_ministry=Canteen.Ministries.ARMEE)
 
     def created_before_year_campaign_end_date(self, year):
-        return self.filter(creation_date__lte=CAMPAIGN_DATES[year]["teledeclaration_end_date"])
+        if year in CAMPAIGN_DATES.keys():
+            return self.filter(creation_date__lte=CAMPAIGN_DATES[year]["teledeclaration_end_date"])
+        elif year >= timezone.now().year:
+            return self  # all the cantines
+        return self.none()
 
     def is_satellite(self):
         return self.filter(is_satellite_query())

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -87,6 +87,24 @@ class TestCanteenVisibleQuerySetAndProperty(TestCase):
         self.assertEqual(self.canteen_armee.publication_status_display_to_public, "draft")
 
 
+class TestCanteenCreatedBeforeQuerySet(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        with freeze_time("2025-01-01"):  # before the 2024 campaign
+            CanteenFactory()
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            CanteenFactory()
+        with freeze_time("2025-04-20"):  # during the 2024 correction campaign
+            CanteenFactory()
+        with freeze_time("2025-12-30"):  # after the 2024 campaign
+            CanteenFactory()
+
+    def test_created_before_year_campaign_end_date(self):
+        self.assertEqual(Canteen.objects.count(), 4)
+        self.assertEqual(Canteen.objects.created_before_year_campaign_end_date(2023).count(), 0)
+        self.assertEqual(Canteen.objects.created_before_year_campaign_end_date(2024).count(), 2)
+
+
 class TestCanteenSatelliteQuerySet(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -101,8 +101,10 @@ class TestCanteenCreatedBeforeQuerySet(TestCase):
 
     def test_created_before_year_campaign_end_date(self):
         self.assertEqual(Canteen.objects.count(), 4)
+        self.assertEqual(Canteen.objects.created_before_year_campaign_end_date(1990).count(), 0)
         self.assertEqual(Canteen.objects.created_before_year_campaign_end_date(2023).count(), 0)
         self.assertEqual(Canteen.objects.created_before_year_campaign_end_date(2024).count(), 2)
+        self.assertEqual(Canteen.objects.created_before_year_campaign_end_date(2025).count(), 4)
 
 
 class TestCanteenSatelliteQuerySet(TestCase):


### PR DESCRIPTION
ticket https://www.notion.so/incubateur-masa/API-Stats-nombre-de-cantines-doit-tre-inf-rieur-dans-les-ann-es-pass-es-22bde24614be80ffa8b1d50a32fa179e?v=1a2de24614be818290f0000c3eddc9db&source=copy_link

Résultats sur la replica
```
for year in range(2020, 2026):
    print(year, Canteen.objects.created_before_year_campaign_end_date(year).count())

2020 0
2021 19264
2022 24374
2023 37380
2024 55058
2025 56374
```