### PR TITLE
fix(Télédéclarations): Répare les tests suite aux ajouts de règles métiers récents et de la fin officielle de la campagne

### DIFF
--- a/data/tests/test_diagnostic_teledeclaration.py
+++ b/data/tests/test_diagnostic_teledeclaration.py
@@ -6,18 +6,24 @@ from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 from data.models import Canteen, Diagnostic, Sector
 
 year_data = 2024
-date_in_teledeclaration_campaign = "2025-03-30"
-date_in_correction_campaign = "2025-04-20"
-date_in_last_teledeclaration_campaign = "2024-02-01"
+date_in_teledeclaration_campaign = "2025-03-30"  # during the 2024 campaign
+date_in_correction_campaign = "2025-04-20"  # during the 2024 correction campaign
+date_in_last_teledeclaration_campaign = "2024-02-01"  # during the 2023 campaign
 
 
+@freeze_time(date_in_last_teledeclaration_campaign)
 class DiagnosticTeledeclaredQuerySetAndPropertyTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.diagnostic_not_filled_draft = DiagnosticFactory(canteen=CanteenFactory(), valeur_totale=None)
-        cls.diagnostic_filled_draft = DiagnosticFactory(canteen=CanteenFactory(), valeur_totale=1000)
-        cls.diagnostic_filled_submitted = DiagnosticFactory(canteen=CanteenFactory(), valeur_totale=1000)
-        cls.diagnostic_filled_submitted.teledeclare(applicant=UserFactory())
+        cls.diagnostic_not_filled_draft = DiagnosticFactory(
+            year=year_data, canteen=CanteenFactory(), valeur_totale=None
+        )
+        cls.diagnostic_filled_draft = DiagnosticFactory(year=year_data, canteen=CanteenFactory(), valeur_totale=1000)
+        cls.diagnostic_filled_submitted = DiagnosticFactory(
+            year=year_data, canteen=CanteenFactory(), valeur_totale=1000
+        )
+        with freeze_time(date_in_teledeclaration_campaign):
+            cls.diagnostic_filled_submitted.teledeclare(applicant=UserFactory())
 
     def test_teledeclared_queryset(self):
         self.assertEqual(Diagnostic.objects.all().count(), 3)


### PR DESCRIPTION
Suite à #6641
Et suite à la fin de la campagne mercredi dernier

Il y avait un test qui cassait
```
ERROR: setUpClass (data.tests.test_diagnostic_teledeclaration.DiagnosticTeledeclaredQuerySetAndPropertyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/unittest/suite.py", line 166, in _handleClassSetUp
    setUpClass()
  File "/home/runner/work/ma-cantine/ma-cantine/.venv/lib/python3.11/site-packages/django/test/testcases.py", line 1430, in setUpClass
    cls.setUpTestData()
    ^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ma-cantine/ma-cantine/data/tests/test_diagnostic_teledeclaration.py", line 20, in setUpTestData
    cls.diagnostic_filled_submitted.teledeclare(applicant=UserFactory())
    ^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ma-cantine/ma-cantine/data/models/diagnostic.py", line 2014, in teledeclare
    raise ValidationError("Ce n'est pas possible de télédéclarer hors de la période de la campagne")
    ^^^^^^^^^^^^^^^^^
django.core.exceptions.ValidationError: ["Ce n'est pas possible de télédéclarer hors de la période de la campagne"]

```