### PR TITLE
improve(Télédéclarations): après la fin de la campagne, il n'est plus possible de modifier un bilan en DRAFT

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1655,7 +1655,7 @@ class Diagnostic(models.Model):
             self.populate_simplified_diagnostic_values()
 
         validation_errors = utils_utils.merge_validation_errors(
-            diagnostic_validators.validate_year(self),
+            diagnostic_validators.validate_year_and_can_edit(self),
             diagnostic_validators.validate_diagnostic_type(self),
             diagnostic_validators.validate_appro_fields_required(self),
             diagnostic_validators.validate_valeur_totale(self),

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -87,6 +87,13 @@ class DiagnosticModelSaveTest(TransactionTestCase):
                 diagnostic = DiagnosticFactory(year=VALUE_NOT_OK_ON_FULL_CLEAN, **VALID_DIAGNOSTIC_WITHOUT_YEAR)
                 self.assertRaises(ValidationError, diagnostic.full_clean)
 
+    def test_can_edit_validation(self):
+        with freeze_time("2025-01-20"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2024)
+            diagnostic.full_clean()  # should not raise
+        with freeze_time("2025-08-30"):  # after the 2024 campaign
+            self.assertRaises(ValidationError, diagnostic.full_clean)
+
     def test_diagnostic_type_validation(self):
         VALID_DIAGNOSTIC_WITHOUT_TYPE = VALID_DIAGNOSTIC_SIMPLE_2025.copy()
         VALID_DIAGNOSTIC_WITHOUT_TYPE.pop("diagnostic_type")

--- a/data/validators/diagnostic.py
+++ b/data/validators/diagnostic.py
@@ -1,15 +1,20 @@
 from decimal import Decimal
 
+from django.utils import timezone
+
+from macantine.utils import get_year_campaign_end_date_or_today_date
 from common.utils import utils as utils_utils
 from data.utils import get_diagnostic_lower_limit_year, get_diagnostic_upper_limit_year
 
 
-def validate_year(instance):
+def validate_year_and_can_edit(instance):
     """
     - extra validation:
         - year must be filled
         - year must be an integer
         - year must be between lower and upper limit years
+        - if year is valid:
+            - after teledeclaration end date, DRAFT diagnostic cannot be edited anymore
     """
     errors = {}
     field_name = "year"
@@ -25,6 +30,16 @@ def validate_year(instance):
             utils_utils.add_validation_error(
                 errors, "year", f"L'année doit être comprise entre {lower_limit_year} et {upper_limit_year}."
             )
+        else:  # valid year, check can_edit validation
+            if instance.pk:
+                if instance.status == instance.DiagnosticStatus.DRAFT:
+                    now = timezone.now()
+                    if now > get_year_campaign_end_date_or_today_date(value):
+                        utils_utils.add_validation_error(
+                            errors,
+                            "year",
+                            f"Le diagnostic de l'année {value} ne peut plus être modifié car la campagne de télédéclaration est terminée.",
+                        )
     return errors
 
 

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -215,8 +215,8 @@ def get_year_campaign_end_date_or_today_date(year):
     year = int(year)
     now = timezone.now()
     if year in CAMPAIGN_DATES.keys():
-        end_date_campaign = CAMPAIGN_DATES[year]["teledeclaration_end_date"]
-        return now if end_date_campaign > now else CAMPAIGN_DATES[year]["teledeclaration_end_date"]
+        campaign_end_date = CAMPAIGN_DATES[year]["teledeclaration_end_date"]
+        return now if campaign_end_date > now else CAMPAIGN_DATES[year]["teledeclaration_end_date"]
     elif year >= now.year:
         return now
     else:


### PR DESCRIPTION
PR 1/3

Nouvelle règle métier : 
- après la campagne de télédéclaration, les diagnostic DRAFT ne sont plus modifiables

Suite : 
- #6637
- #6641