### PR TITLE
feat(Télédéclarations): nouveau script pour télédéclarer tous les bilans en CORRECTION

### DIFF
--- a/macantine/management/commands/teledeclaration_submit_correction.py
+++ b/macantine/management/commands/teledeclaration_submit_correction.py
@@ -13,7 +13,7 @@ from django.core.management.base import BaseCommand
 from django.core.exceptions import ValidationError
 from simple_history.utils import update_change_reason
 
-from data.models import Diagnostic
+from data.models import Diagnostic, User
 
 
 logger = logging.getLogger(__name__)
@@ -45,9 +45,12 @@ class Command(BaseCommand):
         # loop on each diagnostic
         for diagnostic in diagnostics_qs:
             # get the (previous) applicant
-            diagnostic_applicant = (
-                diagnostic.history.filter(status=Diagnostic.DiagnosticStatus.SUBMITTED).first().applicant
-            )
+            try:
+                diagnostic_applicant = (
+                    diagnostic.history.filter(status=Diagnostic.DiagnosticStatus.SUBMITTED).first().applicant
+                )
+            except User.DoesNotExist:
+                diagnostic_applicant = None
             # teledeclare
             try:
                 diagnostic.teledeclare(applicant=diagnostic_applicant)

--- a/macantine/management/commands/teledeclaration_submit_correction.py
+++ b/macantine/management/commands/teledeclaration_submit_correction.py
@@ -45,7 +45,9 @@ class Command(BaseCommand):
         # loop on each diagnostic
         for diagnostic in diagnostics_qs:
             # get the (previous) applicant
-            diagnostic_applicant = diagnostic.history.first().applicant
+            diagnostic_applicant = (
+                diagnostic.history.filter(status=Diagnostic.DiagnosticStatus.SUBMITTED).first().applicant
+            )
             # teledeclare
             try:
                 diagnostic.teledeclare(applicant=diagnostic_applicant)

--- a/macantine/management/commands/teledeclaration_submit_correction.py
+++ b/macantine/management/commands/teledeclaration_submit_correction.py
@@ -11,6 +11,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 from django.core.exceptions import ValidationError
+from simple_history.utils import update_change_reason
 
 from data.models import Diagnostic
 
@@ -48,6 +49,7 @@ class Command(BaseCommand):
             # teledeclare
             try:
                 diagnostic.teledeclare(applicant=diagnostic_applicant)
+                update_change_reason(diagnostic, "Script: teledeclaration_submit_correction")
                 teledeclaration_correction_submitted_count += 1
             except (AttributeError, ValidationError) as e:
                 logger.error(f"Error teledeclaring diagnostic {diagnostic.id}: {e}")

--- a/macantine/management/commands/teledeclaration_submit_correction.py
+++ b/macantine/management/commands/teledeclaration_submit_correction.py
@@ -1,0 +1,58 @@
+"""
+Why this script?
+During the correction campaign, some users will cancel their teledeclaration to make some changes.
+But not all of them will actually re-submit their teledeclaration after making the changes.
+
+How to run?
+python manage.py teledeclaration_submit_correction --year 2025
+"""
+
+import logging
+
+from django.core.management.base import BaseCommand
+from django.core.exceptions import ValidationError
+
+from data.models import Diagnostic
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Submit CORRECTION teledeclarations (during the correction campaign)"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--year",
+            dest="year",
+            type=int,
+            required=True,
+            help="Year of the teledeclaration campaign to process",
+        )
+
+    def handle(self, *args, **options):
+        # init
+        logger.info("Starting task: teledeclaration submit correction")
+        teledeclaration_correction_submitted_count = 0
+        year = options["year"]
+        logger.info(f"Year in input: {year}")
+
+        # queryset
+        diagnostics_qs = Diagnostic.objects.filter(year=year).filter(status=Diagnostic.DiagnosticStatus.CORRECTION)
+        logger.info(f"Diagnostics (correction) found: {diagnostics_qs.count()}")
+
+        # loop on each diagnostic
+        for diagnostic in diagnostics_qs:
+            # get the (previous) applicant
+            diagnostic_applicant = diagnostic.history.first().applicant
+            # teledeclare
+            try:
+                diagnostic.teledeclare(applicant=diagnostic_applicant)
+                teledeclaration_correction_submitted_count += 1
+            except (AttributeError, ValidationError) as e:
+                logger.error(f"Error teledeclaring diagnostic {diagnostic.id}: {e}")
+                continue  # skip to next diagnostic
+
+        result = f"Teledeclarations submitted (correction): {teledeclaration_correction_submitted_count} out of {diagnostics_qs.count()} diagnostics in correction status for year {year}"
+        logger.info(f"Task completed: {result}")
+        return result

