### PR TITLE
fix(Campagne de correction): ne pas afficher le bouton "Modifier mes données" si le bilan n'est pas télédéclaré 

### DIFF
--- a/frontend/src/views/MyProgress/ProgressTab.vue
+++ b/frontend/src/views/MyProgress/ProgressTab.vue
@@ -167,11 +167,11 @@ export default {
   },
   computed: {
     displayEditButton() {
-      const noTD = !this.hasActiveTeledeclaration
+      const notTeledeclared = !this.hasActiveTeledeclaration
       const notUseOtherDiagnostic = !this.usesOtherDiagnosticForMeasure
-      const hasCorrectionCampaignAllowed = this.inCorrectionCampaign && this.hasTeledeclarationToCorrect
-      const inCampaign = this.inTeledeclarationCampaign || hasCorrectionCampaignAllowed
-      return noTD && notUseOtherDiagnostic && inCampaign
+      const isAllowedCorrection = this.inCorrectionCampaign && this.hasTeledeclarationToCorrect
+      const inCampaign = this.inTeledeclarationCampaign || isAllowedCorrection
+      return notTeledeclared && notUseOtherDiagnostic && inCampaign
     },
     isApproTab() {
       return this.measureId === this.approId

--- a/frontend/src/views/MyProgress/ProgressTab.vue
+++ b/frontend/src/views/MyProgress/ProgressTab.vue
@@ -137,6 +137,9 @@ export default {
     diagnostic: Object,
     centralDiagnostic: Object,
     centralKitchenDiagnosticMode: String,
+    inTeledeclarationCampaign: Boolean,
+    inCorrectionCampaign: Boolean,
+    hasTeledeclarationToCorrect: Boolean,
   },
   components: {
     QualityMeasureInfo,

--- a/frontend/src/views/MyProgress/ProgressTab.vue
+++ b/frontend/src/views/MyProgress/ProgressTab.vue
@@ -67,7 +67,7 @@
           </v-col>
           <v-col class="text-right">
             <v-btn
-              v-if="isCanteenTab || (!hasActiveTeledeclaration && !usesOtherDiagnosticForMeasure)"
+              v-if="displayEditButton"
               outlined
               small
               color="primary"
@@ -166,6 +166,13 @@ export default {
     }
   },
   computed: {
+    displayEditButton() {
+      const noTD = !this.hasActiveTeledeclaration
+      const notUseOtherDiagnostic = !this.usesOtherDiagnosticForMeasure
+      const hasCorrectionCampaignAllowed = this.inCorrectionCampaign && this.hasTeledeclarationToCorrect
+      const inCampaign = this.inTeledeclarationCampaign || hasCorrectionCampaignAllowed
+      return noTD && notUseOtherDiagnostic && inCampaign
+    },
     isApproTab() {
       return this.measureId === this.approId
     },

--- a/frontend/src/views/MyProgress/index.vue
+++ b/frontend/src/views/MyProgress/index.vue
@@ -216,6 +216,9 @@
                 :diagnostic="diagnostic"
                 :centralDiagnostic="centralDiagnostic"
                 :centralKitchenDiagnosticMode="centralKitchenDiagnosticMode"
+                :inTeledeclarationCampaign="inTeledeclarationCampaign"
+                :inCorrectionCampaign="inCorrectionCampaign"
+                :hasTeledeclarationToCorrect="hasTeledeclarationToCorrect"
               />
               <v-row class="mt-6 align-center">
                 <v-col v-if="previousTab(item)">


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/BUG-un-bilan-non-TD-peut-tre-modifi-durant-la-campagne-de-correction-33cde24614be8051b8b5f0ddc5c8ad59