### PR TITLE
improve(ETL): accélère le script pour basculer certaines tables brutes vers le Data Warehouse (Postgres COPY à la place de pandas)

### DIFF
--- a/macantine/etl/analysis.py
+++ b/macantine/etl/analysis.py
@@ -166,28 +166,27 @@ class ETL_ANALYSIS_DIAGNOSTIC_RAW(ANALYSIS):
     def __init__(self):
         super().__init__()
         self.warehouse = DataWareHouse()
-        self.dataset_name = "diagnostics_raw"
+        self.dataset_name = "diagnostics_raw_copy"
+        self.model = Diagnostic
 
     def extract_dataset(self):
         """
-        Load raw table into a dataframe.
+        Load raw table into a list of records.
         """
         start = time.time()
         queryset = Diagnostic.objects.all().values()
-        self.df = pd.DataFrame(list(queryset))
-        if self.df.empty:
-            logger.warning("Dataset is empty. Creating an empty dataframe")
+        self.records = list(queryset)
+        if not self.records:
+            logger.warning("Dataset is empty")
         end = time.time()
         logger.info(f"Time spent on raw teledeclaration extraction: {end - start:.2f} seconds")
 
     def transform_dataset(self):
-        """Convert array fields to JSON strings to avoid pandas to_sql type errors."""
-        logger.info("Converting array fields to JSON strings for safe export")
-        if not self.df.empty:
-            self.df = utils.arrays_to_json(self.df)
+        pass  # complex type serialization is handled inside insert_records
 
     def load_dataset(self):
-        super().load_dataset()
+        logger.info(f"Loading {len(self.records)} objects in db")
+        self.warehouse.insert_records(self.records, self.dataset_name, model=self.model)
 
 
 class ETL_ANALYSIS_CANTEEN(etl.EXTRACTOR, ANALYSIS):
@@ -223,29 +222,28 @@ class ETL_ANALYSIS_CANTEEN_RAW(ANALYSIS):
 
     def __init__(self):
         super().__init__()
-        self.dataset_name = "canteens_raw"
+        self.dataset_name = "canteens_raw_copy"
         self.warehouse = DataWareHouse()
+        self.model = Canteen
 
     def extract_dataset(self):
         """
-        Load raw table into a dataframe.
+        Load raw table into a list of records.
         """
         start = time.time()
         queryset = Canteen.all_objects.all().values()
-        self.df = pd.DataFrame(list(queryset))
-        if self.df.empty:
-            logger.warning("Dataset is empty. Creating an empty dataframe")
+        self.records = list(queryset)
+        if not self.records:
+            logger.warning("Dataset is empty")
         end = time.time()
         logger.info(f"Time spent on extraction: {end - start:.2f} seconds")
 
     def transform_dataset(self):
-        """Convert array fields to JSON strings to avoid pandas to_sql type errors."""
-        logger.info("Converting array fields to JSON strings for safe export")
-        if not self.df.empty:
-            self.df = utils.arrays_to_json(self.df)
+        pass  # complex type serialization is handled inside insert_records
 
     def load_dataset(self):
-        super().load_dataset()
+        logger.info(f"Loading {len(self.records)} objects in db")
+        self.warehouse.insert_records(self.records, self.dataset_name, model=self.model)
 
 
 class ETL_ANALYSIS_PURCHASE_RAW(ANALYSIS):
@@ -257,28 +255,27 @@ class ETL_ANALYSIS_PURCHASE_RAW(ANALYSIS):
     def __init__(self):
         super().__init__()
         self.warehouse = DataWareHouse()
-        self.dataset_name = "purchases_raw"
+        self.dataset_name = "purchases_raw_copy"
+        self.model = Purchase
 
     def extract_dataset(self):
         """
-        Load raw table into a dataframe.
+        Load raw table into a list of records.
         """
         start = time.time()
         queryset = Purchase.all_objects.all().values()
-        self.df = pd.DataFrame(list(queryset))
-        if self.df.empty:
-            logger.warning("Dataset is empty. Creating an empty dataframe")
+        self.records = list(queryset)
+        if not self.records:
+            logger.warning("Dataset is empty")
         end = time.time()
         logger.info(f"Time spent on raw purchase extraction: {end - start:.2f} seconds")
 
     def transform_dataset(self):
-        """Convert array fields to JSON strings to avoid pandas to_sql type errors."""
-        logger.info("Converting array fields to JSON strings for safe export")
-        if not self.df.empty:
-            self.df = utils.arrays_to_json(self.df)
+        pass  # complex type serialization is handled inside insert_records
 
     def load_dataset(self):
-        super().load_dataset()
+        logger.info(f"Loading {len(self.records)} objects in db")
+        self.warehouse.insert_records(self.records, self.dataset_name, model=self.model)
 
 
 class ETL_ANALYSIS_USER_RAW(ANALYSIS):
@@ -290,28 +287,27 @@ class ETL_ANALYSIS_USER_RAW(ANALYSIS):
     def __init__(self):
         super().__init__()
         self.warehouse = DataWareHouse()
