### PR TITLE
feat(Observatoire): supprime le message d'alerte sur les données incorrectes pour l'année 2024

### DIFF
--- a/api/serializers/statistics.py
+++ b/api/serializers/statistics.py
@@ -150,7 +150,7 @@ class CanteenStatisticsSerializer(serializers.Serializer):
     def generate_notes(year, egalim_group):
         data = {}
         # Display an alert message while waiting for the stats to be corrected
-        if int(year) < 2025:
+        if int(year) < 2024:
             data["alert"] = {
                 "title": "Les chiffres indiqués sont légèrement inexacts en raison de l’évolution récente de la plateforme ma cantine.",
                 "message": "En effet, le précédent modèle de données reposait sur une déclaration unique pouvant couvrir plusieurs sites, afin de faciliter la déclaration des cuisines centrales. Ce fonctionnement ayant atteint ses limites notamment en matière de transparence des données au niveau des restaurants satellites, nous avons fait évoluer le modèle vers une déclaration par site. Des travaux sont actuellement en cours afin d’adapter les statistiques de l’Observatoire à ce nouveau modèle.",

--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -524,8 +524,8 @@ class CanteenStatsApiTest(APITestCase):
         )  # en 2023
         response_2024 = self.client.get(reverse("canteen_statistics"), {"year": 2024})
         self.assertEqual(response_2024.status_code, status.HTTP_200_OK)
-        body_2025 = response_2024.json()
-        self.assertNotIn("alert", body_2025["notes"])
+        body_2024 = response_2024.json()
+        self.assertNotIn("alert", body_2024["notes"])
 
     def test_cache_mechanism(self):
         # first time: no cache

--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -522,9 +522,9 @@ class CanteenStatsApiTest(APITestCase):
             body_2023["notes"]["alert"]["title"],
             "Les chiffres indiqués sont légèrement inexacts en raison de l’évolution récente de la plateforme ma cantine.",
         )  # en 2023
-        response_2025 = self.client.get(reverse("canteen_statistics"), {"year": 2025})
-        self.assertEqual(response_2025.status_code, status.HTTP_200_OK)
-        body_2025 = response_2025.json()
+        response_2024 = self.client.get(reverse("canteen_statistics"), {"year": 2024})
+        self.assertEqual(response_2024.status_code, status.HTTP_200_OK)
+        body_2025 = response_2024.json()
         self.assertNotIn("alert", body_2025["notes"])
 
     def test_cache_mechanism(self):


### PR DESCRIPTION
Ajouté initialement dans #6446

Ticket : https://www.notion.so/incubateur-masa/Clarifier-les-messages-d-informations-si-des-ann-es-ne-sont-pas-bas-es-sur-les-m-mes-mod-les-311de24614be800c85f1e73612ff024b?pvs=23