### PR TITLE
feat(Télédéclarations): script pour permettre de télédéclarer une liste de bilans hors campagne

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -2028,6 +2028,8 @@ class Diagnostic(models.Model):
                     raise ValidationError(
                         f"{self.canteen.satellites_missing_data_count} satellites du groupe associée à ce diagnostic ne sont pas remplis"
                     )
+            # TODO: check if the applicant is in the canteen.managers ?
+            # TODO: run diagnostic.full_clean() (validators) ?
 
         from api.serializers import CanteenTeledeclarationSerializer, SatelliteTeledeclarationSerializer
 

--- a/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
+++ b/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
@@ -12,8 +12,10 @@ import logging
 from django.core.management.base import BaseCommand
 from django.core.exceptions import ValidationError
 from simple_history.utils import update_change_reason
+from django.utils import timezone
 
 from data.models import Diagnostic, User
+from macantine.utils import get_year_campaign_start_date
 
 
 logger = logging.getLogger(__name__)
@@ -46,6 +48,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--apply",
+            action="store_true",
             help="To apply changes, otherwise just show what would be done (dry run).",
             default=False,
         )
@@ -72,6 +75,12 @@ class Command(BaseCommand):
         applicant = User.objects.get(id=applicant_id)
         logger.info(f"Applicant found: {applicant}")
 
+        if timezone.now() < get_year_campaign_start_date(year):
+            logger.error(
+                f"The campaign for year {year} has not started yet. Start date: {get_year_campaign_start_date(year)}. Aborting."
+            )
+            return
+
         # loop on each diagnostic
         for diagnostic in diagnostics_qs:
             # diagnostic must be in the right year
@@ -84,7 +93,7 @@ class Command(BaseCommand):
                 continue
             # teledeclare
             try:
-                diagnostic.teledeclare(applicant=applicant)
+                diagnostic.teledeclare(applicant=applicant, skip_validations=True)
                 update_change_reason(diagnostic, "Script: teledeclaration_submit_outside_of_campaign")
                 teledeclaration_submitted_count += 1
             except (AttributeError, ValidationError) as e:

--- a/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
+++ b/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
@@ -92,13 +92,14 @@ class Command(BaseCommand):
                 logger.warning(f"Diagnostic {diagnostic.id} is already teledeclared, skipping")
                 continue
             # teledeclare
-            try:
-                diagnostic.teledeclare(applicant=applicant, skip_validations=True)
-                update_change_reason(diagnostic, "Script: teledeclaration_submit_outside_of_campaign")
-                teledeclaration_submitted_count += 1
-            except (AttributeError, ValidationError) as e:
-                logger.error(f"Error teledeclaring diagnostic {diagnostic.id}: {e}")
-                continue  # skip to next diagnostic
+            if apply:
+                try:
+                    diagnostic.teledeclare(applicant=applicant, skip_validations=True)
+                    update_change_reason(diagnostic, "Script: teledeclaration_submit_outside_of_campaign")
+                    teledeclaration_submitted_count += 1
+                except (AttributeError, ValidationError) as e:
+                    logger.error(f"Error teledeclaring diagnostic {diagnostic.id}: {e}")
+                    continue  # skip to next diagnostic
 
         result = f"Teledeclarations submitted (outside of campaign): {teledeclaration_submitted_count} out of {diagnostics_qs.count()} for year {year}"
         logger.info(f"Task completed: {result}")

--- a/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
+++ b/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
@@ -15,7 +15,11 @@ from simple_history.utils import update_change_reason
 from django.utils import timezone
 
 from data.models import Diagnostic, User
