### PR TITLE
fix(Creation de cantine): changement url schemas imports

### DIFF
--- a/2024-frontend/src/services/schemas.js
+++ b/2024-frontend/src/services/schemas.js
@@ -1,5 +1,5 @@
 const getFields = async (schemaFile) => {
-  const url = `https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/charline-l/create-canteen-central-no-sectors/data/schemas/imports/${schemaFile}`
+  const url = `https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/staging/data/schemas/imports/${schemaFile}`
   return await fetch(url)
     .then((response) => response.json())
     .then((json) => json.fields)

--- a/api/views/canteenimport.py
+++ b/api/views/canteenimport.py
@@ -31,8 +31,12 @@ logger = logging.getLogger(__name__)
 
 CANTEEN_SCHEMA_FILE_PATH = "data/schemas/imports/cantines.json"
 CANTEEN_ADMIN_SCHEMA_FILE_PATH = "data/schemas/imports/cantines_admin.json"
-CANTEEN_SCHEMA_URL = f"https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/charline-l/create-canteen-central-no-sectors/{CANTEEN_SCHEMA_FILE_PATH}"
-CANTEEN_ADMIN_SCHEMA_URL = f"https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/charline-l/create-canteen-central-no-sectors/{CANTEEN_ADMIN_SCHEMA_FILE_PATH}"
+CANTEEN_SCHEMA_URL = (
+    f"https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/staging/{CANTEEN_SCHEMA_FILE_PATH}"
+)
+CANTEEN_ADMIN_SCHEMA_URL = (
+    f"https://raw.githubusercontent.com/betagouv/ma-cantine/refs/heads/staging/{CANTEEN_ADMIN_SCHEMA_FILE_PATH}"
+)
 
 
 class ImportCanteensView(APIView):


### PR DESCRIPTION
Suite [#5638](https://github.com/betagouv/ma-cantine/pull/5638)

Une fois la PR mergée il faut changer l'url des schemas d'imports