### PR TITLE
improve(Satellites): clarifie les messages d'erreur pour modifier les RSAT du groupe avec une TD durant la campagne

### DIFF
--- a/2024-frontend/src/components/CanteenModalSatelliteRemove.vue
+++ b/2024-frontend/src/components/CanteenModalSatelliteRemove.vue
@@ -55,7 +55,7 @@ const unlinkSatellite = () => {
   >
     <template #default>
       <p class="fr-mb-2w">
-        En confirmant cette demande « {{ satellite.name }} » ne fera plus parti des restaurants fournis par votre
+        En confirmant cette demande « {{ satellite.name }} » ne fera plus partie des restaurants fournis par votre
         groupe « {{ groupe.name }} » et donc :
       </p>
       <ul>
@@ -66,7 +66,7 @@ const unlinkSatellite = () => {
         </li>
         <li>
           <p>
-            si vous avez déjà effecté une télédéclaration ses donnnées seront conservées
+            si vous avez déjà effecté une télédéclaration ses données seront conservées
           </p>
         </li>
       </ul>

--- a/api/views/canteen_groupe.py
+++ b/api/views/canteen_groupe.py
@@ -62,7 +62,7 @@ class CanteenGroupeSatelliteLinkView(APIView):
             if canteen_groupe.has_diagnostic_teledeclared_for_year(timezone.now().year - 1):
                 return JsonResponse(
                     {
-                        "error": "Vous ne pouvez pas ajouter de restaurant satellite à votre groupe, car il possède un bilan télédéclaré (campagne de télédéclaration en cours). Veuillez annuler la télédéclaration pour pouvoir ajouter le restaurant satellite.",
+                        "error": "Vous ne pouvez pas ajouter de restaurant satellite en cours de campagne avec un bilan télédéclaré. En effet la télédéclaration fige les données, pour effectuer une modification durant la campagne vous devez : aller sur le bilan du groupe et cliquer sur 'corriger' la télédéclaration ; revenir sur cette page pour ajouter le restaurant satellite ; télédéclarer à nouveau le bilan du groupe.",
                     },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
@@ -96,7 +96,7 @@ class CanteenGroupeSatelliteUnlinkView(APIView):
             if canteen_groupe.has_diagnostic_teledeclared_for_year(timezone.now().year - 1):
                 return JsonResponse(
                     {
-                        "error": "Vous ne pouvez pas retirer de restaurant satellite à votre groupe, car il possède un bilan télédéclaré (campagne de télédéclaration en cours). Veuillez annuler la télédéclaration pour pouvoir retirer le restaurant satellite.",
+                        "error": "Vous ne pouvez pas retirer le restaurant satellite en cours de campagne avec un bilan télédéclaré. En effet la télédéclaration fige les données, pour effectuer une modification durant la campagne vous devez : aller sur le bilan du groupe et cliquer sur 'corriger' la télédéclaration ; revenir sur cette page pour retirer le restaurant satellite ; télédéclarer à nouveau le bilan du groupe.",
                     },
                     status=status.HTTP_400_BAD_REQUEST,
                 )


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/Modifier-le-wording-de-rattachement-d-une-RSAT-un-groupe-34cde24614be805aa6a4f3be5cf28c44

|Ajout|Suppression|
|--|--|
| <img width="828" height="610" alt="Capture d’écran 2026-04-27 à 12 13 13" src="https://github.com/user-attachments/assets/064ee97a-98a9-432e-b9b9-f891acd52f37" /> | <img width="1822" height="1108" alt="Capture d’écran 2026-04-27 à 12 13 04" src="https://github.com/user-attachments/assets/ad7f8fe7-59f2-4ef3-982b-0bc5a76c2538" /> |