### PR TITLE
feat(Observatoire): affiche les filtres sélectionnés

### DIFF
--- a/2024-frontend/src/components/FilterByCharacteristics.vue
+++ b/2024-frontend/src/components/FilterByCharacteristics.vue
@@ -4,9 +4,9 @@ import { useStoreFilters } from "@/stores/filters"
 import { getCharacteristicsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
-const economicModel = computed(() => storeFilters.params.economicModel)
-const managementType = computed(() => storeFilters.params.managementType)
-const productionType = computed(() => storeFilters.params.productionType)
+const economicModel = computed(() => storeFilters.get("economicModel"))
+const managementType = computed(() => storeFilters.get("managementType"))
+const productionType = computed(() => storeFilters.get("productionType"))
 const options = ref(getCharacteristicsOptions())
 const storeFilters = useStoreFilters()
 </script>

--- a/2024-frontend/src/components/FilterByCharacteristics.vue
+++ b/2024-frontend/src/components/FilterByCharacteristics.vue
@@ -1,17 +1,17 @@
 <script setup>
 import { ref, computed } from "vue"
-import { useFiltersStore } from "@/stores/filters"
+import { useStoreFilters } from "@/stores/filters"
 import { getCharacteristicsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
-const economicModel = computed(() => filterStore.params.economicModel)
-const managementType = computed(() => filterStore.params.managementType)
-const productionType = computed(() => filterStore.params.productionType)
+const economicModel = computed(() => storeFilters.params.economicModel)
+const managementType = computed(() => storeFilters.params.managementType)
+const productionType = computed(() => storeFilters.params.productionType)
 const options = ref(getCharacteristicsOptions())
 
-const filterStore = useFiltersStore()
+const storeFilters = useStoreFilters()
 const updateFilter = (name, value) => {
-  filterStore.add(name, value)
+  storeFilters.add(name, value)
 }
 </script>
 

--- a/2024-frontend/src/components/FilterByCharacteristics.vue
+++ b/2024-frontend/src/components/FilterByCharacteristics.vue
@@ -8,11 +8,7 @@ const economicModel = computed(() => storeFilters.params.economicModel)
 const managementType = computed(() => storeFilters.params.managementType)
 const productionType = computed(() => storeFilters.params.productionType)
 const options = ref(getCharacteristicsOptions())
-
 const storeFilters = useStoreFilters()
-const updateFilter = (name, value) => {
-  storeFilters.add(name, value)
-}
 </script>
 
 <template>
@@ -20,7 +16,7 @@ const updateFilter = (name, value) => {
     <DsfrCheckboxSet
       legend="Types d’établissement :"
       :modelValue="economicModel"
-      @update:modelValue="updateFilter('economicModel', $event)"
+      @update:modelValue="storeFilters.add('economicModel', $event)"
       :options="options.economicModel"
       small
       inline
@@ -28,7 +24,7 @@ const updateFilter = (name, value) => {
     <DsfrCheckboxSet
       legend="Modes de gestion :"
       :modelValue="managementType"
-      @update:modelValue="updateFilter('managementType', $event)"
+      @update:modelValue="storeFilters.add('managementType', $event)"
       :options="options.managementType"
       small
       inline
@@ -36,7 +32,7 @@ const updateFilter = (name, value) => {
     <DsfrCheckboxSet
       legend="Modes de production :"
       :modelValue="productionType"
-      @update:modelValue="updateFilter('productionType', $event)"
+      @update:modelValue="storeFilters.add('productionType', $event)"
       :options="options.productionType"
       small
       inline

--- a/2024-frontend/src/components/FilterByCharacteristics.vue
+++ b/2024-frontend/src/components/FilterByCharacteristics.vue
@@ -1,12 +1,18 @@
 <script setup>
-import { ref } from "vue"
+import { ref, computed } from "vue"
+import { useFiltersStore } from "@/stores/filters"
 import { getCharacteristicsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
-const economicModel = ref([])
-const managementType = ref([])
-const productionType = ref([])
+const economicModel = computed(() => filterStore.economicModel)
+const managementType = computed(() => filterStore.managementType)
+const productionType = computed(() => filterStore.productionType)
 const options = ref(getCharacteristicsOptions())
+
+const filterStore = useFiltersStore()
+const updateFilter = (name, value) => {
+  filterStore.add(name, value)
+}
 </script>
 
 <template>
@@ -14,6 +20,7 @@ const options = ref(getCharacteristicsOptions())
     <DsfrCheckboxSet
       legend="Types d’établissement :"
       :modelValue="economicModel"
+      @update:modelValue="updateFilter('economicModel', $event)"
       :options="options.economicModel"
       small
       inline
@@ -21,6 +28,7 @@ const options = ref(getCharacteristicsOptions())
     <DsfrCheckboxSet
       legend="Modes de gestion :"
       :modelValue="managementType"
+      @update:modelValue="updateFilter('managementType', $event)"
       :options="options.managementType"
       small
       inline
@@ -28,6 +36,7 @@ const options = ref(getCharacteristicsOptions())
     <DsfrCheckboxSet
       legend="Modes de production :"
       :modelValue="productionType"
+      @update:modelValue="updateFilter('productionType', $event)"
       :options="options.productionType"
       small
       inline

--- a/2024-frontend/src/components/FilterByCharacteristics.vue
+++ b/2024-frontend/src/components/FilterByCharacteristics.vue
@@ -4,9 +4,9 @@ import { useFiltersStore } from "@/stores/filters"
 import { getCharacteristicsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
-const economicModel = computed(() => filterStore.economicModel)
-const managementType = computed(() => filterStore.managementType)
-const productionType = computed(() => filterStore.productionType)
+const economicModel = computed(() => filterStore.params.economicModel)
+const managementType = computed(() => filterStore.params.managementType)
+const productionType = computed(() => filterStore.params.productionType)
 const options = ref(getCharacteristicsOptions())
 
 const filterStore = useFiltersStore()

--- a/2024-frontend/src/components/FilterByCharacteristics.vue
+++ b/2024-frontend/src/components/FilterByCharacteristics.vue
@@ -16,7 +16,7 @@ const storeFilters = useStoreFilters()
     <DsfrCheckboxSet
       legend="Types d’établissement :"
       :modelValue="economicModel"
-      @update:modelValue="storeFilters.add('economicModel', $event)"
+      @update:modelValue="storeFilters.set('economicModel', $event)"
       :options="options.economicModel"
       small
       inline
@@ -24,7 +24,7 @@ const storeFilters = useStoreFilters()
     <DsfrCheckboxSet
       legend="Modes de gestion :"
       :modelValue="managementType"
-      @update:modelValue="storeFilters.add('managementType', $event)"
+      @update:modelValue="storeFilters.set('managementType', $event)"
       :options="options.managementType"
       small
       inline
@@ -32,7 +32,7 @@ const storeFilters = useStoreFilters()
     <DsfrCheckboxSet
       legend="Modes de production :"
       :modelValue="productionType"
-      @update:modelValue="storeFilters.add('productionType', $event)"
+      @update:modelValue="storeFilters.set('productionType', $event)"
       :options="options.productionType"
       small
       inline

--- a/2024-frontend/src/components/FilterByCities.vue
+++ b/2024-frontend/src/components/FilterByCities.vue
@@ -4,23 +4,24 @@ import { useStoreFilters } from "@/stores/filters"
 import { getCitiesOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
+const storeFilters = useStoreFilters()
+const citiesSelected = computed(() => storeFilters.params.cities)
+
 /* Search */
 const search = ref("")
 const options = computed(() => {
   if (search.value.length === 0) return []
   return getCitiesOptionsFromSearch(search.value)
 })
-
-/* Select City */
-const storeFilters = useStoreFilters()
-const citiesSelected = computed(() => storeFilters.params.cities)
-const updateFilter = (value) => {
-  storeFilters.add("cities", value)
-}
 </script>
 <template>
   <AppDropdown label="Communes">
     <DsfrSearchBar v-model="search" placeholder="Rechercher une commune" />
-    <DsfrCheckboxSet :modelValue="citiesSelected" @update:modelValue="updateFilter" :options="options" small />
+    <DsfrCheckboxSet
+      :modelValue="citiesSelected"
+      @update:modelValue="storeFilters.add('cities', value)"
+      :options="options"
+      small
+    />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterByCities.vue
+++ b/2024-frontend/src/components/FilterByCities.vue
@@ -19,7 +19,7 @@ const options = computed(() => {
     <DsfrSearchBar v-model="search" placeholder="Rechercher une commune" />
     <DsfrCheckboxSet
       :modelValue="citiesSelected"
-      @update:modelValue="storeFilters.add('cities', $event)"
+      @update:modelValue="storeFilters.set('cities', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByCities.vue
+++ b/2024-frontend/src/components/FilterByCities.vue
@@ -19,7 +19,7 @@ const options = computed(() => {
     <DsfrSearchBar v-model="search" placeholder="Rechercher une commune" />
     <DsfrCheckboxSet
       :modelValue="citiesSelected"
-      @update:modelValue="storeFilters.add('cities', value)"
+      @update:modelValue="storeFilters.add('cities', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByCities.vue
+++ b/2024-frontend/src/components/FilterByCities.vue
@@ -5,7 +5,7 @@ import { getCitiesOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
 const storeFilters = useStoreFilters()
-const citiesSelected = computed(() => storeFilters.params.cities)
+const citiesSelected = computed(() => storeFilters.get("cities"))
 
 /* Search */
 const search = ref("")

--- a/2024-frontend/src/components/FilterByCities.vue
+++ b/2024-frontend/src/components/FilterByCities.vue
@@ -1,10 +1,8 @@
 <script setup>
 import { ref, computed } from "vue"
+import { useStoreFilters } from "@/stores/filters"
 import { getCitiesOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
-
-/* Model */
-const citiesSelected = ref([])
 
 /* Search */
 const search = ref("")
@@ -12,10 +10,17 @@ const options = computed(() => {
   if (search.value.length === 0) return []
   return getCitiesOptionsFromSearch(search.value)
 })
+
+/* Select City */
+const storeFilters = useStoreFilters()
+const citiesSelected = computed(() => storeFilters.params.cities)
+const updateFilter = (value) => {
+  storeFilters.add("cities", value)
+}
 </script>
 <template>
   <AppDropdown label="Communes">
     <DsfrSearchBar v-model="search" placeholder="Rechercher une commune" />
-    <DsfrCheckboxSet :modelValue="citiesSelected" :options="options" small />
+    <DsfrCheckboxSet :modelValue="citiesSelected" @update:modelValue="updateFilter" :options="options" small />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterByDepartments.vue
+++ b/2024-frontend/src/components/FilterByDepartments.vue
@@ -21,7 +21,7 @@ const options = computed(() => {
     <DsfrSearchBar v-model="search" placeholder="Rechercher un département" />
     <DsfrCheckboxSet
       :modelValue="departementsSelected"
-      @update:modelValue="storeFilters.add('departements', value)"
+      @update:modelValue="storeFilters.add('departements', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByDepartments.vue
+++ b/2024-frontend/src/components/FilterByDepartments.vue
@@ -6,7 +6,7 @@ import AppDropdown from "@/components/AppDropdown.vue"
 
 const departments = ref(getDepartmentsOptionsFromSearch())
 const storeFilters = useStoreFilters()
-const departementsSelected = computed(() => storeFilters.params.departements)
+const departmentsSelected = computed(() => storeFilters.params.departments)
 
 /* Search */
 const search = ref("")
@@ -20,8 +20,8 @@ const options = computed(() => {
   <AppDropdown label="Département">
     <DsfrSearchBar v-model="search" placeholder="Rechercher un département" />
     <DsfrCheckboxSet
-      :modelValue="departementsSelected"
-      @update:modelValue="storeFilters.add('departements', $event)"
+      :modelValue="departmentsSelected"
+      @update:modelValue="storeFilters.add('departments', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByDepartments.vue
+++ b/2024-frontend/src/components/FilterByDepartments.vue
@@ -1,9 +1,8 @@
 <script setup>
 import { ref, computed } from "vue"
+import { useStoreFilters } from "@/stores/filters"
 import { getDepartmentsOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
-
-const departementsSelected = ref([])
 
 /* Get departments */
 const departments = ref(getDepartmentsOptionsFromSearch())
@@ -14,11 +13,18 @@ const options = computed(() => {
   if (departments.value.length === 0) return []
   return getDepartmentsOptionsFromSearch(search.value)
 })
+
+/* Selected departements */
+const storeFilters = useStoreFilters()
+const departementsSelected = computed(() => storeFilters.params.departements)
+const updateFilter = (value) => {
+  storeFilters.add("departements", value)
+}
 </script>
 
 <template>
   <AppDropdown label="Département">
     <DsfrSearchBar v-model="search" placeholder="Rechercher un département" />
-    <DsfrCheckboxSet :modelValue="departementsSelected" :options="options" small />
+    <DsfrCheckboxSet :modelValue="departementsSelected" @update:modelValue="updateFilter" :options="options" small />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterByDepartments.vue
+++ b/2024-frontend/src/components/FilterByDepartments.vue
@@ -4,8 +4,9 @@ import { useStoreFilters } from "@/stores/filters"
 import { getDepartmentsOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
-/* Get departments */
 const departments = ref(getDepartmentsOptionsFromSearch())
+const storeFilters = useStoreFilters()
+const departementsSelected = computed(() => storeFilters.params.departements)
 
 /* Search */
 const search = ref("")
@@ -13,18 +14,16 @@ const options = computed(() => {
   if (departments.value.length === 0) return []
   return getDepartmentsOptionsFromSearch(search.value)
 })
-
-/* Selected departements */
-const storeFilters = useStoreFilters()
-const departementsSelected = computed(() => storeFilters.params.departements)
-const updateFilter = (value) => {
-  storeFilters.add("departements", value)
-}
 </script>
 
 <template>
   <AppDropdown label="Département">
     <DsfrSearchBar v-model="search" placeholder="Rechercher un département" />
-    <DsfrCheckboxSet :modelValue="departementsSelected" @update:modelValue="updateFilter" :options="options" small />
+    <DsfrCheckboxSet
+      :modelValue="departementsSelected"
+      @update:modelValue="storeFilters.add('departements', value)"
+      :options="options"
+      small
+    />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterByDepartments.vue
+++ b/2024-frontend/src/components/FilterByDepartments.vue
@@ -21,7 +21,7 @@ const options = computed(() => {
     <DsfrSearchBar v-model="search" placeholder="Rechercher un département" />
     <DsfrCheckboxSet
       :modelValue="departmentsSelected"
-      @update:modelValue="storeFilters.add('departments', $event)"
+      @update:modelValue="storeFilters.set('departments', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByDepartments.vue
+++ b/2024-frontend/src/components/FilterByDepartments.vue
@@ -6,7 +6,7 @@ import AppDropdown from "@/components/AppDropdown.vue"
 
 const departments = ref(getDepartmentsOptionsFromSearch())
 const storeFilters = useStoreFilters()
-const departmentsSelected = computed(() => storeFilters.params.departments)
+const departmentsSelected = computed(() => storeFilters.get("departments"))
 
 /* Search */
 const search = ref("")

--- a/2024-frontend/src/components/FilterByEPCI.vue
+++ b/2024-frontend/src/components/FilterByEPCI.vue
@@ -19,7 +19,7 @@ const options = computed(() => {
     <DsfrSearchBar v-model="search" placeholder="Rechercher un EPCI" />
     <DsfrCheckboxSet
       :modelValue="EPCISelected"
-      @update:modelValue="storeFilters.add('epcis', value)"
+      @update:modelValue="storeFilters.add('epcis', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByEPCI.vue
+++ b/2024-frontend/src/components/FilterByEPCI.vue
@@ -19,7 +19,7 @@ const options = computed(() => {
     <DsfrSearchBar v-model="search" placeholder="Rechercher un EPCI" />
     <DsfrCheckboxSet
       :modelValue="EPCISelected"
-      @update:modelValue="storeFilters.add('epcis', $event)"
+      @update:modelValue="storeFilters.set('epcis', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByEPCI.vue
+++ b/2024-frontend/src/components/FilterByEPCI.vue
@@ -5,7 +5,7 @@ import { getEPCIOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
 const storeFilters = useStoreFilters()
-const EPCISelected = computed(() => storeFilters.params.epcis)
+const EPCISelected = computed(() => storeFilters.get("epcis"))
 
 /* Search */
 const search = ref("")

--- a/2024-frontend/src/components/FilterByEPCI.vue
+++ b/2024-frontend/src/components/FilterByEPCI.vue
@@ -1,10 +1,8 @@
 <script setup>
 import { ref, computed } from "vue"
+import { useStoreFilters } from "@/stores/filters"
 import { getEPCIOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
-
-/* Model */
-const EPCISelected = ref([])
 
 /* Search */
 const search = ref("")
@@ -12,10 +10,17 @@ const options = computed(() => {
   if (search.value.length === 0) return []
   return getEPCIOptionsFromSearch(search.value)
 })
+
+/* Selected EPCI */
+const storeFilters = useStoreFilters()
+const EPCISelected = computed(() => storeFilters.params.epcis)
+const updateFilter = (value) => {
+  storeFilters.add("epcis", value)
+}
 </script>
 <template>
   <AppDropdown label="EPCI">
     <DsfrSearchBar v-model="search" placeholder="Rechercher un EPCI" />
-    <DsfrCheckboxSet :modelValue="EPCISelected" :options="options" small />
+    <DsfrCheckboxSet :modelValue="EPCISelected" @update:modelValue="updateFilter" :options="options" small />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterByEPCI.vue
+++ b/2024-frontend/src/components/FilterByEPCI.vue
@@ -5,7 +5,7 @@ import { getEPCIOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
 const storeFilters = useStoreFilters()
-const EPCISelected = computed(() => storeFilters.get("epcis"))
+const EPCIsSelected = computed(() => storeFilters.get("epcis"))
 
 /* Search */
 const search = ref("")
@@ -18,7 +18,7 @@ const options = computed(() => {
   <AppDropdown label="EPCI">
     <DsfrSearchBar v-model="search" placeholder="Rechercher un EPCI" />
     <DsfrCheckboxSet
-      :modelValue="EPCISelected"
+      :modelValue="EPCIsSelected"
       @update:modelValue="storeFilters.set('epcis', $event)"
       :options="options"
       small

--- a/2024-frontend/src/components/FilterByEPCI.vue
+++ b/2024-frontend/src/components/FilterByEPCI.vue
@@ -4,23 +4,24 @@ import { useStoreFilters } from "@/stores/filters"
 import { getEPCIOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
+const storeFilters = useStoreFilters()
+const EPCISelected = computed(() => storeFilters.params.epcis)
+
 /* Search */
 const search = ref("")
 const options = computed(() => {
   if (search.value.length === 0) return []
   return getEPCIOptionsFromSearch(search.value)
 })
-
-/* Selected EPCI */
-const storeFilters = useStoreFilters()
-const EPCISelected = computed(() => storeFilters.params.epcis)
-const updateFilter = (value) => {
-  storeFilters.add("epcis", value)
-}
 </script>
 <template>
   <AppDropdown label="EPCI">
     <DsfrSearchBar v-model="search" placeholder="Rechercher un EPCI" />
-    <DsfrCheckboxSet :modelValue="EPCISelected" @update:modelValue="updateFilter" :options="options" small />
+    <DsfrCheckboxSet
+      :modelValue="EPCISelected"
+      @update:modelValue="storeFilters.add('epcis', value)"
+      :options="options"
+      small
+    />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterByPAT.vue
+++ b/2024-frontend/src/components/FilterByPAT.vue
@@ -5,7 +5,7 @@ import { getPATOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
 const storeFilters = useStoreFilters()
-const PATSelected = computed(() => storeFilters.get("pats"))
+const PATsSelected = computed(() => storeFilters.get("pats"))
 
 /* Search */
 const search = ref("")
@@ -18,7 +18,7 @@ const options = computed(() => {
   <AppDropdown label="PAT">
     <DsfrSearchBar v-model="search" placeholder="Rechercher un PAT" />
     <DsfrCheckboxSet
-      :modelValue="PATSelected"
+      :modelValue="PATsSelected"
       @update:modelValue="storeFilters.set('pats', $event)"
       :options="options"
       small

--- a/2024-frontend/src/components/FilterByPAT.vue
+++ b/2024-frontend/src/components/FilterByPAT.vue
@@ -5,7 +5,7 @@ import { getPATOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
 const storeFilters = useStoreFilters()
-const PATSelected = computed(() => storeFilters.params.pats)
+const PATSelected = computed(() => storeFilters.get("pats"))
 
 /* Search */
 const search = ref("")

--- a/2024-frontend/src/components/FilterByPAT.vue
+++ b/2024-frontend/src/components/FilterByPAT.vue
@@ -1,10 +1,8 @@
 <script setup>
 import { ref, computed } from "vue"
+import { useStoreFilters } from "@/stores/filters"
 import { getPATOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
-
-/* Model */
-const PATSelected = ref([])
 
 /* Search */
 const search = ref("")
@@ -12,10 +10,17 @@ const options = computed(() => {
   if (search.value.length === 0) return []
   return getPATOptionsFromSearch(search.value)
 })
+
+/* Select PAT */
+const storeFilters = useStoreFilters()
+const PATSelected = computed(() => storeFilters.params.pats)
+const updateFilter = (value) => {
+  storeFilters.add("pats", value)
+}
 </script>
 <template>
   <AppDropdown label="PAT">
     <DsfrSearchBar v-model="search" placeholder="Rechercher un PAT" />
-    <DsfrCheckboxSet :modelValue="PATSelected" :options="options" small />
+    <DsfrCheckboxSet :modelValue="PATSelected" @update:modelValue="updateFilter" :options="options" small />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterByPAT.vue
+++ b/2024-frontend/src/components/FilterByPAT.vue
@@ -19,7 +19,7 @@ const options = computed(() => {
     <DsfrSearchBar v-model="search" placeholder="Rechercher un PAT" />
     <DsfrCheckboxSet
       :modelValue="PATSelected"
-      @update:modelValue="storeFilters.add('pats', $event)"
+      @update:modelValue="storeFilters.set('pats', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByPAT.vue
+++ b/2024-frontend/src/components/FilterByPAT.vue
@@ -4,23 +4,24 @@ import { useStoreFilters } from "@/stores/filters"
 import { getPATOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
+const storeFilters = useStoreFilters()
+const PATSelected = computed(() => storeFilters.params.pats)
+
 /* Search */
 const search = ref("")
 const options = computed(() => {
   if (search.value.length === 0) return []
   return getPATOptionsFromSearch(search.value)
 })
-
-/* Select PAT */
-const storeFilters = useStoreFilters()
-const PATSelected = computed(() => storeFilters.params.pats)
-const updateFilter = (value) => {
-  storeFilters.add("pats", value)
-}
 </script>
 <template>
   <AppDropdown label="PAT">
     <DsfrSearchBar v-model="search" placeholder="Rechercher un PAT" />
-    <DsfrCheckboxSet :modelValue="PATSelected" @update:modelValue="updateFilter" :options="options" small />
+    <DsfrCheckboxSet
+      :modelValue="PATSelected"
+      @update:modelValue="storeFilters.add('pats', value)"
+      :options="options"
+      small
+    />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterByPAT.vue
+++ b/2024-frontend/src/components/FilterByPAT.vue
@@ -19,7 +19,7 @@ const options = computed(() => {
     <DsfrSearchBar v-model="search" placeholder="Rechercher un PAT" />
     <DsfrCheckboxSet
       :modelValue="PATSelected"
-      @update:modelValue="storeFilters.add('pats', value)"
+      @update:modelValue="storeFilters.add('pats', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByRegions.vue
+++ b/2024-frontend/src/components/FilterByRegions.vue
@@ -21,7 +21,7 @@ const options = computed(() => {
     <DsfrSearchBar v-model="search" placeholder="Rechercher une région" />
     <DsfrCheckboxSet
       :modelValue="regionsSelected"
-      @update:modelValue="storeFilters.add('regions', $event)"
+      @update:modelValue="storeFilters.set('regions', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByRegions.vue
+++ b/2024-frontend/src/components/FilterByRegions.vue
@@ -21,7 +21,7 @@ const options = computed(() => {
     <DsfrSearchBar v-model="search" placeholder="Rechercher une région" />
     <DsfrCheckboxSet
       :modelValue="regionsSelected"
-      @update:modelValue="storeFilters.add('regions', value)"
+      @update:modelValue="storeFilters.add('regions', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByRegions.vue
+++ b/2024-frontend/src/components/FilterByRegions.vue
@@ -6,7 +6,7 @@ import AppDropdown from "@/components/AppDropdown.vue"
 
 const regions = ref(getRegionsOptionsFromSearch())
 const storeFilters = useStoreFilters()
-const regionsSelected = computed(() => storeFilters.params.regions)
+const regionsSelected = computed(() => storeFilters.get("regions"))
 
 /* Search */
 const search = ref("")

--- a/2024-frontend/src/components/FilterByRegions.vue
+++ b/2024-frontend/src/components/FilterByRegions.vue
@@ -1,9 +1,8 @@
 <script setup>
 import { ref, computed } from "vue"
+import { useStoreFilters } from "@/stores/filters"
 import { getRegionsOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
-
-const regionsSelected = ref([])
 
 /* Get regions */
 const regions = ref(getRegionsOptionsFromSearch())
@@ -14,11 +13,18 @@ const options = computed(() => {
   if (regions.value.length === 0) return []
   return getRegionsOptionsFromSearch(search.value)
 })
+
+/* Selected regions */
+const storeFilters = useStoreFilters()
+const regionsSelected = computed(() => storeFilters.params.regions)
+const updateFilter = (value) => {
+  storeFilters.add("regions", value)
+}
 </script>
 
 <template>
   <AppDropdown label="Régions">
     <DsfrSearchBar v-model="search" placeholder="Rechercher une région" />
-    <DsfrCheckboxSet :modelValue="regionsSelected" :options="options" small />
+    <DsfrCheckboxSet :modelValue="regionsSelected" @update:modelValue="updateFilter" :options="options" small />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterByRegions.vue
+++ b/2024-frontend/src/components/FilterByRegions.vue
@@ -4,8 +4,9 @@ import { useStoreFilters } from "@/stores/filters"
 import { getRegionsOptionsFromSearch } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
-/* Get regions */
 const regions = ref(getRegionsOptionsFromSearch())
+const storeFilters = useStoreFilters()
+const regionsSelected = computed(() => storeFilters.params.regions)
 
 /* Search */
 const search = ref("")
@@ -13,18 +14,16 @@ const options = computed(() => {
   if (regions.value.length === 0) return []
   return getRegionsOptionsFromSearch(search.value)
 })
-
-/* Selected regions */
-const storeFilters = useStoreFilters()
-const regionsSelected = computed(() => storeFilters.params.regions)
-const updateFilter = (value) => {
-  storeFilters.add("regions", value)
-}
 </script>
 
 <template>
   <AppDropdown label="Régions">
     <DsfrSearchBar v-model="search" placeholder="Rechercher une région" />
-    <DsfrCheckboxSet :modelValue="regionsSelected" @update:modelValue="updateFilter" :options="options" small />
+    <DsfrCheckboxSet
+      :modelValue="regionsSelected"
+      @update:modelValue="storeFilters.add('regions', value)"
+      :options="options"
+      small
+    />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterBySectors.vue
+++ b/2024-frontend/src/components/FilterBySectors.vue
@@ -29,11 +29,7 @@ const options = computed(() => {
 
 <template>
   <AppDropdown label="Secteurs">
-    <DsfrSearchBar
-      :modelValue="search"
-      placeholder="Rechercher un secteur"
-      @update:modelValue="($event) => (search = $event)"
-    />
+    <DsfrSearchBar v-model="search" placeholder="Rechercher un secteur" />
     <DsfrCheckboxSet
       :modelValue="sectorsSelected"
       @update:modelValue="storeFilters.add('sectors', $event)"

--- a/2024-frontend/src/components/FilterBySectors.vue
+++ b/2024-frontend/src/components/FilterBySectors.vue
@@ -5,7 +5,7 @@ import { getSectorsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
 const storeFilters = useStoreFilters()
-const sectorsSelected = computed(() => storeFilters.params.sectors)
+const sectorsSelected = computed(() => storeFilters.get("sectors"))
 
 /* Get sectors */
 const sectors = ref([])

--- a/2024-frontend/src/components/FilterBySectors.vue
+++ b/2024-frontend/src/components/FilterBySectors.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed } from "vue"
-import { useFiltersStore } from "@/stores/filters"
+import { useStoreFilters } from "@/stores/filters"
 import { getSectorsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
@@ -24,10 +24,10 @@ const options = computed(() => {
 })
 
 /* Select sector */
-const filterStore = useFiltersStore()
-const sectorsSelected = computed(() => filterStore.params.sectors)
+const storeFilters = useStoreFilters()
+const sectorsSelected = computed(() => storeFilters.params.sectors)
 const updateFilter = (value) => {
-  filterStore.add("sectors", value)
+  storeFilters.add("sectors", value)
 }
 </script>
 

--- a/2024-frontend/src/components/FilterBySectors.vue
+++ b/2024-frontend/src/components/FilterBySectors.vue
@@ -32,7 +32,7 @@ const options = computed(() => {
     <DsfrSearchBar v-model="search" placeholder="Rechercher un secteur" />
     <DsfrCheckboxSet
       :modelValue="sectorsSelected"
-      @update:modelValue="storeFilters.add('sectors', $event)"
+      @update:modelValue="storeFilters.set('sectors', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterBySectors.vue
+++ b/2024-frontend/src/components/FilterBySectors.vue
@@ -1,9 +1,8 @@
 <script setup>
 import { ref, computed } from "vue"
+import { useFiltersStore } from "@/stores/filters"
 import { getSectorsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
-
-const sectorsSelected = ref([])
 
 /* Get sectors */
 const sectors = ref([])
@@ -23,11 +22,22 @@ const options = computed(() => {
   })
   return searchedSectors
 })
+
+/* Select sector */
+const filterStore = useFiltersStore()
+const sectorsSelected = computed(() => filterStore.sectors)
+const updateFilter = (value) => {
+  filterStore.add("sectors", value)
+}
 </script>
 
 <template>
   <AppDropdown label="Secteurs">
-    <DsfrSearchBar v-model="search" placeholder="Rechercher un secteur" />
-    <DsfrCheckboxSet :modelValue="sectorsSelected" :options="options" small />
+    <DsfrSearchBar
+      :modelValue="search"
+      placeholder="Rechercher un secteur"
+      @update:modelValue="($event) => (search = $event)"
+    />
+    <DsfrCheckboxSet :modelValue="sectorsSelected" @update:modelValue="updateFilter" :options="options" small />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterBySectors.vue
+++ b/2024-frontend/src/components/FilterBySectors.vue
@@ -4,6 +4,9 @@ import { useStoreFilters } from "@/stores/filters"
 import { getSectorsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
+const storeFilters = useStoreFilters()
+const sectorsSelected = computed(() => storeFilters.params.sectors)
+
 /* Get sectors */
 const sectors = ref([])
 getSectorsOptions().then((response) => {
@@ -22,13 +25,6 @@ const options = computed(() => {
   })
   return searchedSectors
 })
-
-/* Select sector */
-const storeFilters = useStoreFilters()
-const sectorsSelected = computed(() => storeFilters.params.sectors)
-const updateFilter = (value) => {
-  storeFilters.add("sectors", value)
-}
 </script>
 
 <template>
@@ -38,6 +34,11 @@ const updateFilter = (value) => {
       placeholder="Rechercher un secteur"
       @update:modelValue="($event) => (search = $event)"
     />
-    <DsfrCheckboxSet :modelValue="sectorsSelected" @update:modelValue="updateFilter" :options="options" small />
+    <DsfrCheckboxSet
+      :modelValue="sectorsSelected"
+      @update:modelValue="storeFilters.add('sectors', $event)"
+      :options="options"
+      small
+    />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterBySectors.vue
+++ b/2024-frontend/src/components/FilterBySectors.vue
@@ -25,7 +25,7 @@ const options = computed(() => {
 
 /* Select sector */
 const filterStore = useFiltersStore()
-const sectorsSelected = computed(() => filterStore.sectors)
+const sectorsSelected = computed(() => filterStore.params.sectors)
 const updateFilter = (value) => {
   filterStore.add("sectors", value)
 }

--- a/2024-frontend/src/components/FilterByYears.vue
+++ b/2024-frontend/src/components/FilterByYears.vue
@@ -1,14 +1,19 @@
 <script setup>
-import { ref } from "vue"
+import { ref, computed } from "vue"
+import { useFiltersStore } from "@/stores/filters"
 import { getYearsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
-const yearSelected = ref("")
+const filterStore = useFiltersStore()
+const yearSelected = computed(() => filterStore.year)
 const options = ref(getYearsOptions())
+const updateFilter = (value) => {
+  filterStore.update("year", value)
+}
 </script>
 
 <template>
   <AppDropdown label="Années">
-    <DsfrRadioButtonSet :modelValue="yearSelected" :options="options" small />
+    <DsfrRadioButtonSet :modelValue="yearSelected" @update:modelValue="updateFilter" :options="options" small />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterByYears.vue
+++ b/2024-frontend/src/components/FilterByYears.vue
@@ -13,7 +13,7 @@ const yearSelected = computed(() => storeFilters.get("year"))
   <AppDropdown label="Années">
     <DsfrRadioButtonSet
       :modelValue="yearSelected"
-      @update:modelValue="storeFilters.add('year', $event)"
+      @update:modelValue="storeFilters.set('year', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByYears.vue
+++ b/2024-frontend/src/components/FilterByYears.vue
@@ -8,7 +8,7 @@ const filterStore = useFiltersStore()
 const yearSelected = computed(() => filterStore.year)
 const options = ref(getYearsOptions())
 const updateFilter = (value) => {
-  filterStore.update("year", value)
+  filterStore.add("year", value)
 }
 </script>
 

--- a/2024-frontend/src/components/FilterByYears.vue
+++ b/2024-frontend/src/components/FilterByYears.vue
@@ -5,7 +5,7 @@ import { getYearsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
 const filterStore = useFiltersStore()
-const yearSelected = computed(() => filterStore.year)
+const yearSelected = computed(() => filterStore.params.year)
 const options = ref(getYearsOptions())
 const updateFilter = (value) => {
   filterStore.add("year", value)

--- a/2024-frontend/src/components/FilterByYears.vue
+++ b/2024-frontend/src/components/FilterByYears.vue
@@ -1,14 +1,14 @@
 <script setup>
 import { ref, computed } from "vue"
-import { useFiltersStore } from "@/stores/filters"
+import { useStoreFilters } from "@/stores/filters"
 import { getYearsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
-const filterStore = useFiltersStore()
-const yearSelected = computed(() => filterStore.params.year)
+const storeFilters = useStoreFilters()
+const yearSelected = computed(() => storeFilters.params.year)
 const options = ref(getYearsOptions())
 const updateFilter = (value) => {
-  filterStore.add("year", value)
+  storeFilters.add("year", value)
 }
 </script>
 

--- a/2024-frontend/src/components/FilterByYears.vue
+++ b/2024-frontend/src/components/FilterByYears.vue
@@ -4,16 +4,18 @@ import { useStoreFilters } from "@/stores/filters"
 import { getYearsOptions } from "@/services/filters"
 import AppDropdown from "@/components/AppDropdown.vue"
 
+const options = ref(getYearsOptions())
 const storeFilters = useStoreFilters()
 const yearSelected = computed(() => storeFilters.params.year)
-const options = ref(getYearsOptions())
-const updateFilter = (value) => {
-  storeFilters.add("year", value)
-}
 </script>
 
 <template>
   <AppDropdown label="Années">
-    <DsfrRadioButtonSet :modelValue="yearSelected" @update:modelValue="updateFilter" :options="options" small />
+    <DsfrRadioButtonSet
+      :modelValue="yearSelected"
+      @update:modelValue="storeFilters.add('year', value)"
+      :options="options"
+      small
+    />
   </AppDropdown>
 </template>

--- a/2024-frontend/src/components/FilterByYears.vue
+++ b/2024-frontend/src/components/FilterByYears.vue
@@ -13,7 +13,7 @@ const yearSelected = computed(() => storeFilters.params.year)
   <AppDropdown label="Années">
     <DsfrRadioButtonSet
       :modelValue="yearSelected"
-      @update:modelValue="storeFilters.add('year', value)"
+      @update:modelValue="storeFilters.add('year', $event)"
       :options="options"
       small
     />

--- a/2024-frontend/src/components/FilterByYears.vue
+++ b/2024-frontend/src/components/FilterByYears.vue
@@ -6,7 +6,7 @@ import AppDropdown from "@/components/AppDropdown.vue"
 
 const options = ref(getYearsOptions())
 const storeFilters = useStoreFilters()
-const yearSelected = computed(() => storeFilters.params.year)
+const yearSelected = computed(() => storeFilters.get("year"))
 </script>
 
 <template>

--- a/2024-frontend/src/components/ObservatoryResultsFilters.vue
+++ b/2024-frontend/src/components/ObservatoryResultsFilters.vue
@@ -1,0 +1,61 @@
+<script setup>
+import { computed } from "vue"
+import { useStoreFilters } from "@/stores/filters"
+
+const storeFilters = useStoreFilters()
+const filtersList = computed(() => storeFilters.getFilled())
+</script>
+
+<template>
+  <div class="observatory-results-filters ma-cantine--sticky__top fr-pt-4w fr-background-alt--blue-france">
+    <p class="observatory-results-filters__title fr-mb-0">Chiffres clés pour la recherche :</p>
+    <ul class="observatory-results-filters__list ma-cantine--unstyled-list">
+      <li v-for="(filter, index) in filtersList" :key="index" class="r-mr-1w">
+        <DsfrTag
+          @click="storeFilters.remove(filter.name, filter.value)"
+          :label="filter.label"
+          class="fr-tag--dismiss"
+          tagName="button"
+        />
+      </li>
+    </ul>
+    <DsfrButton
+      class="observatory-results-filters__button"
+      tertiary
+      label="Modifier les filtres"
+      icon="fr-icon-filter-fill"
+      @click="$emit('scrollToFilters')"
+    />
+  </div>
+</template>
+
+<style lang="scss">
+.observatory-results-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  @media (min-width: 768px) {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  &__title {
+    flex-shrink: 0;
+  }
+
+  &__list {
+    justify-content: flex-start;
+    flex-grow: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    flex-shrink: 1;
+  }
+
+  &__button {
+    flex-shrink: 0;
+  }
+}
+</style>

--- a/2024-frontend/src/css/global.css
+++ b/2024-frontend/src/css/global.css
@@ -40,7 +40,7 @@ address {
 
 .ma-cantine--sticky__top {
     position: sticky !important;
-    top: 1rem;
+    top: 0;
     z-index: 1;
 }
 

--- a/2024-frontend/src/css/global.css
+++ b/2024-frontend/src/css/global.css
@@ -38,6 +38,12 @@ address {
     z-index: 1;
 }
 
+.ma-cantine--sticky__top {
+    position: sticky !important;
+    top: 1rem;
+    z-index: 1;
+}
+
 
 /* TABLE */
 @media (min-width: 768px) {

--- a/2024-frontend/src/services/filters.js
+++ b/2024-frontend/src/services/filters.js
@@ -92,7 +92,7 @@ const getPATOptionsFromSearch = (search) => {
   const options = firstTenPAT.map((pat) => {
     return {
       label: pat.nom,
-      value: pat.code,
+      value: { value: pat.code, name: pat.nom },
       id: pat.code,
     }
   })

--- a/2024-frontend/src/services/filters.js
+++ b/2024-frontend/src/services/filters.js
@@ -117,7 +117,11 @@ const getDepartmentsOptionsFromSearch = (search) => {
     ? departements.filter((department) => stringsService.checkIfStartsWith(department.nom, search))
     : departements
   return departmentsOptions.map((department) => {
-    return { label: `${department.nom} (${department.code})`, value: department.code, id: department.code }
+    return {
+      label: `${department.nom} (${department.code})`,
+      value: { value: department.code, name: department.nom },
+      id: department.code,
+    }
   })
 }
 

--- a/2024-frontend/src/services/filters.js
+++ b/2024-frontend/src/services/filters.js
@@ -126,7 +126,7 @@ const getRegionsOptionsFromSearch = (search) => {
     ? regionsSortedByName.filter((region) => stringsService.checkIfStartsWith(region.nom, search))
     : regionsSortedByName
   return regionsOptions.map((region) => {
-    return { label: region.nom, value: region.code, id: region.code }
+    return { label: region.nom, value: { value: region.code, name: region.nom }, id: region.code }
   })
 }
 

--- a/2024-frontend/src/services/filters.js
+++ b/2024-frontend/src/services/filters.js
@@ -35,17 +35,19 @@ const getCharacteristicsOptions = () => {
   const economicModelOptions = cantines.economicModel.map((option) => {
     option.hint = ""
     option.id = option.value
+    option.value = { value: option.value, name: option.label }
     return option
   })
 
   const managementTypeOptions = cantines.managementType.map((option) => {
     option.name = "managementType"
     option.id = option.value
+    option.value = { value: option.value, name: option.label }
     return option
   })
 
   const productionTypeOptions = cantines.productionType.map((option) => {
-    return { label: option.label, value: option.value, id: option.value }
+    return { label: option.label, value: { value: option.value, name: option.label }, id: option.value }
   })
 
   const characteristicsOptions = {

--- a/2024-frontend/src/services/filters.js
+++ b/2024-frontend/src/services/filters.js
@@ -34,20 +34,18 @@ const getYearsOptions = () => {
 const getCharacteristicsOptions = () => {
   const economicModelOptions = cantines.economicModel.map((option) => {
     option.hint = ""
-    option.id = option.value
     option.value = { value: option.value, name: option.label }
     return option
   })
 
   const managementTypeOptions = cantines.managementType.map((option) => {
     option.name = "managementType"
-    option.id = option.value
     option.value = { value: option.value, name: option.label }
     return option
   })
 
   const productionTypeOptions = cantines.productionType.map((option) => {
-    return { label: option.label, value: { value: option.value, name: option.label }, id: option.value }
+    return { label: option.label, value: { value: option.value, name: option.label } }
   })
 
   const characteristicsOptions = {
@@ -64,7 +62,6 @@ const getSectorsOptions = async () => {
   sectorsBackend.forEach((sector) => {
     const label = `${sector.categoryName} - ${sector.name}`
     const option = {
-      id: sector.id,
       label: label,
       value: { value: sector.id, name: label },
     }
@@ -81,7 +78,6 @@ const getCitiesOptionsFromSearch = (search) => {
     return {
       label,
       value: { value: city.code, name: label },
-      id: city.code,
     }
   })
   return options
@@ -94,7 +90,6 @@ const getPATOptionsFromSearch = (search) => {
     return {
       label: pat.nom,
       value: { value: pat.code, name: pat.nom },
-      id: pat.code,
     }
   })
   return options
@@ -107,7 +102,6 @@ const getEPCIOptionsFromSearch = (search) => {
     return {
       label: epci.nom,
       value: { value: epci.code, name: epci.nom },
-      id: epci.code,
     }
   })
   return options
@@ -121,7 +115,6 @@ const getDepartmentsOptionsFromSearch = (search) => {
     return {
       label: `${department.nom} (${department.code})`,
       value: { value: department.code, name: department.nom },
-      id: department.code,
     }
   })
 }
@@ -131,7 +124,7 @@ const getRegionsOptionsFromSearch = (search) => {
     ? regionsSortedByName.filter((region) => stringsService.checkIfStartsWith(region.nom, search))
     : regionsSortedByName
   return regionsOptions.map((region) => {
-    return { label: region.nom, value: { value: region.code, name: region.nom }, id: region.code }
+    return { label: region.nom, value: { value: region.code, name: region.nom } }
   })
 }
 

--- a/2024-frontend/src/services/filters.js
+++ b/2024-frontend/src/services/filters.js
@@ -34,18 +34,20 @@ const getYearsOptions = () => {
 const getCharacteristicsOptions = () => {
   const economicModelOptions = cantines.economicModel.map((option) => {
     option.hint = ""
-    option.value = { value: option.value, name: option.label }
+    option.value = { value: option.value, label: option.label }
     return option
   })
 
   const managementTypeOptions = cantines.managementType.map((option) => {
     option.name = "managementType"
-    option.value = { value: option.value, name: option.label }
+    option.value = { value: option.value, label: option.label }
     return option
   })
 
   const productionTypeOptions = cantines.productionType.map((option) => {
-    return { label: option.label, value: { value: option.value, name: option.label } }
+    option.hint = ""
+    option.value = { value: option.value, label: option.label }
+    return option
   })
 
   const characteristicsOptions = {
@@ -62,8 +64,8 @@ const getSectorsOptions = async () => {
   sectorsBackend.forEach((sector) => {
     const label = `${sector.categoryName} - ${sector.name}`
     const option = {
-      label: label,
-      value: { value: sector.id, name: label },
+      label,
+      value: { value: sector.id, label },
     }
     sectorsOptions.push(option)
   })
@@ -77,7 +79,7 @@ const getCitiesOptionsFromSearch = (search) => {
     const label = `${city.nom} (${city.codeDepartement})`
     return {
       label,
-      value: { value: city.code, name: label },
+      value: { value: city.code, label },
     }
   })
   return options
@@ -89,7 +91,7 @@ const getPATOptionsFromSearch = (search) => {
   const options = firstTenPAT.map((pat) => {
     return {
       label: pat.nom,
-      value: { value: pat.code, name: pat.nom },
+      value: { value: pat.code, label: pat.nom },
     }
   })
   return options
@@ -101,7 +103,7 @@ const getEPCIOptionsFromSearch = (search) => {
   const options = firstTenEPCI.map((epci) => {
     return {
       label: epci.nom,
-      value: { value: epci.code, name: epci.nom },
+      value: { value: epci.code, label: epci.nom },
     }
   })
   return options
@@ -114,7 +116,7 @@ const getDepartmentsOptionsFromSearch = (search) => {
   return departmentsOptions.map((department) => {
     return {
       label: `${department.nom} (${department.code})`,
-      value: { value: department.code, name: department.nom },
+      value: { value: department.code, label: department.nom },
     }
   })
 }
@@ -124,7 +126,7 @@ const getRegionsOptionsFromSearch = (search) => {
     ? regionsSortedByName.filter((region) => stringsService.checkIfStartsWith(region.nom, search))
     : regionsSortedByName
   return regionsOptions.map((region) => {
-    return { label: region.nom, value: { value: region.code, name: region.nom } }
+    return { label: region.nom, value: { value: region.code, label: region.nom } }
   })
 }
 

--- a/2024-frontend/src/services/filters.js
+++ b/2024-frontend/src/services/filters.js
@@ -105,7 +105,7 @@ const getEPCIOptionsFromSearch = (search) => {
   const options = firstTenEPCI.map((epci) => {
     return {
       label: epci.nom,
-      value: epci.code,
+      value: { value: epci.code, name: epci.nom },
       id: epci.code,
     }
   })

--- a/2024-frontend/src/services/filters.js
+++ b/2024-frontend/src/services/filters.js
@@ -77,9 +77,10 @@ const getCitiesOptionsFromSearch = (search) => {
   const filteredCities = communes.filter((city) => stringsService.checkIfStartsWith(city.nom, search))
   const firstTenCities = filteredCities.slice(0, 9)
   const options = firstTenCities.map((city) => {
+    const label = `${city.nom} (${city.codeDepartement})`
     return {
-      label: `${city.nom} (${city.codeDepartement})`,
-      value: city.code,
+      label,
+      value: { value: city.code, name: label },
       id: city.code,
     }
   })

--- a/2024-frontend/src/services/filters.js
+++ b/2024-frontend/src/services/filters.js
@@ -60,10 +60,11 @@ const getSectorsOptions = async () => {
   const sectorsBackend = await sectorsService.getSectors()
   const sectorsOptions = []
   sectorsBackend.forEach((sector) => {
+    const label = `${sector.categoryName} - ${sector.name}`
     const option = {
       id: sector.id,
-      label: `${sector.categoryName} - ${sector.name}`,
-      value: sector.id,
+      label: label,
+      value: { value: sector.id, name: label },
     }
     sectorsOptions.push(option)
   })

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -12,6 +12,7 @@ const useStoreFilters = defineStore("filters", () => {
     regions: [],
     departements: [],
     epcis: [],
+    pats: [],
   })
 
   /* Actions to update filters parameters */
@@ -60,6 +61,11 @@ const useStoreFilters = defineStore("filters", () => {
     if (params.epcis.length > 0) {
       params.epcis.forEach((epci) => {
         list.push({ name: "epcis", value: epci.value, label: epci.name })
+      })
+    }
+    if (params.pats.length > 0) {
+      params.pats.forEach((pat) => {
+        list.push({ name: "pats", value: pat.value, label: pat.name })
       })
     }
     return list

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -31,47 +31,47 @@ const useStoreFilters = defineStore("filters", () => {
     if (params.year !== "") list.push({ name: "year", value: "", label: params.year })
     if (params.economicModel.length > 0) {
       params.economicModel.forEach((economicModel) => {
-        list.push({ name: "economicModel", value: economicModel.value, label: economicModel.name })
+        list.push({ name: "economicModel", value: economicModel.value, label: economicModel.label })
       })
     }
     if (params.managementType.length > 0) {
       params.managementType.forEach((managementType) => {
-        list.push({ name: "managementType", value: managementType.value, label: managementType.name })
+        list.push({ name: "managementType", value: managementType.value, label: managementType.label })
       })
     }
     if (params.productionType.length > 0) {
       params.productionType.forEach((productionType) => {
-        list.push({ name: "productionType", value: productionType.value, label: productionType.name })
+        list.push({ name: "productionType", value: productionType.value, label: productionType.label })
       })
     }
     if (params.sectors.length > 0) {
       params.sectors.forEach((sector) => {
-        list.push({ name: "sectors", value: sector.value, label: sector.name })
+        list.push({ name: "sectors", value: sector.value, label: sector.label })
       })
     }
     if (params.regions.length > 0) {
       params.regions.forEach((region) => {
-        list.push({ name: "regions", value: region.value, label: region.name })
+        list.push({ name: "regions", value: region.value, label: region.label })
       })
     }
     if (params.departements.length > 0) {
       params.departements.forEach((departement) => {
-        list.push({ name: "departements", value: departement.value, label: departement.name })
+        list.push({ name: "departements", value: departement.value, label: departement.label })
       })
     }
     if (params.epcis.length > 0) {
       params.epcis.forEach((epci) => {
-        list.push({ name: "epcis", value: epci.value, label: epci.name })
+        list.push({ name: "epcis", value: epci.value, label: epci.label })
       })
     }
     if (params.pats.length > 0) {
       params.pats.forEach((pat) => {
-        list.push({ name: "pats", value: pat.value, label: pat.name })
+        list.push({ name: "pats", value: pat.value, label: pat.label })
       })
     }
     if (params.cities.length > 0) {
       params.cities.forEach((city) => {
-        list.push({ name: "cities", value: city.value, label: city.name })
+        list.push({ name: "cities", value: city.value, label: city.label })
       })
     }
     return list

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -1,0 +1,26 @@
+import { defineStore } from "pinia"
+import { computed, reactive } from "vue"
+
+const useFiltersStore = defineStore("filters", () => {
+  /* Selected */
+  const selected = reactive({
+    year: new Date().getFullYear(),
+  })
+  function update(name, value) {
+    selected[name] = value
+  }
+
+  /* Exported values */
+  const year = computed(() => selected.year)
+
+  /* Actions */
+  function getAllSelected() {
+    const list = []
+    if (selected.year !== "") list.push({ name: "year", value: selected.year })
+    return list
+  }
+
+  return { update, getAllSelected, year }
+})
+
+export { useFiltersStore }

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -9,6 +9,7 @@ const useStoreFilters = defineStore("filters", () => {
     economicModel: [],
     managementType: [],
     productionType: [],
+    regions: [],
   })
 
   /* Actions to update filters parameters */
@@ -42,6 +43,11 @@ const useStoreFilters = defineStore("filters", () => {
     if (params.sectors.length > 0) {
       params.sectors.forEach((sector) => {
         list.push({ name: "sectors", value: sector.value, label: sector.name })
+      })
+    }
+    if (params.regions.length > 0) {
+      params.regions.forEach((region) => {
+        list.push({ name: "regions", value: region.value, label: region.name })
       })
     }
     return list

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -2,7 +2,7 @@ import { defineStore } from "pinia"
 import { reactive } from "vue"
 
 const useStoreFilters = defineStore("filters", () => {
-  /* Filters paramters to send to api */
+  /* Filters parameters to send to api */
   const params = reactive({
     year: new Date().getFullYear(),
     sectors: [],
@@ -10,6 +10,7 @@ const useStoreFilters = defineStore("filters", () => {
     managementType: [],
     productionType: [],
     regions: [],
+    departements: [],
   })
 
   /* Actions to update filters parameters */
@@ -48,6 +49,11 @@ const useStoreFilters = defineStore("filters", () => {
     if (params.regions.length > 0) {
       params.regions.forEach((region) => {
         list.push({ name: "regions", value: region.value, label: region.name })
+      })
+    }
+    if (params.departements.length > 0) {
+      params.departements.forEach((departement) => {
+        list.push({ name: "departements", value: departement.value, label: departement.name })
       })
     }
     return list

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -31,54 +31,16 @@ const useStoreFilters = defineStore("filters", () => {
 
   /* Action to get all parameters with non empty */
   function getFilled() {
-    const list = []
-    if (params.year !== "") list.push({ name: "year", value: "", label: params.year })
-    if (params.economicModel.length > 0) {
-      params.economicModel.forEach((economicModel) => {
-        list.push({ name: "economicModel", value: economicModel.value, label: economicModel.label })
-      })
-    }
-    if (params.managementType.length > 0) {
-      params.managementType.forEach((managementType) => {
-        list.push({ name: "managementType", value: managementType.value, label: managementType.label })
-      })
-    }
-    if (params.productionType.length > 0) {
-      params.productionType.forEach((productionType) => {
-        list.push({ name: "productionType", value: productionType.value, label: productionType.label })
-      })
-    }
-    if (params.sectors.length > 0) {
-      params.sectors.forEach((sector) => {
-        list.push({ name: "sectors", value: sector.value, label: sector.label })
-      })
-    }
-    if (params.regions.length > 0) {
-      params.regions.forEach((region) => {
-        list.push({ name: "regions", value: region.value, label: region.label })
-      })
-    }
-    if (params.departments.length > 0) {
-      params.departments.forEach((department) => {
-        list.push({ name: "departments", value: department.value, label: department.label })
-      })
-    }
-    if (params.epcis.length > 0) {
-      params.epcis.forEach((epci) => {
-        list.push({ name: "epcis", value: epci.value, label: epci.label })
-      })
-    }
-    if (params.pats.length > 0) {
-      params.pats.forEach((pat) => {
-        list.push({ name: "pats", value: pat.value, label: pat.label })
-      })
-    }
-    if (params.cities.length > 0) {
-      params.cities.forEach((city) => {
-        list.push({ name: "cities", value: city.value, label: city.label })
-      })
-    }
-    return list
+    const filledParams = []
+    Object.keys(params).forEach((key) => {
+      if (key === "year" && params.year !== "") filledParams.push({ name: "year", value: "", label: params.year })
+      else if (params[key].length > 0) {
+        params[key].forEach((option) => {
+          filledParams.push({ name: key, value: option.value, label: option.label })
+        })
+      }
+    })
+    return filledParams
   }
 
   return { add, remove, getFilled, get }

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -13,6 +13,7 @@ const useStoreFilters = defineStore("filters", () => {
     departements: [],
     epcis: [],
     pats: [],
+    cities: [],
   })
 
   /* Actions to update filters parameters */
@@ -66,6 +67,11 @@ const useStoreFilters = defineStore("filters", () => {
     if (params.pats.length > 0) {
       params.pats.forEach((pat) => {
         list.push({ name: "pats", value: pat.value, label: pat.name })
+      })
+    }
+    if (params.cities.length > 0) {
+      params.cities.forEach((city) => {
+        list.push({ name: "cities", value: city.value, label: city.name })
       })
     }
     return list

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -25,6 +25,11 @@ const useStoreFilters = defineStore("filters", () => {
     else params[name] = params[name].filter((element) => element.value !== value)
   }
 
+  /* Action to get a filter parameters values */
+  function get(name) {
+    return name === "year" ? params.year : [...params[name]]
+  }
+
   /* Action to get all parameters with non empty */
   function getFilled() {
     const list = []
@@ -77,7 +82,7 @@ const useStoreFilters = defineStore("filters", () => {
     return list
   }
 
-  return { add, remove, getFilled, params }
+  return { add, remove, getFilled, get }
 })
 
 export { useStoreFilters }

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -10,7 +10,7 @@ const useStoreFilters = defineStore("filters", () => {
     managementType: [],
     productionType: [],
     regions: [],
-    departements: [],
+    departments: [],
     epcis: [],
     pats: [],
     cities: [],
@@ -54,9 +54,9 @@ const useStoreFilters = defineStore("filters", () => {
         list.push({ name: "regions", value: region.value, label: region.label })
       })
     }
-    if (params.departements.length > 0) {
-      params.departements.forEach((departement) => {
-        list.push({ name: "departements", value: departement.value, label: departement.label })
+    if (params.departments.length > 0) {
+      params.departments.forEach((department) => {
+        list.push({ name: "departments", value: department.value, label: department.label })
       })
     }
     if (params.epcis.length > 0) {

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -1,58 +1,53 @@
 import { defineStore } from "pinia"
-import { computed, reactive } from "vue"
+import { reactive } from "vue"
 
 const useFiltersStore = defineStore("filters", () => {
-  /* Selection */
-  const selected = reactive({
+  /* Filters paramters to send to api */
+  const params = reactive({
     year: new Date().getFullYear(),
     sectors: [],
     economicModel: [],
     managementType: [],
     productionType: [],
   })
+
+  /* Actions to update filters parameters */
   function add(name, value) {
-    selected[name] = value
+    params[name] = value
   }
   function remove(name, value) {
-    if (value === "") selected[name] = ""
-    else selected[name] = selected[name].filter((element) => element.value !== value)
+    if (value === "") params[name] = ""
+    else params[name] = params[name].filter((element) => element.value !== value)
   }
-
-  /* Exported values */
-  const year = computed(() => selected.year)
-  const sectors = computed(() => selected.sectors)
-  const economicModel = computed(() => selected.economicModel)
-  const managementType = computed(() => selected.managementType)
-  const productionType = computed(() => selected.productionType)
 
   /* Actions */
   function getAllSelected() {
     const list = []
-    if (selected.year !== "") list.push({ name: "year", value: "", label: selected.year })
-    if (selected.economicModel.length > 0) {
-      selected.economicModel.forEach((economicModel) => {
+    if (params.year !== "") list.push({ name: "year", value: "", label: params.year })
+    if (params.economicModel.length > 0) {
+      params.economicModel.forEach((economicModel) => {
         list.push({ name: "economicModel", value: economicModel.value, label: economicModel.name })
       })
     }
-    if (selected.managementType.length > 0) {
-      selected.managementType.forEach((managementType) => {
+    if (params.managementType.length > 0) {
+      params.managementType.forEach((managementType) => {
         list.push({ name: "managementType", value: managementType.value, label: managementType.name })
       })
     }
-    if (selected.productionType.length > 0) {
-      selected.productionType.forEach((productionType) => {
+    if (params.productionType.length > 0) {
+      params.productionType.forEach((productionType) => {
         list.push({ name: "productionType", value: productionType.value, label: productionType.name })
       })
     }
-    if (selected.sectors.length > 0) {
-      selected.sectors.forEach((sector) => {
+    if (params.sectors.length > 0) {
+      params.sectors.forEach((sector) => {
         list.push({ name: "sectors", value: sector.value, label: sector.name })
       })
     }
     return list
   }
 
-  return { add, remove, getAllSelected, year, sectors, economicModel, managementType, productionType }
+  return { add, remove, getAllSelected, params }
 })
 
 export { useFiltersStore }

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia"
 import { reactive } from "vue"
 
-const useFiltersStore = defineStore("filters", () => {
+const useStoreFilters = defineStore("filters", () => {
   /* Filters paramters to send to api */
   const params = reactive({
     year: new Date().getFullYear(),
@@ -50,4 +50,4 @@ const useFiltersStore = defineStore("filters", () => {
   return { add, remove, getFilled, params }
 })
 
-export { useFiltersStore }
+export { useStoreFilters }

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -11,6 +11,7 @@ const useStoreFilters = defineStore("filters", () => {
     productionType: [],
     regions: [],
     departements: [],
+    epcis: [],
   })
 
   /* Actions to update filters parameters */
@@ -54,6 +55,11 @@ const useStoreFilters = defineStore("filters", () => {
     if (params.departements.length > 0) {
       params.departements.forEach((departement) => {
         list.push({ name: "departements", value: departement.value, label: departement.name })
+      })
+    }
+    if (params.epcis.length > 0) {
+      params.epcis.forEach((epci) => {
+        list.push({ name: "epcis", value: epci.value, label: epci.name })
       })
     }
     return list

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -2,10 +2,13 @@ import { defineStore } from "pinia"
 import { computed, reactive } from "vue"
 
 const useFiltersStore = defineStore("filters", () => {
-  /* Selected */
+  /* Selection */
   const selected = reactive({
     year: new Date().getFullYear(),
     sectors: [],
+    economicModel: [],
+    managementType: [],
+    productionType: [],
   })
   function add(name, value) {
     selected[name] = value
@@ -18,11 +21,29 @@ const useFiltersStore = defineStore("filters", () => {
   /* Exported values */
   const year = computed(() => selected.year)
   const sectors = computed(() => selected.sectors)
+  const economicModel = computed(() => selected.economicModel)
+  const managementType = computed(() => selected.managementType)
+  const productionType = computed(() => selected.productionType)
 
   /* Actions */
   function getAllSelected() {
     const list = []
     if (selected.year !== "") list.push({ name: "year", value: "", label: selected.year })
+    if (selected.economicModel.length > 0) {
+      selected.economicModel.forEach((economicModel) => {
+        list.push({ name: "economicModel", value: economicModel.value, label: economicModel.name })
+      })
+    }
+    if (selected.managementType.length > 0) {
+      selected.managementType.forEach((managementType) => {
+        list.push({ name: "managementType", value: managementType.value, label: managementType.name })
+      })
+    }
+    if (selected.productionType.length > 0) {
+      selected.productionType.forEach((productionType) => {
+        list.push({ name: "productionType", value: productionType.value, label: productionType.name })
+      })
+    }
     if (selected.sectors.length > 0) {
       selected.sectors.forEach((sector) => {
         list.push({ name: "sectors", value: sector.value, label: sector.name })
@@ -31,7 +52,7 @@ const useFiltersStore = defineStore("filters", () => {
     return list
   }
 
-  return { add, remove, getAllSelected, year, sectors }
+  return { add, remove, getAllSelected, year, sectors, economicModel, managementType, productionType }
 })
 
 export { useFiltersStore }

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -5,22 +5,33 @@ const useFiltersStore = defineStore("filters", () => {
   /* Selected */
   const selected = reactive({
     year: new Date().getFullYear(),
+    sectors: [],
   })
-  function update(name, value) {
+  function add(name, value) {
     selected[name] = value
+  }
+  function remove(name, value) {
+    if (value === "") selected[name] = ""
+    else selected[name] = selected[name].filter((element) => element.value !== value)
   }
 
   /* Exported values */
   const year = computed(() => selected.year)
+  const sectors = computed(() => selected.sectors)
 
   /* Actions */
   function getAllSelected() {
     const list = []
-    if (selected.year !== "") list.push({ name: "year", value: selected.year })
+    if (selected.year !== "") list.push({ name: "year", value: "", label: selected.year })
+    if (selected.sectors.length > 0) {
+      selected.sectors.forEach((sector) => {
+        list.push({ name: "sectors", value: sector.value, label: sector.name })
+      })
+    }
     return list
   }
 
-  return { update, getAllSelected, year }
+  return { add, remove, getAllSelected, year, sectors }
 })
 
 export { useFiltersStore }

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -20,8 +20,8 @@ const useFiltersStore = defineStore("filters", () => {
     else params[name] = params[name].filter((element) => element.value !== value)
   }
 
-  /* Actions */
-  function getAllSelected() {
+  /* Action to get all parameters with non empty */
+  function getFilled() {
     const list = []
     if (params.year !== "") list.push({ name: "year", value: "", label: params.year })
     if (params.economicModel.length > 0) {
@@ -47,7 +47,7 @@ const useFiltersStore = defineStore("filters", () => {
     return list
   }
 
-  return { add, remove, getAllSelected, params }
+  return { add, remove, getFilled, params }
 })
 
 export { useFiltersStore }

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -21,8 +21,7 @@ const useStoreFilters = defineStore("filters", () => {
     params[name] = value
   }
   function remove(name, value) {
-    if (value === "") params[name] = ""
-    else params[name] = params[name].filter((element) => element.value !== value)
+    params[name] = value === "" ? "" : params[name].filter((element) => element.value !== value)
   }
 
   /* Action to get a filter parameters values */

--- a/2024-frontend/src/stores/filters.js
+++ b/2024-frontend/src/stores/filters.js
@@ -17,7 +17,7 @@ const useStoreFilters = defineStore("filters", () => {
   })
 
   /* Actions to update filters parameters */
-  function add(name, value) {
+  function set(name, value) {
     params[name] = value
   }
   function remove(name, value) {
@@ -43,7 +43,7 @@ const useStoreFilters = defineStore("filters", () => {
     return filledParams
   }
 
-  return { add, remove, getFilled, get }
+  return { set, remove, getFilled, get }
 })
 
 export { useStoreFilters }

--- a/2024-frontend/src/views/Observatoire.vue
+++ b/2024-frontend/src/views/Observatoire.vue
@@ -1,11 +1,15 @@
 <script setup>
+import { computed } from "vue"
 import { useRoute } from "vue-router"
+import { useFiltersStore } from "@/stores/filters"
 import AppFilters from "@/components/AppFilters.vue"
 
 const route = useRoute()
+const filterStore = useFiltersStore()
 const pictoDataVisualization = "/static/images/picto-dsfr/data-visualization.svg"
 const pictoDocuments = "/static/images/picto-dsfr/documents.svg"
 const documentRapport = "/static/documents/Rapport_Bilan_Statistique_EGALIM_2024.pdf"
+const filtersList = computed(() => filterStore.getAllSelected())
 </script>
 
 <template>
@@ -43,6 +47,21 @@ const documentRapport = "/static/documents/Rapport_Bilan_Statistique_EGALIM_2024
   <section class="fr-mt-5w">
     <h2 class="fr-h5">Retrouver les chiffres clés sur votre territoire</h2>
     <AppFilters />
+  </section>
+  <section>
+    <div>
+      <p>Chiffres clés pour la recherche :</p>
+      <div>
+        <DsfrTag
+          v-for="(filter, index) in filtersList"
+          :key="index"
+          :label="filter.value"
+          class="fr-tag--dismiss"
+          tagName="button"
+          @click="filterStore.update(filter.name, '')"
+        />
+      </div>
+    </div>
   </section>
 </template>
 

--- a/2024-frontend/src/views/Observatoire.vue
+++ b/2024-frontend/src/views/Observatoire.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from "vue"
+import { useTemplateRef, computed } from "vue"
 import { useRoute } from "vue-router"
 import { useFiltersStore } from "@/stores/filters"
 import AppFilters from "@/components/AppFilters.vue"
@@ -10,6 +10,11 @@ const pictoDataVisualization = "/static/images/picto-dsfr/data-visualization.svg
 const pictoDocuments = "/static/images/picto-dsfr/documents.svg"
 const documentRapport = "/static/documents/Rapport_Bilan_Statistique_EGALIM_2024.pdf"
 const filtersList = computed(() => filterStore.getAllSelected())
+const filtersRef = useTemplateRef("filters-ref")
+
+const scrollToFilters = () => {
+  filtersRef.value.scrollIntoView({ behavior: "smooth" })
+}
 </script>
 
 <template>
@@ -47,12 +52,12 @@ const filtersList = computed(() => filterStore.getAllSelected())
       </li>
     </ul>
   </section>
-  <section class="fr-mt-5w">
+  <section class="fr-pt-5w" ref="filters-ref">
     <h2 class="fr-h5">Retrouver les chiffres clés sur votre territoire</h2>
     <AppFilters />
   </section>
-  <section class="observatoire__result ma-cantine--sticky__container fr-mt-4w fr-py-4w">
-    <div class="ma-cantine--sticky__top fr-grid-row fr-grid-row--middle">
+  <section class="observatoire__result ma-cantine--sticky__container fr-mt-4w fr-pb-4w">
+    <div class="ma-cantine--sticky__top fr-grid-row fr-grid-row--middle fr-pt-4w fr-background-alt--blue-france">
       <div class="fr-col-10 fr-grid-row fr-grid-row--middle">
         <p class="fr-mb-0 fr-pr-1w">Chiffres clés pour la recherche :</p>
         <DsfrTag
@@ -65,7 +70,7 @@ const filtersList = computed(() => filterStore.getAllSelected())
         />
       </div>
       <div class="fr-col-2">
-        <DsfrButton tertiary label="Modifier les filtres" icon="fr-icon-filter-fill" />
+        <DsfrButton tertiary label="Modifier les filtres" icon="fr-icon-filter-fill" @click="scrollToFilters()" />
       </div>
     </div>
     <br />

--- a/2024-frontend/src/views/Observatoire.vue
+++ b/2024-frontend/src/views/Observatoire.vue
@@ -1,15 +1,15 @@
 <script setup>
 import { useTemplateRef, computed } from "vue"
 import { useRoute } from "vue-router"
-import { useFiltersStore } from "@/stores/filters"
+import { useStoreFilters } from "@/stores/filters"
 import AppFilters from "@/components/AppFilters.vue"
 
 const route = useRoute()
-const filterStore = useFiltersStore()
+const storeFilters = useStoreFilters()
 const pictoDataVisualization = "/static/images/picto-dsfr/data-visualization.svg"
 const pictoDocuments = "/static/images/picto-dsfr/documents.svg"
 const documentRapport = "/static/documents/Rapport_Bilan_Statistique_EGALIM_2024.pdf"
-const filtersList = computed(() => filterStore.getFilled())
+const filtersList = computed(() => storeFilters.getFilled())
 const filtersRef = useTemplateRef("filters-ref")
 
 const scrollToFilters = () => {
@@ -63,7 +63,7 @@ const scrollToFilters = () => {
           :label="filter.label"
           class="fr-tag--dismiss fr-mr-1w"
           tagName="button"
-          @click="filterStore.remove(filter.name, filter.value)"
+          @click="storeFilters.remove(filter.name, filter.value)"
         />
       </div>
       <div class="fr-col-2">

--- a/2024-frontend/src/views/Observatoire.vue
+++ b/2024-frontend/src/views/Observatoire.vue
@@ -30,19 +30,16 @@ const scrollToFilters = () => {
       <li class="fr-col-12 fr-col-sm-6">
         <DsfrTile
           titleTag="p"
-          class="observatoire__force-title-download-vertical"
-          title="Rapport de la campagne 2024"
-          description="Application et des objectifs d’approvisionnements fixés à la restauration collective."
-          to="/#"
-          :imgSrc="pictoDocuments"
-          :download="true"
+          title="Accéder à data.gouv.fr"
+          to="https://www.data.gouv.fr/fr/organizations/ministere-de-l-agriculture-de-l-agroalimentaire-et-de-la-foret/"
+          :imgSrc="pictoDataVisualization"
           small
         />
       </li>
       <li class="fr-col-12 fr-col-sm-6">
         <DsfrTile
           titleTag="p"
-          class="statistics-canteens__force-title-download-vertical"
+          class="observatoire__force-title-download-vertical"
           title="Télécharger le rapport annuel 2024"
           :to="documentRapport"
           :imgSrc="pictoDocuments"

--- a/2024-frontend/src/views/Observatoire.vue
+++ b/2024-frontend/src/views/Observatoire.vue
@@ -53,14 +53,7 @@ const scrollToFilters = () => {
   </section>
   <section class="observatoire__results ma-cantine--sticky__container fr-mt-4w fr-pb-4w">
     <ObservatoryResultsFilters @scrollToFilters="scrollToFilters()" class="ma-cantine--sticky__top" />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <div style="height: 100vh">
-      Contenu
-    </div>
+    <div style="height: 100vh"></div>
   </section>
 </template>
 

--- a/2024-frontend/src/views/Observatoire.vue
+++ b/2024-frontend/src/views/Observatoire.vue
@@ -63,10 +63,10 @@ const scrollToFilters = () => {
         <DsfrTag
           v-for="(filter, index) in filtersList"
           :key="index"
-          :label="filter.value"
+          :label="filter.label"
           class="fr-tag--dismiss fr-mr-1w"
           tagName="button"
-          @click="filterStore.update(filter.name, '')"
+          @click="filterStore.remove(filter.name, filter.value)"
         />
       </div>
       <div class="fr-col-2">

--- a/2024-frontend/src/views/Observatoire.vue
+++ b/2024-frontend/src/views/Observatoire.vue
@@ -1,15 +1,13 @@
 <script setup>
-import { useTemplateRef, computed } from "vue"
+import { useTemplateRef } from "vue"
 import { useRoute } from "vue-router"
-import { useStoreFilters } from "@/stores/filters"
 import AppFilters from "@/components/AppFilters.vue"
+import ObservatoryResultsFilters from "@/components/ObservatoryResultsFilters.vue"
 
 const route = useRoute()
-const storeFilters = useStoreFilters()
 const pictoDataVisualization = "/static/images/picto-dsfr/data-visualization.svg"
 const pictoDocuments = "/static/images/picto-dsfr/documents.svg"
 const documentRapport = "/static/documents/Rapport_Bilan_Statistique_EGALIM_2024.pdf"
-const filtersList = computed(() => storeFilters.getFilled())
 const filtersRef = useTemplateRef("filters-ref")
 
 const scrollToFilters = () => {
@@ -53,23 +51,8 @@ const scrollToFilters = () => {
     <h2 class="fr-h5">Retrouver les chiffres clés sur votre territoire</h2>
     <AppFilters />
   </section>
-  <section class="observatoire__result ma-cantine--sticky__container fr-mt-4w fr-pb-4w">
-    <div class="ma-cantine--sticky__top fr-grid-row fr-grid-row--middle fr-pt-4w fr-background-alt--blue-france">
-      <div class="fr-col-10 fr-grid-row fr-grid-row--middle">
-        <p class="fr-mb-0 fr-pr-1w">Chiffres clés pour la recherche :</p>
-        <DsfrTag
-          v-for="(filter, index) in filtersList"
-          :key="index"
-          :label="filter.label"
-          class="fr-tag--dismiss fr-mr-1w"
-          tagName="button"
-          @click="storeFilters.remove(filter.name, filter.value)"
-        />
-      </div>
-      <div class="fr-col-2">
-        <DsfrButton tertiary label="Modifier les filtres" icon="fr-icon-filter-fill" @click="scrollToFilters()" />
-      </div>
-    </div>
+  <section class="observatoire__results ma-cantine--sticky__container fr-mt-4w fr-pb-4w">
+    <ObservatoryResultsFilters @scrollToFilters="scrollToFilters()" class="ma-cantine--sticky__top" />
     <br />
     <br />
     <br />
@@ -103,7 +86,7 @@ const scrollToFilters = () => {
     }
   }
 
-  &__result {
+  &__results {
     &::before {
       z-index: -1;
       content: "";

--- a/2024-frontend/src/views/Observatoire.vue
+++ b/2024-frontend/src/views/Observatoire.vue
@@ -9,7 +9,7 @@ const filterStore = useFiltersStore()
 const pictoDataVisualization = "/static/images/picto-dsfr/data-visualization.svg"
 const pictoDocuments = "/static/images/picto-dsfr/documents.svg"
 const documentRapport = "/static/documents/Rapport_Bilan_Statistique_EGALIM_2024.pdf"
-const filtersList = computed(() => filterStore.getAllSelected())
+const filtersList = computed(() => filterStore.getFilled())
 const filtersRef = useTemplateRef("filters-ref")
 
 const scrollToFilters = () => {

--- a/2024-frontend/src/views/Observatoire.vue
+++ b/2024-frontend/src/views/Observatoire.vue
@@ -51,19 +51,30 @@ const filtersList = computed(() => filterStore.getAllSelected())
     <h2 class="fr-h5">Retrouver les chiffres clés sur votre territoire</h2>
     <AppFilters />
   </section>
-  <section>
-    <div>
-      <p>Chiffres clés pour la recherche :</p>
-      <div>
+  <section class="observatoire__result ma-cantine--sticky__container fr-mt-4w fr-py-4w">
+    <div class="ma-cantine--sticky__top fr-grid-row fr-grid-row--middle">
+      <div class="fr-col-10 fr-grid-row fr-grid-row--middle">
+        <p class="fr-mb-0 fr-pr-1w">Chiffres clés pour la recherche :</p>
         <DsfrTag
           v-for="(filter, index) in filtersList"
           :key="index"
           :label="filter.value"
-          class="fr-tag--dismiss"
+          class="fr-tag--dismiss fr-mr-1w"
           tagName="button"
           @click="filterStore.update(filter.name, '')"
         />
       </div>
+      <div class="fr-col-2">
+        <DsfrButton tertiary label="Modifier les filtres" icon="fr-icon-filter-fill" />
+      </div>
+    </div>
+    <br />
+    <br />
+    <br />
+    <br />
+    <br />
+    <div style="height: 100vh">
+      Contenu
     </div>
   </section>
 </template>
@@ -87,6 +98,19 @@ const filtersList = computed(() => filterStore.getAllSelected())
 
     .fr-tile__pictogram {
       height: 3.5rem !important;
+    }
+  }
+
+  &__result {
+    &::before {
+      z-index: -1;
+      content: "";
+      background-color: var(--background-alt-blue-france);
+      position: absolute;
+      top: 0;
+      left: calc((100vw - 100%) / 2 * -1);
+      width: 100vw;
+      height: 100%;
     }
   }
 }

--- a/2024-frontend/src/views/Observatoire.vue
+++ b/2024-frontend/src/views/Observatoire.vue
@@ -25,9 +25,12 @@ const filtersList = computed(() => filterStore.getAllSelected())
       <li class="fr-col-12 fr-col-sm-6">
         <DsfrTile
           titleTag="p"
-          title="Accéder à data.gouv.fr"
-          to="https://www.data.gouv.fr/fr/organizations/ministere-de-l-agriculture-de-l-agroalimentaire-et-de-la-foret/"
-          :imgSrc="pictoDataVisualization"
+          class="observatoire__force-title-download-vertical"
+          title="Rapport de la campagne 2024"
+          description="Application et des objectifs d’approvisionnements fixés à la restauration collective."
+          to="/#"
+          :imgSrc="pictoDocuments"
+          :download="true"
           small
         />
       </li>
@@ -66,7 +69,7 @@ const filtersList = computed(() => filterStore.getAllSelected())
 </template>
 
 <style lang="scss">
-.statistics-canteens {
+.observatoire {
   &__force-title-download-vertical {
     align-items: center !important;
     flex-direction: column !important;


### PR DESCRIPTION
## Description

Cette PR contient les fonctionnalités : 
- affichage des filtres sélectionnés dans la section de résultat
- un filtre peut être supprimé au clic sur son étiquette
- les filtres restent affichés en haut de page au scoll 
- un bouton d'accès rapide est présent pour revenir en haut de page et modifier les filtres

## Prévisualisation

<img width="1294" height="905" alt="Capture d’écran 2025-07-28 à 11 47 49" src="https://github.com/user-attachments/assets/4e356745-e01c-4158-a154-95d0fbcfd283" />

<img width="1710" height="342" alt="Capture d’écran 2025-07-28 à 11 48 04" src="https://github.com/user-attachments/assets/97145e31-5061-458c-abf9-062bb3ef299c" />
