### PR TITLE
improve(Télédéclarations): améliorer la commande de resubmit pour prendre en entrée une liste de Diagnostic ID à re-télédéclarer

### DIFF
--- a/macantine/management/commands/teledeclaration_resubmit.py
+++ b/macantine/management/commands/teledeclaration_resubmit.py
@@ -1,21 +1,28 @@
 """
 Why this script?
 We updated/fixed the data of some canteens after they teledeclared.
-To reflect the changes in the Teledeclaration objects, we need to cancel and re-submit these teledeclarations.
+To reflect the changes in the Diagnostic objects, we need to cancel and re-submit these teledeclarations.
 
 How to run?
-python manage.py teledeclaration_resubmit --year 2024 --canteen-siret-list 92341284500011,23456789012345
+python manage.py teledeclaration_resubmit --year 2024 --teledeclaration-id-list 123,456,789
 
-Ran on 2025-04-18 (Campaign for 2024)
+Ran on 2025-04-18 (2024 campaign)
+Ran on 2026-04-15 (last day of 2025 campaign)
 """
 
-from django.core.management.base import BaseCommand
+import logging
 
-from data.models import Canteen, Teledeclaration
+from django.core.management.base import BaseCommand
+from django.core.exceptions import ValidationError
+
+from data.models import Diagnostic
+
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Resubmit teledeclarations for a specified list of canteens"
+    help = "Resubmit teledeclarations for a specified list of diagnostics"
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -26,46 +33,45 @@ class Command(BaseCommand):
             help="Year of the teledeclaration campaign to process",
         )
         parser.add_argument(
-            "--canteen-siret-list",
-            dest="canteen_siret_list",
+            "--teledeclaration-id-list",
+            dest="teledeclaration_id_list",
             type=str,
             required=True,
-            help="Comma-seperated list of canteen SIRETs to process",
+            help="Comma-seperated list of diagnostic IDs to process",
         )
 
     def handle(self, *args, **options):
         # init
-        print("Starting teledeclaration resubmit task")
+        logger.info("Starting task: teledeclaration resubmit")
         teledeclaration_resubmitted_count = 0
         year = options["year"]
-        print("Year in input:", year)
-        canteen_siret_list = options["canteen_siret_list"].split(",")
-        print("SIRET in input list:", len(canteen_siret_list))
+        logger.info(f"Year in input: {year}")
+        teledeclaration_id_list = options["teledeclaration_id_list"].split(",")
+        logger.info(f"Diagnostic IDs in input list: {len(teledeclaration_id_list)}")
 
-        canteen_qs = Canteen.objects.filter(siret__in=canteen_siret_list)
-        print("Canteens found:", canteen_qs.count())
+        # queryset
+        diagnostics_qs = Diagnostic.objects.filter(id__in=teledeclaration_id_list)
+        logger.info(f"Diagnostics (teledeclared) found: {diagnostics_qs.count()}")
 
-        # loop on each canteen
-        for canteen in canteen_qs:
-            # canteen must have submitted a TD during the campaign
-            canteen_td_submitted_for_year_qs = Teledeclaration.objects.filter(canteen=canteen).submitted_for_year(year)
-            if not canteen_td_submitted_for_year_qs.exists():
-                print(f"No teledeclaration for canteen {canteen.siret} for year {year}")
-                continue  # skip canteen
-            canteen_td_submitted_for_year = canteen_td_submitted_for_year_qs.first()
+        # loop on each diagnostic
+        for diagnostic in diagnostics_qs:
+            diagnostic_applicant = diagnostic.applicant
+            # diagnostic must be in the right year
+            if diagnostic.year != year:
+                logger.warning(f"Diagnostic {diagnostic.id} is from year {diagnostic.year}, expected {year}, skipping")
+                continue
+            # diagnostic must be submitted
+            if not diagnostic.is_teledeclared:
+                logger.warning(f"Diagnostic {diagnostic.id} is not teledeclared, skipping")
+                continue
             # cancel TD
-            canteen_td_submitted_for_year.cancel()
+            diagnostic.cancel()
             # recreate TD
             try:
-                Teledeclaration.create_from_diagnostic(
-                    diagnostic=canteen_td_submitted_for_year.diagnostic,
-                    applicant=canteen_td_submitted_for_year.applicant,
-                )
+                diagnostic.teledeclare(applicant=diagnostic_applicant)
                 teledeclaration_resubmitted_count += 1
