### PR TITLE
fix(Création de cantine): correction bug d'affichage du sélecteur de la cantine centrale

### DIFF
--- a/2024-frontend/src/components/CanteenEstablishmentCentralSelector.vue
+++ b/2024-frontend/src/components/CanteenEstablishmentCentralSelector.vue
@@ -30,7 +30,7 @@ const prefillFields = () => {
     }
   })
 }
-if (props.establishmentData.centralProducerSiret) prefillFields()
+if (props.establishmentData?.centralProducerSiret) prefillFields()
 else initFields()
 
 /* Search */


### PR DESCRIPTION
On vérifiait si une propriété de l'objet existait mais l'objet peut lui aussi être vide.