### PR TITLE
refactor(Télédéclarations): homogénéiser les tests des scripts créé récemment

### DIFF
--- a/macantine/management/commands/teledeclaration_resubmit.py
+++ b/macantine/management/commands/teledeclaration_resubmit.py
@@ -15,6 +15,7 @@ import logging
 from django.db import transaction
 from django.core.management.base import BaseCommand
 from django.core.exceptions import ValidationError
+from simple_history.utils import update_change_reason
 
 from data.models import Diagnostic
 
@@ -72,6 +73,7 @@ class Command(BaseCommand):
                     # in a transaction, because the canteen or diagnostic may be in an invalid state and fail to teledeclare again...
                     diagnostic.cancel()
                     diagnostic.teledeclare(applicant=diagnostic_applicant)
+                    update_change_reason(diagnostic, "Script: teledeclaration_resubmit")
                     teledeclaration_resubmitted_count += 1
             except (AttributeError, ValidationError) as e:
                 logger.error(f"Error teledeclaring diagnostic {diagnostic.id}: {e}")

--- a/macantine/tests/test_teledeclaration_resubmit.py
+++ b/macantine/tests/test_teledeclaration_resubmit.py
@@ -214,6 +214,33 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertTrue(diagnostic.is_teledeclared)
 
     @authenticate
+    def test_skip_diagnostic_if_canteen_satellite_validation_error(self):
+        canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        canteen_satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe
+        )
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen_groupe, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+
+            # Change the satellite canteen to make it invalid
+            canteen_satellite.city_insee_code = None
+            canteen_satellite.save()
+            self.assertFalse(canteen_satellite.is_filled)  # model field
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Run the script
+            call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic.id))
+
+            # After running the script, the diagnostic should still be teledeclared (resubmission failed)
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)
+
+    @authenticate
     def test_skip_diagnostic_if_canteen_applicant_deleted(self):
         canteen = CanteenFactory()
         user = UserFactory()

--- a/macantine/tests/test_teledeclaration_resubmit.py
+++ b/macantine/tests/test_teledeclaration_resubmit.py
@@ -20,10 +20,8 @@ class TeledeclarationResubmitScriptTest(TestCase):
 
     @authenticate
     def test_resubmit_single_diagnostic(self):
-        """
-        The script should resubmit a single teledeclared diagnostic.
-        """
         canteen = CanteenFactory(name="First name", city_insee_code="38185")
+
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(
                 canteen=canteen,
@@ -60,9 +58,6 @@ class TeledeclarationResubmitScriptTest(TestCase):
 
     @authenticate
     def test_resubmit_multiple_diagnostics(self):
-        """
-        The script should resubmit multiple teledeclared diagnostics.
-        """
         canteen_1 = CanteenFactory()
         canteen_2 = CanteenFactory()
         canteen_3 = CanteenFactory()
@@ -95,10 +90,8 @@ class TeledeclarationResubmitScriptTest(TestCase):
 
     @authenticate
     def test_skip_diagnostic_from_different_year(self):
-        """
-        The script should skip diagnostics that are from a different year than specified.
-        """
         canteen = CanteenFactory()
+
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic_2024 = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
             diagnostic_2024.teledeclare(applicant=authenticate.user)
@@ -121,9 +114,6 @@ class TeledeclarationResubmitScriptTest(TestCase):
 
     @authenticate
     def test_skip_diagnostic_not_teledeclared(self):
-        """
-        The script should skip diagnostics that are not teledeclared.
-        """
         canteen_1 = CanteenFactory()
         canteen_2 = CanteenFactory()
 
@@ -156,10 +146,8 @@ class TeledeclarationResubmitScriptTest(TestCase):
 
     @authenticate
     def test_skip_diagnostic_not_found(self):
-        """
-        The script should gracefully handle non-existent diagnostic IDs by simply skipping them.
-        """
         canteen = CanteenFactory()
+
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
             diagnostic.teledeclare(applicant=authenticate.user)
@@ -179,10 +167,8 @@ class TeledeclarationResubmitScriptTest(TestCase):
 
     @authenticate
     def test_skip_diagnostic_if_diagnostic_validation_error(self):
-        """
-        The script should skip diagnostics that raise a ValidationError during teledeclaration.
-        """
         canteen = CanteenFactory()
+
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
             diagnostic.teledeclare(applicant=authenticate.user)
@@ -191,9 +177,9 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
 
             # Change the diagnostic to make it invalid
-            Diagnostic.objects.filter(id=diagnostic.id).update(
-                valeur_totale=500, valeur_bio=1000
-            )  # valeur_bio > valeur_totale
+            Diagnostic.objects.filter(id=diagnostic.id).update(valeur_totale=0)
+            diagnostic.refresh_from_db()
+            self.assertFalse(diagnostic.is_filled)  # property
 
         with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Run the script with the diagnostic ID
@@ -205,10 +191,8 @@ class TeledeclarationResubmitScriptTest(TestCase):
 
     @authenticate
     def test_skip_diagnostic_if_canteen_validation_error(self):
-        """
-        The script should skip diagnostics that raise a ValidationError during teledeclaration.
-        """
         canteen = CanteenFactory()
+
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
             diagnostic.teledeclare(applicant=authenticate.user)
@@ -217,7 +201,9 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
 
             # Change the canteen to make it invalid
-            Canteen.objects.filter(id=canteen.id).update(city_insee_code=None)
+            canteen.city_insee_code = None
+            canteen.save()
+            self.assertFalse(canteen.is_filled)  # model field
 
         with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Run the script with the diagnostic ID

--- a/macantine/tests/test_teledeclaration_resubmit.py
+++ b/macantine/tests/test_teledeclaration_resubmit.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_save
 from data.models.canteen import Canteen, fill_geo_fields_from_siret
 from data.models import Diagnostic
 from api.tests.utils import authenticate
-from data.factories import CanteenFactory, DiagnosticFactory
+from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 
 
 class TeledeclarationResubmitScriptTest(TestCase):
@@ -182,7 +182,7 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertFalse(diagnostic.is_filled)  # property
 
         with freeze_time("2025-04-17"):  # during the 2024 correction campaign
-            # Run the script with the diagnostic ID
+            # Run the script
             call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic.id))
 
             # After running the script, the diagnostic should still be teledeclared (resubmission failed)
