### PR TITLE
refactor(Open Data): indiquer explicitement les identifiants des jeux de données

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -174,16 +174,14 @@ ENABLE_WASTE_MEASUREMENTS= Optionnel - `True` pour rendre l'outil évaluation ga
 SHOW_MANAGEMENT_INFORMATION_BANNER= Optionnel - `True` pour afficher une bannière dans la page d'accueil du tableau de bord
 ```
 
-### Mise à jour des métadonnées sur data gouv
+### Mise à jour des métadonnées sur data.gouv.fr
 
 Nous gérons deux jeux de données sur data.gouv.fr, dont un jeu mis à jour régulièrement : le registre national des cantines.
-Afin que l'outil **explore** de data.gouv.fr lise les dernière données, il faut mettre à jour de façon factice l'URL qui pointe vers la ressource. Pour cela, il faut renseigner ces variables d'environnement :
+Afin que l'outil **explore** de data.gouv.fr lise les dernière données, il faut mettre à jour de façon factice l'URL qui pointe vers la ressource.
 
 ```
-DATAGOUV_DATASET_ID=<ID du dataset sur data.gouv.fr dont on souhaite mettre à jour les métadonnées. Le dataset est l'objet comprenant les différents fichiers (csv, xlsx...). Cet ID peut être trouvé via l'API de data.gouv.fr>
-DATAGOUV_API_KEY=<Clé d'API DataGouv d'un compte ayant les droits sur le jeu>
+DATAGOUV_API_KEY=<Clé d'API data.gouv.fr d'un compte ayant les droits sur les jeux>
 ```
-
 
 ### Création des tables / Migration de la base de données
 

--- a/macantine/etl/open_data.py
+++ b/macantine/etl/open_data.py
@@ -140,8 +140,7 @@ class OPEN_DATA(etl.TRANSFORMER_LOADER):
             self._load_data_parquet(filepath)
             self._load_data_xlsx(filepath)
 
-            dataset_id = os.getenv("DATAGOUV_DATASET_ID", "")
-            update_dataset_resources(dataset_id)
+            update_dataset_resources(self.datagouv_dataset_id)
         except Exception as e:
             logger.error(f"Error saving validated data: {e}")
 
@@ -150,6 +149,7 @@ class ETL_OPEN_DATA_CANTEEN(etl.EXTRACTOR, OPEN_DATA):
     def __init__(self):
         super().__init__()
         self.dataset_name = "registre_cantines"
+        self.datagouv_dataset_id = "registre-national-des-cantines"
         self.schema = json.load(open("data/schemas/export_opendata/schema_cantines.json"))
         self.schema_url = "https://raw.githubusercontent.com/betagouv/ma-cantine/staging/data/schemas/export_opendata/schema_cantines.json"
         self.columns = [field["name"] for field in self.schema["fields"]]
@@ -178,6 +178,7 @@ class ETL_OPEN_DATA_TELEDECLARATIONS(etl.EXTRACTOR, OPEN_DATA):
         self.years = [year]
         self.year = year
         self.dataset_name = f"campagne_td_{year}"
+        self.datagouv_dataset_id = "resultats-de-campagnes-de-teledeclaration-des-cantines"
         self.schema = json.load(open("data/schemas/export_opendata/schema_teledeclarations.json"))
         self.schema_url = "https://raw.githubusercontent.com/betagouv/ma-cantine/staging/data/schemas/export_opendata/schema_teledeclarations.json"
         self.view = TeledeclarationOpenDataListView


### PR DESCRIPTION
on jongle entre 2 jeux de données
donc pas de raison d'avoir une seule variable d'env
autant indiquer explicitement tout ca dans le code