### PR TITLE
refactor(Télédéclarations): clarifier les méthodes pour récupérer les dates de fin de campagne

### DIFF
--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -499,7 +499,7 @@ class CanteenStatsApiTest(APITestCase):
             response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             body = response.json()
-            self.assertEqual(body["notes"]["canteenCountDescription"], "Au 1 avril 2024")
+            self.assertEqual(body["notes"]["canteenCountDescription"], "Au 11 juin 2024")  # end of campaign
 
     def test_notes_canteen_count_description_after_campaign(self):
         with freeze_time("2024-11-01"):

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -212,11 +212,13 @@ def is_in_teledeclaration_or_correction(year=None):
 
 
 def get_year_campaign_end_date_or_today_date(year):
+    """
+    Return the year's campaign end date
+    """
     year = int(year)
     now = timezone.now()
     if year in CAMPAIGN_DATES.keys():
-        campaign_end_date = CAMPAIGN_DATES[year]["teledeclaration_end_date"]
-        return now if campaign_end_date > now else CAMPAIGN_DATES[year]["teledeclaration_end_date"]
+        return CAMPAIGN_DATES[year]["teledeclaration_end_date"]
     elif year >= now.year:
         return now
     else:
@@ -224,12 +226,15 @@ def get_year_campaign_end_date_or_today_date(year):
 
 
 def get_year_correction_end_date_or_campaign_end_date_or_today_date(year):
+    """
+    Return the year's correction end date
+    Fallback to the year's campaign end date if it doens't exist
+    """
     year = int(year)
     now = timezone.now()
     if year in CAMPAIGN_DATES.keys():
         if CAMPAIGN_DATES[year]["correction_end_date"]:
-            correction_end_date = CAMPAIGN_DATES[year]["correction_end_date"]
-            return now if correction_end_date > now else CAMPAIGN_DATES[year]["correction_end_date"]
+            return CAMPAIGN_DATES[year]["correction_end_date"]
         else:
             return get_year_campaign_end_date_or_today_date(year)
     elif year >= now.year:


### PR DESCRIPTION
Clarifie les méthodes `get_year_campaign_end_date_or_today_date` & `get_year_correction_end_date_or_campaign_end_date_or_today_date`

Jusqu'à présent elle renvoyé `timezone.now()` pendant la campagne, et non la vrai date de fin de la campagne de télédéclaration (ou de correction).
C'était dû à l'Observatoire.

J'ai opté pour simplifier