-from macantine.utils import get_year_campaign_start_date
+from macantine.utils import (
+    get_year_campaign_start_date,
+    get_year_campaign_end_date_or_today_date,
+    get_year_correction_end_date_or_campaign_end_date_or_today_date,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -27,7 +31,6 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             "--year",
-            dest="year",
             type=int,
             required=True,
             help="Year of the teledeclaration campaign to process",
@@ -64,6 +67,7 @@ class Command(BaseCommand):
         applicant_id = options["applicant_id"]
         logger.info(f"Applicant ID in input: {applicant_id}")
         apply = options["apply"]
+        now = timezone.now()
 
         if not apply:
             logger.info("Dry run mode, no changes will be applied.")
@@ -75,7 +79,7 @@ class Command(BaseCommand):
         applicant = User.objects.get(id=applicant_id)
         logger.info(f"Applicant found: {applicant}")
 
-        if timezone.now() < get_year_campaign_start_date(year):
+        if now < get_year_campaign_start_date(year):
             logger.error(
                 f"The campaign for year {year} has not started yet. Start date: {get_year_campaign_start_date(year)}. Aborting."
             )
@@ -91,6 +95,20 @@ class Command(BaseCommand):
             if diagnostic.is_teledeclared:
                 logger.warning(f"Diagnostic {diagnostic.id} is already teledeclared, skipping")
                 continue
+            # diagnostic DRAFT: must be after campaign end date
+            if diagnostic.status == Diagnostic.DiagnosticStatus.DRAFT:
+                if now < get_year_campaign_end_date_or_today_date(year):
+                    logger.warning(
+                        f"Diagnostic {diagnostic.id} is in DRAFT status but the campaign for year {year} has not ended yet, skipping"
+                    )
+                    continue
+            # diagnostic CORRECTION: must be after campaign end date
+            if diagnostic.status == Diagnostic.DiagnosticStatus.CORRECTION:
+                if now < get_year_correction_end_date_or_campaign_end_date_or_today_date(year):
+                    logger.warning(
+                        f"Diagnostic {diagnostic.id} is in CORRECTION status but the correction campaign for year {year} has not ended yet, skipping"
+                    )
+                    continue
             # teledeclare
             if apply:
                 try:

--- a/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
+++ b/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
@@ -1,0 +1,96 @@
+"""
+Why this script?
+After the teledeclaration campaign, we might want to EXCEPTIONNALY submit some diagnostics.
+
+How to run?
+python manage.py teledeclaration_submit_outside_of_campaign --year 2025 --diagnostic-id-list 123,456,789 --applicant-id 42
+python manage.py teledeclaration_submit_outside_of_campaign --year 2025 --diagnostic-id-list 123,456,789 --applicant-id 42 --apply
+"""
+
+import logging
+
+from django.core.management.base import BaseCommand
+from django.core.exceptions import ValidationError
+from simple_history.utils import update_change_reason
+
+from data.models import Diagnostic, User
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Submit teledeclarations outside of the campaign"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--year",
+            dest="year",
+            type=int,
+            required=True,
+            help="Year of the teledeclaration campaign to process",
+        )
+        parser.add_argument(
+            "--diagnostic-id-list",
+            dest="diagnostic_id_list",
+            type=str,
+            required=True,
+            help="Comma-separated list of diagnostic IDs to process",
+        )
+        parser.add_argument(
+            "--applicant-id",
+            dest="applicant_id",
+            type=int,
+            required=True,
+            help="ID of the applicant (User) to set when teledeclaring",
+        )
+        parser.add_argument(
+            "--apply",
+            help="To apply changes, otherwise just show what would be done (dry run).",
+            default=False,
+        )
+
+    def handle(self, *args, **options):
+        # init
+        logger.info("Starting task: teledeclaration submit outside of campaign")
+        teledeclaration_submitted_count = 0
+        year = options["year"]
+        logger.info(f"Year in input: {year}")
+        diagnostic_id_list = options["diagnostic_id_list"].split(",")
+        logger.info(f"Diagnostic IDs in input list: {len(diagnostic_id_list)}")
+        applicant_id = options["applicant_id"]
+        logger.info(f"Applicant ID in input: {applicant_id}")
+        apply = options["apply"]
+
+        if not apply:
+            logger.info("Dry run mode, no changes will be applied.")
+
+        # queryset
+        diagnostics_qs = Diagnostic.objects.filter(id__in=diagnostic_id_list)
+        logger.info(f"Diagnostics found: {diagnostics_qs.count()}")
+
+        applicant = User.objects.get(id=applicant_id)
+        logger.info(f"Applicant found: {applicant}")
+
+        # loop on each diagnostic
+        for diagnostic in diagnostics_qs:
+            # diagnostic must be in the right year
+            if diagnostic.year != year:
+                logger.warning(f"Diagnostic {diagnostic.id} is from year {diagnostic.year}, expected {year}, skipping")
+                continue
+            # diagnostic must not be submitted
+            if diagnostic.is_teledeclared:
+                logger.warning(f"Diagnostic {diagnostic.id} is already teledeclared, skipping")
+                continue
+            # teledeclare
+            try:
+                diagnostic.teledeclare(applicant=applicant)
+                update_change_reason(diagnostic, "Script: teledeclaration_submit_outside_of_campaign")
+                teledeclaration_submitted_count += 1
+            except (AttributeError, ValidationError) as e:
+                logger.error(f"Error teledeclaring diagnostic {diagnostic.id}: {e}")
+                continue  # skip to next diagnostic
+
+        result = f"Teledeclarations submitted (outside of campaign): {teledeclaration_submitted_count} out of {diagnostics_qs.count()} for year {year}"
+        logger.info(f"Task completed: {result}")
+        return result

