### PR TITLE
fix(Observatoire): corrige l'affichage des 3 premiers blocs des résultats

### DIFF
--- a/2024-frontend/src/components/ObservatoryResultsTop.vue
+++ b/2024-frontend/src/components/ObservatoryResultsTop.vue
@@ -7,7 +7,7 @@ const props = defineProps(["canteensCount", "teledeclarationsCount"])
 
 /* Filters */
 const storeFilters = useStoreFilters()
-const filtersParams = storeFilters.getAll()
+const filtersParams = storeFilters.getAllParams()
 
 /* Canteen */
 const canteenTitle = computed(() => {


### PR DESCRIPTION
Suite [#5546](https://github.com/betagouv/ma-cantine/pull/5546) et [#5548](https://github.com/betagouv/ma-cantine/pull/5548)

Le nom de la fonction n'a pas été modifié dans la PR suivant celle des correctifs.