### PR TITLE
feat(Télédéclaration): déplace le bloc de correction

### DIFF
--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -7,7 +7,7 @@
       ]"
     />
     <v-row align="center">
-      <v-col v-if="canteen" cols="12" md="9" lg="10">
+      <v-col v-if="canteen" cols="12" md="8">
         <DataInfoBadge
           :currentYear="+year === currentYear"
           :inTeledeclaration="inTeledeclarationCampaign"
@@ -22,31 +22,33 @@
           <span>SIREN : {{ canteen.sirenUniteLegale }}</span>
         </p>
       </v-col>
-      <v-col cols="12" md="3" lg="2">
+      <v-col cols="12" md="4">
         <div v-if="hasActiveTeledeclaration">
-          <p v-if="inTeledeclarationCampaign || inCorrectionCampaign">
-            En cas d'erreur, vous pouvez modifier vos données
-            <span v-if="campaignEndDate">
-              jusqu’au
-              {{ campaignEndDate.toLocaleString("fr-FR", { month: "long", day: "numeric", year: "numeric" }) }} (heure
-              de Paris).
-            </span>
-            <span v-else>
-              jusqu’à la fin de la campagne.
-            </span>
-          </p>
-          <TeledeclarationCancelDialog
-            v-model="cancelDialog"
-            v-if="inTeledeclarationCampaign || inCorrectionCampaign"
-            @cancel="cancelTeledeclaration"
-            :diagnostic="diagnostic"
-          >
-            <template v-slot:activator="{ on, attrs }">
-              <v-btn outlined small color="primary" class="fr-btn--tertiary px-2" v-on="on" v-bind="attrs">
-                Corriger ma télédéclaration
-              </v-btn>
-            </template>
-          </TeledeclarationCancelDialog>
+          <DsfrCallout v-if="inTeledeclarationCampaign || inCorrectionCampaign" class="mb-0">
+            <p>
+              En cas d'erreur, vous pouvez modifier vos données
+              <span v-if="campaignEndDate">
+                jusqu’au
+                {{ campaignEndDate.toLocaleString("fr-FR", { month: "long", day: "numeric", year: "numeric" }) }} (heure
+                de Paris).
+              </span>
+              <span v-else>
+                jusqu’à la fin de la campagne.
+              </span>
+            </p>
+            <TeledeclarationCancelDialog
+              v-model="cancelDialog"
+              v-if="inTeledeclarationCampaign || inCorrectionCampaign"
+              @cancel="cancelTeledeclaration"
+              :diagnostic="diagnostic"
+            >
+              <template v-slot:activator="{ on, attrs }">
+                <v-btn outlined small color="primary" class="fr-btn--tertiary px-2" v-on="on" v-bind="attrs">
+                  Corriger ma télédéclaration
+                </v-btn>
+              </template>
+            </TeledeclarationCancelDialog>
+          </DsfrCallout>
         </div>
       </v-col>
     </v-row>
@@ -268,6 +270,7 @@ import ProductionTypeTag from "@/components/ProductionTypeTag"
 import ProgressTab from "./ProgressTab"
 import DsfrTabsVue from "@/components/DsfrTabs"
 import DsfrNativeSelect from "@/components/DsfrNativeSelect"
+import DsfrCallout from "@/components/DsfrCallout"
 import DownloadLink from "@/components/DownloadLink"
 import TeledeclarationPreview from "@/components/TeledeclarationPreview"
 import TeledeclarationCancelDialog from "@/components/TeledeclarationCancelDialog"
