### PR TITLE
feat(Observatoire): affiche le bandeau d'information des armées

### DIFF
--- a/2024-frontend/src/views/Observatoire.vue
+++ b/2024-frontend/src/views/Observatoire.vue
@@ -53,6 +53,10 @@ const scrollToFilters = () => {
   </section>
   <section class="observatoire__results ma-cantine--sticky__container fr-mt-4w fr-pb-4w">
     <ObservatoryResultsFilters @scrollToFilters="scrollToFilters()" class="ma-cantine--sticky__top" />
+    <DsfrNotice
+      class="fr-my-2w"
+      title="Pour des raisons de confidentialité, les cantines des armées ne sont pas intégrées dans cet observatoire."
+    />
     <div style="height: 100vh"></div>
   </section>
 </template>


### PR DESCRIPTION
## Description

Affiche aux utilisateurs un bandeau informatif sur le cas des cantines des armées

## Prévisualisation

<img width="1366" height="707" alt="Capture d’écran 2025-07-28 à 12 18 26" src="https://github.com/user-attachments/assets/6473d775-0005-45ad-a2e3-1e7cf1ab7ecb" />
