### PR TITLE
improve(Metabase): exporter les TD générés [1TD1Site]

### DIFF
--- a/api/views/diagnostic_teledeclaration.py
+++ b/api/views/diagnostic_teledeclaration.py
@@ -313,8 +313,8 @@ class DiagnosticTeledeclaredAnalysisListView(ListAPIView):
 
     def get_queryset(self):
         return (
-            Diagnostic.objects.with_meal_price()
-            .valid_td_all_years(CAMPAIGN_DATES.keys())
+            Diagnostic.all_objects.with_meal_price()
+            .valid_td_site_all_years(CAMPAIGN_DATES.keys())
             .order_by("teledeclaration_date")
         )
 

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -168,8 +168,8 @@ class DiagnosticQuerySet(models.QuerySet):
     def teledeclared_site_for_year(self, year):
         """
         Only return site TDs
-        - exclude groupes (2025+)
-        - exclude central & central servings (2024 and before)
+        - before 2025: exclude central & central servings
+        - 2025: exclude groupes
         """
         return (
             self.teledeclared_for_year(year)

--- a/macantine/etl/analysis.py
+++ b/macantine/etl/analysis.py
@@ -65,7 +65,7 @@ class ETL_ANALYSIS_TELEDECLARATIONS(etl.EXTRACTOR, ANALYSIS):
         self.delete_duplicates_cc_csat()
         self.df = utils.filter_dataframe_with_schema_cols(self.df, self.schema)
 
-    def load_dataset(self, versionning=False):
+    def load_dataset(self, versionning=True):
         """
         Load in database with versionning. This function is called by a manually launched task
         """

--- a/macantine/management/commands/teledeclaration_generate_1td1site.py
+++ b/macantine/management/commands/teledeclaration_generate_1td1site.py
@@ -97,7 +97,7 @@ class Command(BaseCommand):
                 )
 
         # Done!
-        diagnostic_teledeclared_generated_qs = Diagnostic.objects.filter(
+        diagnostic_teledeclared_generated_qs = Diagnostic.all_objects.filter(
             generated_from_groupe_diagnostic=True, year=year
         )
         diagnostic_teledeclared_archived_qs = Diagnostic.objects.filter(

--- a/macantine/management/commands/teledeclaration_generate_1td1site.py
+++ b/macantine/management/commands/teledeclaration_generate_1td1site.py
@@ -155,7 +155,8 @@ def process_groupe_diagnostic_teledeclared(diagnostic, apply=False):
     if diagnostic.satellites_count:
         for satellite_dict in diagnostic.satellites_snapshot:
             create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, apply=apply)
-            archive_existing_diagnostic_teledeclared_satellite(satellite_dict, diagnostic.year, apply=apply)
+            archive_existing_diagnostic_teledeclared_satellite(diagnostic, satellite_dict, apply=apply)
+        update_diagnostic_teledeclared_creation_date(diagnostic, apply=apply)
 
 
 def create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, apply=False):
@@ -200,6 +201,7 @@ def create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, app
         setattr(diagnostic_satellite, field, updated_diagnostic_appro_fields[field])
 
     # change some last fields
+    # diagnostic_satellite.creation_date = diagnostic.teledeclaration_date  # won't work. see update_diagnostic_teledeclared_creation_date
     diagnostic_satellite.teledeclaration_mode = Diagnostic.TeledeclarationMode.SITE
     diagnostic_satellite.satellites_snapshot = None
     diagnostic_satellite.generated_from_groupe_diagnostic = True
@@ -213,18 +215,18 @@ def create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, app
             )
 
 
-def archive_existing_diagnostic_teledeclared_satellite(satellite_dict, year, apply=False):
+def archive_existing_diagnostic_teledeclared_satellite(diagnostic, satellite_dict, apply=False):
     """
     Some satellite canteens may already have a submitted diagnostic for the given year.
     How come? If they had teledeclared individually before being linked to the groupe.
     We need to archive these diagnostics, as they are now overridden by the one generated from their groupe's diagnostic.
     """