-            except Exception as e:
-                print(f"Failed to resubmit teledeclaration for canteen {canteen.siret} for year {year}")
-                print(e)
-                continue
+            except ValidationError as e:
+                logger.error(f"Error teledeclaring diagnostic {diagnostic.id}: {e}")
+                continue  # skip to next diagnostic
 
-        print("Done!")
-        print("Teledeclarations resubmitted:", teledeclaration_resubmitted_count)
+        logger.info(f"Done! Teledeclarations resubmitted: {teledeclaration_resubmitted_count}")

--- a/macantine/management/commands/teledeclaration_resubmit.py
+++ b/macantine/management/commands/teledeclaration_resubmit.py
@@ -74,4 +74,8 @@ class Command(BaseCommand):
                 logger.error(f"Error teledeclaring diagnostic {diagnostic.id}: {e}")
                 continue  # skip to next diagnostic
 
-        logger.info(f"Done! Teledeclarations resubmitted: {teledeclaration_resubmitted_count}")
+        result = (
+            f"Teledeclarations resubmitted: {teledeclaration_resubmitted_count} out of {len(teledeclaration_id_list)}"
+        )
+        logger.info(f"Task completed: {result}")
+        return result

--- a/macantine/management/commands/teledeclaration_resubmit.py
+++ b/macantine/management/commands/teledeclaration_resubmit.py
@@ -12,6 +12,7 @@ Ran on 2026-04-15 (last day of 2025 campaign)
 
 import logging
 
+from django.db import transaction
 from django.core.management.base import BaseCommand
 from django.core.exceptions import ValidationError
 
@@ -64,12 +65,14 @@ class Command(BaseCommand):
             if not diagnostic.is_teledeclared:
                 logger.warning(f"Diagnostic {diagnostic.id} is not teledeclared, skipping")
                 continue
-            # cancel TD
-            diagnostic.cancel()
-            # recreate TD
+
             try:
-                diagnostic.teledeclare(applicant=diagnostic_applicant)
-                teledeclaration_resubmitted_count += 1
+                with transaction.atomic():
+                    # cancel & recreate TD
+                    # in a transaction, because the canteen or diagnostic may be in an invalid state and fail to teledeclare again...
+                    diagnostic.cancel()
+                    diagnostic.teledeclare(applicant=diagnostic_applicant)
+                    teledeclaration_resubmitted_count += 1
             except ValidationError as e:
                 logger.error(f"Error teledeclaring diagnostic {diagnostic.id}: {e}")
                 continue  # skip to next diagnostic

--- a/macantine/tests/test_teledeclaration_resubmit.py
+++ b/macantine/tests/test_teledeclaration_resubmit.py
@@ -39,12 +39,14 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertEqual(diagnostic.canteen_snapshot["name"], "First name")
             self.assertEqual(diagnostic.canteen_snapshot["city_insee_code"], "38185")
             original_diagnostic_id = diagnostic.id
+            original_teledeclaration_date = diagnostic.teledeclaration_date
 
             # we make some changes on the canteen
             canteen.name = "New name"
             canteen.city_insee_code = "34172"
             canteen.save()
 
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Run the script
             call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic.id))
 
@@ -52,6 +54,7 @@ class TeledeclarationResubmitScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertEqual(diagnostic.id, original_diagnostic_id)
             self.assertTrue(diagnostic.is_teledeclared)
+            self.assertNotEqual(diagnostic.teledeclaration_date, original_teledeclaration_date)
             self.assertEqual(diagnostic.canteen_snapshot["name"], "New name")
             self.assertEqual(diagnostic.canteen_snapshot["city_insee_code"], "34172")
 
@@ -76,6 +79,7 @@ class TeledeclarationResubmitScriptTest(TestCase):
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 3)
 
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Run the script with multiple diagnostic IDs
             diagnostic_ids = f"{diagnostic_1.id},{diagnostic_2.id},{diagnostic_3.id}"
             call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=diagnostic_ids)
@@ -107,6 +111,7 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
             self.assertEqual(Diagnostic.all_objects.in_year(2025).teledeclared().count(), 1)
 
+        with freeze_time("2026-04-17"):  # during the 2025 correction campaign
             # Run the script with 2024 year, but pass 2025 diagnostic ID
             call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic_2025.id))
 
