### PR TITLE
fix(Observatoire): le chiffre des pourcentages de produits de durables inclu le bio

### DIFF
--- a/2024-frontend/src/components/ObservatoryGraphSustainable.vue
+++ b/2024-frontend/src/components/ObservatoryGraphSustainable.vue
@@ -4,7 +4,7 @@ import { useStoreFilters } from "@/stores/filters"
 import GraphBase from "@/components/GraphBase.vue"
 import GraphGauge from "@/components/GraphGauge.vue"
 
-const props = defineProps(["sustainablePercent", "bioPercent"])
+const props = defineProps(["egalimPercent", "bioPercent"])
 const storeFilters = useStoreFilters()
 const title = "Produits durable et de qualité dont les produits bio"
 
@@ -13,7 +13,7 @@ const objectives = [
   { name: "50%", value: 50 },
   { name: "20%", value: 20 },
 ]
-const stats = reactive([props.sustainablePercent, props.bioPercent])
+const stats = reactive([props.egalimPercent, props.bioPercent])
 const legends = ["durables et de qualité dont bio", "bio et en conversion bio"]
 
 /* Function to generate descriptions */

--- a/2024-frontend/src/components/ObservatoryPurchases.vue
+++ b/2024-frontend/src/components/ObservatoryPurchases.vue
@@ -17,7 +17,7 @@ const keyMeasureId = keyMeasures[0].id
       <AppLinkRouter :to="{ name: 'KeyMeasurePage', params: { id: keyMeasureId } }" title="En savoir plus sur la loi" />
     </ObservatoryBadgeTitle>
     <div>
-      <ObservatoryGraphSustainable :bioPercent="stats.bioPercent" :sustainablePercent="stats.sustainablePercent" />
+      <ObservatoryGraphSustainable :bioPercent="stats.bioPercent" :egalimPercent="stats.egalimPercent" />
     </div>
   </div>
 </template>

--- a/api/serializers/statistics.py
+++ b/api/serializers/statistics.py
@@ -150,6 +150,6 @@ class CanteenStatisticsSerializer(serializers.Serializer):
             locale.setlocale(locale.LC_TIME, "fr_FR.UTF-8")
             data["canteen_count_description"] = f"Au {canteen_created_before_date.strftime('%-d %B %Y')}"
         # egalim objectives
-        data["bio_percent_egalim_objective"] = EGALIM_OBJECTIVES["bio_percent"]
-        data["egalim_percent_egalim_objective"] = EGALIM_OBJECTIVES["egalim_percent"]
+        data["bio_percent_objective"] = EGALIM_OBJECTIVES["bio_percent"]
+        data["egalim_percent_objective"] = EGALIM_OBJECTIVES["egalim_percent"]
         return data

--- a/api/serializers/statistics.py
+++ b/api/serializers/statistics.py
@@ -151,5 +151,5 @@ class CanteenStatisticsSerializer(serializers.Serializer):
             data["canteen_count_description"] = f"Au {canteen_created_before_date.strftime('%-d %B %Y')}"
         # egalim objectives
         data["bio_percent_egalim_objective"] = EGALIM_OBJECTIVES["bio_percent"]
-        data["sustainable_percent_egalim_objective"] = EGALIM_OBJECTIVES["sustainable_percent"]
+        data["egalim_percent_egalim_objective"] = EGALIM_OBJECTIVES["egalim_percent"]
         return data

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -31,7 +31,7 @@ def convert_date_string_to_datetime(date_string, time_start_or_end="start"):
 # TODO: improve (depends on the year & region)
 EGALIM_OBJECTIVES = {
     "bio_percent": 20,
-    "sustainable_percent": 50,
+    "egalim_percent": 50,
 }
 
 


### PR DESCRIPTION
Suite [#5572](https://github.com/betagouv/ma-cantine/pull/5572) et [#5570](https://github.com/betagouv/ma-cantine/pull/5570)

Remplace "sustainable" par "egalim" car ce qu'on affiche est le chiffre sustainable + bio