### PR TITLE
improve(Télédéclarations): Règles métiers: après la fin de la campagne de correction, il n'est plus possible de modifier un bilan en CORRECTION

### DIFF
--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -88,8 +88,23 @@ class DiagnosticModelSaveTest(TransactionTestCase):
                 self.assertRaises(ValidationError, diagnostic.full_clean)
 
     def test_can_edit_validation(self):
+        # DRAFT diagnostic cannot be edited after campaign end date
         with freeze_time("2025-01-20"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2024)
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.DRAFT)
+            diagnostic.full_clean()  # should not raise
+        with freeze_time("2025-04-18"):  # during the 2024 correction campaign
+            self.assertRaises(ValidationError, diagnostic.full_clean)
+        with freeze_time("2025-08-30"):  # after the 2024 campaign
+            self.assertRaises(ValidationError, diagnostic.full_clean)
+
+        # CORRECTION diagnostic can be edited after correction end date
+        with freeze_time("2025-01-20"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2024)
+            diagnostic.teledeclare(applicant=UserFactory(), skip_validations=True)
+        with freeze_time("2025-04-18"):  # during the 2024 correction campaign
+            diagnostic.cancel()
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
             diagnostic.full_clean()  # should not raise
         with freeze_time("2025-08-30"):  # after the 2024 campaign
             self.assertRaises(ValidationError, diagnostic.full_clean)

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -87,18 +87,19 @@ class DiagnosticModelSaveTest(TransactionTestCase):
                 diagnostic = DiagnosticFactory(year=VALUE_NOT_OK_ON_FULL_CLEAN, **VALID_DIAGNOSTIC_WITHOUT_YEAR)
                 self.assertRaises(ValidationError, diagnostic.full_clean)
 
-    def test_can_edit_validation(self):
-        # DRAFT diagnostic cannot be edited after campaign end date
+    def test_can_edit_status_draft_validation(self):
+        # DRAFT diagnostic cannot be edited during the campaign but not after
         with freeze_time("2025-01-20"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2024)
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.DRAFT)
             diagnostic.full_clean()  # should not raise
         with freeze_time("2025-04-18"):  # during the 2024 correction campaign
             self.assertRaises(ValidationError, diagnostic.full_clean)
-        with freeze_time("2025-08-30"):  # after the 2024 campaign
+        with freeze_time("2025-08-30"):  # after the 2024 correction campaign
             self.assertRaises(ValidationError, diagnostic.full_clean)
 
-        # CORRECTION diagnostic can be edited after correction end date
+    def test_can_edit_status_correction_validation(self):
+        # CORRECTION diagnostic can be edited during the campaign & correction but not after correction
         with freeze_time("2025-01-20"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2024)
             diagnostic.teledeclare(applicant=UserFactory(), skip_validations=True)
@@ -106,7 +107,7 @@ class DiagnosticModelSaveTest(TransactionTestCase):
             diagnostic.cancel()
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
             diagnostic.full_clean()  # should not raise
-        with freeze_time("2025-08-30"):  # after the 2024 campaign
+        with freeze_time("2025-08-30"):  # after the 2024 correction campaign
             self.assertRaises(ValidationError, diagnostic.full_clean)
 
     def test_diagnostic_type_validation(self):

--- a/data/validators/diagnostic.py
+++ b/data/validators/diagnostic.py
@@ -2,7 +2,10 @@ from decimal import Decimal
 
 from django.utils import timezone
 
-from macantine.utils import get_year_campaign_end_date_or_today_date
+from macantine.utils import (
+    get_year_campaign_end_date_or_today_date,
+    get_year_correction_end_date_or_campaign_end_date_or_today_date,
+)
 from common.utils import utils as utils_utils
 from data.utils import get_diagnostic_lower_limit_year, get_diagnostic_upper_limit_year
 
@@ -15,6 +18,7 @@ def validate_year_and_can_edit(instance):
         - year must be between lower and upper limit years
         - if year is valid:
             - after teledeclaration end date, DRAFT diagnostic cannot be edited anymore
+            - after correction end date, CORRECTION diagnostic cannot be edited anymore
     """
     errors = {}
     field_name = "year"
@@ -32,13 +36,20 @@ def validate_year_and_can_edit(instance):
             )
         else:  # valid year, check can_edit validation
             if instance.pk:
+                now = timezone.now()
                 if instance.status == instance.DiagnosticStatus.DRAFT:
-                    now = timezone.now()
                     if now > get_year_campaign_end_date_or_today_date(value):
                         utils_utils.add_validation_error(
                             errors,
                             "year",
                             f"Le diagnostic de l'année {value} ne peut plus être modifié car la campagne de télédéclaration est terminée.",
+                        )
+                elif instance.status == instance.DiagnosticStatus.CORRECTION:
+                    if now > get_year_correction_end_date_or_campaign_end_date_or_today_date(value):
+                        utils_utils.add_validation_error(
+                            errors,
+                            "year",
+                            f"Le diagnostic de l'année {value} ne peut plus être modifié car la période de correction est terminée.",
                         )
     return errors
 

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -223,6 +223,21 @@ def get_year_campaign_end_date_or_today_date(year):
         return None
 
 
+def get_year_correction_end_date_or_campaign_end_date_or_today_date(year):
+    year = int(year)
+    now = timezone.now()
+    if year in CAMPAIGN_DATES.keys():
+        if CAMPAIGN_DATES[year]["correction_end_date"]:
+            correction_end_date = CAMPAIGN_DATES[year]["correction_end_date"]
+            return now if correction_end_date > now else CAMPAIGN_DATES[year]["correction_end_date"]
+        else:
+            return get_year_campaign_end_date_or_today_date(year)
+    elif year >= now.year:
+        return now
+    else:
+        return None
+
+
 def set_satellite_common_fields_from_groupe_diagnostic(diagnostic, satellite_dict) -> dict:
     """
     Generate a dict with common fields values for a satellite from a groupe diagnostic


### PR DESCRIPTION
Suite de #6636

Nouvelle règle métier : 
- après la campagne de correction, les diagnostics CORRECTION ne sont plus modifiables

Suite : 
- #6641