### PR TITLE
feat(Observatoire): brancher 1TD1Site pour 2025

### DIFF
--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -8,6 +8,7 @@ from rest_framework.test import APITestCase
 from common.cache.utils import CACHE_GET_QUERY_COUNT, CACHE_SET_QUERY_COUNT
 from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 from data.models import Canteen, Diagnostic, Sector, SectorCategory
+from macantine.tests.test_etl_common import setUpTestData as ETLCommonSetUpTestData
 
 year_data = 2023
 date_in_2023_teledeclaration_campaign = "2024-04-01"  # during the 2023 campaign
@@ -558,37 +559,52 @@ class CanteenStatsApiTest(APITestCase):
 class CanteenStats1Td1SiteApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        with freeze_time(date_in_2023_teledeclaration_campaign):
-            groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
-            CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
-            CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
-            diagnostic = DiagnosticFactory(canteen=groupe, year=2023, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE)
-            diagnostic.teledeclare(applicant=UserFactory())
-            # Create a fake diagnostic for 2023 generated
-            fake_satellite_generated = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
-            fake_satellite_generated_diagnostic = DiagnosticFactory(
-                year=2023, canteen=fake_satellite_generated, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
-            )
-            fake_satellite_generated_diagnostic.teledeclare(applicant=UserFactory())
-            fake_satellite_generated_diagnostic.generated_from_groupe_diagnostic = True
-            fake_satellite_generated_diagnostic.save()
+        ETLCommonSetUpTestData(cls)
+        # with freeze_time(date_in_2023_teledeclaration_campaign):
+        #     groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        #     CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
+        #     CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
+        #     diagnostic = DiagnosticFactory(canteen=groupe, year=2023, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE)
+        #     diagnostic.teledeclare(applicant=UserFactory())
+        #     # Create a fake diagnostic for 2023 generated
+        #     fake_satellite_generated = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
+        #     fake_satellite_generated_diagnostic = DiagnosticFactory(
+        #         year=2023, canteen=fake_satellite_generated, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        #     )
+        #     fake_satellite_generated_diagnostic.teledeclare(applicant=UserFactory())
+        #     fake_satellite_generated_diagnostic.generated_from_groupe_diagnostic = True
+        #     fake_satellite_generated_diagnostic.save()
 
-        with freeze_time("2025-03-30"):  # during the 2024 campaign
-            diagnostic = DiagnosticFactory(canteen=groupe, year=2024, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE)
-            diagnostic.teledeclare(applicant=UserFactory())
+        # with freeze_time("2025-03-30"):  # during the 2024 campaign
+        #     diagnostic = DiagnosticFactory(canteen=groupe, year=2024, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE)
+        #     diagnostic.teledeclare(applicant=UserFactory())
 
+        call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
+        call_command("teledeclaration_generate_1td1site", year=2023, apply=True)
+
+    def test_user_1td1site_diagnostics_for_2025(self):
+        self.assertEqual(Diagnostic.all_objects.teledeclared_for_year(2025), 1 + 1)
+
+        response = self.client.get(reverse("canteen_statistics"), {"year": 2025})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["canteenCount"], 4)  # groupe ignored
+        self.assertEqual(body["teledeclarationsCount"], 2)  # 2 satellites
 
     def test_use_1td1site_diagnostics_for_2024(self):
         response = self.client.get(reverse("canteen_statistics"), {"year": 2024})
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(body["canteenCount"], 3)  # groupe ignored
+        self.assertEqual(body["canteenCount"], 4)  # groupe ignored
         self.assertEqual(body["teledeclarationsCount"], 2)  # 2 satellites
 
     def test_not_use_1td1site_diagnostics_for_2023(self):
         response = self.client.get(reverse("canteen_statistics"), {"year": 2023})
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(body["canteenCount"], 3)  # groupe ignored
+        self.assertEqual(body["canteenCount"], 4)  # groupe ignored
         self.assertEqual(body["teledeclarationsCount"], 1)  # groupe