-        self.dataset_name = "users_raw"
+        self.dataset_name = "users_raw_copy"
+        self.model = User
 
     def extract_dataset(self):
         """
-        Load raw table into a dataframe.
+        Load raw table into a list of records.
         """
         start = time.time()
         queryset = User.objects.all().values()
-        self.df = pd.DataFrame(list(queryset))
-        if self.df.empty:
-            logger.warning("Dataset is empty. Creating an empty dataframe")
+        self.records = list(queryset)
+        if not self.records:
+            logger.warning("Dataset is empty")
         end = time.time()
         logger.info(f"Time spent on raw user extraction: {end - start:.2f} seconds")
 
     def transform_dataset(self):
-        """Convert array fields to JSON strings to avoid pandas to_sql type errors."""
-        logger.info("Converting array fields to JSON strings for safe export")
-        if not self.df.empty:
-            self.df = utils.arrays_to_json(self.df)
+        pass  # complex type serialization is handled inside insert_records
 
     def load_dataset(self):
-        super().load_dataset()
+        logger.info(f"Loading {len(self.records)} objects in db")
+        self.warehouse.insert_records(self.records, self.dataset_name, model=self.model)
 
 
 class ETL_ANALYSIS_CANTEEN_MANAGER_RAW(ANALYSIS):
@@ -323,25 +319,24 @@ class ETL_ANALYSIS_CANTEEN_MANAGER_RAW(ANALYSIS):
     def __init__(self):
         super().__init__()
         self.warehouse = DataWareHouse()
-        self.dataset_name = "canteen_managers_raw"
+        self.dataset_name = "canteen_managers_raw_copy"
+        self.model = Canteen.managers.through
 
     def extract_dataset(self):
         """
-        Load raw table into a dataframe.
+        Load raw table into a list of records.
         """
         start = time.time()
         queryset = Canteen.managers.through.objects.values("canteen_id", "user_id")
-        self.df = pd.DataFrame(list(queryset))
-        if self.df.empty:
-            logger.warning("Dataset is empty. Creating an empty dataframe")
+        self.records = list(queryset)
+        if not self.records:
+            logger.warning("Dataset is empty")
         end = time.time()
         logger.info(f"Time spent on raw canteen manager extraction: {end - start:.2f} seconds")
 
     def transform_dataset(self):
-        """Convert array fields to JSON strings to avoid pandas to_sql type errors."""
-        logger.info("Converting array fields to JSON strings for safe export")
-        if not self.df.empty:
-            self.df = utils.arrays_to_json(self.df)
+        pass  # complex type serialization is handled inside insert_records
 
     def load_dataset(self):
-        super().load_dataset()
+        logger.info(f"Loading {len(self.records)} objects in db")
+        self.warehouse.insert_records(self.records, self.dataset_name, model=self.model)

--- a/macantine/etl/data_ware_house.py
+++ b/macantine/etl/data_ware_house.py
@@ -31,12 +31,15 @@ class DataWareHouse:
             echo=False,
         )
 
+    def read_dataframe(self, table_name):
+        return pd.read_sql(sql=table_name, index_col="id", con=self.engine)
+
     def insert_dataframe(self, dataframe, table, dtype=None):
         start = time.time()
         dataframe.to_sql(
             name=table,
             con=self.engine,
-            if_exists="delete_rows",
+            if_exists="delete_rows",  # "replace" (drops and recreates the table)
             index=False,
             dtype=dtype,
             chunksize=1000,
@@ -159,6 +162,3 @@ class DataWareHouse:
 
         end = time.time()
         logger.info(f"Inserted {len(records)} rows into table {table} in {end - start:.2f} seconds")
-
-    def read_dataframe(self, table_name):
-        return pd.read_sql(sql=table_name, index_col="id", con=self.engine)

--- a/macantine/etl/data_ware_house.py
+++ b/macantine/etl/data_ware_house.py
@@ -1,8 +1,14 @@
 import logging
 import os
 import time
+from datetime import date, datetime
+from decimal import Decimal
+from io import StringIO
+from uuid import UUID
 
 import pandas as pd
+from django.contrib.postgres.fields import ArrayField
+from django.db import models
 from dotenv import load_dotenv
 from sqlalchemy import URL, create_engine
 
@@ -38,6 +44,121 @@ class DataWareHouse:
         )
         end = time.time()
         logger.info(f"Inserted {len(dataframe)} rows into table {table} in {end - start:.2f} seconds")
