### PR TITLE
feat(Création de cantine): ajoute une description dans le sélecteur de mode de production pour les cuisines centrales

### DIFF
--- a/2024-frontend/src/components/CanteenEstablishmentForm.vue
+++ b/2024-frontend/src/components/CanteenEstablishmentForm.vue
@@ -8,6 +8,7 @@ import { useValidators } from "@/validators.js"
 import { formatError } from "@/utils.js"
 import sectorsService from "@/services/sectors"
 import openDataService from "@/services/openData.js"
+import arraysService from "@/services/arrays.js"
 import options from "@/constants/canteen-establishment-form-options"
 import CanteenEstablishmentSearch from "@/components/CanteenEstablishmentSearch.vue"
 
@@ -56,16 +57,16 @@ const selectEstablishment = (canteenInfos) => {
 /* Production type */
 const productionTypeOptions = computed(() => {
   const isDisabled = form.hasSiret === "no-siret"
-  const hint = isDisabled
+  const disabledHint = isDisabled
     ? "Ce mode de production n'est pas disponible pour les établissements rattachés à une unité légale"
-    : ""
-  const optionsWithDisabled = [...options.productionType]
+    : false
+  const optionsWithDisabled = arraysService.createCopy(options.productionType)
   const indexCentralType = optionsWithDisabled.findIndex((option) => option.value === "central")
   const indexCentralServingType = optionsWithDisabled.findIndex((option) => option.value === "central_serving")
   optionsWithDisabled[indexCentralType].disabled = isDisabled
-  optionsWithDisabled[indexCentralType].hint = hint
+  optionsWithDisabled[indexCentralType].hint = disabledHint || optionsWithDisabled[indexCentralType].hint
   optionsWithDisabled[indexCentralServingType].disabled = isDisabled
-  optionsWithDisabled[indexCentralServingType].hint = hint
+  optionsWithDisabled[indexCentralServingType].hint = disabledHint || optionsWithDisabled[indexCentralType].hint
   return optionsWithDisabled
 })
 

--- a/2024-frontend/src/constants/canteen-establishment-form-options.js
+++ b/2024-frontend/src/constants/canteen-establishment-form-options.js
@@ -35,9 +35,20 @@ const managementType = [
 
 const productionType = [
   { label: "Produit sur place les repas qu'il sert à ses convives", value: "site" },
-  { label: "Sert des repas préparés par un autre établissement", value: "site_cooked_elsewhere" },
-  { label: "Livre des repas mais n'a pas de lieu de service en propre", value: "central" },
-  { label: "Livre des repas et accueille aussi des convives sur place", value: "central_serving" },
+  {
+    label: "Sert des repas préparés par un autre établissement",
+    value: "site_cooked_elsewhere",
+  },
+  {
+    label: "Livre des repas mais n'a pas de lieu de service en propre",
+    value: "central",
+    hint: "Vous devrez ajouter vos satellites depuis votre tableau de bord",
+  },
+  {
+    label: "Livre des repas et accueille aussi des convives sur place",
+    value: "central_serving",
+    hint: "Vous devrez ajouter vos satellites depuis votre tableau de bord",
+  },
 ]
 
 export default {

--- a/2024-frontend/src/services/arrays.js
+++ b/2024-frontend/src/services/arrays.js
@@ -1,0 +1,5 @@
+const createCopy = (array) => {
+  return JSON.parse(JSON.stringify(array))
+}
+
+export default { createCopy }


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/Frontend-Ajout-d-une-description-pour-le-type-de-production-central-264de24614be8063865fd6be556eae11

|Avant|Après|
|--|--|
| <img width="410" height="169" alt="Capture d’écran 2025-09-04 à 18 22 16" src="https://github.com/user-attachments/assets/7e523678-8279-4181-8917-820631adfe58" /> | <img width="543" height="259" alt="Capture d’écran 2025-09-04 à 18 20 01" src="https://github.com/user-attachments/assets/7edd7bb3-efba-4f2d-adf5-6e58b54bb872" /> |
|Si SIREN garde une description "disabled"|  <img width="631" height="595" alt="Capture d’écran 2025-09-04 à 18 23 00" src="https://github.com/user-attachments/assets/261fb2a3-d032-4ece-9420-6dcfa4df6fb7" /> |
