### PR TITLE
improve(Cantines): nouveau queryset pour exclure facilement les livreurs de repas (avec ou sans convives)

### DIFF
--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -49,6 +49,14 @@ def has_siret_or_siren_unite_legale_query():
     return has_siret_query | has_siren_unite_legale_query
 
 
+def is_central_query():
+    return Q(production_type=Canteen.ProductionType.CENTRAL)
+
+
+def is_central_cuisine_query():
+    return Q(production_type__in=[Canteen.ProductionType.CENTRAL, Canteen.ProductionType.CENTRAL_SERVING])
+
+
 def is_serving_query():
     return Q(
         production_type__in=[
@@ -61,10 +69,6 @@ def is_serving_query():
 
 def is_satellite_query():
     return Q(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
-
-
-def is_central_cuisine_query():
-    return Q(production_type__in=[Canteen.ProductionType.CENTRAL, Canteen.ProductionType.CENTRAL_SERVING])
 
 
 def has_missing_data_query():
@@ -102,6 +106,12 @@ class CanteenQuerySet(SoftDeletionQuerySet):
         if canteen_created_before_date:
             return self.filter(creation_date__lt=canteen_created_before_date)
         return self.none()
+
+    def exclude_central(self):
+        return self.exclude(is_central_query())
+
+    def exclude_central_cuisine(self):
+        return self.exclude(is_central_cuisine_query())
 
     def is_satellite(self):
         return self.filter(is_satellite_query())
@@ -272,6 +282,12 @@ class CanteenManager(SoftDeletionManager):
 
     def created_before_year_campaign_end_date(self, year):
         return self.get_queryset().created_before_year_campaign_end_date(year)
+
+    def exclude_central(self):
+        return self.get_queryset().exclude_central()
+
+    def exclude_central_cuisine(self):
+        return self.get_queryset().exclude_central_cuisine()
 
     def is_satellite(self):
         return self.get_queryset().is_satellite()

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -107,11 +107,11 @@ class CanteenQuerySet(SoftDeletionQuerySet):
             return self.filter(creation_date__lt=canteen_created_before_date)
         return self.none()
 
+    def is_central(self):
+        return self.filter(is_central_query())
+
     def exclude_central(self):
         return self.exclude(is_central_query())
-
-    def exclude_central_cuisine(self):
-        return self.exclude(is_central_cuisine_query())
 
     def is_satellite(self):
         return self.filter(is_satellite_query())
@@ -283,11 +283,11 @@ class CanteenManager(SoftDeletionManager):
     def created_before_year_campaign_end_date(self, year):
         return self.get_queryset().created_before_year_campaign_end_date(year)
 
+    def is_central(self):
+        return self.get_queryset().is_central()
+
     def exclude_central(self):
         return self.get_queryset().exclude_central()
-
-    def exclude_central_cuisine(self):
-        return self.get_queryset().exclude_central_cuisine()
 
     def is_satellite(self):
         return self.get_queryset().is_satellite()

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -594,6 +594,13 @@ class Canteen(SoftDeletionModel):
         return self.siret or self.siren_unite_legale or ""
 
     @property
+    def is_central_cuisine(self) -> bool:
+        return self.production_type and self.production_type in [
+            Canteen.ProductionType.CENTRAL,
+            Canteen.ProductionType.CENTRAL_SERVING,
+        ]
+
+    @property
     def is_serving(self):
         return self.production_type and self.production_type in [
             Canteen.ProductionType.CENTRAL_SERVING,
@@ -606,13 +613,6 @@ class Canteen(SoftDeletionModel):
         if self.siret:
             return Canteen.objects.get_satellites(self.siret)
         return Canteen.objects.none()
-
-    @property
-    def is_central_cuisine(self) -> bool:
-        return self.production_type and self.production_type in [
-            Canteen.ProductionType.CENTRAL,
-            Canteen.ProductionType.CENTRAL_SERVING,
-        ]
 
     @property
     def is_satellite(self) -> bool:

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -167,7 +167,7 @@ class TestCanteenCentralAndSatelliteQuerySet(TestCase):
         cls.canteen_on_site_central_2 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=cls.canteen_central_2.siret
         )
-        cls.canteen_on_site_central_2 = CanteenFactory(
+        cls.canteen_on_site_central_3 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=cls.canteen_central_2.siret
         )
         cls.canteen_central_serving_1 = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL_SERVING)

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -152,7 +152,7 @@ class TestCanteenCreatedBeforeQuerySet(TestCase):
         self.assertEqual(Canteen.objects.created_before_year_campaign_end_date(2025).count(), 4)
 
 
-class TestCanteenSatelliteQuerySet(TestCase):
+class TestCanteenCentralAndSatelliteQuerySet(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.canteen_central_1 = CanteenFactory(
@@ -170,13 +170,22 @@ class TestCanteenSatelliteQuerySet(TestCase):
         cls.canteen_on_site_central_2 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=cls.canteen_central_2.siret
         )
+        cls.canteen_central_serving_1 = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL_SERVING)
+
+    def test_exclude_central(self):
+        self.assertEqual(Canteen.objects.count(), 6)
+        self.assertEqual(Canteen.objects.exclude_central().count(), 4)
+
+    def test_exclude_central_cuisine(self):
+        self.assertEqual(Canteen.objects.count(), 6)
+        self.assertEqual(Canteen.objects.exclude_central_cuisine().count(), 3)
 
     def test_is_satellite(self):
-        self.assertEqual(Canteen.objects.count(), 5)
+        self.assertEqual(Canteen.objects.count(), 6)
         self.assertEqual(Canteen.objects.is_satellite().count(), 3)
 
     def test_annotate_with_central_kitchen_id(self):
-        self.assertEqual(Canteen.objects.count(), 5)
+        self.assertEqual(Canteen.objects.count(), 6)
         self.assertEqual(
             Canteen.objects.annotate_with_central_kitchen_id()
             .filter(id=self.canteen_on_site_central_1.id)
@@ -199,12 +208,12 @@ class TestCanteenSatelliteQuerySet(TestCase):
         )
 
     def test_get_satellites(self):
-        self.assertEqual(Canteen.objects.count(), 5)
+        self.assertEqual(Canteen.objects.count(), 6)
         self.assertEqual(Canteen.objects.get_satellites(self.canteen_central_1.siret).count(), 1)
         self.assertEqual(Canteen.objects.get_satellites(self.canteen_central_2.siret).count(), 2)
 
     def test_annotate_with_satellites_in_db_count(self):
-        self.assertEqual(Canteen.objects.count(), 5)
+        self.assertEqual(Canteen.objects.count(), 6)
         self.assertEqual(
             Canteen.objects.annotate_with_satellites_in_db_count()
             .filter(id=self.canteen_central_1.id)

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -172,13 +172,13 @@ class TestCanteenCentralAndSatelliteQuerySet(TestCase):
         )
         cls.canteen_central_serving_1 = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL_SERVING)
 
+    def test_is_central(self):
+        self.assertEqual(Canteen.objects.count(), 6)
+        self.assertEqual(Canteen.objects.is_central().count(), 2)
+
     def test_exclude_central(self):
         self.assertEqual(Canteen.objects.count(), 6)
         self.assertEqual(Canteen.objects.exclude_central().count(), 4)
-
-    def test_exclude_central_cuisine(self):
-        self.assertEqual(Canteen.objects.count(), 6)
-        self.assertEqual(Canteen.objects.exclude_central_cuisine().count(), 3)
 
     def test_is_satellite(self):
         self.assertEqual(Canteen.objects.count(), 6)


### PR DESCRIPTION
### Quoi

2 nouvelles querysets sur le modèle `Canteen`
- is_central
- exclude_central

### Pourquoi

Cette queryset sera utile quand on souhaitera exclure les livreur de repas des stats "nombre de cantines" (prochaine PR)

### Note

Actuellement les CENTRAL_SERVING existent encore. à terme on souhaite les supprimer, en les transformant en CENTRAL + créer leur ON_SITE_CENTRAL "fictif"