### PR TITLE
refactor(Diagnostic): dupliquer (et adapter) les queryset depuis Teledeclaration vers Diagnostic (2/3) [1TD1Site]

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -74,6 +74,9 @@ class DiagnosticQuerySet(models.QuerySet):
         return self.teledeclared().in_year(year).in_campaign(year)
 
     def with_meal_price(self):
+        """
+        Le coût denrées est calculé en divisant la valeur d'achat alimentaire total par le nombre de repas annuels.
+        """
         return self.annotate(
             canteen_yearly_meal_count=Cast(KT("canteen_snapshot__yearly_meal_count"), output_field=IntegerField())
         ).annotate(
@@ -84,6 +87,14 @@ class DiagnosticQuerySet(models.QuerySet):
         )
 
     def exclude_aberrant_values(self):
+        """
+        Ici nous supprimons les TD dont les déclarations paraissent erronées et sont impactantes.
+        Sont supprimées, les TD dont :
+        - Valeur d'achat alimentaires > 1 million d'euros ET
+        - Coût denrées > 20 €
+        Dans le cas particulier où le nombre de repas annuel n'est pas renseigné,
+        nous laissons la TD même si la valeur alimentaire est > 1 million d'€)
+        """
         return self.with_meal_price().exclude(meal_price__gt=20, value_total_ht__gt=1000000)
 
     def publicly_visible(self):

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -55,7 +55,7 @@ class TeledeclarationQuerySet(models.QuerySet):
     def cancelled(self):
         return self.filter(status=Teledeclaration.TeledeclarationStatus.CANCELLED)
 
-    def aberrant_values(self):
+    def exclude_aberrant_values(self):
         return self.exclude(meal_price__gt=20, value_total_ht__gt=1000000)
 
     def in_year(self, year):
@@ -97,7 +97,7 @@ class TeledeclarationQuerySet(models.QuerySet):
                     value_bio_ht_agg__isnull=False,
                 )
                 .canteen_for_stat(year)  # Chaine de traitement n°6
-                .aberrant_values()  # Chaîne de traitement
+                .exclude_aberrant_values()  # Chaîne de traitement
             )
         else:
             return self.none()

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -74,13 +74,12 @@ class DiagnosticQuerySetTest(TestCase):
             year=year_data,
             creation_date=date_in_teledeclaration_campaign,
             canteen=cls.deleted_canteen,
-            value_total_ht=1000.00,
+            value_total_ht=1000001.00,  # aberrant
             value_bio_ht=200.00,
         )
         with freeze_time(date_in_teledeclaration_campaign):
             cls.deleted_canteen_diagnostic.teledeclare()
 
-    @freeze_time(date_in_teledeclaration_campaign)
     def test_teledeclared_for_year(self):
         teledeclarations = Diagnostic.objects.teledeclared_for_year(year_data)
         self.assertEqual(teledeclarations.count(), 6)
@@ -89,6 +88,11 @@ class DiagnosticQuerySetTest(TestCase):
         self.assertIn(self.deleted_canteen_diagnostic, teledeclarations)
         teledeclarations = Diagnostic.objects.teledeclared_for_year(year_data - 1)
         self.assertEqual(teledeclarations.count(), 4)
+
+    def test_aberrant_values(self):
+        self.assertEqual(Diagnostic.objects.count(), 10)
+        print(Diagnostic.objects.with_meal_price().first().__dict__)
+        self.assertEqual(Diagnostic.objects.aberrant_values().count(), 1)
 
     def test_publicly_visible(self):
         self.assertEqual(Diagnostic.objects.count(), 10)

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -20,7 +20,7 @@ class DiagnosticQuerySetTest(TestCase):
         cls.valid_canteen_3 = CanteenFactory(
             siret="12345678901235", siren_unite_legale="123456789", yearly_meal_count=100
         )
-        cls.valid_canteen_4 = CanteenFactory(siret="12345678901230", yearly_meal_count=0)
+        cls.valid_canteen_4 = CanteenFactory(siret="12345678901230", yearly_meal_count=0)  # not aberrant
         cls.valid_canteen_sat = CanteenFactory(
             siret="12345678901232", production_type=Canteen.ProductionType.ON_SITE_CENTRAL
         )
@@ -89,7 +89,7 @@ class DiagnosticQuerySetTest(TestCase):
             year=year_data,
             creation_date=date_in_teledeclaration_campaign,
             canteen=cls.deleted_canteen,
-            value_total_ht=1000001.00,  # aberrant
+            value_total_ht=1000001.00,  # aberrant (and meal_price > 20)
             value_bio_ht=200.00,
         )
         with freeze_time(date_in_teledeclaration_campaign):


### PR DESCRIPTION
suite de #5613

cette fois-ci on s'attaque à `aberrant_values`