### PR TITLE
improve(Tableau de bord): Colonne 'commune': cacher le message "Non renseignée" pour les groupes

### DIFF
--- a/2024-frontend/src/components/GestionnaireCanteensTable.vue
+++ b/2024-frontend/src/components/GestionnaireCanteensTable.vue
@@ -37,7 +37,7 @@ const rows = computed(() => {
   props.canteens.forEach((canteen) => {
     const name = canteensTableService.getNameInfos(canteen)
     const siret = canteensTableService.getSiretOrSirenInfos(canteen)
-    const city = canteensTableService.getCityInfos(canteen)
+    const city = canteen.productionType !== "groupe" ? canteensTableService.getCityInfos(canteen) : ""
     const productionType = canteensTableService.getProductionTypeInfos(canteen) || "Non renseigné"
     const diagnostic = canteensTableService.getDiagnosticInfos(canteen, props.campaign)
     const actions = getDropdownLinks(canteen)

--- a/2024-frontend/src/services/canteensTable.js
+++ b/2024-frontend/src/services/canteensTable.js
@@ -33,7 +33,7 @@ const getCityInfos = (canteen) => {
   let city = ""
   if (canteen.city) city += canteen.city
   if (canteen.postalCode) city += ` (${canteen.postalCode})`
-  if (!canteen.city && !canteen.postalCode) city = "Non renseigné"
+  if (!canteen.city && !canteen.postalCode) city = "Non renseignée"
   return city
 }
 


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/Ne-pas-afficher-le-champ-Non-renseign-pour-les-communes-si-la-cantine-est-un-groupe-348de24614be80dca6b2d0a73e82ee4c

<img width="896" height="358" alt="Capture d’écran 2026-04-20 à 19 58 00" src="https://github.com/user-attachments/assets/6bd9da4e-c10d-446b-9c90-615778ccc575" />