-    diagnostic_qs = Diagnostic.objects.teledeclared().filter(canteen__id=satellite_dict["id"], year=year)
+    diagnostic_qs = Diagnostic.objects.teledeclared().filter(canteen__id=satellite_dict["id"], year=diagnostic.year)
     if diagnostic_qs.count() == 0:
         return
     elif diagnostic_qs.count() > 1:
         logger.warning(
-            f"Task warning: Multiple diagnostics found for Canteen: {satellite_dict['id']} / Year: {year}. Only the first one will be archived."
+            f"Task warning: Multiple diagnostics found for Canteen: {satellite_dict['id']} / Year: {diagnostic.year}. Only the first one will be archived."
         )
     else:  # diagnostic_qs.count() == 1
         if apply:
@@ -235,3 +237,17 @@ def archive_existing_diagnostic_teledeclared_satellite(satellite_dict, year, app
                     function="array_append",
                 )
             )
+
+
+def update_diagnostic_teledeclared_creation_date(diagnostic, apply=False):
+    """
+    To keep the creation_date of the diagnostic of the satellite aligned with the one of the groupe, we update it with the teledeclaration_date of the groupe's diagnostic.
+    This way, if the groupe's diagnostic is created before the satellite teledeclares, the diagnostic of the satellite will have an older creation_date than its teledeclaration_date, which is coherent.
+    """
+    if apply:
+        diagnostic_qs = Diagnostic.all_objects.filter(
+            generated_from_groupe_diagnostic=True,
+            year=diagnostic.year,
+            teledeclaration_id=diagnostic.teledeclaration_id,
+        )
+        diagnostic_qs.update(creation_date=diagnostic.teledeclaration_date)

--- a/macantine/management/commands/teledeclaration_generate_1td1site.py
+++ b/macantine/management/commands/teledeclaration_generate_1td1site.py
@@ -23,9 +23,9 @@ class Command(BaseCommand):
     Notes:
     - groupe vs central:
         - before 2025, satellites were linked to CENTRAL & CENTRAL_SERVING
-        - in 2025, CENTRAL & CENTRAL_SERVING were migrated to GROUPE
+        - in 2025, satellites are now linked to GROUPE (CENTRAL & CENTRAL_SERVING were migrated)
     - appro values distribution:
-        - in 2024 (and before), we divide by the number of satellites
+        - before 2025, we divide by the number of satellites
         - in 2025, we divide by the yearly_meal_count
 
     Usage:
@@ -71,7 +71,7 @@ class Command(BaseCommand):
             Diagnostic.objects.teledeclared_for_year(year=year)
             .annotate(canteen_snapshot_production_type=F("canteen_snapshot__production_type"))
             .annotate(
-                satellites_count=Func(
+                satellites_count_annotated=Func(
                     "satellites_snapshot", function="jsonb_array_length", output_field=IntegerField()
                 )
             )
@@ -143,7 +143,7 @@ def cleanup_before_task(year, apply=False):
 
 def process_groupe_diagnostic_teledeclared(diagnostic, apply=False):
     """
-    2024 and before
+    before 2025
     - central & central_serving (very similar to groups)
     - except that each satellite will have the same appro values
     - no distinction between central and central serving (following macantine/management/commands/canteen_migrate_central_to_groupe.py)
@@ -152,7 +152,7 @@ def process_groupe_diagnostic_teledeclared(diagnostic, apply=False):
     - each satellite will have its own appro values based on its yearly_meal_count
     """
     # for each satellite, create a diagnostic (and archive any existing diagnostic)
-    if diagnostic.satellites_count:
+    if diagnostic.satellites_count_annotated:
         for satellite_dict in diagnostic.satellites_snapshot:
             create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, apply=apply)
             archive_existing_diagnostic_teledeclared_satellite(diagnostic, satellite_dict, apply=apply)

--- a/macantine/tests/test_teledeclaration_1td1site_2024.py
+++ b/macantine/tests/test_teledeclaration_1td1site_2024.py
@@ -431,6 +431,34 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
 
 class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
     @authenticate
