### PR TITLE
fix(Synthèse télédéclaration): regroupe l'affichage de l'objectif viande et poisson

### DIFF
--- a/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
@@ -3,12 +3,15 @@
     <CentralKitchenInfo :canteen="canteen" v-if="usesCentralKitchenDiagnostics" />
 
     <p>
-      La loi EGalim impose {{ applicableRules.qualityThreshold }} % de produits durables et de qualité et durable, dont
-      {{ applicableRules.bioThreshold }} % de bio
+      La loi EGalim impose : {{ applicableRules.qualityThreshold }} % de produits durables et de qualité et durable,
+      dont {{ applicableRules.bioThreshold }} % de bio,
       <span v-if="applicableRules.qualityThreshold !== 50">
-        - en respectant
+        en respectant
         <a href="https://ma-cantine.agriculture.gouv.fr/blog/16">les différents seuils fixés pour l'Outre-mer</a>
+        ,
       </span>
+      et 60% à l'ensemble Viandes, volailles et produits de la mer, non indépendamment, cet objectif est fixé à 100%
+      pour les restaurants de l'État.
     </p>
 
     <div v-if="tabs.length" class="mb-8">
@@ -97,12 +100,6 @@
                 <br />
                 EGalim
               </p>
-              <p
-                v-if="applicableRules.viandesVolaillesEgalimThreshold"
-                class="mt-1 mb-0 fr-text-sm grey--text text--darken-1"
-              >
-                <i>objectif : {{ applicableRules.viandesVolaillesEgalimThreshold }} %</i>
-              </p>
             </v-col>
             <v-col cols="12" sm="4" class="pa-4">
               <v-icon large class="grey--text text--darken-3 mb-2">$france-line</v-icon>
@@ -124,12 +121,6 @@
                 de produits de la mer
                 <br />
                 et aquaculture EGalim
-              </p>
-              <p
-                v-if="applicableRules.produitsDeLaMerEgalimThreshold"
-                class="mt-1 mb-0 fr-text-sm grey--text text--darken-1"
-              >
-                <i>objectif : {{ applicableRules.produitsDeLaMerEgalimThreshold }} %</i>
               </p>
             </v-col>
           </v-row>

--- a/frontend/src/components/DiagnosticSummary/QualityMeasureSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/QualityMeasureSummary.vue
@@ -56,11 +56,6 @@
               de viandes et volailles EGalim
             </p>
           </v-col>
-          <v-col class="py-0" v-if="applicableRules.viandesVolaillesEgalimThreshold" cols="12" sm="4" md="3">
-            <p class="mb-0 grey--text text-darken-1">
-              <i>objectif : {{ applicableRules.viandesVolaillesEgalimThreshold }} %</i>
-            </p>
-          </v-col>
         </v-row>
         <v-row class="py-2 px-3">
           <p class="mb-0">
@@ -79,9 +74,14 @@
               de produits de la mer et aquaculture EGalim
             </p>
           </v-col>
-          <v-col class="py-0" v-if="applicableRules.produitsDeLaMerEgalimThreshold" cols="12" sm="4" md="3">
-            <p class="mb-0 grey--text text-darken-1">
-              <i>objectif : {{ applicableRules.produitsDeLaMerEgalimThreshold }} %</i>
+        </v-row>
+        <v-row class="py-2 pl-0 pr-3">
+          <v-col class="py-0">
+            <p class="mb-0">
+              <i>
+                Objectif de 60% pour l'ensemble Viandes, volailles et produits de la mer, non indépendamment. Cet
+                objectif est fixé à 100% pour les restaurants de l'État.
+              </i>
             </p>
           </v-col>
         </v-row>


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/Synth-se-cot-gestionnaire-regrouper-viande-et-poissons-avec-le-mm-objectif-312de24614be8062835cda81b04fa9a6