### PR TITLE
fix(Télédéclarations): évite que le script de resubmit plante sur un cas particulier d'applicant id manquant

### DIFF
--- a/macantine/management/commands/teledeclaration_resubmit.py
+++ b/macantine/management/commands/teledeclaration_resubmit.py
@@ -73,7 +73,7 @@ class Command(BaseCommand):
                     diagnostic.cancel()
                     diagnostic.teledeclare(applicant=diagnostic_applicant)
                     teledeclaration_resubmitted_count += 1
-            except ValidationError as e:
+            except (AttributeError, ValidationError) as e:
                 logger.error(f"Error teledeclaring diagnostic {diagnostic.id}: {e}")
                 continue  # skip to next diagnostic
 


### PR DESCRIPTION
Dans #6644 on a remis à jour la commande `teledeclaration_resubmit`
Ca a bien tourné une première fois, mais là j'ai une erreur pas géré
```
File ~/app_ef9ea261-c63f-446f-9c68-a4d39bbb464f/data/models/diagnostic.py:1990, in Diagnostic.teledeclare(self, applicant, skip_validations)
   1987 # applicant data
   1988 self.applicant = applicant
   1989 self.applicant_snapshot = {
-> 1990     "id": applicant.id,
   1991     "name": applicant.get_full_name(),
   1992     "email": applicant.email,
   1993 }
   1995 # aggregated data & EGalim stats
   1996 # TODO: compute on save() instead
   1997 self.populate_aggregated_values()

AttributeError: 'NoneType' object has no attribute 'id'
```

Ce fix permet d'ignorer la TD problématique, on traitera ca plus tard dans les TD "restantes / à TD car en CORRECTION"