### PR TITLE
fix(Admin): permet de supprimer en rapidemment les cantines d'un gestionnaire

### DIFF
--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -216,7 +216,7 @@ class CanteenInline(admin.TabularInline):
         return True
 
     def has_delete_permission(self, request, obj=None):
-        return False
+        return True
 
     @admin.display(description="Gestionnaire")
     def help(self, obj):


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/Admin-django-l-action-group-pour-supprimer-un-utilisateur-de-ieurs-cantines-est-KO-273de24614be802389b8e14166320aaf
