### PR TITLE
feat(Observatoire): pour 2025 remplace "télédéclarations" par "sites télédéclarés"

### DIFF
--- a/2024-frontend/src/components/ObservatoryNumbers.vue
+++ b/2024-frontend/src/components/ObservatoryNumbers.vue
@@ -16,7 +16,7 @@ const canteenTitle = computed(() => {
 
 /* 1TD1SITE */
 const is1td1siteYear = computed(() => {
-  const yearsWith1td1site = [2025, 2024]
+  const yearsWith1td1site = [2024, 2025]
   return filtersParams.year && yearsWith1td1site.includes(filtersParams.year)
 })
 

--- a/2024-frontend/src/components/ObservatoryNumbers.vue
+++ b/2024-frontend/src/components/ObservatoryNumbers.vue
@@ -16,7 +16,7 @@ const canteenTitle = computed(() => {
 
 /* 1TD1SITE */
 const is1td1siteYear = computed(() => {
-  const yearsWith1td1site = [2024]
+  const yearsWith1td1site = [2025, 2024]
   return filtersParams.year && yearsWith1td1site.includes(filtersParams.year)
 })
 


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/Mise-jour-de-l-observatoire-2025-uniquement-le-bloc-du-haut-pas-encore-dispo-311de24614be80829e4ff567a4d1b372