### PR TITLE
fix(CI): répare la récuparation du language-pack-fr pour les tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,10 @@ jobs:
 
       # needed for strftime in French
       - name: Install Apt Packages
-        run: sudo apt-get install --fix-missing language-pack-fr
+        # run: sudo apt-get install language-pack-fr
+        run: |
+          sudo apt-get install -y locales
+          sudo locale-gen fr_FR.UTF-8
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
 
       # needed for strftime in French
       - name: Install Apt Packages
-        # run: sudo apt-get install language-pack-fr
         run: |
           sudo apt-get install -y locales
           sudo locale-gen fr_FR.UTF-8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
       # needed for strftime in French
       - name: Install Apt Packages
-        run: sudo apt-get install -qq language-pack-fr
+        run: sudo apt-get install --fix-missing language-pack-fr
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
Suite à son ajout dans la CI dans #5542

Il y avait des erreurs 404 sur `sudo apt-get install language-pack-fr`

Résolu avec un package alternatif