### PR TITLE
improve(Télédéclarations): après la fin de la campagne de correction, il n'est plus possible de modifier un bilan en SUBMITTED

### DIFF
--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -82,6 +82,7 @@ class DiagnosticUpdateView(UpdateAPIView):
 
     def perform_update(self, serializer):
         if self.get_object().is_teledeclared:
+            # if the user wants to cancel, see DiagnosticTeledeclarationCancelView
             raise PermissionDenied("Ce n'est pas possible de modifier un bilan télédéclaré.")
         serializer.is_valid(raise_exception=True)
         diagnostic = serializer.save()

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -110,6 +110,18 @@ class DiagnosticModelSaveTest(TransactionTestCase):
         with freeze_time("2025-08-30"):  # after the 2024 correction campaign
             self.assertRaises(ValidationError, diagnostic.full_clean)
 
+    def test_can_edit_status_submitted_validation(self):
+        # SUBMITTED diagnostic can be edited during the campaign & correction but not after campaign
+        with freeze_time("2025-01-20"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2024)
+            diagnostic.teledeclare(applicant=UserFactory(), skip_validations=True)
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.SUBMITTED)
+            diagnostic.full_clean()  # should not raise
+        with freeze_time("2025-04-18"):  # during the 2024 correction campaign
+            diagnostic.full_clean()  # should not raise
+        with freeze_time("2025-08-30"):  # after the 2024 correction campaign
+            self.assertRaises(ValidationError, diagnostic.full_clean)
+
     def test_diagnostic_type_validation(self):
         VALID_DIAGNOSTIC_WITHOUT_TYPE = VALID_DIAGNOSTIC_SIMPLE_2025.copy()
         VALID_DIAGNOSTIC_WITHOUT_TYPE.pop("diagnostic_type")

--- a/data/validators/diagnostic.py
+++ b/data/validators/diagnostic.py
@@ -19,6 +19,7 @@ def validate_year_and_can_edit(instance):
         - if year is valid:
             - after teledeclaration end date, DRAFT diagnostic cannot be edited anymore
             - after correction end date, CORRECTION diagnostic cannot be edited anymore
+            - after correction end date, SUBMITTED diagnostic cannot be edited (e.g. cancelled) anymore
     """
     errors = {}
     field_name = "year"
@@ -50,6 +51,13 @@ def validate_year_and_can_edit(instance):
                             errors,
                             "year",
                             f"Le diagnostic de l'année {value} ne peut plus être modifié car la période de correction est terminée.",
+                        )
+                elif instance.status == instance.DiagnosticStatus.SUBMITTED:
+                    if now > get_year_correction_end_date_or_campaign_end_date_or_today_date(value):
+                        utils_utils.add_validation_error(
+                            errors,
+                            "year",
+                            f"Le diagnostic de l'année {value} ne peut plus être modifié car la campagne de télédéclaration est terminée.",
                         )
     return errors
 


### PR DESCRIPTION
Suite de #6636 (DRAFT) & #6637 (CORRECTION)

Nouvelle règle métier :
- après la campagne de correction, les diagnostics SUBMITTED ne sont plus modifiables