@@ -137,6 +142,7 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
             self.assertFalse(diagnostic_not_teledeclared.is_teledeclared)
 
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Run the script with both diagnostic IDs
             diagnostic_ids = f"{diagnostic_teledeclared.id},{diagnostic_not_teledeclared.id}"
             call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=diagnostic_ids)
@@ -149,7 +155,7 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertFalse(diagnostic_not_teledeclared.is_teledeclared)
 
     @authenticate
-    def test_handle_non_existent_diagnostic(self):
+    def test_skip_diagnostic_not_found(self):
         """
         The script should gracefully handle non-existent diagnostic IDs by simply skipping them.
         """
@@ -161,11 +167,62 @@ class TeledeclarationResubmitScriptTest(TestCase):
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
 
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Run the script with a mix of valid and non-existent diagnostic IDs
             fake_id = 99999
             diagnostic_ids = f"{diagnostic.id},{fake_id}"
             call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=diagnostic_ids)
 
             # After running the script, the valid diagnostic should still be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_if_diagnostic_validation_error(self):
+        """
+        The script should skip diagnostics that raise a ValidationError during teledeclaration.
+        """
+        canteen = CanteenFactory()
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+
+            # Change the diagnostic to make it invalid
+            Diagnostic.objects.filter(id=diagnostic.id).update(
+                valeur_totale=500, valeur_bio=1000
+            )  # valeur_bio > valeur_totale
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Run the script with the diagnostic ID
+            call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic.id))
+
+            # After running the script, the diagnostic should still be teledeclared (resubmission failed)
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_if_canteen_validation_error(self):
+        """
+        The script should skip diagnostics that raise a ValidationError during teledeclaration.
+        """
+        canteen = CanteenFactory()
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+
+            # Change the canteen to make it invalid
+            Canteen.objects.filter(id=canteen.id).update(city_insee_code=None)
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Run the script with the diagnostic ID
+            call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic.id))
+
+            # After running the script, the diagnostic should still be teledeclared (resubmission failed)
             diagnostic.refresh_from_db()
             self.assertTrue(diagnostic.is_teledeclared)

