### PR TITLE
ci: enlève Quentin de la liste des auto-reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -5,7 +5,6 @@ addReviewers: true
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
-  - qloridant
   - raphodn
   - Charline-L
 


### PR DESCRIPTION
Suite au départ de @qloridant 