### PR TITLE
improve(Diagnostics): API : une fois le diagnostic télédéclaré, le mettre en lecture-seule [1TD1Site]

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -3,7 +3,7 @@ from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from oauth2_provider.contrib.rest_framework.permissions import TokenHasResourceScope
 from rest_framework import permissions
 
-from data.models import Canteen, Diagnostic, Teledeclaration
+from data.models import Canteen
 
 
 class IsAuthenticated(permissions.IsAuthenticated):
@@ -73,23 +73,6 @@ class IsCanteenManagerUrlParam(permissions.BasePermission):
             return canteen.managers.filter(id=request.user.id).exists()
         except Canteen.DoesNotExist:
             return False
-
-
-class CanEditDiagnostic(permissions.BasePermission):
-    """
-    This is for actions only permitted by managers of
-    the diagnostic's canteen
-    """
-
-    def has_object_permission(self, request, view, obj):
-        if not isinstance(obj, Diagnostic):
-            return False
-        is_manager = obj.canteen.managers.filter(id=request.user.id).exists()
-        has_submitted_teledeclaration = (
-            obj.teledeclaration_set.filter(status=Teledeclaration.TeledeclarationStatus.SUBMITTED).count() > 0
-        )
-
-        return is_manager and not has_submitted_teledeclaration
 
 
 class IsLinkedCanteenManager(permissions.BasePermission):

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -129,6 +129,7 @@ class ManagerDiagnosticSerializer(DiagnosticSerializer):
                 self.fields.pop(field)
 
     def validate(self, data):
+        # TODO: move these rules to the model
         total = self.return_value(self, data, "value_total_ht")
         if total is not None and isinstance(total, Decimal):
             bio = self.return_value(self, data, "value_bio_ht")


### PR DESCRIPTION
suite de #5706

On adapte la logique API pour le basculement de Teledeclaration vers Diagnostic