+    def test_set_correct_creation_date(self):
+        """
+        The creation date of the generated diagnostics should be the date of the teledeclaration of the central diagnostic.
+        """
+        central = CanteenFactory(
+            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=420, daily_meal_count=3
+        )
+        satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
+        )
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            central_diagnostic = DiagnosticFactory(
+                canteen=central,
+                year=2024,
+                valeur_totale=10000,
+                valeur_bio=2000,
+            )
+            central_diagnostic.teledeclare(applicant=authenticate.user)
+
+        # Run the script
+        call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
+
+        # After the script is run
+        diagnostic_generated = Diagnostic.all_objects.in_year(2024).teledeclared().get(canteen=satellite)
+        self.assertEqual(diagnostic_generated.creation_date, central_diagnostic.teledeclaration_date)
+
+    @authenticate
     def test_empty_satellites_snapshot(self):
         """
         The satellites_snapshot should be empty for the generated diagnostics.

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -221,8 +221,8 @@ def set_satellite_common_fields_from_groupe_diagnostic(diagnostic, satellite_dic
     Generate a dict with common fields values for a satellite from a groupe diagnostic
 
     Rules:
-    - in 2024 (and before), we keep the group values for: geo data, sector_list, line_ministry.
-    We also change the yearly_meal_count (divided by the number of satellites)
+    - before 2025, we override the satellite with the groupe's values: geo data, sector_list, line_ministry. We also change the yearly_meal_count (divided by the number of satellites)
+    - in 2025, we stop overriding fields
     """
     from data.models import Canteen  # avoid circular import
 
@@ -243,10 +243,16 @@ def set_satellite_common_fields_from_groupe_diagnostic(diagnostic, satellite_dic
             "sector_list",
             "line_ministry",
         ]
-        for field in fields_overridden_by_groupe:
-            if field in diagnostic.canteen_snapshot:
-                updated_common_fields[field] = diagnostic.canteen_snapshot[field]
-        # yearly_meal_count
+    elif diagnostic.year == 2025:
+        fields_overridden_by_groupe = []
+
+    # build dict
+    for field in fields_overridden_by_groupe:
+        if field in diagnostic.canteen_snapshot:
+            updated_common_fields[field] = diagnostic.canteen_snapshot[field]
+
+    # yearly_meal_count (before 2025)
+    if diagnostic.year <= 2024:
         divisor = len(diagnostic.satellites_snapshot) if diagnostic.satellites_snapshot else 0
         try:
             updated_common_fields["yearly_meal_count"] = int(
@@ -268,7 +274,7 @@ def set_satellite_diagnostic_appro_values_from_groupe_diagnostic(diagnostic, sat
     - the other fields (WASTE_FIELDS, DIVERSIFICATION_FIELDS, PLASTIC_FIELDS, INFO_FIELDS) stay the same
 
     Rules:
-    - in 2024 (and before), we divide by the number of satellites
+    - before 2025, we divide by the number of satellites
     - in 2025, we divide by the yearly_meal_count
     """
     from data.models import Diagnostic  # avoid circular import
@@ -276,13 +282,13 @@ def set_satellite_diagnostic_appro_values_from_groupe_diagnostic(diagnostic, sat
     appro_fields_satellite = {}
 
     # get the divisor
-    if diagnostic.year == 2025:
-        divisor = satellite_dict.get("yearly_meal_count")
-    else:  # 2024 and before
+    if diagnostic.year <= 2024:
         divisor = len(diagnostic.satellites_snapshot) if diagnostic.satellites_snapshot else 0
         # no +1 for central_serving? we already added it in canteen_migrate_central_to_groupe.py
+    elif diagnostic.year == 2025:
+        divisor = satellite_dict.get("yearly_meal_count")
 
-    # divide values
+    # build dict
     for field in Diagnostic.APPRO_1TD1SITE_FIELDS:
         try:
             value = getattr(diagnostic, field) / divisor


### PR DESCRIPTION
Suite à #6468 (nouvelle queryset `Diagnostic.all_objects`)
On s'en sert dans la queryset des exports Metabase