### PR TITLE
fix(Télédéclaration): corrige l'affichage du pourcentage des valeurs durables et de qualité

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -225,7 +225,7 @@ export const hasApproGraphData = (diagnostic) => {
   return graphDataKeys.some((k) => Object.hasOwn(diagnostic, k))
 }
 
-export const getSustainableTotal = (diagnostic, options) => {
+export const getSustainableTotal = (diagnostic, type) => {
   const valeurSiqo = diagnostic.valeurSiqo || 0
   const valeurExternalitesPerformance = diagnostic.valeurExternalitesPerformance || 0
   const valeurEgalimAutres = diagnostic.valeurEgalimAutres || 0
@@ -236,7 +236,7 @@ export const getSustainableTotal = (diagnostic, options) => {
   const sumAllValues = valeurSiqo + valeurExternalitesPerformance + valeurEgalimAutres
   const sumAllPourcentages = pourcentageSiqo + pourcentageExternalitesPerformance + pourcentageEgalimAutres
 
-  return options?.percentageOnly ? sumAllPourcentages : sumAllValues
+  return type === "pourcentages" ? sumAllPourcentages : sumAllValues
 }
 
 // returns a dict of integers (null/0-100) for the appro %

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -225,15 +225,18 @@ export const hasApproGraphData = (diagnostic) => {
   return graphDataKeys.some((k) => Object.hasOwn(diagnostic, k))
 }
 
-export const getSustainableTotal = (diagnostic) => {
-  const sustainableSum =
-    (diagnostic.valeurSiqo || 0) +
-    (diagnostic.valeurExternalitesPerformance || 0) +
-    (diagnostic.valeurEgalimAutres || 0) +
-    (diagnostic.percentageValeurSiqo || 0) +
-    (diagnostic.percentageValeurExternalitesPerformance || 0) +
-    (diagnostic.percentageValeurEgalimAutres || 0)
-  return sustainableSum
+export const getSustainableTotal = (diagnostic, options) => {
+  const valeurSiqo = diagnostic.valeurSiqo || 0
+  const valeurExternalitesPerformance = diagnostic.valeurExternalitesPerformance || 0
+  const valeurEgalimAutres = diagnostic.valeurEgalimAutres || 0
+  const pourcentageSiqo = diagnostic.percentageValeurSiqo || 0
+  const pourcentageExternalitesPerformance = diagnostic.percentageValeurExternalitesPerformance || 0
+  const pourcentageEgalimAutres = diagnostic.percentageValeurEgalimAutres || 0
+
+  const sumAllValues = valeurSiqo + valeurExternalitesPerformance + valeurEgalimAutres
+  const sumAllPourcentages = pourcentageSiqo + pourcentageExternalitesPerformance + pourcentageEgalimAutres
+
+  return options?.percentageOnly ? sumAllPourcentages : sumAllValues
 }
 
 // returns a dict of integers (null/0-100) for the appro %

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -225,7 +225,7 @@ export const hasApproGraphData = (diagnostic) => {
   return graphDataKeys.some((k) => Object.hasOwn(diagnostic, k))
 }
 
-export const getSustainableTotal = (diagnostic, type) => {
+export const getSustainableTotal = (diagnostic) => {
   const valeurSiqo = diagnostic.valeurSiqo || 0
   const valeurExternalitesPerformance = diagnostic.valeurExternalitesPerformance || 0
   const valeurEgalimAutres = diagnostic.valeurEgalimAutres || 0
@@ -236,7 +236,7 @@ export const getSustainableTotal = (diagnostic, type) => {
   const sumAllValues = valeurSiqo + valeurExternalitesPerformance + valeurEgalimAutres
   const sumAllPourcentages = pourcentageSiqo + pourcentageExternalitesPerformance + pourcentageEgalimAutres
 
-  return type === "pourcentages" ? sumAllPourcentages : sumAllValues
+  return diagnostic.percentageValeurTotale ? sumAllPourcentages : sumAllValues
 }
 
 // returns a dict of integers (null/0-100) for the appro %


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/Erreur-de-SIQO-8598954-34cde24614be81189466f87c827a59b3?v=1f3de24614be80e6ae4c000c60420853

Régression suite aux correctifs de #6658 : 

- les champs "pourcentages" ont été rajouté au serializer 
- mais parfois il y a les pourcentages et les valeurs brutes (dans la partie admin)
- la fonction "getSustainableTotal" ne s'attendait pas à avoir les deux