--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -559,52 +559,38 @@ class CanteenStatsApiTest(APITestCase):
 class CanteenStats1Td1SiteApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        ETLCommonSetUpTestData(cls)
-        # with freeze_time(date_in_2023_teledeclaration_campaign):
-        #     groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
-        #     CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
-        #     CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
-        #     diagnostic = DiagnosticFactory(canteen=groupe, year=2023, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE)
-        #     diagnostic.teledeclare(applicant=UserFactory())
-        #     # Create a fake diagnostic for 2023 generated
-        #     fake_satellite_generated = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL)
-        #     fake_satellite_generated_diagnostic = DiagnosticFactory(
-        #         year=2023, canteen=fake_satellite_generated, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
-        #     )
-        #     fake_satellite_generated_diagnostic.teledeclare(applicant=UserFactory())
-        #     fake_satellite_generated_diagnostic.generated_from_groupe_diagnostic = True
-        #     fake_satellite_generated_diagnostic.save()
-
-        # with freeze_time("2025-03-30"):  # during the 2024 campaign
-        #     diagnostic = DiagnosticFactory(canteen=groupe, year=2024, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE)
-        #     diagnostic.teledeclare(applicant=UserFactory())
+        ETLCommonSetUpTestData(cls, with_diagnostics=True)
 
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
         call_command("teledeclaration_generate_1td1site", year=2023, apply=True)
 
     def test_user_1td1site_diagnostics_for_2025(self):
-        self.assertEqual(Diagnostic.all_objects.teledeclared_for_year(2025), 1 + 1)
+        self.assertEqual(Diagnostic.objects.teledeclared_for_year(2025).count(), 1)  # 1 groupe
+        self.assertEqual(Diagnostic.all_objects.teledeclared_for_year(2025).count(), 1 + 1)
 
         response = self.client.get(reverse("canteen_statistics"), {"year": 2025})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(body["canteenCount"], 4)  # groupe ignored
-        self.assertEqual(body["teledeclarationsCount"], 2)  # 2 satellites
+        self.assertEqual(body["teledeclarationsCount"], 1)  # 1 groupe with 1 satellite
 
     def test_use_1td1site_diagnostics_for_2024(self):
+        self.assertEqual(Diagnostic.objects.teledeclared_for_year(2024).count(), 3)  # 1 groupe + 2 sites
+        self.assertEqual(Diagnostic.all_objects.teledeclared_for_year(2024).count(), 3 + 1)
+
         response = self.client.get(reverse("canteen_statistics"), {"year": 2024})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(body["canteenCount"], 4)  # groupe ignored
-        self.assertEqual(body["teledeclarationsCount"], 2)  # 2 satellites
+        self.assertEqual(body["teledeclarationsCount"], 2 + 1)  # 1 groupe with 2 satellites + 2 sites
 
     def test_not_use_1td1site_diagnostics_for_2023(self):
+        self.assertEqual(Diagnostic.objects.teledeclared_for_year(2023).count(), 2)  # 1 groupe + 1 site (1 armée)
+        self.assertEqual(Diagnostic.all_objects.teledeclared_for_year(2023).count(), 2 + 1)
+
         response = self.client.get(reverse("canteen_statistics"), {"year": 2023})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(body["canteenCount"], 4)  # groupe ignored
-        self.assertEqual(body["teledeclarationsCount"], 1)  # groupe
+        self.assertEqual(body["teledeclarationsCount"], 1)  # 1 groupe

--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -566,27 +566,38 @@ class CanteenStats1Td1SiteApiTest(APITestCase):
         call_command("teledeclaration_generate_1td1site", year=2023, apply=True)
 
     def test_user_1td1site_diagnostics_for_2025(self):
-        self.assertEqual(Diagnostic.objects.teledeclared_for_year(2025).count(), 1)  # 1 groupe
+        """
+        - 1 groupe teledeclared (has 1 satellite)
+        """
+        self.assertEqual(Diagnostic.objects.teledeclared_for_year(2025).count(), 1)
         self.assertEqual(Diagnostic.all_objects.teledeclared_for_year(2025).count(), 1 + 1)
 
         response = self.client.get(reverse("canteen_statistics"), {"year": 2025})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(body["teledeclarationsCount"], 1)  # 1 groupe with 1 satellite
