### PR TITLE
fix(Celery): ajouter les paramètres manquant pour les exports

### DIFF
--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -404,6 +404,7 @@ def export_datasets(datasets: dict):
         etl.load_dataset()
 
 
+@app.task()
 def export_dataset_td_analysis():
     """
     Export the Teledeclaration datasets for analysis (Metabase)
@@ -415,6 +416,7 @@ def export_dataset_td_analysis():
     export_datasets(datasets)
 
 
+@app.task()
 def export_dataset_td_opendata():
     """
     Export the Teledeclaration datasets for opendata (data.gouv.fr) (1 per year)
@@ -430,6 +432,7 @@ def export_dataset_td_opendata():
     export_datasets(datasets)
 
 
+@app.task()
 def export_dataset_canteen_analysis():
     """
     Export the Canteen datasets for analysis (Metabase)
@@ -441,6 +444,7 @@ def export_dataset_canteen_analysis():
     export_datasets(datasets)
 
 
+@app.task()
 def export_dataset_canteen_opendata():
     """
     Export the Canteen datasets for opendata (data.gouv.fr)


### PR DESCRIPTION
Suite à #5699 j'ai oublié de mettre les `@app.task()` au-dessus :facepalm: 