### PR TITLE
refactor(1TD1Site): nouveau queryset with_satellites_snapshot_stats pour pré-calculer certains champs dont on a besoin dans le script de génération

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator
 from django.db import models, transaction
 from django.db.models import Case, F, Func, IntegerField, Q, Sum, When
+from django.db.models.expressions import RawSQL
 from django.db.models.fields.json import KT
 from django.db.models.functions import Cast
 from django.utils import timezone
@@ -200,6 +201,12 @@ class DiagnosticQuerySet(models.QuerySet):
         return self.annotate(
             satellites_snapshot_count_annotated=Func(
                 "satellites_snapshot", function="jsonb_array_length", output_field=IntegerField()
+            )
+        ).annotate(
+            satellites_snapshot_yearly_meal_count_sum=RawSQL(
+                sql="(SELECT SUM((elem->>'yearly_meal_count')::integer) FROM jsonb_array_elements(satellites_snapshot) AS elem)",
+                params=[],
+                output_field=IntegerField(),
             )
         )
 

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1,12 +1,11 @@
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator
-from django.db import models
-from django.db.models import Case, F, IntegerField, Q, Sum, When
+from django.db import models, transaction
+from django.db.models import Case, F, Func, IntegerField, Q, Sum, When
 from django.db.models.fields.json import KT
 from django.db.models.functions import Cast
 from django.utils import timezone
-from django.db import transaction
 from simple_history.models import HistoricalRecords
 
 from common.utils import utils as utils_utils
@@ -194,6 +193,13 @@ class DiagnosticQuerySet(models.QuerySet):
             meal_price=Case(
                 When(canteen_yearly_meal_count__gt=0, then=F("valeur_totale") / F("canteen_yearly_meal_count")),
                 default=None,
+            )
+        )
+
+    def with_satellites_snapshot_stats(self):
+        return self.annotate(
+            satellites_snapshot_count_annotated=Func(
+                "satellites_snapshot", function="jsonb_array_length", output_field=IntegerField()
             )
         )
 

--- a/data/tests/test_diagnostic_teledeclaration.py
+++ b/data/tests/test_diagnostic_teledeclaration.py
@@ -5,7 +5,6 @@ from freezegun import freeze_time
 from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 from data.models import Canteen, Diagnostic, Sector
 
-
 year_data = 2024
 date_in_teledeclaration_campaign = "2025-03-30"
 date_in_correction_campaign = "2025-04-20"
@@ -269,6 +268,13 @@ class DiagnosticTeledeclaredSnapshotsTest(TestCase):
         with freeze_time(date_in_teledeclaration_campaign):
             cls.diagnostic_groupe.teledeclare(applicant=cls.user)
             cls.diagnostic_site.teledeclare(applicant=cls.user)
+
+    def test_with_satellites_snapshot_stats_queryset(self):
+        self.assertEqual(Diagnostic.objects.count(), 2)
+        diagnostics = Diagnostic.objects.with_satellites_snapshot_stats()
+        self.assertEqual(diagnostics.count(), 2)
+        self.assertEqual(diagnostics.get(id=self.diagnostic_groupe.id).satellites_snapshot_count_annotated, 1)
+        self.assertEqual(diagnostics.get(id=self.diagnostic_site.id).satellites_snapshot_count_annotated, None)
 
     def test_diagnostic_canteen_snapshot(self):
         # groupe

--- a/data/tests/test_diagnostic_teledeclaration.py
+++ b/data/tests/test_diagnostic_teledeclaration.py
@@ -240,9 +240,11 @@ class DiagnosticTeledeclaredSnapshotsTest(TestCase):
         cls.user = UserFactory()
         # groupe + satellite
         cls.canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
-        cls.canteen_satellite = CanteenFactory(
-            production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
-            groupe=cls.canteen_groupe,
+        cls.canteen_satellite_1 = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=cls.canteen_groupe, yearly_meal_count=550
+        )
+        cls.canteen_satellite_2 = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=cls.canteen_groupe, yearly_meal_count=650
         )
         cls.diagnostic_groupe = DiagnosticFactory(
             canteen=cls.canteen_groupe,
@@ -273,8 +275,12 @@ class DiagnosticTeledeclaredSnapshotsTest(TestCase):
         self.assertEqual(Diagnostic.objects.count(), 2)
         diagnostics = Diagnostic.objects.with_satellites_snapshot_stats()
         self.assertEqual(diagnostics.count(), 2)
-        self.assertEqual(diagnostics.get(id=self.diagnostic_groupe.id).satellites_snapshot_count_annotated, 1)
+        # satellites_snapshot_count_annotated
+        self.assertEqual(diagnostics.get(id=self.diagnostic_groupe.id).satellites_snapshot_count_annotated, 2)
         self.assertEqual(diagnostics.get(id=self.diagnostic_site.id).satellites_snapshot_count_annotated, None)
+        # satellites_snapshot_yearly_meal_count_sum
+        self.assertEqual(diagnostics.get(id=self.diagnostic_groupe.id).satellites_snapshot_yearly_meal_count_sum, 1200)
+        self.assertEqual(diagnostics.get(id=self.diagnostic_site.id).satellites_snapshot_yearly_meal_count_sum, None)
 
     def test_diagnostic_canteen_snapshot(self):
         # groupe
@@ -302,8 +308,11 @@ class DiagnosticTeledeclaredSnapshotsTest(TestCase):
     def test_diagnostic_satellites_snapshot(self):
         # groupe
         self.assertIsNotNone(self.diagnostic_groupe.satellites_snapshot)
-        self.assertEqual(len(self.diagnostic_groupe.satellites_snapshot), 1)
-        self.assertEqual(self.diagnostic_groupe.satellites_snapshot[0]["id"], self.canteen_satellite.id)
+        self.assertEqual(len(self.diagnostic_groupe.satellites_snapshot), 2)
+        self.assertEqual(
+            self.diagnostic_groupe.satellites_snapshot[0]["id"], self.canteen_satellite_2.id
+        )  # default ordering by -creation_date
+        self.assertEqual(self.diagnostic_groupe.satellites_snapshot[1]["id"], self.canteen_satellite_1.id)
         # site
         self.assertIsNone(self.diagnostic_site.satellites_snapshot)
 

--- a/data/tests/test_diagnostic_teledeclaration.py
+++ b/data/tests/test_diagnostic_teledeclaration.py
@@ -306,12 +306,10 @@ class DiagnosticTeledeclaredSnapshotsTest(TestCase):
         )
 
     def test_diagnostic_satellites_snapshot(self):