+        self.assertEqual(body["teledeclarationsCount"], 1)  # 1 satellite
 
     def test_use_1td1site_diagnostics_for_2024(self):
-        self.assertEqual(Diagnostic.objects.teledeclared_for_year(2024).count(), 3)  # 1 groupe + 2 sites
+        """
+        - 1 groupe teledeclared (has 1 satellite)
+        - 2 sites teledeclared
+        """
+        self.assertEqual(Diagnostic.objects.teledeclared_for_year(2024).count(), 3)
         self.assertEqual(Diagnostic.all_objects.teledeclared_for_year(2024).count(), 3 + 1)
 
         response = self.client.get(reverse("canteen_statistics"), {"year": 2024})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(body["teledeclarationsCount"], 2 + 1)  # 1 groupe with 2 satellites + 2 sites
+        self.assertEqual(body["teledeclarationsCount"], 3)  # 1 satellite + 2 sites
 
     def test_not_use_1td1site_diagnostics_for_2023(self):
-        self.assertEqual(Diagnostic.objects.teledeclared_for_year(2023).count(), 2)  # 1 groupe + 1 site (1 armée)
+        """
+        - 1 groupe teledeclared (has 1 satellite)
+        - 1 site teledeclared (armée)
+        """
+        self.assertEqual(Diagnostic.objects.teledeclared_for_year(2023).count(), 2)
         self.assertEqual(Diagnostic.all_objects.teledeclared_for_year(2023).count(), 2 + 1)
 
         response = self.client.get(reverse("canteen_statistics"), {"year": 2023})

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -226,7 +226,7 @@ class DiagnosticQuerySet(models.QuerySet):
     def valid_td_site_by_year(self, year):
         year = int(year)
         if year in CAMPAIGN_DATES.keys():
-            if year in [2024]:
+            if year in [2024, 2025]:
                 return self.teledeclared_site_for_year(year).filter(
                     has_arrayfield_missing_query("invalid_reason_list")
                 )

--- a/macantine/tests/test_etl_analysis.py
+++ b/macantine/tests/test_etl_analysis.py
@@ -95,14 +95,14 @@ class TeledeclarationETLAnalysisTest(TestCase):
 
     def test_teledeclaration_extract(self):
         # all years combined
-        # 2022: 3 teledeclarations (1 groupe with 1 satellite)
-        # 2023: 1 teledeclaration (1 is cancelled, 1 armee)
-        # 2024: 2 teledeclarations
-        # 2025: 1 teledeclaration
+        # 2022: 3 teledeclarations: 1 groupe with 1 satellite + 2 sites
+        # 2023: 2 teledeclarations: 1 groupe with 1 satellite + 1 site (1 armee, 1 cancelled)
+        # 2024: 3 teledeclarations: 1 groupe with 1 satellite + 2 sites
+        # 2025: 1 teledeclaration: 1 groupe with 1 satellite
         etl_td = ETL_ANALYSIS_TELEDECLARATIONS()
         etl_td.extract_dataset()
 
-        self.assertEqual(etl_td.len_dataset(), 3 + 1 + 2 + 1)
+        self.assertEqual(etl_td.len_dataset(), 3 + 2 + 3 + 1)
         self.assertEqual(
             etl_td.df.iloc[0]["id"], self.canteen_site_earlier_diagnostic_2022.teledeclaration_id
         )  # Order by teledeclaration created date ascending

--- a/macantine/tests/test_etl_common.py
+++ b/macantine/tests/test_etl_common.py
@@ -13,81 +13,83 @@ def setUpTestData(cls, with_diagnostics=False):
     cls.canteen_site_manager_1 = UserFactory(email="gestionnaire1@example.com")
     cls.canteen_site_manager_2 = UserFactory(email="gestionnaire2@example.com")
     cls.canteen_groupe_manager = UserFactory()
