### PR TITLE
refactor(Achats): lister les groupes de caractéristiques pour faciliter leur réutilisation

### DIFF
--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -251,33 +251,17 @@ def canteen_summary(canteen):
 
 
 def simple_diag_data(purchases, data):
-    # TODO: is CONVERSION_BIO used?
-    bio_filter = Q(characteristics__overlap=[Purchase.Characteristic.BIO, Purchase.Characteristic.CONVERSION_BIO])
+    bio_filter = Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_BIO)
     bio_commerce_equitable_filter = bio_filter & Q(
         characteristics__contains=[Purchase.Characteristic.COMMERCE_EQUITABLE]
     )
-    siqo_filter = Q(
-        characteristics__overlap=[
-            Purchase.Characteristic.LABEL_ROUGE,
-            Purchase.Characteristic.AOCAOP,
-            Purchase.Characteristic.IGP,
-            Purchase.Characteristic.STG,
-        ]
-    )
-    egalim_autres_filter = Q(
-        characteristics__overlap=[
-            Purchase.Characteristic.HVE,
-            Purchase.Characteristic.PECHE_DURABLE,
-            Purchase.Characteristic.RUP,
-            Purchase.Characteristic.FERMIER,
-            Purchase.Characteristic.COMMERCE_EQUITABLE,
-        ]
-    )
+    siqo_filter = Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_SIQO)
+    egalim_autres_filter = Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EGALIM_AUTRES)
     egalim_autres_commerce_equitable_filter = egalim_autres_filter & Q(
         characteristics__contains=[Purchase.Characteristic.COMMERCE_EQUITABLE]
     )
     externalities_performance_filter = Q(
-        characteristics__overlap=[Purchase.Characteristic.EXTERNALITES, Purchase.Characteristic.PERFORMANCE]
+        characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EXTERNALITES_PERFORMANCE
     )
 
     data["valeur_totale"] = purchases.aggregate(total=Sum("price_ht"))["total"] or 0
@@ -323,14 +307,13 @@ def complete_diag_data(purchases, data):
         purchase_family = purchases.filter(family=family.upper())
         for label in Diagnostic.APPRO_LABELS_EGALIM:
             if label.upper() == "AOCAOP_IGP_STG":
-                aocaop_igp_stg = [
-                    Purchase.Characteristic.AOCAOP,
-                    Purchase.Characteristic.IGP,
-                    Purchase.Characteristic.STG,
-                ]
-                purchase_family_label = purchase_family.filter(characteristics__overlap=aocaop_igp_stg).distinct()
+                purchase_family_label = purchase_family.filter(
+                    characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_AOCAOP_IGP_STG
+                ).distinct()
                 # the remaining stats should ignore already counted labels
