### PR TITLE
fix(1TD1Site): ajuste le creation_date (= teledeclaration_date du groupe)

### DIFF
--- a/macantine/management/commands/teledeclaration_generate_1td1site.py
+++ b/macantine/management/commands/teledeclaration_generate_1td1site.py
@@ -97,7 +97,7 @@ class Command(BaseCommand):
                 )
 
         # Done!
-        diagnostic_teledeclared_generated_qs = Diagnostic.objects.filter(
+        diagnostic_teledeclared_generated_qs = Diagnostic.all_objects.filter(
             generated_from_groupe_diagnostic=True, year=year
         )
         diagnostic_teledeclared_archived_qs = Diagnostic.objects.filter(

--- a/macantine/management/commands/teledeclaration_generate_1td1site.py
+++ b/macantine/management/commands/teledeclaration_generate_1td1site.py
@@ -156,7 +156,7 @@ def process_groupe_diagnostic_teledeclared(diagnostic, apply=False):
         for satellite_dict in diagnostic.satellites_snapshot:
             create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, apply=apply)
             archive_existing_diagnostic_teledeclared_satellite(diagnostic, satellite_dict, apply=apply)
-        update_diagnostic_teledeclared_creation_date(diagnostic, apply=apply)
+        update_generated_diagnostic_teledeclared_creation_date(diagnostic, apply=apply)
 
 
 def create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, apply=False):
@@ -201,7 +201,7 @@ def create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, app
         setattr(diagnostic_satellite, field, updated_diagnostic_appro_fields[field])
 
     # change some last fields
-    # diagnostic_satellite.creation_date = diagnostic.teledeclaration_date  # won't work. see update_diagnostic_teledeclared_creation_date
+    # diagnostic_satellite.creation_date = diagnostic.teledeclaration_date  # won't work. see update_generated_diagnostic_teledeclared_creation_date
     diagnostic_satellite.teledeclaration_mode = Diagnostic.TeledeclarationMode.SITE
     diagnostic_satellite.satellites_snapshot = None
     diagnostic_satellite.generated_from_groupe_diagnostic = True
@@ -239,7 +239,7 @@ def archive_existing_diagnostic_teledeclared_satellite(diagnostic, satellite_dic
             )
 
 