--- a/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
+++ b/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
@@ -1,6 +1,9 @@
 """
 Why this script?
-After the teledeclaration campaign, we might want to EXCEPTIONNALY submit some diagnostics.
+During or after the teledeclaration campaign, we might want to EXCEPTIONNALY submit some diagnostics.
+- DRAFT diagnostics: only if the campaign has ended (otherwise users can submit them by themselves)
+- CORRECTION diagnostics: only if the correction campaign has ended (otherwise users can submit them by themselves)
+- diagnostics must be from the right year
 
 How to run?
 python manage.py teledeclaration_submit_outside_of_campaign --year 2025 --diagnostic-id-list 123,456,789 --applicant-id 42

--- a/macantine/tests/test_teledeclaration_submit_outside_of_campaign.py
+++ b/macantine/tests/test_teledeclaration_submit_outside_of_campaign.py
@@ -299,3 +299,33 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             # After running the script, the diagnostic should be teledeclared
             diagnostic.refresh_from_db()
             self.assertTrue(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_submit_diagnostic_even_if_satellite_validation_error(self):
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=groupe, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+
+            # Change the satellite canteen to make it invalid
+            satellite.city_insee_code = None
+            satellite.save()
+            self.assertFalse(satellite.is_filled)  # model field
+
+        with freeze_time("2025-08-30"):  # after the 2024 campaign
+            # Run the script
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=str(diagnostic.id),
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, the diagnostic should be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)

--- a/macantine/tests/test_teledeclaration_submit_outside_of_campaign.py
+++ b/macantine/tests/test_teledeclaration_submit_outside_of_campaign.py
@@ -83,80 +83,6 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             self.assertTrue(diagnostic_3.is_teledeclared)
 
     @authenticate
-    def test_cannot_submit_diagnostic_before_campaign(self):
-        canteen = CanteenFactory()
-
-        with freeze_time("2025-01-01"):  # before the 2024 campaign
-            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-
-            # Before running the script
-            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
-
-            # Run the script
-            call_command(
-                "teledeclaration_submit_outside_of_campaign",
-                year=2024,
-                diagnostic_id_list=str(diagnostic.id),
-                applicant_id=authenticate.user.id,
-                apply=True,
-            )
-
-            # After running the script, the diagnostic should not be teledeclared
-            diagnostic.refresh_from_db()
-            self.assertFalse(diagnostic.is_teledeclared)
-
-    @authenticate
-    def test_cannot_submit_diagnostic_draft_during_campaign(self):
-        canteen = CanteenFactory()
-
-        with freeze_time("2025-03-30"):  # during the 2024 campaign
-            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-
-            # Before running the script
-            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
-
-            # Run the script
-            call_command(
-                "teledeclaration_submit_outside_of_campaign",
-                year=2024,
-                diagnostic_id_list=str(diagnostic.id),
-                applicant_id=authenticate.user.id,
-                apply=True,
-            )
-
-            # After running the script, the diagnostic should not be teledeclared
-            diagnostic.refresh_from_db()
-            self.assertFalse(diagnostic.is_teledeclared)
-
-    @authenticate
-    def test_cannot_submit_diagnostic_correction_during_correction_campaign(self):
-        canteen = CanteenFactory()
-
-        with freeze_time("2025-03-30"):  # during the 2024 campaign
-            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=authenticate.user)
-
-            # Before running the script
-            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
-
-        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
-            # Cancel the teledeclaration
-            diagnostic.cancel()
-
-            # Run the script
-            call_command(
-                "teledeclaration_submit_outside_of_campaign",
-                year=2024,
-                diagnostic_id_list=str(diagnostic.id),
-                applicant_id=authenticate.user.id,
-                apply=True,
-            )
-
-            # After running the script, the diagnostic should not be teledeclared
-            diagnostic.refresh_from_db()
-            self.assertFalse(diagnostic.is_teledeclared)
-
-    @authenticate
     def test_skip_diagnostic_from_different_year(self):
         canteen = CanteenFactory()
         with freeze_time("2025-03-30"):  # during the 2024 campaign
@@ -244,6 +170,80 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             # After running the script, the valid diagnostic should be teledeclared
             diagnostic.refresh_from_db()
             self.assertTrue(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_if_before_campaign(self):
+        canteen = CanteenFactory()
+
+        with freeze_time("2025-01-01"):  # before the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+
+            # Run the script
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=str(diagnostic.id),
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, the diagnostic should not be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertFalse(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_draft_if_during_campaign(self):
+        canteen = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+
+            # Run the script
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=str(diagnostic.id),
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, the diagnostic should not be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertFalse(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_correction_if_during_correction_campaign(self):
+        canteen = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Cancel the teledeclaration
+            diagnostic.cancel()
+
+            # Run the script
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=str(diagnostic.id),
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, the diagnostic should not be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertFalse(diagnostic.is_teledeclared)
 
     @authenticate
     def test_submit_diagnostic_even_if_diagnostic_validation_error(self):

--- a/macantine/tests/test_teledeclaration_submit_outside_of_campaign.py
+++ b/macantine/tests/test_teledeclaration_submit_outside_of_campaign.py
@@ -106,7 +106,7 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             self.assertFalse(diagnostic.is_teledeclared)
 
     @authenticate
-    def test_submit_diagnostic_during_campaign(self):
+    def test_cannot_submit_diagnostic_draft_during_campaign(self):
         canteen = CanteenFactory()
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
@@ -124,21 +124,25 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 apply=True,
             )
 
-            # After running the script, the diagnostic should be teledeclared
+            # After running the script, the diagnostic should not be teledeclared
             diagnostic.refresh_from_db()
-            self.assertTrue(diagnostic.is_teledeclared)
+            self.assertFalse(diagnostic.is_teledeclared)
 
     @authenticate
-    def test_submit_diagnostic_during_correction_campaign(self):
+    def test_cannot_submit_diagnostic_correction_during_correction_campaign(self):
         canteen = CanteenFactory()
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=authenticate.user)
 
             # Before running the script
-            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
 
         with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Cancel the teledeclaration
+            diagnostic.cancel()
+
             # Run the script
             call_command(
                 "teledeclaration_submit_outside_of_campaign",
@@ -148,9 +152,9 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 apply=True,
             )
 
-            # After running the script, the diagnostic should be teledeclared
+            # After running the script, the diagnostic should not be teledeclared
             diagnostic.refresh_from_db()
-            self.assertTrue(diagnostic.is_teledeclared)
+            self.assertFalse(diagnostic.is_teledeclared)
 
     @authenticate
     def test_skip_diagnostic_from_different_year(self):

--- a/macantine/tests/test_teledeclaration_submit_outside_of_campaign.py
+++ b/macantine/tests/test_teledeclaration_submit_outside_of_campaign.py
@@ -1,0 +1,301 @@
+from django.core.management import call_command
+from django.test import TestCase
+from freezegun import freeze_time
+from django.db.models.signals import post_save
+
+from data.models.canteen import Canteen, fill_geo_fields_from_siret
+from data.models import Diagnostic
+from api.tests.utils import authenticate
+from data.factories import CanteenFactory, DiagnosticFactory
+
+
+class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
+    def setUp(self):
+        post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
+        return super().setUp()
+
+    def tearDown(self):
+        post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
+        return super().tearDown()
+
+    @authenticate
+    def test_submit_single_diagnostic_after_campaign(self):
+        canteen = CanteenFactory(name="First name", city_insee_code="38185")
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(
+                canteen=canteen,
+                year=2024,
+                valeur_totale=10000,
+                valeur_bio=2000,
+            )
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+
+        with freeze_time("2025-08-30"):  # after the 2024 campaign
+            # Run the script
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=str(diagnostic.id),
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)
+            self.assertEqual(diagnostic.applicant, authenticate.user)
+
+    @authenticate
+    def test_submit_multiple_diagnostics_after_campaign(self):
+        canteen_1 = CanteenFactory()
+        canteen_2 = CanteenFactory()
+        canteen_3 = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic_1 = DiagnosticFactory(canteen=canteen_1, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic_2 = DiagnosticFactory(canteen=canteen_2, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic_3 = DiagnosticFactory(canteen=canteen_3, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+
+        with freeze_time("2025-08-30"):  # after the 2024 campaign
+            # Run the script with multiple diagnostic IDs
+            diagnostic_ids = f"{diagnostic_1.id},{diagnostic_2.id},{diagnostic_3.id}"
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=diagnostic_ids,
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script
+            diagnostic_1.refresh_from_db()
+            diagnostic_2.refresh_from_db()
+            diagnostic_3.refresh_from_db()
+
+            self.assertTrue(diagnostic_1.is_teledeclared)
+            self.assertTrue(diagnostic_2.is_teledeclared)
+            self.assertTrue(diagnostic_3.is_teledeclared)
+
+    @authenticate
+    def test_cannot_submit_diagnostic_before_campaign(self):
+        canteen = CanteenFactory()
+
+        with freeze_time("2025-01-01"):  # before the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+
+            # Run the script
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=str(diagnostic.id),
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, the diagnostic should not be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertFalse(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_submit_diagnostic_during_campaign(self):
+        canteen = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+
+            # Run the script
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=str(diagnostic.id),
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, the diagnostic should be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_submit_diagnostic_during_correction_campaign(self):
+        canteen = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Run the script
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=str(diagnostic.id),
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, the diagnostic should be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_from_different_year(self):
+        canteen = CanteenFactory()
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+        with freeze_time("2026-04-15"):  # during the 2025 campaign
+            diagnostic_2025 = DiagnosticFactory(canteen=canteen, year=2025, valeur_totale=10000, valeur_bio=2000)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+            self.assertEqual(Diagnostic.all_objects.in_year(2025).teledeclared().count(), 0)
+
+        with freeze_time("2026-08-30"):  # after the 2025 campaign
+            # Run the script with 2024 year, but pass 2025 diagnostic ID
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=str(diagnostic_2025.id),
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, 2025 diagnostic should not be affected
+            diagnostic_2025.refresh_from_db()
+            self.assertFalse(diagnostic_2025.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_teledeclared(self):
+        canteen_1 = CanteenFactory()
+        canteen_2 = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic_teledeclared = DiagnosticFactory(
+                canteen=canteen_1, year=2024, valeur_totale=10000, valeur_bio=2000
+            )
+            diagnostic_teledeclared.teledeclare(applicant=authenticate.user)
+            diagnostic_not_teledeclared = DiagnosticFactory(
+                canteen=canteen_2, year=2024, valeur_totale=10000, valeur_bio=2000
+            )
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+            self.assertFalse(diagnostic_not_teledeclared.is_teledeclared)
+
+        with freeze_time("2025-08-30"):  # after the 2024 campaign
+            # Run the script with both diagnostic IDs
+            diagnostic_ids = f"{diagnostic_teledeclared.id},{diagnostic_not_teledeclared.id}"
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=diagnostic_ids,
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, the teledeclared one should not be affected
+            diagnostic_teledeclared.refresh_from_db()
+            diagnostic_not_teledeclared.refresh_from_db()
+
+            self.assertTrue(diagnostic_teledeclared.is_teledeclared)
+            self.assertTrue(diagnostic_not_teledeclared.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_not_found(self):
+        canteen = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+
+        with freeze_time("2025-08-30"):  # after the 2024 campaign
+            # Run the script with a mix of valid and non-existent diagnostic IDs
+            fake_id = 99999
+            diagnostic_ids = f"{diagnostic.id},{fake_id}"
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=diagnostic_ids,
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, the valid diagnostic should be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_submit_diagnostic_even_if_diagnostic_validation_error(self):
+        canteen = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
+
+            # Change the diagnostic to make it invalid
+            Diagnostic.objects.filter(id=diagnostic.id).update(valeur_totale=0)
+            diagnostic.refresh_from_db()
+            self.assertFalse(diagnostic.is_filled)  # property
+
+        with freeze_time("2025-08-30"):  # after the 2024 campaign
+            # Run the script
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=str(diagnostic.id),
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, the diagnostic should be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_submit_diagnostic_even_if_canteen_validation_error(self):
+        canteen = CanteenFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+
+            # Change the canteen to make it invalid
+            canteen.city_insee_code = None
+            canteen.save()
+            self.assertFalse(canteen.is_filled)  # model field
+
+        with freeze_time("2025-08-30"):  # after the 2024 campaign
+            # Run the script
+            call_command(
+                "teledeclaration_submit_outside_of_campaign",
+                year=2024,
+                diagnostic_id_list=str(diagnostic.id),
+                applicant_id=authenticate.user.id,
+                apply=True,
+            )
+
+            # After running the script, the diagnostic should be teledeclared
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -211,6 +211,14 @@ def is_in_teledeclaration_or_correction(year=None):
     return is_in_teledeclaration(year) or is_in_correction(year)
 
 
+def get_year_campaign_start_date(year):
+    year = int(year)
+    if year in CAMPAIGN_DATES:
+        return CAMPAIGN_DATES[year]["teledeclaration_start_date"]
+    else:
+        return None
+
+
 def get_year_campaign_end_date_or_today_date(year):
     """
     Return the year's campaign end date


### PR DESCRIPTION
Nouvelle management command `teledeclaration_submit_outside_of_campaign`
- prend en paramètres une liste de diagnostic + un applicant
- ne peut pas être lancée AVANT le début de la campagne
- mais peut être lancé à tout moment pendant ou après la campagne, avec qq garde-fous
  - diagnostic DRAFT : seulement après teledeclaration_end_date
  - diagnostic CORRECTION : seulement après correction_end_date