--- a/macantine/tests/test_teledeclaration_resubmit.py
+++ b/macantine/tests/test_teledeclaration_resubmit.py
@@ -1,0 +1,171 @@
+from django.core.management import call_command
+from django.test import TestCase
+from freezegun import freeze_time
+from django.db.models.signals import post_save
+
+from data.models.canteen import Canteen, fill_geo_fields_from_siret
+from data.models import Diagnostic
+from api.tests.utils import authenticate
+from data.factories import CanteenFactory, DiagnosticFactory
+
+
+class TeledeclarationResubmitScriptTest(TestCase):
+    def setUp(self):
+        post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
+        return super().setUp()
+
+    def tearDown(self):
+        post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
+        return super().tearDown()
+
+    @authenticate
+    def test_resubmit_single_diagnostic(self):
+        """
+        The script should resubmit a single teledeclared diagnostic.
+        """
+        canteen = CanteenFactory(name="First name", city_insee_code="38185")
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(
+                canteen=canteen,
+                year=2024,
+                valeur_totale=10000,
+                valeur_bio=2000,
+            )
+            diagnostic.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+            diagnostic.refresh_from_db()
+            self.assertEqual(diagnostic.canteen_snapshot["name"], "First name")
+            self.assertEqual(diagnostic.canteen_snapshot["city_insee_code"], "38185")
+            original_diagnostic_id = diagnostic.id
+
+            # we make some changes on the canteen
+            canteen.name = "New name"
+            canteen.city_insee_code = "34172"
+            canteen.save()
+
+            # Run the script
+            call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic.id))
+
+            # After running the script
+            diagnostic.refresh_from_db()
+            self.assertEqual(diagnostic.id, original_diagnostic_id)
+            self.assertTrue(diagnostic.is_teledeclared)
+            self.assertEqual(diagnostic.canteen_snapshot["name"], "New name")
+            self.assertEqual(diagnostic.canteen_snapshot["city_insee_code"], "34172")
+
+    @authenticate
+    def test_resubmit_multiple_diagnostics(self):
+        """
+        The script should resubmit multiple teledeclared diagnostics.
+        """
+        canteen_1 = CanteenFactory()
+        canteen_2 = CanteenFactory()
+        canteen_3 = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic_1 = DiagnosticFactory(canteen=canteen_1, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic_2 = DiagnosticFactory(canteen=canteen_2, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic_3 = DiagnosticFactory(canteen=canteen_3, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            diagnostic_1.teledeclare(applicant=authenticate.user)
+            diagnostic_2.teledeclare(applicant=authenticate.user)
+            diagnostic_3.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 3)
+
+            # Run the script with multiple diagnostic IDs
+            diagnostic_ids = f"{diagnostic_1.id},{diagnostic_2.id},{diagnostic_3.id}"
+            call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=diagnostic_ids)
+
+            # After running the script
+            diagnostic_1.refresh_from_db()
+            diagnostic_2.refresh_from_db()
+            diagnostic_3.refresh_from_db()
+
+            self.assertTrue(diagnostic_1.is_teledeclared)
+            self.assertTrue(diagnostic_2.is_teledeclared)
+            self.assertTrue(diagnostic_3.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_from_different_year(self):
+        """
+        The script should skip diagnostics that are from a different year than specified.
+        """
+        canteen = CanteenFactory()
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic_2024 = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic_2024.teledeclare(applicant=authenticate.user)
+
+        with freeze_time("2026-04-15"):  # during the 2025 campaign
+            diagnostic_2025 = DiagnosticFactory(canteen=canteen, year=2025, valeur_totale=10000, valeur_bio=2000)
+            diagnostic_2025.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+            self.assertEqual(Diagnostic.all_objects.in_year(2025).teledeclared().count(), 1)
+
+            # Run the script with 2024 year, but pass 2025 diagnostic ID
+            call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic_2025.id))
+
+            # After running the script, 2025 diagnostic should not be affected
+            diagnostic_2025.refresh_from_db()
+            self.assertTrue(diagnostic_2025.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_not_teledeclared(self):
+        """
+        The script should skip diagnostics that are not teledeclared.
+        """
+        canteen_1 = CanteenFactory()
+        canteen_2 = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic_teledeclared = DiagnosticFactory(
+                canteen=canteen_1, year=2024, valeur_totale=10000, valeur_bio=2000
+            )
+            diagnostic_teledeclared.teledeclare(applicant=authenticate.user)
+
+            # Create a diagnostic that is not teledeclared
+            diagnostic_not_teledeclared = DiagnosticFactory(
+                canteen=canteen_2, year=2024, valeur_totale=10000, valeur_bio=2000
+            )
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+            self.assertFalse(diagnostic_not_teledeclared.is_teledeclared)
+
+            # Run the script with both diagnostic IDs
+            diagnostic_ids = f"{diagnostic_teledeclared.id},{diagnostic_not_teledeclared.id}"
+            call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=diagnostic_ids)
+
+            # After running the script, only the teledeclared one should be affected
+            diagnostic_teledeclared.refresh_from_db()
+            diagnostic_not_teledeclared.refresh_from_db()
+
+            self.assertTrue(diagnostic_teledeclared.is_teledeclared)
+            self.assertFalse(diagnostic_not_teledeclared.is_teledeclared)
+
+    @authenticate
+    def test_handle_non_existent_diagnostic(self):
+        """
+        The script should gracefully handle non-existent diagnostic IDs by simply skipping them.
+        """
+        canteen = CanteenFactory()
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+
+            # Run the script with a mix of valid and non-existent diagnostic IDs
+            fake_id = 99999
+            diagnostic_ids = f"{diagnostic.id},{fake_id}"
+            call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=diagnostic_ids)
+
+            # After running the script, the valid diagnostic should still be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)


### PR DESCRIPTION
### Quoi

Dans #5276 on avait créé une management command `teledeclaration_resubmit` (campagne 2024)

On adapte ici la commande pour la campagne 2025
- prendre en entrée une liste de diagnostic_id au lieu de canteen_siret
- ajout de tests

### Pourquoi

- des cantines ont corrigé leur données après avoir TD. Donc ces données n'apparaissent pas dans leur snapshot.
On a besoin de cancel/teledeclare pour avoir les MAJ.
- comment on obtient la liste des diagnostic_id ? travail coté data/déploiement pour sortir un tableau Metabase