-                purchase_family = purchase_family.exclude(characteristics__overlap=aocaop_igp_stg).distinct()
+                purchase_family = purchase_family.exclude(
+                    characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_AOCAOP_IGP_STG
+                ).distinct()
             else:
                 purchase_family_label = purchase_family.filter(
                     Q(characteristics__contains=[Purchase.Characteristic[label.upper()]])
@@ -360,11 +343,7 @@ def complete_diag_data(purchases, data):
             other_labels_characteristics.append(characteristic)
         # France total
         purchase_family_label = purchase_family.filter(
-            characteristics__overlap=[
-                Purchase.Characteristic.FRANCE,
-                Purchase.Characteristic.CIRCUIT_COURT,
-                Purchase.Characteristic.LOCAL,
-            ]
+            characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL
         ).distinct()
         key = "valeur_" + family + "_france"
         data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
@@ -381,22 +360,14 @@ def misc_totals(purchases, data):
     # meat_poultry
     meat_poultry_purchases = purchases.filter(family=Purchase.Family.VIANDES_VOLAILLES)
     data["valeur_viandes_volailles"] = meat_poultry_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-    meat_poultry_egalim = meat_poultry_purchases.filter(
-        characteristics__overlap=[
-            label.upper() for label in Diagnostic.APPRO_LABELS_EGALIM
-        ]  # TODO: manage AOCAOP/IGP/STG
-    )
+    meat_poultry_egalim = meat_poultry_purchases.filter(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EGALIM)
     data["valeur_viandes_volailles_egalim"] = meat_poultry_egalim.aggregate(total=Sum("price_ht"))["total"] or 0
     meat_poultry_france = meat_poultry_purchases.filter(characteristics__contains=[Purchase.Characteristic.FRANCE])
     data["valeur_viandes_volailles_france"] = meat_poultry_france.aggregate(total=Sum("price_ht"))["total"] or 0
     # fish
     fish_purchases = purchases.filter(family=Purchase.Family.PRODUITS_DE_LA_MER)
     data["valeur_produits_de_la_mer"] = fish_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-    fish_egalim = fish_purchases.filter(
-        characteristics__overlap=[
-            label.upper() for label in Diagnostic.APPRO_LABELS_EGALIM
-        ]  # TODO: manage AOCAOP/IGP/STG
-    )
+    fish_egalim = fish_purchases.filter(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EGALIM)
     data["valeur_produits_de_la_mer_egalim"] = fish_egalim.aggregate(total=Sum("price_ht"))["total"] or 0
 
 

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -252,30 +252,32 @@ def canteen_summary(canteen):
 
 def simple_diag_data(purchases, data):
     # TODO: is CONVERSION_BIO used?
-    bio_filter = Q(characteristics__contains=[Purchase.Characteristic.BIO]) | Q(
-        characteristics__contains=[Purchase.Characteristic.CONVERSION_BIO]
-    )
+    bio_filter = Q(characteristics__overlap=[Purchase.Characteristic.BIO, Purchase.Characteristic.CONVERSION_BIO])
     bio_commerce_equitable_filter = bio_filter & Q(
         characteristics__contains=[Purchase.Characteristic.COMMERCE_EQUITABLE]
     )
-    siqo_filter = (
-        Q(characteristics__contains=[Purchase.Characteristic.LABEL_ROUGE])
-        | Q(characteristics__contains=[Purchase.Characteristic.AOCAOP])
-        | Q(characteristics__contains=[Purchase.Characteristic.IGP])
-        | Q(characteristics__contains=[Purchase.Characteristic.STG])
+    siqo_filter = Q(
+        characteristics__overlap=[
+            Purchase.Characteristic.LABEL_ROUGE,
+            Purchase.Characteristic.AOCAOP,
+            Purchase.Characteristic.IGP,
+            Purchase.Characteristic.STG,
+        ]
     )
-    egalim_autres_filter = (
-        Q(characteristics__contains=[Purchase.Characteristic.HVE])
-        | Q(characteristics__contains=[Purchase.Characteristic.PECHE_DURABLE])
-        | Q(characteristics__contains=[Purchase.Characteristic.RUP])
-        | Q(characteristics__contains=[Purchase.Characteristic.FERMIER])
-        | Q(characteristics__contains=[Purchase.Characteristic.COMMERCE_EQUITABLE])
+    egalim_autres_filter = Q(
+        characteristics__overlap=[
+            Purchase.Characteristic.HVE,
+            Purchase.Characteristic.PECHE_DURABLE,
+            Purchase.Characteristic.RUP,
+            Purchase.Characteristic.FERMIER,
+            Purchase.Characteristic.COMMERCE_EQUITABLE,
+        ]
     )
     egalim_autres_commerce_equitable_filter = egalim_autres_filter & Q(
         characteristics__contains=[Purchase.Characteristic.COMMERCE_EQUITABLE]
     )
-    externalities_performance_filter = Q(characteristics__contains=[Purchase.Characteristic.EXTERNALITES]) | Q(
-        characteristics__contains=[Purchase.Characteristic.PERFORMANCE]
+    externalities_performance_filter = Q(
+        characteristics__overlap=[Purchase.Characteristic.EXTERNALITES, Purchase.Characteristic.PERFORMANCE]
     )
 
     data["valeur_totale"] = purchases.aggregate(total=Sum("price_ht"))["total"] or 0
@@ -321,17 +323,14 @@ def complete_diag_data(purchases, data):
         purchase_family = purchases.filter(family=family.upper())
         for label in Diagnostic.APPRO_LABELS_EGALIM:
             if label.upper() == "AOCAOP_IGP_STG":
-                purchase_family_label = purchase_family.filter(
-                    Q(characteristics__contains=[Purchase.Characteristic.AOCAOP])
-                    | Q(characteristics__contains=[Purchase.Characteristic.IGP])
-                    | Q(characteristics__contains=[Purchase.Characteristic.STG])
-                ).distinct()
+                aocaop_igp_stg = [
+                    Purchase.Characteristic.AOCAOP,
+                    Purchase.Characteristic.IGP,
+                    Purchase.Characteristic.STG,
+                ]
+                purchase_family_label = purchase_family.filter(characteristics__overlap=aocaop_igp_stg).distinct()
                 # the remaining stats should ignore already counted labels
-                purchase_family = purchase_family.exclude(
-                    Q(characteristics__contains=[Purchase.Characteristic.AOCAOP])
-                    | Q(characteristics__contains=[Purchase.Characteristic.IGP])
-                    | Q(characteristics__contains=[Purchase.Characteristic.STG])
-                ).distinct()
+                purchase_family = purchase_family.exclude(characteristics__overlap=aocaop_igp_stg).distinct()
             else:
                 purchase_family_label = purchase_family.filter(
                     Q(characteristics__contains=[Purchase.Characteristic[label.upper()]])
@@ -361,9 +360,11 @@ def complete_diag_data(purchases, data):
             other_labels_characteristics.append(characteristic)
         # France total
         purchase_family_label = purchase_family.filter(
-            Q(characteristics__contains=[Purchase.Characteristic.FRANCE])
-            | Q(characteristics__contains=[Purchase.Characteristic.CIRCUIT_COURT])
-            | Q(characteristics__contains=[Purchase.Characteristic.LOCAL])
+            characteristics__overlap=[
+                Purchase.Characteristic.FRANCE,
+                Purchase.Characteristic.CIRCUIT_COURT,
+                Purchase.Characteristic.LOCAL,
+            ]
         ).distinct()
         key = "valeur_" + family + "_france"
         data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
@@ -381,7 +382,9 @@ def misc_totals(purchases, data):
     meat_poultry_purchases = purchases.filter(family=Purchase.Family.VIANDES_VOLAILLES)
     data["valeur_viandes_volailles"] = meat_poultry_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
     meat_poultry_egalim = meat_poultry_purchases.filter(
-        characteristics__overlap=[label.upper() for label in Diagnostic.APPRO_LABELS_EGALIM]
+        characteristics__overlap=[
+            label.upper() for label in Diagnostic.APPRO_LABELS_EGALIM
+        ]  # TODO: manage AOCAOP/IGP/STG
     )
     data["valeur_viandes_volailles_egalim"] = meat_poultry_egalim.aggregate(total=Sum("price_ht"))["total"] or 0
     meat_poultry_france = meat_poultry_purchases.filter(characteristics__contains=[Purchase.Characteristic.FRANCE])
@@ -390,7 +393,9 @@ def misc_totals(purchases, data):
     fish_purchases = purchases.filter(family=Purchase.Family.PRODUITS_DE_LA_MER)
     data["valeur_produits_de_la_mer"] = fish_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
     fish_egalim = fish_purchases.filter(
-        characteristics__overlap=[label.upper() for label in Diagnostic.APPRO_LABELS_EGALIM]
+        characteristics__overlap=[
+            label.upper() for label in Diagnostic.APPRO_LABELS_EGALIM
+        ]  # TODO: manage AOCAOP/IGP/STG
     )
     data["valeur_produits_de_la_mer_egalim"] = fish_egalim.aggregate(total=Sum("price_ht"))["total"] or 0
 

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -67,13 +67,53 @@ class Purchase(SoftDeletionModel):
         AUTOUR_SERVICE = "AUTOUR_SERVICE", "200 km autour du lieu de service"
         AUTRE = "AUTRE", "Autre"
 
+    CHARACTERISTIC_LABELS_BIO = [
+        Characteristic.BIO,
+        Characteristic.CONVERSION_BIO,  # not used anymore
+    ]
+
+    CHARACTERISTIC_LABELS_AOCAOP_IGP_STG = [
+        Characteristic.AOCAOP,
+        Characteristic.IGP,
+        Characteristic.STG,
+    ]
+
+    CHARACTERISTIC_LABELS_SIQO = [Characteristic.LABEL_ROUGE] + CHARACTERISTIC_LABELS_AOCAOP_IGP_STG
+
+    CHARACTERISTIC_LABELS_EXTERNALITES_PERFORMANCE = [
+        Characteristic.EXTERNALITES,
+        Characteristic.PERFORMANCE,
+        Characteristic.EQUIVALENTS,  # not used anymore
+    ]
+
+    CHARACTERISTIC_LABELS_EGALIM_AUTRES = [
+        Characteristic.HVE,
+        Characteristic.PECHE_DURABLE,
+        Characteristic.RUP,
+        Characteristic.FERMIER,
+        Characteristic.COMMERCE_EQUITABLE,
+    ]
+
+    CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL = [
+        Characteristic.FRANCE,
+        Characteristic.CIRCUIT_COURT,
+        Characteristic.LOCAL,
+    ]
+
+    CHARACTERISTIC_LABELS_EGALIM = (
+        CHARACTERISTIC_LABELS_BIO
+        + CHARACTERISTIC_LABELS_SIQO
+        + CHARACTERISTIC_LABELS_EXTERNALITES_PERFORMANCE
+        + CHARACTERISTIC_LABELS_EGALIM_AUTRES
+    )
+
     canteen = models.ForeignKey(Canteen, on_delete=models.CASCADE)
     date = models.DateField(default=date.today)
     description = models.TextField(null=True, blank=True, verbose_name="description du produit")
     provider = models.TextField(null=True, blank=True, verbose_name="fournisseur")
     category = models.CharField(
         max_length=255, choices=PurchaseCategory.choices, null=True, blank=True, verbose_name="catégorie"
-    )  # not used anymore ?
+    )  # not used anymore
     family = models.CharField(
         max_length=255, choices=Family.choices, null=True, blank=True, verbose_name="famille de produits"
     )

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -14,7 +14,7 @@ from .softdeletionmodel import SoftDeletionModel
 
 
 class Purchase(SoftDeletionModel):
-    class PurchaseCategory(models.TextChoices):
+    class PurchaseCategory(models.TextChoices):  # not used anymore
         VIANDES_VOLAILLES = "VIANDES_VOLAILLES", "Viandes, volailles"
         PRODUITS_DE_LA_MER = "PRODUITS_DE_LA_MER", "Produits de la mer"
         FRUITS_ET_LEGUMES = "FRUITS_ET_LEGUMES", "Fruits, légumes, légumineuses et oléagineux"

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -14,19 +14,7 @@ class PurchaseModelSaveTest(TransactionTestCase):
 
     # def test_purchase_canteen_validation(self):
     # def test_purchase_date_validation(self):
-
-    def test_purchase_category_validation(self):
-        """
-        - field is optional
-        - must be one of the choices if provided
-        """
-        for TUPLE_OK in [(None, None), ("", ""), *((key, key) for key in Purchase.PurchaseCategory.values)]:
-            with self.subTest(category=TUPLE_OK[0]):
-                purchase = PurchaseFactory(category=TUPLE_OK[0])
-                self.assertEqual(purchase.category, TUPLE_OK[1])
-        for VALUE_NOT_OK in ["  ", 123, "invalid", "123"]:
-            with self.subTest(category=VALUE_NOT_OK):
-                self.assertRaises(ValidationError, PurchaseFactory, category=VALUE_NOT_OK)
+    # def test_purchase_category_validation(self):  # not used anymore
 
     def test_purchase_family_validation(self):
         """


### PR DESCRIPTION
1e étape
- on créait ces "groupes de caractéristiques" coté `Purchase`
- on remplace `contains` par `overlap`

mais il y a pas mal de "doublon" avec `Diagnostic`, donc à voir comment on merge tout ca :)
- exception de AOCAOP IGP STG, séparé coté Purchase, regroupé coté Diagnostic