-def update_diagnostic_teledeclared_creation_date(diagnostic, apply=False):
+def update_generated_diagnostic_teledeclared_creation_date(diagnostic, apply=False):
     """
     To keep the creation_date of the diagnostic of the satellite aligned with the one of the groupe, we update it with the teledeclaration_date of the groupe's diagnostic.
     This way, if the groupe's diagnostic is created before the satellite teledeclares, the diagnostic of the satellite will have an older creation_date than its teledeclaration_date, which is coherent.

--- a/macantine/management/commands/teledeclaration_generate_1td1site.py
+++ b/macantine/management/commands/teledeclaration_generate_1td1site.py
@@ -155,7 +155,8 @@ def process_groupe_diagnostic_teledeclared(diagnostic, apply=False):
     if diagnostic.satellites_count:
         for satellite_dict in diagnostic.satellites_snapshot:
             create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, apply=apply)
-            archive_existing_diagnostic_teledeclared_satellite(satellite_dict, diagnostic.year, apply=apply)
+            archive_existing_diagnostic_teledeclared_satellite(diagnostic, satellite_dict, apply=apply)
+        update_diagnostic_teledeclared_creation_date(diagnostic, apply=apply)
 
 
 def create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, apply=False):
@@ -200,6 +201,7 @@ def create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, app
         setattr(diagnostic_satellite, field, updated_diagnostic_appro_fields[field])
 
     # change some last fields
+    # diagnostic_satellite.creation_date = diagnostic.teledeclaration_date  # won't work. see update_diagnostic_teledeclared_creation_date
     diagnostic_satellite.teledeclaration_mode = Diagnostic.TeledeclarationMode.SITE
     diagnostic_satellite.satellites_snapshot = None
     diagnostic_satellite.generated_from_groupe_diagnostic = True
@@ -213,18 +215,18 @@ def create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, app
             )
 
 
-def archive_existing_diagnostic_teledeclared_satellite(satellite_dict, year, apply=False):
+def archive_existing_diagnostic_teledeclared_satellite(diagnostic, satellite_dict, apply=False):
     """
     Some satellite canteens may already have a submitted diagnostic for the given year.
     How come? If they had teledeclared individually before being linked to the groupe.
     We need to archive these diagnostics, as they are now overridden by the one generated from their groupe's diagnostic.
     """
-    diagnostic_qs = Diagnostic.objects.teledeclared().filter(canteen__id=satellite_dict["id"], year=year)
+    diagnostic_qs = Diagnostic.objects.teledeclared().filter(canteen__id=satellite_dict["id"], year=diagnostic.year)
     if diagnostic_qs.count() == 0:
         return
     elif diagnostic_qs.count() > 1:
         logger.warning(
-            f"Task warning: Multiple diagnostics found for Canteen: {satellite_dict['id']} / Year: {year}. Only the first one will be archived."
+            f"Task warning: Multiple diagnostics found for Canteen: {satellite_dict['id']} / Year: {diagnostic.year}. Only the first one will be archived."
         )
     else:  # diagnostic_qs.count() == 1
         if apply:
@@ -235,3 +237,17 @@ def archive_existing_diagnostic_teledeclared_satellite(satellite_dict, year, app
                     function="array_append",
                 )
             )
+
+
+def update_diagnostic_teledeclared_creation_date(diagnostic, apply=False):
+    """
+    To keep the creation_date of the diagnostic of the satellite aligned with the one of the groupe, we update it with the teledeclaration_date of the groupe's diagnostic.
+    This way, if the groupe's diagnostic is created before the satellite teledeclares, the diagnostic of the satellite will have an older creation_date than its teledeclaration_date, which is coherent.
+    """
+    if apply:
+        diagnostic_qs = Diagnostic.all_objects.filter(
+            generated_from_groupe_diagnostic=True,
+            year=diagnostic.year,
+            teledeclaration_id=diagnostic.teledeclaration_id,
+        )
+        diagnostic_qs.update(creation_date=diagnostic.teledeclaration_date)

--- a/macantine/tests/test_teledeclaration_1td1site_2024.py
+++ b/macantine/tests/test_teledeclaration_1td1site_2024.py
@@ -431,6 +431,34 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
 
 class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
     @authenticate
+    def test_set_correct_creation_date(self):
+        """
+        The creation date of the generated diagnostics should be the date of the teledeclaration of the central diagnostic.
+        """
+        central = CanteenFactory(
+            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=420, daily_meal_count=3
+        )
+        satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
+        )
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            central_diagnostic = DiagnosticFactory(
+                canteen=central,
+                year=2024,
+                valeur_totale=10000,
+                valeur_bio=2000,
+            )
+            central_diagnostic.teledeclare(applicant=authenticate.user)
+
+        # Run the script
+        call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
+
+        # After the script is run
+        diagnostic_generated = Diagnostic.all_objects.in_year(2024).teledeclared().get(canteen=satellite)
+        self.assertEqual(diagnostic_generated.creation_date, central_diagnostic.teledeclaration_date)
+
+    @authenticate
     def test_empty_satellites_snapshot(self):
         """
         The satellites_snapshot should be empty for the generated diagnostics.


### PR DESCRIPTION
Suite à la création du script `teledeclaration_generate_1td1site` dans #5627

### Quoi

On avait oublié de corriger le `creation_date` des TD générés

### Comment

En faisant un update sur toutes les TD générées pour un groupe donné

### Post-MEP

relancer `python manage.py teledeclaration_generate_1td1site --year 2024 --apply`