-        # groupe
+        # groupe (default canteen ordering when snapshot is -creation_date)
         self.assertIsNotNone(self.diagnostic_groupe.satellites_snapshot)
         self.assertEqual(len(self.diagnostic_groupe.satellites_snapshot), 2)
-        self.assertEqual(
-            self.diagnostic_groupe.satellites_snapshot[0]["id"], self.canteen_satellite_2.id
-        )  # default ordering by -creation_date
+        self.assertEqual(self.diagnostic_groupe.satellites_snapshot[0]["id"], self.canteen_satellite_2.id)
         self.assertEqual(self.diagnostic_groupe.satellites_snapshot[1]["id"], self.canteen_satellite_1.id)
         # site
         self.assertIsNone(self.diagnostic_site.satellites_snapshot)

--- a/macantine/management/commands/teledeclaration_generate_1td1site.py
+++ b/macantine/management/commands/teledeclaration_generate_1td1site.py
@@ -3,7 +3,7 @@ import time
 from copy import deepcopy
 
 from django.core.management.base import BaseCommand
-from django.db.models import F, Func, IntegerField, Value
+from django.db.models import F, Func, Value
 from django.db.utils import IntegrityError
 
 from api.serializers import CanteenTeledeclarationSerializer
@@ -70,11 +70,7 @@ class Command(BaseCommand):
         diagnostic_qs = (
             Diagnostic.objects.teledeclared_for_year(year=year)
             .annotate(canteen_snapshot_production_type=F("canteen_snapshot__production_type"))
-            .annotate(
-                satellites_count_annotated=Func(
-                    "satellites_snapshot", function="jsonb_array_length", output_field=IntegerField()
-                )
-            )
+            .with_satellites_snapshot_stats()
             .filter(
                 canteen_snapshot_production_type__in=[
                     Canteen.ProductionType.CENTRAL,
@@ -152,7 +148,7 @@ def process_groupe_diagnostic_teledeclared(diagnostic, apply=False):
     - each satellite will have its own appro values based on its yearly_meal_count
     """
     # for each satellite, create a diagnostic (and archive any existing diagnostic)
-    if diagnostic.satellites_count_annotated:
+    if diagnostic.satellites_snapshot_count_annotated:
         for satellite_dict in diagnostic.satellites_snapshot:
             create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, apply=apply)
             archive_existing_diagnostic_teledeclared_satellite(diagnostic, satellite_dict, apply=apply)

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -283,6 +283,7 @@ def set_satellite_diagnostic_appro_values_from_groupe_diagnostic(diagnostic, sat
     Rules:
     - before 2025, we divide by the number of satellites
     - in 2025, we divide by the satellite's yearly_meal_count (ratio)
+        - Note: requires with_satellites_snapshot_stats() queryset
     """
     from data.models import Diagnostic  # avoid circular import
 
@@ -293,13 +294,8 @@ def set_satellite_diagnostic_appro_values_from_groupe_diagnostic(diagnostic, sat
         divisor = len(diagnostic.satellites_snapshot) if diagnostic.satellites_snapshot else 0
         # no +1 for central_serving? we already added it in canteen_migrate_central_to_groupe.py
     elif diagnostic.year == 2025:
-        satellites_yearly_meal_count_sum = sum(
-            satellite["yearly_meal_count"]
-            for satellite in diagnostic.satellites_snapshot
-            if satellite.get("yearly_meal_count")
-        )
         divisor = (
-            satellites_yearly_meal_count_sum / satellite_dict.get("yearly_meal_count")
+            diagnostic.satellites_snapshot_yearly_meal_count_sum / satellite_dict.get("yearly_meal_count")
             if satellite_dict.get("yearly_meal_count")
             else 0
         )


### PR DESCRIPTION
### Quoi

Suite à #6618 (gestion de 2025 dans le script de génération).
J'ai remonté certains calculs dans une queryset dédié
- plus clair
- testable
- accélère le script ?