### PR TITLE
refactor(Télédéclaration): nouveau queryset pour calculer le pourcentage bio & egalim des achats

### DIFF
--- a/common/utils/badges.py
+++ b/common/utils/badges.py
@@ -1,42 +1,29 @@
-from django.db.models import F, FloatField, Q, Sum
-from django.db.models.functions import Cast
+from django.db.models import Q
 
 from data.department_choices import Department
 from data.region_choices import Region
+from macantine.utils import EGALIM_OBJECTIVES
 
 
 def badges_for_queryset(teledeclaration_year_queryset):
     badge_querysets = {}
-    appro_total = teledeclaration_year_queryset
-    if appro_total:
-        appro_total = teledeclaration_year_queryset.count()
-        appro_share_query = teledeclaration_year_queryset.filter(
-            value_total_ht__gt=0
-        )  # Avoid division by zero for TD with value_total_ht < 1, rounded t 0 when casting as int
-        appro_share_query = appro_share_query.annotate(
-            bio_share=Cast(Sum("value_bio_ht_agg", default=0), FloatField())
-            / Cast(Sum("value_total_ht"), FloatField())
-        )
-        teledeclaration_year_queryset.annotate(bio_share=F("value_bio_ht_agg") / F("value_total_ht"))
-        appro_share_query = appro_share_query.annotate(
-            combined_share=Cast(
-                Sum("value_bio_ht_agg", default=0)
-                + Sum("value_sustainable_ht_agg", default=0)
-                + Sum("value_externality_performance_ht_agg", default=0)
-                + Sum("value_egalim_others_ht_agg", default=0),
-                FloatField(),
-            )
-            / Cast(Sum("value_total_ht"), FloatField()),
-        )
+    if teledeclaration_year_queryset:
+        # Avoid division by zero for TD with value_total_ht < 1, rounded to 0 when casting as int
+        teledeclaration_year_queryset = teledeclaration_year_queryset.filter(value_total_ht__gt=0)
+        # Calculate the share of bio & egalim
+        teledeclaration_year_queryset = teledeclaration_year_queryset.with_appro_percent_stats()
         # Saint-Martin should be in group 1
         group_1 = [Region.guadeloupe, Region.martinique, Region.guyane, Region.la_reunion]
         group_2 = [Region.mayotte]
         # should have a group 3 with Saint-Pierre-et-Miquelon
-        badge_querysets["appro"] = appro_share_query.filter(
-            Q(combined_share__gte=0.5, bio_share__gte=0.2)
-            | Q(canteen__region__in=group_1, combined_share__gte=0.2, bio_share__gte=0.05)
-            | Q(canteen__department=Department.saint_martin, combined_share__gte=0.2, bio_share__gte=0.05)
-            | Q(canteen__region__in=group_2, combined_share__gte=0.05, bio_share__gte=0.02)
-            | Q(canteen__department=Department.saint_pierre_et_miquelon, combined_share__gte=0.3, bio_share__gte=0.1)
+        badge_querysets["appro"] = teledeclaration_year_queryset.filter(
+            Q(
+                egalim_percent__gte=EGALIM_OBJECTIVES["egalim_percent"],
+                bio_percent__gte=EGALIM_OBJECTIVES["bio_percent"],
+            )
+            | Q(canteen__region__in=group_1, egalim_percent__gte=20, bio_percent__gte=5)
+            | Q(canteen__department=Department.saint_martin, egalim_percent__gte=20, bio_percent__gte=5)
+            | Q(canteen__region__in=group_2, egalim_percent__gte=5, bio_percent__gte=2)
+            | Q(canteen__department=Department.saint_pierre_et_miquelon, egalim_percent__gte=30, bio_percent__gte=10)
         ).distinct()
     return badge_querysets

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from django.db.models import Q
+from django.db.models import F, Q
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 from django.utils import timezone
@@ -114,6 +114,16 @@ class TeledeclarationQuerySet(models.QuerySet):
 
     def publicly_visible(self):
         return self.exclude(canteen__line_ministry=Canteen.Ministries.ARMEE)
+
+    def with_appro_percent_stats(self):
+        return self.annotate(
+            bio_percent=100 * F("value_bio_ht_agg") / F("value_total_ht"),
+            value_egalim_ht_agg=F("value_bio_ht_agg")
+            + F("value_sustainable_ht_agg")
+            + F("value_externality_performance_ht_agg")
+            + F("value_egalim_others_ht_agg"),
+            egalim_percent=100 * F("value_egalim_ht_agg") / F("value_total_ht"),
+        )
 
 
 class Teledeclaration(models.Model):

--- a/data/tests/test_teledeclaration.py
+++ b/data/tests/test_teledeclaration.py
@@ -16,7 +16,6 @@ date_in_last_teledeclaration_campaign = "2024-02-01"
 class TeledeclarationQuerySetTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        """Create canteens for testing."""
         cls.valid_canteen_1 = CanteenFactory(siret="12345678901234", deletion_date=None, yearly_meal_count=100)
         cls.valid_canteen_2 = CanteenFactory(siren_unite_legale="123456789", deletion_date=None)
         cls.valid_canteen_3 = CanteenFactory(
@@ -36,7 +35,6 @@ class TeledeclarationQuerySetTest(TestCase):
             deletion_date=now().replace(month=3, day=1),
         )
 
-        """Create diagnostics and teledeclarations for testing."""
         for index, canteen in enumerate(
             [cls.valid_canteen_1, cls.valid_canteen_2, cls.valid_canteen_3, cls.valid_canteen_5_armee]
         ):
@@ -74,6 +72,9 @@ class TeledeclarationQuerySetTest(TestCase):
             canteen=cls.valid_canteen_4,
             value_total_ht=1000.00,
             value_bio_ht=200.00,
+            value_sustainable_ht=100.00,
+            value_externality_performance_ht=100.00,
+            value_egalim_others_ht=100.00,
         )
         user_correction_campaign = UserFactory.create()
         cls.valid_correction_td = Teledeclaration.create_from_diagnostic(
@@ -180,6 +181,12 @@ class TeledeclarationQuerySetTest(TestCase):
     def test_publicly_visible(self):
         self.assertEqual(Teledeclaration.objects.count(), 13)
         self.assertEqual(Teledeclaration.objects.publicly_visible().count(), 11)  # 2 belong to canteen_army
+
+    def test_with_appro_percent_stats(self):
+        teledeclarations = Teledeclaration.objects.with_appro_percent_stats()
+        td_1 = teledeclarations.get(id=self.valid_correction_td.id)
+        self.assertEqual(td_1.bio_percent, 20)
+        self.assertEqual(td_1.egalim_percent, 50)
 
 
 class TestTeledeclarationModelConstraintsTest(TestCase):


### PR DESCRIPTION
on va en avoir besoin pour calculer le nombre de cantines qui ont atteint l’objectif EGalim