--- a/macantine/tests/test_teledeclaration_submit_correction.py
+++ b/macantine/tests/test_teledeclaration_submit_correction.py
@@ -1,0 +1,196 @@
+from django.core.management import call_command
+from django.test import TestCase
+from freezegun import freeze_time
+from django.db.models.signals import post_save
+
+from data.models.canteen import Canteen, fill_geo_fields_from_siret
+from data.models import Diagnostic
+from api.tests.utils import authenticate
+from data.factories import CanteenFactory, DiagnosticFactory
+
+
+class TeledeclarationSubmitCorrectionScriptTest(TestCase):
+    def setUp(self):
+        post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
+        return super().setUp()
+
+    def tearDown(self):
+        post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
+        return super().tearDown()
+
+    @authenticate
+    def test_submit_single_diagnostic_in_correction(self):
+        canteen = CanteenFactory(name="First name", city_insee_code="38185")
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(
+                canteen=canteen,
+                year=2024,
+                valeur_totale=10000,
+                valeur_bio=2000,
+            )
+            diagnostic.teledeclare(applicant=authenticate.user)
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+            diagnostic.refresh_from_db()
+            self.assertEqual(diagnostic.canteen_snapshot["name"], "First name")
+            self.assertEqual(diagnostic.canteen_snapshot["city_insee_code"], "38185")
+            original_diagnostic_id = diagnostic.id
+            original_teledeclaration_date = diagnostic.teledeclaration_date
+
+            # Make some changes on the canteen
+            canteen.name = "New name"
+            canteen.city_insee_code = "34172"
+            canteen.save()
+
+            # Cancel the teledeclaration
+            diagnostic.cancel()
+
+            # Run the script
+            call_command("teledeclaration_submit_correction", year=2024)
+
+            # After running the script
+            diagnostic.refresh_from_db()
+            self.assertEqual(diagnostic.id, original_diagnostic_id)
+            self.assertTrue(diagnostic.is_teledeclared)
+            self.assertEqual(diagnostic.applicant, authenticate.user)
+            self.assertNotEqual(diagnostic.teledeclaration_date, original_teledeclaration_date)
+            self.assertEqual(diagnostic.canteen_snapshot["name"], "New name")
+            self.assertEqual(diagnostic.canteen_snapshot["city_insee_code"], "34172")
+
+    @authenticate
+    def test_submit_multiple_diagnostics_in_correction(self):
+        canteen_1 = CanteenFactory()
+        canteen_2 = CanteenFactory()
+        canteen_3 = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic_1 = DiagnosticFactory(canteen=canteen_1, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic_2 = DiagnosticFactory(canteen=canteen_2, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic_3 = DiagnosticFactory(canteen=canteen_3, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            diagnostic_1.teledeclare(applicant=authenticate.user)
+            diagnostic_2.teledeclare(applicant=authenticate.user)
+            diagnostic_3.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 3)
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # cancel 2 teledeclarations
+            diagnostic_1.cancel()
+            diagnostic_2.cancel()
+
+            # Run the script
+            call_command("teledeclaration_submit_correction", year=2024)
+
+            # After running the script
+            diagnostic_1.refresh_from_db()
+            diagnostic_2.refresh_from_db()
+            diagnostic_3.refresh_from_db()
+
+            self.assertTrue(diagnostic_1.is_teledeclared)
+            self.assertTrue(diagnostic_2.is_teledeclared)
+            self.assertTrue(diagnostic_3.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_teledeclared(self):
+        canteen = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic_teledeclared = DiagnosticFactory(
+                canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000
+            )
+            diagnostic_teledeclared.teledeclare(applicant=authenticate.user)
+            original_teledeclaration_date = diagnostic_teledeclared.teledeclaration_date
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+            self.assertTrue(diagnostic_teledeclared.is_teledeclared)
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Run the script
+            call_command("teledeclaration_submit_correction", year=2024)
+
+            # After running the script, the diagnostic should still be teledeclared (not cancelled and re-teledeclared)
+            diagnostic_teledeclared.refresh_from_db()
+
+            self.assertTrue(diagnostic_teledeclared.is_teledeclared)
+            self.assertEqual(diagnostic_teledeclared.teledeclaration_date, original_teledeclaration_date)
+
+    @authenticate
+    def test_skip_diagnostic_in_draft(self):
+        canteen = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic_draft = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+            self.assertFalse(diagnostic_draft.is_teledeclared)
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Run the script
+            call_command("teledeclaration_submit_correction", year=2024)
+
+            # After running the script, the diagnostic should still be in draft (not teledeclared)
+            diagnostic_draft.refresh_from_db()
+
+            self.assertFalse(diagnostic_draft.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_if_diagnostic_validation_error(self):
+        """
+        The script should skip diagnostics that raise a ValidationError during teledeclaration.
+        """
+        canteen = CanteenFactory()
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+
+            # Cancel the teledeclaration
+            diagnostic.cancel()
+
+            # Change the diagnostic to make it invalid
+            Diagnostic.objects.filter(id=diagnostic.id).update(
+                valeur_totale=500, valeur_bio=1000
+            )  # valeur_bio > valeur_totale
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Run the script
+            call_command("teledeclaration_submit_correction", year=2024)
+
+            # After running the script, the diagnostic should still be in CORRECTION (resubmission failed)
+            diagnostic.refresh_from_db()
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
+
+    @authenticate
+    def test_skip_diagnostic_if_canteen_validation_error(self):
+        """
+        The script should skip diagnostics that raise a ValidationError during teledeclaration.
+        """
+        canteen = CanteenFactory()
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+
+            # Cancel the teledeclaration
+            diagnostic.cancel()
+
+            # Change the canteen to make it invalid
+            Canteen.objects.filter(id=canteen.id).update(city_insee_code=None)
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Run the script
+            call_command("teledeclaration_submit_correction", year=2024)
+
+            # After running the script, the diagnostic should still be in CORRECTION (resubmission failed)
+            diagnostic.refresh_from_db()
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)

--- a/macantine/tests/test_teledeclaration_submit_correction.py
+++ b/macantine/tests/test_teledeclaration_submit_correction.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_save
 from data.models.canteen import Canteen, fill_geo_fields_from_siret
 from data.models import Diagnostic
 from api.tests.utils import authenticate
-from data.factories import CanteenFactory, DiagnosticFactory
+from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 
 
 class TeledeclarationSubmitCorrectionScriptTest(TestCase):
@@ -188,6 +188,33 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             canteen.city_insee_code = None
             canteen.save()
             self.assertFalse(canteen.is_filled)  # model field
+
+            # Run the script
+            call_command("teledeclaration_submit_correction", year=2024)
+
+            # After running the script, the diagnostic should still be in CORRECTION (teledeclaration failed)
+            diagnostic.refresh_from_db()
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
+
+    @authenticate
+    def test_skip_diagnostic_if_canteen_applicant_deleted(self):
+        canteen = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+        user = UserFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Cancel the teledeclaration
+            diagnostic.cancel()
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
+
+            # Change the canteen to make it invalid
+            user.delete()
 
             # Run the script
             call_command("teledeclaration_submit_correction", year=2024)

--- a/macantine/tests/test_teledeclaration_submit_correction.py
+++ b/macantine/tests/test_teledeclaration_submit_correction.py
@@ -164,7 +164,7 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             # Run the script
             call_command("teledeclaration_submit_correction", year=2024)
 
-            # After running the script, the diagnostic should still be in CORRECTION (resubmission failed)
+            # After running the script, the diagnostic should still be in CORRECTION (teledeclaration failed)
             diagnostic.refresh_from_db()
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
@@ -191,6 +191,6 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             # Run the script
             call_command("teledeclaration_submit_correction", year=2024)
 
-            # After running the script, the diagnostic should still be in CORRECTION (resubmission failed)
+            # After running the script, the diagnostic should still be in CORRECTION (teledeclaration failed)
             diagnostic.refresh_from_db()
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)

--- a/macantine/tests/test_teledeclaration_submit_correction.py
+++ b/macantine/tests/test_teledeclaration_submit_correction.py
@@ -46,6 +46,7 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
 
             # Cancel the teledeclaration
             diagnostic.cancel()
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
             # Run the script
             call_command("teledeclaration_submit_correction", year=2024)
@@ -127,7 +128,7 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             diagnostic_draft = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
 
             # Before running the script
-            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
             self.assertFalse(diagnostic_draft.is_teledeclared)
 
         with freeze_time("2025-04-17"):  # during the 2024 correction campaign
@@ -141,10 +142,8 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
 
     @authenticate
     def test_skip_diagnostic_if_diagnostic_validation_error(self):
-        """
-        The script should skip diagnostics that raise a ValidationError during teledeclaration.
-        """
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
             diagnostic.teledeclare(applicant=authenticate.user)
@@ -152,15 +151,16 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
 
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Cancel the teledeclaration
             diagnostic.cancel()
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
             # Change the diagnostic to make it invalid
-            Diagnostic.objects.filter(id=diagnostic.id).update(
-                valeur_totale=500, valeur_bio=1000
-            )  # valeur_bio > valeur_totale
+            Diagnostic.objects.filter(id=diagnostic.id).update(valeur_totale=0)
+            diagnostic.refresh_from_db()
+            self.assertFalse(diagnostic.is_filled)  # property
 
-        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Run the script
             call_command("teledeclaration_submit_correction", year=2024)
 
@@ -170,10 +170,8 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
 
     @authenticate
     def test_skip_diagnostic_if_canteen_validation_error(self):
-        """
-        The script should skip diagnostics that raise a ValidationError during teledeclaration.
-        """
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
             diagnostic.teledeclare(applicant=authenticate.user)
@@ -181,13 +179,16 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
 
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Cancel the teledeclaration
             diagnostic.cancel()
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
             # Change the canteen to make it invalid
-            Canteen.objects.filter(id=canteen.id).update(city_insee_code=None)
+            canteen.city_insee_code = None
+            canteen.save()
+            self.assertFalse(canteen.is_filled)  # model field
 
-        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Run the script
             call_command("teledeclaration_submit_correction", year=2024)
 


### PR DESCRIPTION
Nouvelle management command `teledeclaration_submit_correction`
- inspirée de `teledeclaration_resubmit`
- teledeclare toutes les TD avec le statut "CORRECTION"

Prochaine PR: tâche cron pour lancer cette commande toutes les nuit (juste avant minuit)