-    cls.canteen_site = CanteenFactory(
-        name="Cantine",
-        siret="21380185500015",
-        city_insee_code="38185",
-        epci="200040715",
-        epci_lib="Grenoble-Alpes-Métropole",
-        pat_list=["1294", "1295"],
-        pat_lib_list=[
-            "PAT du Département de l'Isère",
-            "Projet Alimentaire inter Territorial de la Grande région grenobloise",
-        ],
-        department="38",
-        department_lib="Isère",
-        region="84",
-        region_lib="Auvergne-Rhône-Alpes",
-        management_type=Canteen.ManagementType.DIRECT,
-        production_type=Canteen.ProductionType.ON_SITE,
-        economic_model=Canteen.EconomicModel.PUBLIC,
-        sector_list=[Sector.SANTE_HOPITAL, Sector.SOCIAL_CRECHE],
-        declaration_donnees_2022=True,
-        declaration_donnees_2023=False,
-        declaration_donnees_2024=True,
-        declaration_donnees_2025=False,
-        managers=[cls.canteen_site_manager_1, cls.canteen_site_manager_2],
-    )
-    cls.canteen_site_without_manager = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[])
-    cls.canteen_site_earlier = CanteenFactory(
-        production_type=Canteen.ProductionType.ON_SITE,
-        management_type=Canteen.ManagementType.DIRECT,
-        economic_model=Canteen.EconomicModel.PUBLIC,
-        sector_list=[Sector.EDUCATION_SUPERIEUR_UNIVERSITAIRE],
-        line_ministry=Canteen.Ministries.ENSEIGNEMENT_SUPERIEUR,
-        managers=[cls.canteen_site_manager_2],
-        # creation_date=timezone.now() - timezone.timedelta(days=10),
-    )
-    Canteen.objects.filter(id=cls.canteen_site_earlier.id).update(
-        creation_date=timezone.now() - timezone.timedelta(days=10)
-    )
-    cls.canteen_site_deleted = CanteenFactory(
-        production_type=Canteen.ProductionType.ON_SITE,
-        deletion_date=timezone.now(),
-    )
-    cls.canteen_site_armee = CanteenFactory(
-        production_type=Canteen.ProductionType.ON_SITE,
-        management_type=Canteen.ManagementType.DIRECT,
-        economic_model=Canteen.EconomicModel.PUBLIC,
-        sector_list=[Sector.ADMINISTRATION_PRISON],
-        line_ministry=Canteen.Ministries.ARMEE,
-        managers=[cls.canteen_site_manager_2],
-    )
-    cls.canteen_groupe = CanteenFactory(
-        production_type=Canteen.ProductionType.GROUPE,
-        management_type=Canteen.ManagementType.CONCEDED,
-        managers=[cls.canteen_groupe_manager],
-    )
-    cls.canteen_satellite = CanteenFactory(
-        production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
-        management_type=Canteen.ManagementType.DIRECT,
-        economic_model=Canteen.EconomicModel.PUBLIC,
-        groupe=cls.canteen_groupe,
-        central_producer_siret="22730656663081",
-        city_insee_code="38185",
-        epci="200040715",
-        epci_lib="Grenoble-Alpes-Métropole",
-        pat_list=["1294", "1295"],
-        pat_lib_list=[
-            "PAT du Département de l'Isère",
-            "Projet Alimentaire inter Territorial de la Grande région grenobloise",
-        ],
-        department="38",
-        department_lib="Isère",
-        region="84",
-        region_lib="Auvergne-Rhône-Alpes",
-        sector_list=[Sector.EDUCATION_PRIMAIRE],
-    )
+
+    with freeze_time("2023-05-14"):  # during the 2022 campaign
+        cls.canteen_site = CanteenFactory(
+            name="Cantine",
+            siret="21380185500015",
+            city_insee_code="38185",
+            epci="200040715",
+            epci_lib="Grenoble-Alpes-Métropole",
+            pat_list=["1294", "1295"],
+            pat_lib_list=[
+                "PAT du Département de l'Isère",
+                "Projet Alimentaire inter Territorial de la Grande région grenobloise",
+            ],
+            department="38",
+            department_lib="Isère",
+            region="84",
+            region_lib="Auvergne-Rhône-Alpes",
+            management_type=Canteen.ManagementType.DIRECT,
+            production_type=Canteen.ProductionType.ON_SITE,
+            economic_model=Canteen.EconomicModel.PUBLIC,
+            sector_list=[Sector.SANTE_HOPITAL, Sector.SOCIAL_CRECHE],
+            declaration_donnees_2022=True,
+            declaration_donnees_2023=False,
+            declaration_donnees_2024=True,
+            declaration_donnees_2025=False,
+            managers=[cls.canteen_site_manager_1, cls.canteen_site_manager_2],
+        )
+        cls.canteen_site_without_manager = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[])
+        cls.canteen_site_earlier = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE,
+            management_type=Canteen.ManagementType.DIRECT,
+            economic_model=Canteen.EconomicModel.PUBLIC,
+            sector_list=[Sector.EDUCATION_SUPERIEUR_UNIVERSITAIRE],
+            line_ministry=Canteen.Ministries.ENSEIGNEMENT_SUPERIEUR,
+            managers=[cls.canteen_site_manager_2],
+            # creation_date=timezone.now() - timezone.timedelta(days=10),
+        )
+        Canteen.objects.filter(id=cls.canteen_site_earlier.id).update(
+            creation_date=timezone.now() - timezone.timedelta(days=10)
+        )
+        cls.canteen_site_deleted = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE,
+            deletion_date=timezone.now(),
+        )
+        cls.canteen_site_armee = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE,
+            management_type=Canteen.ManagementType.DIRECT,
+            economic_model=Canteen.EconomicModel.PUBLIC,
+            sector_list=[Sector.ADMINISTRATION_PRISON],
+            line_ministry=Canteen.Ministries.ARMEE,
+            managers=[cls.canteen_site_manager_2],
+        )
+        cls.canteen_groupe = CanteenFactory(
+            production_type=Canteen.ProductionType.GROUPE,
+            management_type=Canteen.ManagementType.CONCEDED,
+            managers=[cls.canteen_groupe_manager],
+        )
+        cls.canteen_satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+            management_type=Canteen.ManagementType.DIRECT,
+            economic_model=Canteen.EconomicModel.PUBLIC,
+            groupe=cls.canteen_groupe,
+            central_producer_siret="22730656663081",
+            city_insee_code="38185",
+            epci="200040715",
+            epci_lib="Grenoble-Alpes-Métropole",
+            pat_list=["1294", "1295"],
+            pat_lib_list=[
+                "PAT du Département de l'Isère",
+                "Projet Alimentaire inter Territorial de la Grande région grenobloise",
+            ],
+            department="38",
+            department_lib="Isère",
+            region="84",
+            region_lib="Auvergne-Rhône-Alpes",
+            sector_list=[Sector.EDUCATION_PRIMAIRE],
+        )
 
     if with_diagnostics:
         with freeze_time("2023-05-14"):  # during the 2022 campaign

