### PR TITLE
refactor(Télédéclaration): supprime un serializer plus utilisé #1TD1Site

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -46,10 +46,9 @@ from .blogpost import BlogPostSerializer  # noqa: F401
 from .password import PasswordSerializer  # noqa: F401
 from .managerinvitation import ManagerInvitationSerializer  # noqa: F401
 from .teledeclaration import (  # noqa: F401
-    ShortTeledeclarationSerializer,
     CampaignDatesSerializer,
     CampaignDatesFullSerializer,
-)  # noqa: F401
+)
 from .purchase import (  # noqa: F401
     PurchaseSerializer,
     PurchaseSummarySerializer,

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -5,7 +5,6 @@ from rest_framework import serializers
 
 from data.models import Diagnostic
 
-from .teledeclaration import ShortTeledeclarationSerializer
 from .utils import appro_to_percentages
 
 logger = logging.getLogger(__name__)
@@ -153,8 +152,6 @@ class ManagerDiagnosticSerializer(DiagnosticSerializer):
 
 
 class FullDiagnosticSerializer(DiagnosticSerializer):
-    teledeclaration = ShortTeledeclarationSerializer(source="latest_submitted_teledeclaration")
-
     class Meta:
         model = Diagnostic
         fields = (

--- a/api/serializers/teledeclaration.py
+++ b/api/serializers/teledeclaration.py
@@ -1,19 +1,5 @@
 from rest_framework import serializers
 
-from data.models import Teledeclaration
-
-
-class ShortTeledeclarationSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Teledeclaration
-        fields = (
-            "id",
-            "creation_date",
-            "modification_date",
-            "status",
-        )
-        read_only_fields = fields
-
 
 class CampaignDatesSerializer(serializers.Serializer):
     year = serializers.IntegerField()

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1623,13 +1623,6 @@ class Diagnostic(models.Model):
         return None
 
     @property
-    def latest_submitted_teledeclaration(self):
-        submitted_teledeclarations = self.teledeclaration_set.submitted()
-        if submitted_teledeclarations.count() == 0:
-            return None
-        return submitted_teledeclarations.order_by("-creation_date").first()
-
-    @property
     def appro_badge(self) -> bool | None:
         total = self.valeur_totale
         if total:


### PR DESCRIPTION
Le serializer `ShortTeledeclarationSerializer` n'a plus l'air d'avoir d'utilité

A double check dans le frontend :eyes: 