### PR TITLE
build(deps): Retour en arrière version incompatible avec django-vite-plugin

### DIFF
--- a/2024-frontend/package.json
+++ b/2024-frontend/package.json
@@ -32,7 +32,7 @@
     "eslint": "^9.32.0",
     "eslint-plugin-vue": "^9.33.0",
     "prettier": "^3.5.3",
-    "vite": "^7.1.3",
+    "vite": "^6.3.5",
     "vite-plugin-vue-devtools": "^7.7.6"
   }
 }


### PR DESCRIPTION
Issue : https://github.com/protibimbok/django-vite-plugin/issues/85