--- a/macantine/tests/test_etl_common.py
+++ b/macantine/tests/test_etl_common.py
@@ -14,84 +14,84 @@ def setUpTestData(cls, with_diagnostics=False):
     cls.canteen_site_manager_2 = UserFactory(email="gestionnaire2@example.com")
     cls.canteen_groupe_manager = UserFactory()
 
-    with freeze_time("2023-05-14"):  # during the 2022 campaign
-        cls.canteen_site = CanteenFactory(
-            name="Cantine",
-            siret="21380185500015",
-            city_insee_code="38185",
-            epci="200040715",
-            epci_lib="Grenoble-Alpes-Métropole",
-            pat_list=["1294", "1295"],
-            pat_lib_list=[
-                "PAT du Département de l'Isère",
-                "Projet Alimentaire inter Territorial de la Grande région grenobloise",
-            ],
-            department="38",
-            department_lib="Isère",
-            region="84",
-            region_lib="Auvergne-Rhône-Alpes",
-            management_type=Canteen.ManagementType.DIRECT,
-            production_type=Canteen.ProductionType.ON_SITE,
-            economic_model=Canteen.EconomicModel.PUBLIC,
-            sector_list=[Sector.SANTE_HOPITAL, Sector.SOCIAL_CRECHE],
-            declaration_donnees_2022=True,
-            declaration_donnees_2023=False,
-            declaration_donnees_2024=True,
-            declaration_donnees_2025=False,
-            managers=[cls.canteen_site_manager_1, cls.canteen_site_manager_2],
-        )
-        cls.canteen_site_without_manager = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[])
-        cls.canteen_site_earlier = CanteenFactory(
-            production_type=Canteen.ProductionType.ON_SITE,
-            management_type=Canteen.ManagementType.DIRECT,
-            economic_model=Canteen.EconomicModel.PUBLIC,
-            sector_list=[Sector.EDUCATION_SUPERIEUR_UNIVERSITAIRE],
-            line_ministry=Canteen.Ministries.ENSEIGNEMENT_SUPERIEUR,
-            managers=[cls.canteen_site_manager_2],
-            # creation_date=timezone.now() - timezone.timedelta(days=10),
-        )
-        Canteen.objects.filter(id=cls.canteen_site_earlier.id).update(
-            creation_date=timezone.now() - timezone.timedelta(days=10)
-        )
-        cls.canteen_site_deleted = CanteenFactory(
-            production_type=Canteen.ProductionType.ON_SITE,
-            deletion_date=timezone.now(),
-        )
-        cls.canteen_site_armee = CanteenFactory(
-            production_type=Canteen.ProductionType.ON_SITE,
-            management_type=Canteen.ManagementType.DIRECT,
-            economic_model=Canteen.EconomicModel.PUBLIC,
-            sector_list=[Sector.ADMINISTRATION_PRISON],
-            line_ministry=Canteen.Ministries.ARMEE,
-            managers=[cls.canteen_site_manager_2],
-        )
-        cls.canteen_groupe = CanteenFactory(
-            production_type=Canteen.ProductionType.GROUPE,
-            management_type=Canteen.ManagementType.CONCEDED,
-            managers=[cls.canteen_groupe_manager],
-        )
-        cls.canteen_satellite = CanteenFactory(
-            production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
-            management_type=Canteen.ManagementType.DIRECT,
-            economic_model=Canteen.EconomicModel.PUBLIC,
-            groupe=cls.canteen_groupe,
-            central_producer_siret="22730656663081",
-            city_insee_code="38185",
-            epci="200040715",
-            epci_lib="Grenoble-Alpes-Métropole",
-            pat_list=["1294", "1295"],
-            pat_lib_list=[
-                "PAT du Département de l'Isère",
-                "Projet Alimentaire inter Territorial de la Grande région grenobloise",
-            ],
-            department="38",
-            department_lib="Isère",
-            region="84",
-            region_lib="Auvergne-Rhône-Alpes",
-            sector_list=[Sector.EDUCATION_PRIMAIRE],
-        )
+    cls.canteen_site = CanteenFactory(
+        name="Cantine",
+        siret="21380185500015",
+        city_insee_code="38185",
+        epci="200040715",
+        epci_lib="Grenoble-Alpes-Métropole",
+        pat_list=["1294", "1295"],
+        pat_lib_list=[
+            "PAT du Département de l'Isère",
+            "Projet Alimentaire inter Territorial de la Grande région grenobloise",
+        ],
+        department="38",
+        department_lib="Isère",
+        region="84",
+        region_lib="Auvergne-Rhône-Alpes",
+        management_type=Canteen.ManagementType.DIRECT,
+        production_type=Canteen.ProductionType.ON_SITE,
+        economic_model=Canteen.EconomicModel.PUBLIC,
+        sector_list=[Sector.SANTE_HOPITAL, Sector.SOCIAL_CRECHE],
+        declaration_donnees_2022=True,
+        declaration_donnees_2023=False,
+        declaration_donnees_2024=True,
+        declaration_donnees_2025=False,
+        managers=[cls.canteen_site_manager_1, cls.canteen_site_manager_2],
+    )
+    cls.canteen_site_without_manager = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[])
+    cls.canteen_site_earlier = CanteenFactory(
+        production_type=Canteen.ProductionType.ON_SITE,
+        management_type=Canteen.ManagementType.DIRECT,
+        economic_model=Canteen.EconomicModel.PUBLIC,
+        sector_list=[Sector.EDUCATION_SUPERIEUR_UNIVERSITAIRE],
+        line_ministry=Canteen.Ministries.ENSEIGNEMENT_SUPERIEUR,
+        managers=[cls.canteen_site_manager_2],
+        # creation_date=timezone.now() - timezone.timedelta(days=10),
+    )
+    Canteen.objects.filter(id=cls.canteen_site_earlier.id).update(
+        creation_date=timezone.now() - timezone.timedelta(days=10)
+    )
+    cls.canteen_site_deleted = CanteenFactory(
+        production_type=Canteen.ProductionType.ON_SITE,
+        deletion_date=timezone.now(),
+    )
+    cls.canteen_site_armee = CanteenFactory(
+        production_type=Canteen.ProductionType.ON_SITE,
+        management_type=Canteen.ManagementType.DIRECT,
+        economic_model=Canteen.EconomicModel.PUBLIC,
+        sector_list=[Sector.ADMINISTRATION_PRISON],
+        line_ministry=Canteen.Ministries.ARMEE,
+        managers=[cls.canteen_site_manager_2],
+    )
+    cls.canteen_groupe = CanteenFactory(
+        production_type=Canteen.ProductionType.GROUPE,
+        management_type=Canteen.ManagementType.CONCEDED,
+        managers=[cls.canteen_groupe_manager],
+    )
+    cls.canteen_satellite = CanteenFactory(
+        production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+        management_type=Canteen.ManagementType.DIRECT,
+        economic_model=Canteen.EconomicModel.PUBLIC,
+        groupe=cls.canteen_groupe,
+        central_producer_siret="22730656663081",
+        city_insee_code="38185",
+        epci="200040715",
+        epci_lib="Grenoble-Alpes-Métropole",
+        pat_list=["1294", "1295"],
+        pat_lib_list=[
+            "PAT du Département de l'Isère",
+            "Projet Alimentaire inter Territorial de la Grande région grenobloise",
+        ],
+        department="38",
+        department_lib="Isère",
+        region="84",
+        region_lib="Auvergne-Rhône-Alpes",
+        sector_list=[Sector.EDUCATION_PRIMAIRE],
+    )
 
     if with_diagnostics:
