### PR TITLE
improve(API Stats): renvoyer les objectifs EGalim DROM si une region correspond

### DIFF
--- a/api/serializers/statistics.py
+++ b/api/serializers/statistics.py
@@ -156,7 +156,7 @@ class CanteenStatisticsSerializer(serializers.Serializer):
         return data
 
     @staticmethod
-    def generate_notes(year):
+    def generate_notes(year, egalim_group):
         data = {}
         data["warnings"] = [
             "Pour des raisons de confidentialité, les cantines des armées ne sont pas intégrées dans cet observatoire."
@@ -166,8 +166,9 @@ class CanteenStatisticsSerializer(serializers.Serializer):
             locale.setlocale(locale.LC_TIME, "fr_FR.UTF-8")
             data["canteen_count_description"] = f"Au {canteen_created_before_date.strftime('%-d %B %Y')}"
         # egalim objectives
-        data["bio_percent_objective"] = EGALIM_OBJECTIVES["hexagone"]["bio_percent"]
-        data["egalim_percent_objective"] = EGALIM_OBJECTIVES["hexagone"]["egalim_percent"]
+        data["egalim_group"] = egalim_group
+        data["bio_percent_objective"] = EGALIM_OBJECTIVES[egalim_group]["bio_percent"]
+        data["egalim_percent_objective"] = EGALIM_OBJECTIVES[egalim_group]["egalim_percent"]
         return data
 
     @staticmethod

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -210,7 +210,6 @@ def filter_by_diagnostic_params(queryset, query_params):
                 bio_percent=100 * Cast(Sum("value_bio_ht", default=0) / Sum("value_total_ht"), FloatField())
             )
             if param_bio_rate:
