### PR TITLE
refactor: ne plus utiliser d'imports relatifs dans le code

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -16,6 +16,7 @@ from .canteen import (  # noqa: F401
     MinimalCanteenSerializer,
     CanteenSummarySerializer,
     CanteenAnalysisSerializer,
+    CanteenManagerSerializer,
 )
 from .diagnostic import (  # noqa: F401
     ManagerDiagnosticSerializer,
@@ -36,7 +37,7 @@ from .diagnostic import (  # noqa: F401
 from .wastemeasurement import WasteMeasurementSerializer  # noqa: F401
 from .sector import SectorSerializer  # noqa: F401
 from .partnertype import PartnerTypeSerializer  # noqa: F401
-from .blogpost import BlogPostSerializer  # noqa: F401
+from .blogpost import BlogPostSerializer, BlogPostAuthorSerializer  # noqa: F401
 from .password import PasswordSerializer  # noqa: F401
 from .managerinvitation import ManagerInvitationSerializer  # noqa: F401
 from .teledeclaration import (  # noqa: F401

--- a/api/serializers/blogpost.py
+++ b/api/serializers/blogpost.py
@@ -1,12 +1,11 @@
 from rest_framework import serializers
 
+from api.serializers import BlogPostAuthorSerializer
 from data.models import BlogPost
-
-from .user import BlogPostAuthor
 
 
 class BlogPostSerializer(serializers.ModelSerializer):
-    author = BlogPostAuthor()
+    author = BlogPostAuthorSerializer()
     tags = serializers.SlugRelatedField(many=True, read_only=True, slug_field="name")
 
     class Meta:

--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -3,20 +3,19 @@ import logging
 from drf_base64.fields import Base64ImageField
 from rest_framework import serializers
 
-from data.models import Canteen, CanteenImage, Diagnostic, Sector
-
-from .diagnostic import (
+from api.serializers import (
     ApproDiagnosticSerializer,
+    CanteenManagerSerializer,
     CentralKitchenDiagnosticSerializer,
     FullDiagnosticSerializer,
+    ManagerInvitationSerializer,
     PublicApproDiagnosticSerializer,
     PublicDiagnosticSerializer,
     PublicServiceDiagnosticSerializer,
+    ResourceActionFullSerializer,
+    SectorSerializer,
 )
-from .managerinvitation import ManagerInvitationSerializer
-from .resourceaction import ResourceActionFullSerializer
-from .sector import SectorSerializer
-from .user import CanteenManagerSerializer
+from data.models import Canteen, CanteenImage, Diagnostic, Sector
 
 logger = logging.getLogger(__name__)
 

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -3,10 +3,9 @@ from decimal import Decimal, InvalidOperation
 
 from rest_framework import serializers
 
+from api.serializers import ShortTeledeclarationSerializer
+from api.serializers.utils import appro_to_percentages
 from data.models import Diagnostic
-
-from .teledeclaration import ShortTeledeclarationSerializer
-from .utils import appro_to_percentages
 
 logger = logging.getLogger(__name__)
 

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -1,9 +1,8 @@
 from drf_base64.fields import Base64FileField
 from rest_framework import serializers
 
+from api.serializers.utils import appro_to_percentages
 from data.models import Purchase
-
-from .utils import appro_to_percentages
 
 
 class PurchaseSerializer(serializers.ModelSerializer):

--- a/api/serializers/resourceaction.py
+++ b/api/serializers/resourceaction.py
@@ -28,11 +28,11 @@ class ResourceActionFullSerializer(ResourceActionSerializer):
         )
 
     def get_resource(self, obj):
-        from .wasteaction import WasteActionSerializer
+        from api.serializers import WasteActionSerializer
 
         return WasteActionSerializer(obj.resource).data
 
     def get_canteen(self, obj):
-        from .canteen import MinimalCanteenSerializer
+        from api.serializers import MinimalCanteenSerializer
 
         return MinimalCanteenSerializer(obj.canteen).data

--- a/api/serializers/user.py
+++ b/api/serializers/user.py
@@ -68,7 +68,7 @@ class CanteenManagerSerializer(serializers.ModelSerializer):
         )
 
 
-class BlogPostAuthor(serializers.ModelSerializer):
+class BlogPostAuthorSerializer(serializers.ModelSerializer):
     avatar = Base64ImageField(required=False, allow_null=True)
 
     class Meta:

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate, get_oauth2_token
 from data.factories import (
     CanteenFactory,
     DiagnosticFactory,
@@ -18,8 +19,6 @@ from data.factories import (
 )
 from data.models import Canteen, Diagnostic, Teledeclaration
 from data.utils import CreationSource
-
-from .utils import authenticate, get_oauth2_token
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -8,11 +8,10 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate, get_oauth2_token
 from data.factories import CanteenFactory, DiagnosticFactory, SectorFactory
 from data.models import Canteen, Diagnostic, Teledeclaration
 from data.utils import CreationSource
-
-from .utils import authenticate, get_oauth2_token
 
 
 class TestDiagnosticsApi(APITestCase):

--- a/api/tests/test_import_canteens.py
+++ b/api/tests/test_import_canteens.py
@@ -8,11 +8,10 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import SectorFactory, UserFactory
 from data.models import Canteen, ImportFailure, ImportType, ManagerInvitation
 from data.utils import CreationSource
-
-from .utils import authenticate
 
 
 class TestCanteenSchema(TestCase):

--- a/api/tests/test_import_diagnostics.py
+++ b/api/tests/test_import_diagnostics.py
@@ -13,6 +13,7 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from common.api.adresse import ADRESSE_CSV_API_URL
 from data.department_choices import Department
 from data.factories import CanteenFactory, DiagnosticFactory, SectorFactory, UserFactory
@@ -26,8 +27,6 @@ from data.models import (
 from data.models.teledeclaration import Teledeclaration
 from data.region_choices import Region
 from data.utils import CreationSource
-
-from .utils import authenticate
 
 NEXT_YEAR = datetime.date.today().year + 1
 

--- a/api/tests/test_import_purchases.py
+++ b/api/tests/test_import_purchases.py
@@ -13,12 +13,11 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import CanteenFactory
 from data.models import ImportFailure, ImportType
 from data.models.purchase import Purchase
 from data.utils import CreationSource
-
-from .utils import authenticate
 
 
 class TestPurchaseSchema(TestCase):

--- a/api/tests/test_initial_data.py
+++ b/api/tests/test_initial_data.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import (
     CanteenFactory,
     CommunityEventFactory,
@@ -14,8 +15,6 @@ from data.factories import (
     VideoTutorialFactory,
 )
 from data.models import Canteen
-
-from .utils import authenticate
 
 
 class TestInitialDataApi(APITestCase):

--- a/api/tests/test_inquiry.py
+++ b/api/tests/test_inquiry.py
@@ -4,10 +4,9 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories.canteen import CanteenFactory
 from data.factories.user import UserFactory
-
-from .utils import authenticate
 
 
 class TestInquiry(APITestCase):

--- a/api/tests/test_manager_invitations.py
+++ b/api/tests/test_manager_invitations.py
@@ -4,11 +4,10 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import CanteenFactory, UserFactory
 from data.factories.managerinvitation import ManagerInvitationFactory
 from data.models import ManagerInvitation
-
-from .utils import authenticate
 
 
 class TestManagerInvitationApi(APITestCase):

--- a/api/tests/test_messages.py
+++ b/api/tests/test_messages.py
@@ -3,10 +3,9 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import CanteenFactory
 from data.models import Message
-
-from .utils import authenticate
 
 
 @override_settings(CONTACT_EMAIL="contact@example.com")

--- a/api/tests/test_published_canteens.py
+++ b/api/tests/test_published_canteens.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import (
     CanteenFactory,
     DiagnosticFactory,
@@ -12,8 +13,6 @@ from data.factories import (
     UserFactory,
 )
 from data.models import Canteen, CanteenImage, Diagnostic, Teledeclaration
-
-from .utils import authenticate
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -3,6 +3,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import (
     CanteenFactory,
     DiagnosticFactory,
@@ -11,8 +12,6 @@ from data.factories import (
 )
 from data.models import Canteen, Diagnostic, Purchase
 from data.utils import CreationSource
-
-from .utils import authenticate
 
 
 class TestPurchaseApi(APITestCase):

--- a/api/tests/test_relation_central_satellite.py
+++ b/api/tests/test_relation_central_satellite.py
@@ -2,10 +2,9 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import CanteenFactory, SectorFactory, UserFactory
 from data.models import Canteen
-
-from .utils import authenticate
 
 
 class TestRelationCentralSatellite(APITestCase):

--- a/api/tests/test_reservation_expe.py
+++ b/api/tests/test_reservation_expe.py
@@ -2,10 +2,9 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import CanteenFactory, ReservationExpeFactory
 from data.models import ReservationExpe
-
-from .utils import authenticate
 
 
 class TestReservationExpeApi(APITestCase):

--- a/api/tests/test_reviews.py
+++ b/api/tests/test_reviews.py
@@ -2,10 +2,9 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import CanteenFactory, DiagnosticFactory, ReviewFactory
 from data.models import Review
-
-from .utils import authenticate
 
 
 class TestReviews(APITestCase):

--- a/api/tests/test_signals.py
+++ b/api/tests/test_signals.py
@@ -2,10 +2,9 @@ from django.urls import reverse
 from freezegun import freeze_time
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate, get_oauth2_token
 from data.factories import DiagnosticFactory
 from data.models import AuthenticationMethodHistoricalRecords
-
-from .utils import authenticate, get_oauth2_token
 
 
 @freeze_time("2022-08-30")  # during the 2021 campaign

--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from api.serializers.teledeclaration import TeledeclarationAnalysisSerializer
+from api.tests.utils import authenticate
 from data.factories import (
     CanteenFactory,
     DiagnosticFactory,
@@ -12,8 +13,6 @@ from data.factories import (
     UserFactory,
 )
 from data.models import Canteen, Diagnostic, Teledeclaration
-
-from .utils import authenticate
 
 
 class TestTeledeclarationCreateApi(APITestCase):

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -4,9 +4,8 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate, get_oauth2_token
 from data.factories import UserFactory
-
-from .utils import authenticate, get_oauth2_token
 
 
 class TestLoggedUserApi(APITestCase):

--- a/api/tests/test_vegetarian_expe.py
+++ b/api/tests/test_vegetarian_expe.py
@@ -2,10 +2,9 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import CanteenFactory, VegetarianExpeFactory
 from data.models import VegetarianExpe
-
-from .utils import authenticate
 
 
 class TestVegetarianExpeApi(APITestCase):

--- a/api/tests/test_waste_measurements.py
+++ b/api/tests/test_waste_measurements.py
@@ -6,10 +6,9 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import CanteenFactory, WasteMeasurementFactory
 from data.models import Canteen, WasteMeasurement
-
-from .utils import authenticate
 
 
 class TestWasteMeasurementsApi(APITestCase):

--- a/api/views/canteenimport.py
+++ b/api/views/canteenimport.py
@@ -16,15 +16,14 @@ from simple_history.utils import update_change_reason
 
 from api.permissions import IsAuthenticated
 from api.serializers import FullCanteenSerializer
+from api.views import AddManagerView
+from api.views.utils import camelize
 from common.api import validata
 from common.api.adresse import fetch_geo_data_from_code_csv
 from common.utils import file_import
 from common.utils.siret import normalise_siret
 from data.models import Canteen, ImportFailure, ImportType, Sector
 from data.utils import CreationSource
-
-from .canteen import AddManagerView
-from .utils import camelize
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/diagnosticimport.py
+++ b/api/views/diagnosticimport.py
@@ -18,6 +18,8 @@ from simple_history.utils import update_change_reason
 
 from api.permissions import IsAuthenticated
 from api.serializers import FullCanteenSerializer
+from api.views import AddManagerView
+from api.views.utils import camelize
 from common.api.adresse import fetch_geo_data_from_code_csv
 from common.utils import file_import
 from common.utils.siret import normalise_siret
@@ -25,9 +27,6 @@ from data.models import Canteen, ImportFailure, ImportType, Sector
 from data.models.diagnostic import Diagnostic
 from data.models.teledeclaration import Teledeclaration
 from data.utils import CreationSource
-
-from .canteen import AddManagerView
-from .utils import camelize
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/purchaseimport.py
+++ b/api/views/purchaseimport.py
@@ -15,13 +15,12 @@ from rest_framework.views import APIView
 
 from api.permissions import IsAuthenticated
 from api.serializers import PurchaseSerializer
+from api.views.utils import camelize
 from common.api import validata
 from common.utils import file_import
 from common.utils.siret import normalise_siret
 from data.models import Canteen, ImportFailure, ImportType, Purchase
 from data.utils import CreationSource
-
-from .utils import camelize
 
 logger = logging.getLogger(__name__)
 

--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -23,6 +23,7 @@ from api.serializers import (
     FullDiagnosticSerializer,
     TeledeclarationAnalysisSerializer,
 )
+from api.views.utils import camelize
 from data.models import Canteen, Diagnostic, Teledeclaration
 from macantine.utils import (
     CAMPAIGN_DATES,
@@ -30,8 +31,6 @@ from macantine.utils import (
     is_in_teledeclaration,
     is_in_teledeclaration_or_correction,
 )
-
-from .utils import camelize
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Tentative d'homogénéiser le code et d'arrêter les imports relatifs
- ca créé une ligne séparée dans les imports en haut
- on ne sait pas à quel fichier ca fait référence

Bon je ne touche pas à l'utilisation des imports dans __init__ ... ca viendra plus tard, faudra que je demande à une IA vu le taf que ca demandera haha