+        # 2022 campaign
         with freeze_time("2023-05-14"):  # during the 2022 campaign
             cls.canteen_site_diagnostic_2022 = DiagnosticFactory(
                 canteen=cls.canteen_site,
@@ -114,7 +114,13 @@ def setUpTestData(cls, with_diagnostics=False):
                 canteen=cls.canteen_groupe, year=2022, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
             )
             cls.canteen_groupe_diagnostic_2022.teledeclare(cls.canteen_groupe_manager)
+
+        # 2023 campaign
         with freeze_time("2024-04-01"):  # during the 2023 campaign
+            cls.canteen_groupe_diagnostic_2023 = DiagnosticFactory(
+                canteen=cls.canteen_groupe, year=2023, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+            )
+            cls.canteen_groupe_diagnostic_2023.teledeclare(cls.canteen_groupe_manager)
             cls.canteen_site_diagnostic_2023 = DiagnosticFactory(
                 canteen=cls.canteen_site,
                 year=2023,
@@ -130,7 +136,13 @@ def setUpTestData(cls, with_diagnostics=False):
                 canteen=cls.canteen_site_armee, year=2023, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
             )
             cls.canteen_site_armee_diagnostic_2023.teledeclare(cls.canteen_site_manager_2)
+
+        # 2024 campaign
         with freeze_time("2025-03-30"):  # during the 2024 campaign