+
+    def insert_records(self, records: list, table: str, model):
+        """
+        Bulk-insert a list of dicts into a warehouse table using PostgreSQL text COPY.
+        The table is created if missing, then truncated before each load.
+        SQL types are derived from Django model field metadata.
+        """
+        import json
+
+        if not records:
+            logger.warning(f"No records to insert into {table}")
+            return
+
+        if model is None:
+            raise ValueError("insert_records requires a Django model to determine SQL column types")
+
+        start = time.time()
+        columns = list(records[0].keys())
+
+        def _field_to_pg_type(field):
+            if isinstance(field, models.BooleanField):
+                return "BOOLEAN"
+            if isinstance(field, (models.SmallIntegerField, models.IntegerField, models.BigIntegerField)):
+                return "BIGINT"
+            if isinstance(field, (models.FloatField, models.DecimalField)):
+                return "DOUBLE PRECISION"
+            if isinstance(field, (models.DateTimeField,)):
+                return "TIMESTAMPTZ"
+            if isinstance(field, (models.DateField,)):
+                return "DATE"
+            if isinstance(field, (models.TimeField,)):
+                return "TIME"
+            if isinstance(field, (models.UUIDField,)):
+                return "UUID"
+            if isinstance(field, (models.JSONField,)):
+                return "TEXT"
+            if isinstance(field, ArrayField):
+                return "TEXT"
+            if isinstance(field, (models.BinaryField,)):
+                return "BYTEA"
+            if isinstance(
+                field, (models.CharField, models.TextField, models.EmailField, models.URLField, models.SlugField)
+            ):
+                return "TEXT"
+            return "TEXT"
+
+        field_map = {field.name: field for field in model._meta.get_fields() if hasattr(field, "attname")}
+        attname_map = {field.attname: field for field in model._meta.get_fields() if hasattr(field, "attname")}
+        col_types = {}
+        for col in columns:
+            field = field_map.get(col) or attname_map.get(col)
+            col_types[col] = _field_to_pg_type(field) if field is not None else "TEXT"
+
+        def _serialize(val):
+            if val is None:
+                return None
+            if isinstance(val, (list, dict)):
+                return json.dumps(val, default=str)
+            if isinstance(val, bytes):
+                return f"\\x{val.hex()}"
+            if isinstance(val, UUID):
+                return str(val)
+            if isinstance(val, Decimal):
+                return float(val)
+            if isinstance(val, (datetime, date)):
+                return val.isoformat()
+            return str(val)
+
+        buffer = StringIO()
+        for record in records:
+            row = []
+            for col in columns:
+                value = _serialize(record[col])
+                if value is None:
+                    row.append(r"\N")
+                    continue
+                text = str(value)
+                text = text.replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n").replace("\r", "\\r")
+                row.append(text)
+            buffer.write("\t".join(row) + "\n")
+        buffer.seek(0)
+
+        raw_conn = self.engine.raw_connection()
+        try:
+            cur = raw_conn.cursor()
+            col_defs = ", ".join(f'"{col}" {col_types[col]}' for col in columns)
+            # CREATE TABLE IF NOT EXISTS preserves dbt metadata (views, grants, etc.) on the table.
+            # Caveat: if the Django model gains new columns, they won't appear here until the table
+            # is manually altered or dropped. TRUNCATE clears rows without dropping the table.
+            cur.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS "{table}" ({col_defs});
+                """
+            )
+
+            # Keep table identity for dbt, but ensure it can store current extract types.
+            # This widens existing columns when needed and adds newly introduced columns.
+            for col in columns:
+                pg_type = col_types[col]
+                cur.execute(f'ALTER TABLE "{table}" ADD COLUMN IF NOT EXISTS "{col}" {pg_type}')
+                cur.execute(f'ALTER TABLE "{table}" ALTER COLUMN "{col}" TYPE {pg_type} USING "{col}"::{pg_type}')
+
+            cur.execute(f'TRUNCATE TABLE "{table}"')
+
+            quoted_columns = ", ".join(f'"{col}"' for col in columns)
+            cur.copy_expert(
+                sql=f'COPY "{table}" ({quoted_columns}) FROM STDIN WITH (FORMAT text)',
+                file=buffer,
+            )
+            raw_conn.commit()
+        finally:
+            raw_conn.close()
+
+        end = time.time()
+        logger.info(f"Inserted {len(records)} rows into table {table} in {end - start:.2f} seconds")
 
     def read_dataframe(self, table_name):
         return pd.read_sql(sql=table_name, index_col="id", con=self.engine)


### PR DESCRIPTION
Suite de #6427

Cela concerne la commande suivante
```
python manage.py export_dataset --model Raw --destination analysis
```
- 4 datasets d'exportés actuellement
- pandas prend 133 secondes (test en local)
- Postgres COPY prend 33 secondes (local)
- pgcopy prend 43 secondes (local)

### Contraintes

- ne plus dépendre de pandas (load tout en mémoire, passe par l'objet DataFrame, lent)
- ne pas dropper les tables à chaque lancement, car dbt a besoin de garder une persistence (relations)
- utilser au maximum le modèle Django existant (simplifier la serialization avant envoi)
- pouvoir à terme rajouter une étape de sanitization/anonymization

### Workflow

Django queryset --> values / list --> serialization (règles en fonction du type) --> SQL

### Postgres COPY

- pas de lib
- raw `COPY`

### pgcopy (essayé, abandonné)

https://github.com/altaurog/pgcopy/releases/tag/2.0a1
- versions précédentes j'avais des soucis sur l'install avec psycopg2
- utilise postgresql `COPY` under the hood