@@ -294,6 +297,7 @@ export default {
     ProgressTab,
     DsfrTabsVue,
     DsfrNativeSelect,
+    DsfrCallout,
     DownloadLink,
     TeledeclarationPreview,
     TeledeclarationCancelDialog,

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -23,7 +23,31 @@
         </p>
       </v-col>
       <v-col cols="12" md="3" lg="2">
-        ICI
+        <div v-if="hasActiveTeledeclaration">
+          <p v-if="inTeledeclarationCampaign || inCorrectionCampaign">
+            En cas d'erreur, vous pouvez modifier vos données
+            <span v-if="campaignEndDate">
+              jusqu’au
+              {{ campaignEndDate.toLocaleString("fr-FR", { month: "long", day: "numeric", year: "numeric" }) }} (heure
+              de Paris).
+            </span>
+            <span v-else>
+              jusqu’à la fin de la campagne.
+            </span>
+          </p>
+          <TeledeclarationCancelDialog
+            v-model="cancelDialog"
+            v-if="inTeledeclarationCampaign || inCorrectionCampaign"
+            @cancel="cancelTeledeclaration"
+            :diagnostic="diagnostic"
+          >
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn outlined small color="primary" class="fr-btn--tertiary px-2" v-on="on" v-bind="attrs">
+                Corriger ma télédéclaration
+              </v-btn>
+            </template>
+          </TeledeclarationCancelDialog>
+        </div>
       </v-col>
     </v-row>
     <v-row v-if="canteen" class="mt-5 mt-md-10">
@@ -49,29 +73,6 @@
             target="_blank"
             class="mr-4"
           />
-          <p v-if="inTeledeclarationCampaign || inCorrectionCampaign">
-            En cas d'erreur, vous pouvez modifier vos données
-            <span v-if="campaignEndDate">
-              jusqu’au
-              {{ campaignEndDate.toLocaleString("fr-FR", { month: "long", day: "numeric", year: "numeric" }) }} (heure
-              de Paris).
-            </span>
-            <span v-else>
-              jusqu’à la fin de la campagne.
-            </span>
-          </p>
-          <TeledeclarationCancelDialog
-            v-model="cancelDialog"
-            v-if="inTeledeclarationCampaign || inCorrectionCampaign"
-            @cancel="cancelTeledeclaration"
-            :diagnostic="diagnostic"
-          >
-            <template v-slot:activator="{ on, attrs }">
-              <v-btn outlined small color="primary" class="fr-btn--tertiary px-2" v-on="on" v-bind="attrs">
-                Corriger ma télédéclaration
-              </v-btn>
-            </template>
-          </TeledeclarationCancelDialog>
         </div>
         <div v-else-if="isSatelliteWithCompleteCentralDiagnostic">
           <p>

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -6,7 +6,7 @@
         { to: { name: 'DashboardManager' }, title: canteen ? canteen.name : 'Dashboard' },
       ]"
     />
-    <v-row align="end">
+    <v-row align="center">
       <v-col v-if="canteen" cols="12" md="9" lg="10">
         <DataInfoBadge
           :currentYear="+year === currentYear"
@@ -23,15 +23,7 @@
         </p>
       </v-col>
       <v-col cols="12" md="3" lg="2">
-        <v-btn
-          v-if="canteenPreviews.length > 1"
-          outlined
-          color="primary"
-          class="fr-btn--tertiary"
-          :to="{ name: 'GestionnaireTableauDeBord' }"
-        >
-          Changer d'établissement
-        </v-btn>
+        ICI
       </v-col>
     </v-row>
     <v-row v-if="canteen" class="mt-5 mt-md-10">


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/Remonter-le-bloc-En-cas-d-erreur-au-niveau-du-titre-de-la-page-du-bilan-33cde24614be8023b837fa44856bd432

|Avant|Après|
|--|--|
| <img width="1342" height="713" alt="Capture d’écran 2026-04-10 à 15 48 41" src="https://github.com/user-attachments/assets/adde9997-21ec-4cf3-a2c6-4f76bd91236f" /> | <img width="1351" height="654" alt="Capture d’écran 2026-04-10 à 15 48 30" src="https://github.com/user-attachments/assets/1c43dddd-a5a7-4562-8a10-57f5a97225f3" /> |