### PR TITLE
refactor(Télédéclarations): simplifier le code des règles métiers encadrant la TD

### DIFF
--- a/data/validators/diagnostic.py
+++ b/data/validators/diagnostic.py
@@ -18,8 +18,7 @@ def validate_year_and_can_edit(instance):
         - year must be between lower and upper limit years
         - if year is valid:
             - after teledeclaration end date, DRAFT diagnostic cannot be edited anymore
-            - after correction end date, CORRECTION diagnostic cannot be edited anymore
-            - after correction end date, SUBMITTED diagnostic cannot be edited (e.g. cancelled) anymore
+            - after correction end date, any diagnostic cannot be edited anymore
     """
     errors = {}
     field_name = "year"
@@ -38,27 +37,19 @@ def validate_year_and_can_edit(instance):
         else:  # valid year, check can_edit validation
             if instance.pk:
                 now = timezone.now()
-                if instance.status == instance.DiagnosticStatus.DRAFT:
-                    if now > get_year_campaign_end_date_or_today_date(value):
+                if now > get_year_campaign_end_date_or_today_date(value):
+                    if instance.status == instance.DiagnosticStatus.DRAFT:
                         utils_utils.add_validation_error(
                             errors,
                             "year",
                             f"Le diagnostic de l'année {value} ne peut plus être modifié car la campagne de télédéclaration est terminée.",
                         )
-                elif instance.status == instance.DiagnosticStatus.CORRECTION:
-                    if now > get_year_correction_end_date_or_campaign_end_date_or_today_date(value):
-                        utils_utils.add_validation_error(
-                            errors,
-                            "year",
-                            f"Le diagnostic de l'année {value} ne peut plus être modifié car la période de correction est terminée.",
-                        )
-                elif instance.status == instance.DiagnosticStatus.SUBMITTED:
-                    if now > get_year_correction_end_date_or_campaign_end_date_or_today_date(value):
-                        utils_utils.add_validation_error(
-                            errors,
-                            "year",
-                            f"Le diagnostic de l'année {value} ne peut plus être modifié car la campagne de télédéclaration est terminée.",
-                        )
+                if now > get_year_correction_end_date_or_campaign_end_date_or_today_date(value):
+                    utils_utils.add_validation_error(
+                        errors,
+                        "year",
+                        f"Le diagnostic de l'année {value} ne peut plus être modifié car la période de correction est terminée.",
+                    )
     return errors
 
 


### PR DESCRIPTION
Suite aux changements dans #6636 & #6637 & #6641

Clarifie et simplifie les règles métiers
- après la campagne (et la correction), plus aucun Diagnostic n'est modifiable