### PR TITLE
fix(Diagnostic): autoriser seulement les bilans de l'année correspondant à la campagne de télédéclarer [1TD1site]

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1540,6 +1540,8 @@ class Diagnostic(models.Model):
         """
         if not is_in_teledeclaration_or_correction():
             raise ValidationError("Ce n'est pas possible de télédéclarer hors de la période de la campagne")
+        if not is_in_teledeclaration_or_correction(self.year):
+            raise ValidationError("Ce diagnostic n'est pas dans la bonne année de télédéclaration")
         if self.is_teledeclared:
             raise ValidationError("Ce diagnostic a déjà été télédéclaré")
         if not self.is_filled:
@@ -1583,6 +1585,8 @@ class Diagnostic(models.Model):
             raise ValidationError(
                 "Ce n'est pas possible d'annuler une télédéclaration hors de la période de la campagne"
             )
+        if not is_in_teledeclaration_or_correction(self.year):
+            raise ValidationError("Ce diagnostic n'est pas dans la bonne année de télédéclaration")
         if not self.is_teledeclared:
             raise ValidationError("Ce diagnostic doit avoir été télédéclaré")
 

--- a/macantine/tests/test_utils.py
+++ b/macantine/tests/test_utils.py
@@ -36,17 +36,46 @@ class TestCampaignDates(TestCase):
             self.assertFalse(is_in_correction())
             self.assertTrue(is_in_teledeclaration_or_correction())
 
+        with freeze_time("2025-03-30"):  # during the campaign
+            self.assertTrue(is_in_teledeclaration())
+            self.assertFalse(is_in_correction())
+            self.assertTrue(is_in_teledeclaration_or_correction())
+            # test a diagnostic with the correct year
+            self.assertTrue(is_in_teledeclaration(2024))
+            self.assertFalse(is_in_correction(2024))
+            self.assertTrue(is_in_teledeclaration_or_correction(2024))
+            # diagnostic in the future
+            self.assertFalse(is_in_teledeclaration(2025))
+            self.assertFalse(is_in_correction(2025))
+            self.assertFalse(is_in_teledeclaration_or_correction(2025))
+            # diagnostic in the past
+            self.assertFalse(is_in_teledeclaration(2023))
+            self.assertFalse(is_in_correction(2023))
+            self.assertFalse(is_in_teledeclaration_or_correction(2023))
+
         with freeze_time("2025-04-06"):  # last day of campaign
             self.assertTrue(is_in_teledeclaration())
             self.assertFalse(is_in_correction())
             self.assertTrue(is_in_teledeclaration_or_correction())
 
-        with freeze_time("2025-04-07"):  # after campaign
+        with freeze_time("2025-04-07"):  # after campaign (and not yet in correction)
             self.assertFalse(is_in_teledeclaration())
             self.assertFalse(is_in_correction())
             self.assertFalse(is_in_teledeclaration_or_correction())
 
-        with freeze_time("2025-04-20"):  # middle of correction campaign
+        with freeze_time("2025-04-20"):  # during the correction campaign
             self.assertFalse(is_in_teledeclaration())
             self.assertTrue(is_in_correction())
             self.assertTrue(is_in_teledeclaration_or_correction())
+            # test a diagnostic with the correct year
+            self.assertFalse(is_in_teledeclaration(2024))
+            self.assertTrue(is_in_correction(2024))
+            self.assertTrue(is_in_teledeclaration_or_correction(2024))
+            # diagnostic in the future
+            self.assertFalse(is_in_teledeclaration(2025))
+            self.assertFalse(is_in_correction(2025))
+            self.assertFalse(is_in_teledeclaration_or_correction(2025))
+            # diagnostic in the past
+            self.assertFalse(is_in_teledeclaration(2023))
+            self.assertFalse(is_in_correction(2023))
+            self.assertFalse(is_in_teledeclaration_or_correction(2023))

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -121,12 +121,16 @@ CAMPAIGN_DATES = {
 }
 
 
-def is_in_teledeclaration():
+def is_in_teledeclaration(year=None):
     """
-    Check if the current date is within the teledeclaration period.
+    Check if the current date is within a teledeclaration period.
+    If year is passed, double check that it corresponds to the current campaign year.
     """
     now = timezone.now()
     now_campaign_year = now.year - 1
+    if year is not None:
+        if year != now_campaign_year:
+            return False
     if now_campaign_year in CAMPAIGN_DATES:
         start_date = CAMPAIGN_DATES[now_campaign_year]["teledeclaration_start_date"]
         end_date = CAMPAIGN_DATES[now_campaign_year]["teledeclaration_end_date"]
@@ -134,12 +138,16 @@ def is_in_teledeclaration():
     return False
 
 
-def is_in_correction():
+def is_in_correction(year=None):
     """
-    Check if the current date is within the correction period.
+    Check if the current date is within a correction period.
+    If year is passed, double check that it corresponds to the current campaign year.
     """
     now = timezone.now()
     now_campaign_year = now.year - 1
+    if year is not None:
+        if year != now_campaign_year:
+            return False
     if now_campaign_year in CAMPAIGN_DATES:
         if "correction_start_date" in CAMPAIGN_DATES[now_campaign_year]:
             start_date = CAMPAIGN_DATES[now_campaign_year]["correction_start_date"]
@@ -148,11 +156,11 @@ def is_in_correction():
     return False
 
 
-def is_in_teledeclaration_or_correction():
+def is_in_teledeclaration_or_correction(year=None):
     """
     Check if the current date is within the teledeclaration or correction period.
     """
-    return is_in_teledeclaration() or is_in_correction()
+    return is_in_teledeclaration(year) or is_in_correction(year)
 
 
 def get_year_campaign_end_date_or_today_date(year):


### PR DESCRIPTION
Il y avait une "faille", un bilan d'une année passée pouvait être télédéclaré si c'était pendant une campagne de télédéclaration.
On rajoute donc un check sur l'année.