+            cls.canteen_groupe_diagnostic_2024 = DiagnosticFactory(
+                canteen=cls.canteen_groupe, year=2024, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+            )
+            cls.canteen_groupe_diagnostic_2024.teledeclare(cls.canteen_groupe_manager)
             cls.canteen_site_earlier_diagnostic_2024 = DiagnosticFactory(
                 canteen=cls.canteen_site_earlier, year=2024, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
             )
@@ -146,6 +158,8 @@ def setUpTestData(cls, with_diagnostics=False):
                 valeur_egalim_autres=200,
             )
             cls.canteen_site_diagnostic_2024.teledeclare(cls.canteen_site_manager_1)
+
+        # 2025 campaign
         with freeze_time("2026-01-30"):  # during the 2025 campaign
             cls.canteen_groupe_diagnostic_2025 = DiagnosticFactory(
                 canteen=cls.canteen_groupe, year=2025, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -131,21 +131,21 @@ class TeledeclarationETLOpenDataTest(TestCase):
             etl_td_2022.df.iloc[0]["id"], self.canteen_site_earlier_diagnostic_2022.teledeclaration_id
         )  # Order by teledeclaration created date ascending
 
-        # 2023: 1 teledeclaration (1 is cancelled, 1 is hidden (armee))
+        # 2023: 2 teledeclarations (1 groupe, 1 is cancelled, 1 is hidden (armee))
         etl_td_2023 = ETL_OPEN_DATA_TELEDECLARATIONS(2023)
         etl_td_2023.extract_dataset()
 
