### PR TITLE
refactor(ETL): rajouter 1TD1Site dans les exports brutes

### DIFF
--- a/macantine/etl/analysis.py
+++ b/macantine/etl/analysis.py
@@ -181,7 +181,7 @@ class ETL_ANALYSIS_DIAGNOSTIC_RAW(ANALYSIS):
         Load raw table into a dataframe.
         """
         start = time.time()
-        queryset = Diagnostic.objects.all().values()
+        queryset = Diagnostic.all_objects.all().values()
         self.df = pd.DataFrame(list(queryset))
         if self.df.empty:
             logger.warning("Dataset is empty. Creating an empty dataframe")


### PR DESCRIPTION
Suite de #6427

Et après avoir mis en place 1TD1Site

Il faut qu'on passe le queryset de Diagnostic RAW de `all` à `all_objects`