### PR TITLE
feat(Télédéclaration): bloque la télédéclaration pour les cantines sites ayant plus de 3 secteurs

### DIFF
--- a/data/factories/canteen.py
+++ b/data/factories/canteen.py
@@ -25,7 +25,7 @@ class CanteenFactory(factory.django.DjangoModelFactory):
             for sector in extracted:
                 self.sectors.add(sector)
         else:
-            for _ in range(random.randint(1, 4)):
+            for _ in range(random.randint(1, 3)):
                 self.sectors.add(SectorFactory.create())
 
     @factory.post_generation

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -83,7 +83,7 @@ def has_missing_data_query():
         | Q(management_type=None)
         | Q(economic_model=None)
         # serving-specific rules (with annotate_with_sectors_count)
-        | (is_serving_query() & (Q(sectors__count__isnull=True) | Q(sectors__count__gt=3)))
+        | (is_serving_query() & (Q(sectors__count=0) | Q(sectors__count__gt=3)))
         # satellite-specific rules
         | (is_satellite_query() & has_charfield_missing_query("central_producer_siret"))
         | (is_satellite_query() & Q(central_producer_siret=F("siret")))

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -199,10 +199,14 @@ class CanteenQuerySet(SoftDeletionQuerySet):
         return self.filter(has_charfield_missing_query("city_insee_code"))
 
     def has_missing_data(self):
-        return self.annotate_with_requires_line_ministry().filter(has_missing_data_query())
+        return (
+            self.annotate_with_requires_line_ministry().annotate_with_sectors_count().filter(has_missing_data_query())
+        )
 
     def filled(self):
-        return self.annotate_with_requires_line_ministry().exclude(has_missing_data_query())
+        return (
+            self.annotate_with_requires_line_ministry().annotate_with_sectors_count().exclude(has_missing_data_query())
+        )
 
     def group_and_count_by_field(self, field):
         """

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -82,8 +82,8 @@ def has_missing_data_query():
         | Q(production_type=None)
         | Q(management_type=None)
         | Q(economic_model=None)
-        # serving-specific rules
-        | (is_serving_query() & (Q(sectors=None)))
+        # serving-specific rules (with annotate_with_sectors_count)
+        | (is_serving_query() & (Q(sectors__count__isnull=True) | Q(sectors__count__gt=3)))
         # satellite-specific rules
         | (is_satellite_query() & has_charfield_missing_query("central_producer_siret"))
         | (is_satellite_query() & Q(central_producer_siret=F("siret")))
@@ -183,6 +183,9 @@ class CanteenQuerySet(SoftDeletionQuerySet):
         )
         return self.annotate(requires_line_ministry=Exists(has_sector_requiring_line_ministry))
 
+    def annotate_with_sectors_count(self):
+        return self.annotate(Count("sectors"))
+
     def has_siret(self):
         return self.exclude(has_charfield_missing_query("siret"))
 
@@ -216,6 +219,7 @@ class CanteenQuerySet(SoftDeletionQuerySet):
 
         # prep missing data action
         self = self.annotate_with_requires_line_ministry()
+        self = self.annotate_with_sectors_count()
         # prep add satellites action
         self = self.annotate_with_satellites_in_db_count()
         self = self.annotate_with_central_kitchen_id()

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -597,6 +597,7 @@ export const missingCanteenData = (canteen, sectors) => {
 
   // sectors checks
   if (lineMinistryRequired(canteen, sectors) && !canteen.lineMinistry) return true
+  if (canteen.sectors && canteen.sectors.length > 3) return true
 
   // production type specific checks
   const yearlyMealCountKey = "yearlyMealCount"

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -123,6 +123,16 @@
                 Mettre à jour vos satellites
               </router-link>
             </li>
+            <li v-if="missingCanteenData" class="mb-1">
+              <router-link
+                :to="{
+                  name: 'GestionnaireCantineModifier',
+                  params: { canteenUrlComponent: $store.getters.getCanteenUrlComponent(canteen) },
+                }"
+              >
+                Mettre à jour votre établissement
+              </router-link>
+            </li>
             <li v-if="missingDeclarationMode">
               Choisir comment les données sont saisis pour vos satellites
             </li>


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/Teledeclaration-Bloquer-la-TD-si-plus-de-3-secteurs-sont-renseign-s-264de24614be807b8bccdfb6e377ad34?pvs=23


<img width="1282" height="658" alt="Capture d’écran 2025-09-08 à 23 10 39" src="https://github.com/user-attachments/assets/e3ae5221-93d9-4891-a85a-fbdf359ad48b" />