-        self.assertEqual(Diagnostic.objects.filter(year=2023).count(), 2)
-        self.assertEqual(Diagnostic.objects.filter(year=2023).teledeclared().count(), 1)
-        self.assertEqual(etl_td_2023.len_dataset(), 0)
+        self.assertEqual(Diagnostic.objects.filter(year=2023).count(), 3)
+        self.assertEqual(Diagnostic.objects.filter(year=2023).teledeclared().count(), 2)
+        self.assertEqual(etl_td_2023.len_dataset(), 1)
 
-        # 2024: 2 teledeclaratios
+        # 2024: 3 teledeclarations
         etl_td_2024 = ETL_OPEN_DATA_TELEDECLARATIONS(2024)
         etl_td_2024.extract_dataset()
 
-        self.assertEqual(Diagnostic.objects.filter(year=2024).count(), 2)
-        self.assertEqual(Diagnostic.objects.filter(year=2024).teledeclared().count(), 2)
-        self.assertEqual(etl_td_2024.len_dataset(), 2)
+        self.assertEqual(Diagnostic.objects.filter(year=2024).count(), 3)
+        self.assertEqual(Diagnostic.objects.filter(year=2024).teledeclared().count(), 3)
+        self.assertEqual(etl_td_2024.len_dataset(), 3)
 
         # 2025: 1 teledeclaration (1 groupe) (TODO after 1TD1Site: remove groupe and split data by satellite)
         etl_td_2025 = ETL_OPEN_DATA_TELEDECLARATIONS(2025)
@@ -171,7 +171,7 @@ class TeledeclarationETLOpenDataTest(TestCase):
         # Check the schema matching
         self.assertEqual(len(etl_td_2024.df.columns), len(schema_cols))
         self.assertEqual(set(etl_td_2024.df.columns), set(schema_cols))
-        self.assertEqual(etl_td_2024.len_dataset(), 2)
+        self.assertEqual(etl_td_2024.len_dataset(), 3)
 
         canteen_site_earlier_diagnostic_2024 = etl_td_2024.df[
             etl_td_2024.df.canteen_id == self.canteen_site_earlier.id


### PR DESCRIPTION
Similaire à #6472 (brancher 1td1site sur 2024)
mais ici pour 2025

J'ai enrichi les tests de ETLCommonSetUpTestData au passage, pour m'en servir dans `test_canteen_statistics`

PR Frontend : #6622