-                print("in param_bio")
                 qs_diag = qs_diag.filter(bio_percent__gte=100 * float(param_bio_rate))
         if param_combined_rate or appro_badge_requested:
             qs_diag = qs_diag.annotate(

--- a/data/region_choices.py
+++ b/data/region_choices.py
@@ -33,3 +33,20 @@ class Region(models.TextChoices):
     polynesie_francaise = "987", "987 - Polynésie Française"
     nouvelle_caledonie = "988", "988 - Nouvelle Calédonie"
     ile_de_clipperton = "989", "989 - Île de Clipperton"
+
+
+REGION_HEXAGONE_LIST = [
+    Region.ile_de_france,
+    Region.centre_val_de_loire,
+    Region.bourgogne_franche_comte,
+    Region.normandie,
+    Region.hauts_de_france,
+    Region.grand_est,
+    Region.pays_de_la_loire,
+    Region.bretagne,
+    Region.nouvelle_aquitaine,
+    Region.occitanie,
+    Region.auvergne_rhone_alpes,
+    Region.provence_alpes_cote_d_azur,
+    Region.corse,
+]

--- a/macantine/tests/test_utils.py
+++ b/macantine/tests/test_utils.py
@@ -17,7 +17,7 @@ class TestEgalimObjectives(TestCase):
         self.assertEqual(get_egalim_group([Region.mayotte]), "groupe_2")
         self.assertEqual(get_egalim_group([Region.saint_pierre_et_miquelon]), "groupe_3")
         self.assertEqual(get_egalim_group([Region.bretagne, Region.guadeloupe]), "hexagone")
-        # self.assertEqual(get_egalim_group([Region.guadeloupe, Region.bretagne]), "hexagone")
+        self.assertEqual(get_egalim_group([Region.guadeloupe, Region.bretagne]), "hexagone")
         self.assertEqual(get_egalim_group([Region.guadeloupe, Region.martinique]), "groupe_1")
         self.assertEqual(get_egalim_group([Region.guadeloupe, Region.mayotte]), "groupe_1")
         self.assertEqual(get_egalim_group([]), "hexagone")

--- a/macantine/tests/test_utils.py
+++ b/macantine/tests/test_utils.py
@@ -16,6 +16,10 @@ class TestEgalimObjectives(TestCase):
         self.assertEqual(get_egalim_group([Region.guadeloupe]), "groupe_1")
         self.assertEqual(get_egalim_group([Region.mayotte]), "groupe_2")
         self.assertEqual(get_egalim_group([Region.saint_pierre_et_miquelon]), "groupe_3")
+        self.assertEqual(get_egalim_group([Region.bretagne, Region.guadeloupe]), "hexagone")
+        # self.assertEqual(get_egalim_group([Region.guadeloupe, Region.bretagne]), "hexagone")
+        self.assertEqual(get_egalim_group([Region.guadeloupe, Region.martinique]), "groupe_1")
+        self.assertEqual(get_egalim_group([Region.guadeloupe, Region.mayotte]), "groupe_1")
         self.assertEqual(get_egalim_group([]), "hexagone")
         self.assertEqual(get_egalim_group(None), "hexagone")
 

--- a/macantine/tests/test_utils.py
+++ b/macantine/tests/test_utils.py
@@ -1,11 +1,23 @@
 from django.test import TestCase
 from freezegun import freeze_time
 
+from data.region_choices import Region
 from macantine.utils import (
+    get_egalim_group,
     is_in_correction,
     is_in_teledeclaration,
     is_in_teledeclaration_or_correction,
 )
+
+
+class TestEgalimObjectives(TestCase):
+    def test_get_egalim_group(self):
+        self.assertEqual(get_egalim_group([Region.bretagne]), "hexagone")
+        self.assertEqual(get_egalim_group([Region.guadeloupe]), "groupe_1")
+        self.assertEqual(get_egalim_group([Region.mayotte]), "groupe_2")
+        self.assertEqual(get_egalim_group([Region.saint_pierre_et_miquelon]), "groupe_3")
+        self.assertEqual(get_egalim_group([]), "hexagone")
+        self.assertEqual(get_egalim_group(None), "hexagone")
 
 
 class TestCampaignDates(TestCase):

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -6,7 +6,7 @@ import redis as r
 from django.conf import settings
 from django.utils import timezone
 
-from data.region_choices import Region
+from data.region_choices import REGION_HEXAGONE_LIST, Region
 
 logger = logging.getLogger(__name__)
 redis = r.from_url(settings.REDIS_URL, decode_responses=True)
@@ -37,17 +37,30 @@ def convert_date_string_to_datetime(date_string, time_start_or_end="start"):
 # groupe 2 : Mayotte
 # groupe 3 : Saint-Pierre-et-Miquelon
 EGALIM_OBJECTIVES = {
-    "hexagone": {"region_list": [], "bio_percent": 20, "egalim_percent": 50},
+    "hexagone": {
+        "region_list": REGION_HEXAGONE_LIST
+        + [
+            Region.saint_barthelemy,
+            Region.terres_australes_et_antarctiques_francaises,
+            Region.wallis_et_futuna,
+            Region.polynesie_francaise,
+            Region.nouvelle_caledonie,
+            Region.ile_de_clipperton,
+        ],
+        "bio_percent": 20,
+        "egalim_percent": 50,
+    },
     "groupe_1": {
         "region_list": [Region.guadeloupe, Region.martinique, Region.guyane, Region.la_reunion, Region.saint_martin],
         "bio_percent": 5,
         "egalim_percent": 20,
     },
-    "groupe_2": {"region_list": [Region.mayotte], "bio_percent": 2, "egalim_percent": 5},
     "groupe_3": {"region_list": [Region.saint_pierre_et_miquelon], "bio_percent": 10, "egalim_percent": 30},
+    "groupe_2": {"region_list": [Region.mayotte], "bio_percent": 2, "egalim_percent": 5},
 }
 
 
+# TODO: prendre en compte les department, epci, pat & city_insee_code
 def get_egalim_group(region_list):
     if region_list and len(region_list):
         for group_name, details in EGALIM_OBJECTIVES.items():

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -32,37 +32,40 @@ def convert_date_string_to_datetime(date_string, time_start_or_end="start"):
 
 # https://ma-cantine.agriculture.gouv.fr/blog/16/
 # TODO: improve (depends on the year)
-# groupe 0 : hexagone
-# groupe 1 : Guadeloupe, Guyane, Martinique, La Réunion, Saint-Martin
-# groupe 2 : Mayotte
-# groupe 3 : Saint-Pierre-et-Miquelon
+HEXAGONE_LIST = REGION_HEXAGONE_LIST + [
+    Region.saint_barthelemy,
+    Region.terres_australes_et_antarctiques_francaises,
+    Region.wallis_et_futuna,
+    Region.polynesie_francaise,
+    Region.nouvelle_caledonie,
+    Region.ile_de_clipperton,
+]
+GROUP_1_LIST = [Region.guadeloupe, Region.martinique, Region.guyane, Region.la_reunion, Region.saint_martin]
+GROUP_2_LIST = [Region.mayotte]
+GROUP_3_LIST = [Region.saint_pierre_et_miquelon]
 EGALIM_OBJECTIVES = {
     "hexagone": {
-        "region_list": REGION_HEXAGONE_LIST
-        + [
-            Region.saint_barthelemy,
-            Region.terres_australes_et_antarctiques_francaises,
-            Region.wallis_et_futuna,
-            Region.polynesie_francaise,
-            Region.nouvelle_caledonie,
-            Region.ile_de_clipperton,
-        ],
+        "region_list": HEXAGONE_LIST,
         "bio_percent": 20,
         "egalim_percent": 50,
     },
     "groupe_1": {
-        "region_list": [Region.guadeloupe, Region.martinique, Region.guyane, Region.la_reunion, Region.saint_martin],
+        "region_list": GROUP_1_LIST,
         "bio_percent": 5,
         "egalim_percent": 20,
     },
-    "groupe_3": {"region_list": [Region.saint_pierre_et_miquelon], "bio_percent": 10, "egalim_percent": 30},
-    "groupe_2": {"region_list": [Region.mayotte], "bio_percent": 2, "egalim_percent": 5},
+    "groupe_3": {"region_list": GROUP_3_LIST, "bio_percent": 10, "egalim_percent": 30},
+    "groupe_2": {"region_list": GROUP_2_LIST, "bio_percent": 2, "egalim_percent": 5},
 }
 
 
 # TODO: prendre en compte les department, epci, pat & city_insee_code
 def get_egalim_group(region_list):
     if region_list and len(region_list):
+        # first check if one of the regions is in "hexagone"
+        if any(region in HEXAGONE_LIST for region in region_list):
+            return "hexagone"
+        # then check if one of the regions is in any of the other groups
         for group_name, details in EGALIM_OBJECTIVES.items():
             if any(region in details["region_list"] for region in region_list):
                 return group_name

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -48,6 +48,14 @@ EGALIM_OBJECTIVES = {
 }
 
 
+def get_egalim_group(region_list):
+    if region_list and len(region_list):
+        for group_name, details in EGALIM_OBJECTIVES.items():
+            if any(region in details["region_list"] for region in region_list):
+                return group_name
+    return "hexagone"  # default
+
+
 CAMPAIGN_DATES = {
     2021: {
         "teledeclaration_start_date": datetime(2022, 7, 16, 0, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")),


### PR DESCRIPTION
On avait déjà les objectifs EGalim dans les notes grâce à #5572
Et on a enrichi l'object EGALIM_OBJECTIVES avec les DROM dans #5589

Nouvelle méthode `get_egalim_group` pour obtenir le bon groupe en fonction de la région choisie.