### PR TITLE
refactor(Diagnostic): dupliquer (et adapter) les queryset depuis Teledeclaration vers Diagnostic (4/4) [1TD1Site]

### DIFF
--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -105,6 +105,21 @@ class DiagnosticQuerySetTest(TestCase):
         diagnostics = Diagnostic.objects.teledeclared_for_year(year_data - 1)
         self.assertEqual(diagnostics.count(), 4)
 
+    def test_valid_td_by_year(self):
+        diagnostics = Diagnostic.objects.valid_td_by_year(year_data)
+        self.assertEqual(diagnostics.count(), 5)
+        self.assertIn(self.valid_canteen_diagnostic_1, diagnostics)
+        self.assertNotIn(self.invalid_canteen_diagnostic, diagnostics)  # canteen without siret
+        self.assertNotIn(self.deleted_canteen_diagnostic, diagnostics)  # canteen deleted
+
+    def test_historical_valid_td(self):
+        diagnostics = Diagnostic.objects.historical_valid_td([year_data])
+        self.assertEqual(diagnostics.count(), 5)
+        diagnostics = Diagnostic.objects.historical_valid_td([year_data - 1])
+        self.assertEqual(diagnostics.count(), 4)
+        diagnostics = Diagnostic.objects.historical_valid_td([year_data, year_data - 1])
+        self.assertEqual(diagnostics.count(), 5 + 4)
+
     def test_with_meal_price(self):
         self.assertEqual(Diagnostic.objects.count(), 11)
         diagnostics = Diagnostic.objects.with_meal_price()

--- a/data/tests/test_teledeclaration.py
+++ b/data/tests/test_teledeclaration.py
@@ -128,7 +128,6 @@ class TeledeclarationQuerySetTest(TestCase):
         cls.canteen_sat_td.teledeclaration_mode = Teledeclaration.TeledeclarationMode.SATELLITE_WITHOUT_APPRO
         cls.canteen_sat_diagnostic.save()
 
-    @freeze_time("2025-03-30")
     def test_submitted_for_year(self):
         teledeclarations = Teledeclaration.objects.submitted_for_year(year_data)
         self.assertEqual(teledeclarations.count(), 8)
@@ -138,7 +137,6 @@ class TeledeclarationQuerySetTest(TestCase):
         teledeclarations = Teledeclaration.objects.submitted_for_year(year_data - 1)
         self.assertEqual(teledeclarations.count(), 4)
 
-    @freeze_time("2025-03-30")
     def test_valid_td_by_year(self):
         teledeclarations = Teledeclaration.objects.valid_td_by_year(year_data)
         self.assertEqual(teledeclarations.count(), 5)


### PR DESCRIPTION
- [x] `canteen_for_stat`
- [x] `valid_td_by_year` - grâce à #5636 (nouveau champ `Diagnostic.teledeclaration_mode`)
- [x] `historical_valid_td`

et basculé les tests aussi