@@ -206,7 +206,30 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertFalse(canteen.is_filled)  # model field
 
         with freeze_time("2025-04-17"):  # during the 2024 correction campaign
-            # Run the script with the diagnostic ID
+            # Run the script
+            call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic.id))
+
+            # After running the script, the diagnostic should still be teledeclared (resubmission failed)
+            diagnostic.refresh_from_db()
+            self.assertTrue(diagnostic.is_teledeclared)
+
+    @authenticate
+    def test_skip_diagnostic_if_canteen_applicant_deleted(self):
+        canteen = CanteenFactory()
+        user = UserFactory()
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Delete the user
+            user.delete()
+
+            # Run the script
             call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic.id))
 
             # After running the script, the diagnostic should still be teledeclared (resubmission failed)

--- a/macantine/tests/test_teledeclaration_submit_correction.py
+++ b/macantine/tests/test_teledeclaration_submit_correction.py
@@ -169,7 +169,7 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
 
     @authenticate
     def test_skip_diagnostic_if_canteen_validation_error(self):
-        canteen = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+        canteen = CanteenFactory()
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
@@ -197,7 +197,7 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
 
     @authenticate
     def test_skip_diagnostic_if_canteen_applicant_deleted(self):
-        canteen = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+        canteen = CanteenFactory()
         user = UserFactory()
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
@@ -212,7 +212,7 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             diagnostic.cancel()
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
-            # Change the canteen to make it invalid
+            # Delete the user
             user.delete()
 
             # Run the script

--- a/macantine/tests/test_teledeclaration_submit_correction.py
+++ b/macantine/tests/test_teledeclaration_submit_correction.py
@@ -196,6 +196,37 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
     @authenticate
+    def test_skip_diagnostic_if_canteen_satellite_validation_error(self):
+        canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        canteen_satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe
+        )
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            diagnostic = DiagnosticFactory(canteen=canteen_groupe, year=2024, valeur_totale=10000, valeur_bio=2000)
+            diagnostic.teledeclare(applicant=authenticate.user)
+
+            # Before running the script
+            self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
+
+        with freeze_time("2025-04-17"):  # during the 2024 correction campaign
+            # Cancel the teledeclaration
+            diagnostic.cancel()
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
+
+            # Change the satellite canteen to make it invalid
+            canteen_satellite.city_insee_code = None
+            canteen_satellite.save()
+            self.assertFalse(canteen_satellite.is_filled)  # model field
+
+            # Run the script
+            call_command("teledeclaration_submit_correction", year=2024)
+
+            # After running the script, the diagnostic should still be in CORRECTION (teledeclaration failed)
+            diagnostic.refresh_from_db()
+            self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
+
+    @authenticate
     def test_skip_diagnostic_if_canteen_applicant_deleted(self):
         canteen = CanteenFactory()
         user = UserFactory()

--- a/macantine/tests/test_teledeclaration_submit_correction.py
+++ b/macantine/tests/test_teledeclaration_submit_correction.py
@@ -21,6 +21,7 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
     @authenticate
     def test_submit_single_diagnostic_in_correction(self):
         canteen = CanteenFactory(name="First name", city_insee_code="38185")
+
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(
                 canteen=canteen,
@@ -116,7 +117,6 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
 
             # After running the script, the diagnostic should still be teledeclared (not cancelled and re-teledeclared)
             diagnostic_teledeclared.refresh_from_db()
-
             self.assertTrue(diagnostic_teledeclared.is_teledeclared)
             self.assertEqual(diagnostic_teledeclared.teledeclaration_date, original_teledeclaration_date)
 
@@ -137,7 +137,6 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
 
             # After running the script, the diagnostic should still be in draft (not teledeclared)
             diagnostic_draft.refresh_from_db()
-
             self.assertFalse(diagnostic_draft.is_teledeclared)
 
     @authenticate


### PR DESCRIPTION
Suite à #6644 & #6666 & #6671 

Refaire une passe sur les tests, et homogénéiser
- pas besoin de commentaires, les noms des tests devraient suffire
- teledeclaration_resubmit: tests: clarifier la création d'un diagnostic invalid et d'une canteen invalid
- teledeclaration_resubmit: ajout d'un test si l'utilisateur a été supprimé
- teledeclaration_resubmit: ajout d'un update_change_reason
- teledeclaration_resubmit & teledeclaration_submit_correction: ajout d'un test concernant groupe & satellite