### PR TITLE
feat(Observatoire): ajoute le graphique des secteurs

### DIFF
--- a/2024-frontend/src/components/GraphPie.vue
+++ b/2024-frontend/src/components/GraphPie.vue
@@ -2,7 +2,7 @@
 import { computed } from "vue"
 
 const props = defineProps(["percents", "legends"])
-const colors = ["#A94645", "#C3992A", "134CB6A", "#FFCA00", "#695240"]
+const colors = ["#A94645", "#C3992A", "#695240", "#FFCA00", "#34CB6A", "#FF9575", "#297254", "#CE614A"]
 
 const stats = computed(() => {
   const formattedStats = []
@@ -23,11 +23,13 @@ const stats = computed(() => {
 
 const background = computed(() => {
   const slices = []
+  let previousValue = 0
   for (let i = 0; i < stats.value.length; i++) {
-    const previousValue = i === 0 ? 0 : stats.value[i - 1].percent
     const currentValue = stats.value[i].percent
+    const nextValue = previousValue + currentValue
     const color = colors[i]
-    slices.push(`${color} ${previousValue}% ${previousValue + currentValue}%`)
+    slices.push(`${color} ${previousValue}% ${nextValue}%`)
+    previousValue = nextValue
   }
   return `conic-gradient(${slices.join(",")})`
 })

--- a/2024-frontend/src/components/GraphPie.vue
+++ b/2024-frontend/src/components/GraphPie.vue
@@ -37,7 +37,7 @@ const background = computed(() => {
 <template>
   <div class="graph-pie fr-mt-4w fr-mb-3w">
     <div class="graph-pie__circle" :style="`background: ${background}`"></div>
-    <div class="graph-pie__legends-container">
+    <div>
       <div v-for="stat in stats" :key="stat" class="fr-mb-2w">
         <p class="fr-h6 fr-mb-0">{{ stat.percent }}%</p>
         <p class="fr-mb-0">{{ stat.legend }}</p>
@@ -54,7 +54,6 @@ const background = computed(() => {
   align-items: flex-start;
 
   @media (min-width: 768px) {
-    align-items: center;
     flex-direction: row;
   }
 
@@ -64,12 +63,6 @@ const background = computed(() => {
     height: 10rem;
     border-radius: 100%;
     overflow: hidden;
-  }
-
-  &__legends-container {
-    @media (min-width: 768px) {
-      align-self: center;
-    }
   }
 }
 </style>

--- a/2024-frontend/src/components/ObservatoryCanteens.vue
+++ b/2024-frontend/src/components/ObservatoryCanteens.vue
@@ -3,6 +3,7 @@ import ObservatoryBadgeTitle from "@/components/ObservatoryBadgeTitle.vue"
 import ObservatoryGraphProductionType from "@/components/ObservatoryGraphProductionType.vue"
 import ObservatoryGraphEconomicModel from "@/components/ObservatoryGraphEconomicModel.vue"
 import ObservatoryGraphManagementType from "@/components/ObservatoryGraphManagementType.vue"
+import ObservatoryGraphSectors from "@/components/ObservatoryGraphSectors.vue"
 
 defineProps(["stats"])
 const canteenBadge = "/static/images/badges/canteen.svg"
@@ -28,6 +29,9 @@ const canteenBadge = "/static/images/badges/canteen.svg"
       </li>
       <li class="fr-col-12 fr-col-md-6 fr-mb-4w">
         <ObservatoryGraphManagementType :managementTypes="stats.managementTypes" :canteensCount="stats.canteenCount" />
+      </li>
+      <li class="fr-col-12 fr-col-md-6 fr-mb-4w">
+        <ObservatoryGraphSectors :sectorCategories="stats.sectorCategories" :canteensCount="stats.canteenCount" />
       </li>
     </ol>
   </div>

--- a/2024-frontend/src/components/ObservatoryGraphSectors.vue
+++ b/2024-frontend/src/components/ObservatoryGraphSectors.vue
@@ -1,0 +1,60 @@
+<script setup>
+import { computed } from "vue"
+import { useStoreFilters } from "@/stores/filters"
+import GraphPie from "@/components/GraphPie.vue"
+import GraphBase from "@/components/GraphBase.vue"
+import cantines from "@/data/cantines.json"
+
+const props = defineProps(["sectorCategories", "canteensCount"])
+const storeFilters = useStoreFilters()
+const title = "Segments de secteurs"
+
+/* Calculate graph props */
+const graph = computed(() => {
+  const sectorCategoriesName = Object.keys(props.sectorCategories)
+  const legends = []
+  const percents = []
+  for (let i = 0; i < sectorCategoriesName.length; i++) {
+    const sectorCategorie = sectorCategoriesName[i]
+    const isEmpty = props.sectorCategories[sectorCategorie] === 0
+    if (!isEmpty) {
+      const count = props.sectorCategories[sectorCategorie]
+      const percent = Math.round((count / props.canteensCount) * 100)
+      const canteen = count > 1 ? "cantines" : "cantine"
+      const type = cantines.sectorCategorie[sectorCategorie] || "Inconnu"
+      const legend = `${type} soit ${count} ${canteen}`
+      percents.push(percent)
+      legends.push(legend)
+    }
+  }
+  if (percents.length === 0) {
+    percents.push(100)
+    legends.push("Inconnu")
+  }
+  return {
+    legends,
+    percents,
+  }
+})
+
+/* Description */
+const getResultsDescription = () => {
+  const results = []
+  for (let i = 0; i < graph.value.percents.length; i++) {
+    results.push(`${graph.value.percents[i]}% ${graph.value.legends[i].toLocaleLowerCase()}`)
+  }
+  return results.join(", ")
+}
+const description = computed(() => {
+  const filters = storeFilters.getSelectionLabels()
+  const results = getResultsDescription()
+  return `Pour la recherche ${filters}, le pourcentage des cantines réparties par "${title}" est : ${results}.`
+})
+</script>
+
+<template>
+  <h3 class="fr-h6 fr-mb-2w">{{ title }}</h3>
+  <GraphBase :valuesToVerify="graph.percents" :description="description">
+    <GraphPie :percents="graph.percents" :legends="graph.legends" />
+  </GraphBase>
+</template>

--- a/2024-frontend/src/data/cantines.json
+++ b/2024-frontend/src/data/cantines.json
@@ -50,5 +50,14 @@
       "label": "Centrale et site",
       "value": "central_serving"
     }
-  ]
+  ],
+  "sectorCategorie": {
+    "administration": "Administration",
+    "autres": "Autres",
+    "education": "Enseignement",
+    "enterprise": "Entreprise",
+    "health": "Santé",
+    "leisure": "Loisirs",
+    "social": "Social / Médico-social"
+  }
 }


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/Frontend-graphique-typologie-de-cantine-232de24614be80bfaca9cafd85138b47

En attendant d'améliorer ce graphique avec les nouveaux chiffres de l'API on fait une première version en camembert.

<img width="634" height="771" alt="Capture d’écran 2025-08-08 à 14 07 44" src="https://github.com/user-attachments/assets/50f51c87-8ca9-4cfb-92a8-f56382b97f1d" />