### PR TITLE
refactor: réorganise les champs dans les modèles (Meta & timestamps en bas)

### DIFF
--- a/data/models/blogpost.py
+++ b/data/models/blogpost.py
@@ -7,14 +7,6 @@ from .blogtag import BlogTag
 
 
 class BlogPost(models.Model):
-    class Meta:
-        verbose_name = "article de blog"
-        verbose_name_plural = "articles de blog"
-        ordering = ["-display_date"]
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-
     title = models.TextField(verbose_name="titre")
     tagline = models.TextField(null=True, blank=True, verbose_name="description courte")
     display_date = models.DateField(default=timezone.now, verbose_name="date affichée")
@@ -29,6 +21,14 @@ class BlogPost(models.Model):
         related_name="blog_posts",
     )
     tags = models.ManyToManyField(BlogTag, blank=True, verbose_name="étiquettes")
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "article de blog"
+        verbose_name_plural = "articles de blog"
+        ordering = ["-display_date"]
 
     @property
     def url_path(self):

--- a/data/models/blogpost.py
+++ b/data/models/blogpost.py
@@ -30,9 +30,9 @@ class BlogPost(models.Model):
         verbose_name_plural = "articles de blog"
         ordering = ["-display_date"]
 
+    def __str__(self):
+        return f'Blog post "{self.title}"'
+
     @property
     def url_path(self):
         return f"/blog/{self.id}"
-
-    def __str__(self):
-        return f'Blog post "{self.title}"'

--- a/data/models/blogtag.py
+++ b/data/models/blogtag.py
@@ -2,14 +2,14 @@ from django.db import models
 
 
 class BlogTag(models.Model):
-    class Meta:
-        verbose_name = "étiquette de blog"
-        verbose_name_plural = "étiquettes de blog"
+    name = models.TextField()
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
 
-    name = models.TextField()
+    class Meta:
+        verbose_name = "étiquette de blog"
+        verbose_name_plural = "étiquettes de blog"
 
     @classmethod
     def choices(self):

--- a/data/models/blogtag.py
+++ b/data/models/blogtag.py
@@ -11,9 +11,9 @@ class BlogTag(models.Model):
         verbose_name = "étiquette de blog"
         verbose_name_plural = "étiquettes de blog"
 
-    @classmethod
-    def choices(self):
-        return [(x.id, x.__str__()) for x in self.objects.all()]
-
     def __str__(self):
         return self.name
+
+    @classmethod
+    def choices(cls):
+        return [(x.id, x.__str__()) for x in cls.objects.all()]

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -379,18 +379,6 @@ class CanteenManager(SoftDeletionManager):
 
 
 class Canteen(DirtyFieldsMixin, SoftDeletionModel):
-    objects = CanteenManager.from_queryset(CanteenQuerySet)()
-    all_objects = CanteenManager.from_queryset(CanteenQuerySet)(alive_only=False)
-
-    class Meta:
-        verbose_name = "cantine"
-        verbose_name_plural = "cantines"
-        ordering = ["-creation_date"]
-        indexes = [
-            models.Index(fields=["siret"]),
-            models.Index(fields=["central_producer_siret"]),
-        ]
-
     class ManagementType(models.TextChoices):
         DIRECT = "direct", "Directe"
         CONCEDED = "conceded", "Concédée"
@@ -494,11 +482,6 @@ class Canteen(DirtyFieldsMixin, SoftDeletionModel):
         "creation_source",
         "import_source",
     ]
-
-    import_source = models.TextField(null=True, blank=True, verbose_name="Source de l'import de la cantine")
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-    history = HistoricalRecords()
 
     name = models.TextField(verbose_name="nom")
 
@@ -673,6 +656,23 @@ class Canteen(DirtyFieldsMixin, SoftDeletionModel):
         null=True,
         verbose_name="Source de création de la cantine",
     )
+
+    import_source = models.TextField(null=True, blank=True, verbose_name="Source de l'import de la cantine")
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    history = HistoricalRecords()
+
+    objects = CanteenManager.from_queryset(CanteenQuerySet)()
+    all_objects = CanteenManager.from_queryset(CanteenQuerySet)(alive_only=False)
+
+    class Meta:
+        verbose_name = "cantine"
+        verbose_name_plural = "cantines"
+        ordering = ["-creation_date"]
+        indexes = [
+            models.Index(fields=["siret"]),
+            models.Index(fields=["central_producer_siret"]),
+        ]
 
     def normalize_fields(self):
         for field_name in ["siret", "siren_unite_legale", "epci", "central_producer_siret"]:

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -674,6 +674,9 @@ class Canteen(DirtyFieldsMixin, SoftDeletionModel):
             models.Index(fields=["central_producer_siret"]),
         ]
 
+    def __str__(self):
+        return self.name
+
     def normalize_fields(self):
         for field_name in ["siret", "siren_unite_legale", "epci", "central_producer_siret"]:
             setattr(self, field_name, utils_utils.normalize_string(getattr(self, field_name)))
@@ -929,9 +932,6 @@ class Canteen(DirtyFieldsMixin, SoftDeletionModel):
         if self.is_groupe or self.line_ministry == Canteen.Ministries.ARMEE:
             return Canteen.PublicationStatus.DRAFT
         return Canteen.PublicationStatus.PUBLISHED
-
-    def __str__(self):
-        return self.name
 
     def _get_region(self):
         return get_region_from_department(self.department)

--- a/data/models/communityevent.py
+++ b/data/models/communityevent.py
@@ -9,20 +9,20 @@ class CommunityEventQuerySet(models.QuerySet):
 
 
 class CommunityEvent(models.Model):
-    class Meta:
-        verbose_name = "événement"
-        ordering = ["start_date"]
-
-    objects = CommunityEventQuerySet.as_manager()
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-
     title = models.TextField(verbose_name="titre")
     start_date = models.DateTimeField(verbose_name="date de début")
     end_date = models.DateTimeField(verbose_name="date de fin")
     tagline = models.TextField(null=True, blank=True, verbose_name="description courte")
     link = models.TextField(verbose_name="lien pour s'inscrire")
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    objects = CommunityEventQuerySet.as_manager()
+
+    class Meta:
+        verbose_name = "événement"
+        ordering = ["start_date"]
 
     def clean(self):
         self.validate_dates()

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -322,15 +322,6 @@ class DiagnosticManager(models.Manager):
 
 
 class Diagnostic(models.Model):
-    class Meta:
-        verbose_name = "diagnostic"
-        verbose_name_plural = "diagnostics"
-        constraints = [
-            models.UniqueConstraint(
-                fields=["canteen", "year", "generated_from_groupe_diagnostic"], name="annual_diagnostic"
-            ),
-        ]
-
     class DiagnosticStatus(models.TextChoices):
         DRAFT = "DRAFT", "Brouillon"
         CORRECTION = "CORRECTION", "En correction"
@@ -854,13 +845,6 @@ class Diagnostic(models.Model):
         "percentage_valeur_produits_de_la_mer_egalim",
         "percentage_valeur_produits_de_la_mer_france",
     ]
-
-    objects = DiagnosticManager.from_queryset(DiagnosticQuerySet)(exclude_generated=True)
-    all_objects = DiagnosticManager.from_queryset(DiagnosticQuerySet)()
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-    history = HistoricalRecords(excluded_fields=["canteen_snapshot", "satellites_snapshot", "applicant_snapshot"])
 
     canteen = models.ForeignKey(
         Canteen, on_delete=models.SET_NULL, null=True, related_name="diagnostics", verbose_name="cantine"
@@ -1658,6 +1642,22 @@ class Diagnostic(models.Model):
         size=None,
         verbose_name="bilan ignoré dans les stats (raisons)",
     )
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    history = HistoricalRecords(excluded_fields=["canteen_snapshot", "satellites_snapshot", "applicant_snapshot"])
+
+    objects = DiagnosticManager.from_queryset(DiagnosticQuerySet)(exclude_generated=True)
+    all_objects = DiagnosticManager.from_queryset(DiagnosticQuerySet)()
+
+    class Meta:
+        verbose_name = "diagnostic"
+        verbose_name_plural = "diagnostics"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["canteen", "year", "generated_from_groupe_diagnostic"], name="annual_diagnostic"
+            ),
+        ]
 
     def __str__(self):
         return f"Diagnostic pour {self.canteen.name} ({self.year})"

--- a/data/models/importfailure.py
+++ b/data/models/importfailure.py
@@ -5,19 +5,19 @@ from .importtype import ImportType
 
 
 class ImportFailure(models.Model):
-    class Meta:
-        verbose_name = "échec d'import de masse"
-        verbose_name_plural = "échec d'import de masse"
-
-    creation_date = models.DateTimeField(auto_now_add=True, verbose_name="date de création")
-    modification_date = models.DateTimeField(auto_now=True, verbose_name="date de modification")
-
     file = models.FileField(null=True, blank=True, upload_to="import-errors/%Y/%m/%d/", verbose_name="fichier")
     user = models.ForeignKey(
         get_user_model(), null=True, blank=True, on_delete=models.SET_NULL, verbose_name="utilisateur"
     )
     details = models.TextField(null=True, blank=True, verbose_name="détails")
     import_type = models.TextField(null=True, blank=True, choices=ImportType.choices, verbose_name="type d'import")
+
+    creation_date = models.DateTimeField(auto_now_add=True, verbose_name="date de création")
+    modification_date = models.DateTimeField(auto_now=True, verbose_name="date de modification")
+
+    class Meta:
+        verbose_name = "échec d'import de masse"
+        verbose_name_plural = "échec d'import de masse"
 
     @property
     def details_short(self):

--- a/data/models/managerinvitation.py
+++ b/data/models/managerinvitation.py
@@ -5,18 +5,18 @@ from .canteen import Canteen
 
 
 class ManagerInvitation(models.Model):
+    email = models.EmailField(_("email address"))
+    canteen = models.ForeignKey(Canteen, on_delete=models.CASCADE)
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
     class Meta:
         verbose_name = "invitation de gestion"
         verbose_name_plural = "invitations de gestion"
         constraints = [
             models.UniqueConstraint(fields=["canteen", "email"], name="deduplicate_invitation"),
         ]
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-
-    email = models.EmailField(_("email address"))
-    canteen = models.ForeignKey(Canteen, on_delete=models.CASCADE)
 
     def __str__(self):
         return f"{self.email}"

--- a/data/models/message.py
+++ b/data/models/message.py
@@ -33,6 +33,17 @@ class Message(models.Model):
     class Meta:
         ordering = ["-creation_date"]
 
+    def __str__(self):
+        return f"Message envoyé de {self.sender_email} à {self.canteen_name}"
+
+    @property
+    def canteen_name(self):
+        return self.destination_canteen.name if self.destination_canteen else "⚠️ Cantine inconnue"
+
+    @property
+    def recipients(self):
+        return [user.email for user in self.destination_canteen.managers.all()] if self.destination_canteen else []
+
     def send(self):
         if self.status == Message.Status.SENT:
             logger.exception(f"Attempt to send an already sent message: {self.id}")
@@ -68,14 +79,3 @@ class Message(models.Model):
             raise Exception(f"Cannot block message already sent on {self.sent_date}")
         self.status = Message.Status.BLOCKED
         self.save()
-
-    def __str__(self):
-        return f"Message envoyé de {self.sender_email} à {self.canteen_name}"
-
-    @property
-    def canteen_name(self):
-        return self.destination_canteen.name if self.destination_canteen else "⚠️ Cantine inconnue"
-
-    @property
-    def recipients(self):
-        return [user.email for user in self.destination_canteen.managers.all()] if self.destination_canteen else []

--- a/data/models/message.py
+++ b/data/models/message.py
@@ -11,16 +11,10 @@ logger = logging.getLogger(__name__)
 
 
 class Message(models.Model):
-    class Meta:
-        ordering = ["-creation_date"]
-
     class Status(models.TextChoices):
         PENDING = "PENDING", "En attente de validation"
         SENT = "SENT", "Envoyé"
         BLOCKED = "BLOCKED", "Bloqué"
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
 
     destination_canteen = models.ForeignKey(
         Canteen, on_delete=models.SET_NULL, null=True, blank=True, verbose_name="destinataire"
@@ -32,6 +26,12 @@ class Message(models.Model):
     status = models.CharField(max_length=255, choices=Status.choices, default=Status.PENDING, verbose_name="État")
 
     sent_date = models.DateField(null=True, blank=True)
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["-creation_date"]
 
     def send(self):
         if self.status == Message.Status.SENT:

--- a/data/models/partner.py
+++ b/data/models/partner.py
@@ -96,13 +96,8 @@ class Partner(models.Model):
         verbose_name = "partenaire"
         verbose_name_plural = "partenaires"
 
-    @property
-    def url_slug(self):
-        return f"{self.id}--{quote(self.name)}"
-
-    @property
-    def url_path(self):
-        return f"/acteurs-de-l-eco-systeme/{self.url_slug}"
+    def __str__(self):
+        return f'Partenaire "{self.name}"'
 
     def save(self, **kwargs):
         max_image_size = 1600
@@ -110,5 +105,10 @@ class Partner(models.Model):
             self.image = optimize_image(self.image, self.image.name, max_image_size)
         super().save(**kwargs)
 
-    def __str__(self):
-        return f'Partenaire "{self.name}"'
+    @property
+    def url_slug(self):
+        return f"{self.id}--{quote(self.name)}"
+
+    @property
+    def url_path(self):
+        return f"/acteurs-de-l-eco-systeme/{self.url_slug}"

--- a/data/models/partner.py
+++ b/data/models/partner.py
@@ -32,13 +32,6 @@ class Partner(models.Model):
         NETWORK = "network", "Mise en réseau d’acteurs de terrain"
         FINANCIAL = "financial", "Aide financière / matérielle"
 
-    class Meta:
-        verbose_name = "partenaire"
-        verbose_name_plural = "partenaires"
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-
     name = models.TextField(verbose_name="nom")
     short_description = models.TextField(verbose_name="description courte")
     long_description = RichTextUploadingField(null=True, blank=True, verbose_name="description longue")
@@ -95,6 +88,13 @@ class Partner(models.Model):
     contact_name = models.TextField(verbose_name="Nom de contact", blank=True, null=True)
     contact_message = models.TextField(verbose_name="Commentaires sur la demande", blank=True, null=True)
     contact_phone_number = models.CharField("Numéro téléphone", max_length=50, null=True, blank=True)
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "partenaire"
+        verbose_name_plural = "partenaires"
 
     @property
     def url_slug(self):

--- a/data/models/partnertype.py
+++ b/data/models/partnertype.py
@@ -11,9 +11,9 @@ class PartnerType(models.Model):
         verbose_name = "Partenaire (type)"
         verbose_name_plural = "Partenaire (types)"
 
-    @classmethod
-    def choices(self):
-        return [(x.id, x.__str__()) for x in self.objects.all()]
-
     def __str__(self):
         return self.name
+
+    @classmethod
+    def choices(cls):
+        return [(x.id, x.__str__()) for x in cls.objects.all()]

--- a/data/models/partnertype.py
+++ b/data/models/partnertype.py
@@ -2,14 +2,14 @@ from django.db import models
 
 
 class PartnerType(models.Model):
-    class Meta:
-        verbose_name = "Partenaire (type)"
-        verbose_name_plural = "Partenaire (types)"
+    name = models.TextField()
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
 
-    name = models.TextField()
+    class Meta:
+        verbose_name = "Partenaire (type)"
+        verbose_name_plural = "Partenaire (types)"
 
     @classmethod
     def choices(self):

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -14,12 +14,6 @@ from .softdeletionmodel import SoftDeletionModel
 
 
 class Purchase(SoftDeletionModel):
-    class Meta:
-        verbose_name = "achat"
-        verbose_name_plural = "achats"
-        ordering = ["-date", "-creation_date"]
-        indexes = [models.Index(fields=["import_source"])]
-
     class PurchaseCategory(models.TextChoices):
         VIANDES_VOLAILLES = "VIANDES_VOLAILLES", "Viandes, volailles"
         PRODUITS_DE_LA_MER = "PRODUITS_DE_LA_MER", "Produits de la mer"
@@ -73,9 +67,6 @@ class Purchase(SoftDeletionModel):
         AUTOUR_SERVICE = "AUTOUR_SERVICE", "200 km autour du lieu de service"
         AUTRE = "AUTRE", "Autre"
 
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-
     canteen = models.ForeignKey(Canteen, on_delete=models.CASCADE)
     date = models.DateField(default=date.today)
     description = models.TextField(null=True, blank=True, verbose_name="description du produit")
@@ -114,6 +105,15 @@ class Purchase(SoftDeletionModel):
         null=True,
         verbose_name="Source de création de l'achat",
     )
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "achat"
+        verbose_name_plural = "achats"
+        ordering = ["-date", "-creation_date"]
+        indexes = [models.Index(fields=["import_source"])]
 
     def clean(self, *args, **kwargs):
         validation_errors = utils_utils.merge_validation_errors(

--- a/data/models/reservationexpe.py
+++ b/data/models/reservationexpe.py
@@ -8,13 +8,6 @@ from data.utils import make_optional_positive_decimal_field
 
 
 class ReservationExpe(models.Model):
-    class Meta:
-        verbose_name = "expérimentation réservation"
-        verbose_name_plural = "expérimentations réservation"
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-
     canteen = models.ForeignKey(Canteen, on_delete=models.CASCADE, verbose_name="cantine")
 
     has_reservation_system = models.BooleanField(
@@ -153,3 +146,10 @@ class ReservationExpe(models.Model):
     money_saved = make_optional_positive_decimal_field(
         verbose_name="Gains générés par l'évitement du gaspillage laimentaire en euros sur 3 ans",
     )
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "expérimentation réservation"
+        verbose_name_plural = "expérimentations réservation"

--- a/data/models/resourceaction.py
+++ b/data/models/resourceaction.py
@@ -17,17 +17,6 @@ class ResourceActionQuerySet(models.QuerySet):
 
 
 class ResourceAction(models.Model):
-    class Meta:
-        unique_together = ("resource", "canteen")
-        verbose_name = "ressource : action (cantine)"
-        verbose_name_plural = "ressources : actions (cantines)"
-
-    objects = ResourceActionQuerySet.as_manager()
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-    history = HistoricalRecords()
-
     # resource = only waste_actions for now
     # but we use the term resource to have a consistent API once we regroup resources
     resource = models.ForeignKey(
@@ -39,6 +28,17 @@ class ResourceAction(models.Model):
 
     is_done = models.BooleanField(null=True, blank=True, verbose_name="mis en place")
     is_favorite = models.BooleanField(null=True, blank=True, verbose_name="favori")
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    history = HistoricalRecords()
+
+    objects = ResourceActionQuerySet.as_manager()
+
+    class Meta:
+        unique_together = ("resource", "canteen")
+        verbose_name = "ressource : action (cantine)"
+        verbose_name_plural = "ressources : actions (cantines)"
 
     def save(self, *args, **kwargs):
         self.full_clean()

--- a/data/models/resourceaction.py
+++ b/data/models/resourceaction.py
@@ -22,7 +22,7 @@ class ResourceAction(models.Model):
         verbose_name = "ressource : action (cantine)"
         verbose_name_plural = "ressources : actions (cantines)"
 
-    objects = models.Manager.from_queryset(ResourceActionQuerySet)()
+    objects = ResourceActionQuerySet.as_manager()
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)

--- a/data/models/review.py
+++ b/data/models/review.py
@@ -4,13 +4,6 @@ from django.db import models
 
 
 class Review(models.Model):
-    class Meta:
-        verbose_name = "évaluation du site"
-        verbose_name_plural = "évaluations du site"
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, verbose_name="utilisateur")
     rating = models.PositiveSmallIntegerField(
         verbose_name="score",
@@ -20,3 +13,10 @@ class Review(models.Model):
     page = models.CharField(max_length=100, verbose_name="page")
     hasCanteen = models.BooleanField(default=False, verbose_name="eu une cantine au moment de l'évaluation")
     hasDiagnostic = models.BooleanField(default=False, verbose_name="eu un diagnostic au moment de l'évaluation")
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "évaluation du site"
+        verbose_name_plural = "évaluations du site"

--- a/data/models/sector.py
+++ b/data/models/sector.py
@@ -278,10 +278,6 @@ def annotate_with_sector_category_list(queryset):
 
 
 class SectorM2M(models.Model):
-    class Meta:
-        verbose_name = "secteur d'activité"
-        verbose_name_plural = "secteurs d'activité"
-
     class Categories(models.TextChoices):
         ADMINISTRATION = "administration", "Administration"
         ENTERPRISE = "enterprise", "Entreprise"
@@ -290,9 +286,6 @@ class SectorM2M(models.Model):
         SOCIAL = "social", "Social / Médico-social"
         LEISURE = "leisure", "Loisirs"
         AUTRES = "autres", "Autres"
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
 
     name = models.TextField()
     category = models.CharField(
@@ -304,9 +297,16 @@ class SectorM2M(models.Model):
     )
     has_line_ministry = models.BooleanField(default=False, verbose_name="Afficher le champ « Ministère de tutelle »")
 
-    @classmethod
-    def choices(self):
-        return [(x.id, x.__str__()) for x in self.objects.all()]
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "secteur d'activité"
+        verbose_name_plural = "secteurs d'activité"
 
     def __str__(self):
         return self.name
+
+    @classmethod
+    def choices(cls):
+        return [(x.id, x.__str__()) for x in cls.objects.all()]

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -151,16 +151,6 @@ class Teledeclaration(models.Model):
         SUBMITTED = "SUBMITTED", "Télédéclaré"
         CANCELLED = "CANCELLED", "Annulé"
 
-    class Meta:
-        verbose_name = "télédéclaration"
-        verbose_name_plural = "télédéclarations"
-        constraints = [
-            models.UniqueConstraint(
-                fields=["year", "canteen"], condition=models.Q(status="SUBMITTED"), name="unique_submitted_td"
-            )
-        ]
-        indexes = [models.Index(fields=["canteen", "year"])]
-
     class TeledeclarationMode(models.TextChoices):
         SATELLITE_WITHOUT_APPRO = (
             "SATELLITE_WITHOUT_APPRO",
@@ -176,20 +166,6 @@ class Teledeclaration(models.Model):
         )
         SITE = "SITE", "Cantine déclarant ses propres données"
 
-    objects = TeledeclarationQuerySet.as_manager()
-
-    # Fields that pertain to the teledeclaration. These fields
-    # will not change and should contain all information to be
-    # sent to the system that will treat the teledeclarations.
-
-    declared_data = models.JSONField(verbose_name="Champs", encoder=CustomJSONEncoder)
-
-    # Structured non-null fields for validation / querying.
-    # These fields cannot be null and will not change if the
-    # canteen or diagnostic objects change.
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
     year = models.IntegerField(verbose_name="année")
     canteen_siret = models.TextField(null=True, blank=True)
     canteen_siren_unite_legale = models.TextField(null=True, blank=True)
@@ -265,6 +241,29 @@ class Teledeclaration(models.Model):
         null=True,
         blank=True,
     )
+
+    # Fields that pertain to the teledeclaration. These fields
+    # will not change and should contain all information to be
+    # sent to the system that will treat the teledeclarations.
+    declared_data = models.JSONField(verbose_name="Champs", encoder=CustomJSONEncoder)
+
+    # Structured non-null fields for validation / querying.
+    # These fields cannot be null and will not change if the
+    # canteen or diagnostic objects change.
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    objects = TeledeclarationQuerySet.as_manager()
+
+    class Meta:
+        verbose_name = "télédéclaration"
+        verbose_name_plural = "télédéclarations"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["year", "canteen"], condition=models.Q(status="SUBMITTED"), name="unique_submitted_td"
+            )
+        ]
+        indexes = [models.Index(fields=["canteen", "year"])]
 
     @property
     def is_declared_by_cc(self):

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -176,7 +176,7 @@ class Teledeclaration(models.Model):
         )
         SITE = "SITE", "Cantine déclarant ses propres données"
 
-    objects = models.Manager.from_queryset(TeledeclarationQuerySet)()
+    objects = TeledeclarationQuerySet.as_manager()
 
     # Fields that pertain to the teledeclaration. These fields
     # will not change and should contain all information to be

--- a/data/models/teledeclaration.py
+++ b/data/models/teledeclaration.py
@@ -265,6 +265,10 @@ class Teledeclaration(models.Model):
         ]
         indexes = [models.Index(fields=["canteen", "year"])]
 
+    def __str__(self):
+        canteen_name = self.declared_data["canteen"]["name"] if self.declared_data.get("canteen") else ""
+        return f"Télédéclaration pour {self.year} '{canteen_name}'"
+
     @property
     def is_declared_by_cc(self):
         return self.teledeclaration_mode and self.teledeclaration_mode in [
@@ -443,7 +447,3 @@ class Teledeclaration(models.Model):
             using=using,
             update_fields=update_fields,
         )
-
-    def __str__(self):
-        canteen_name = self.declared_data["canteen"]["name"] if self.declared_data.get("canteen") else ""
-        return f"Télédéclaration pour {self.year} '{canteen_name}'"

--- a/data/models/user.py
+++ b/data/models/user.py
@@ -160,8 +160,6 @@ class User(DirtyFieldsMixin, AbstractUser):
         "nb_cantines_td_todo_2025",
     ]
 
-    objects = UserManager.from_queryset(UserQuerySet)()
-
     avatar = models.ImageField("Photo de profil", null=True, blank=True)
     email = models.EmailField(_("email address"), unique=True)
     email_confirmed = models.BooleanField(default="False", verbose_name="adresse email confirmée")
@@ -241,6 +239,8 @@ class User(DirtyFieldsMixin, AbstractUser):
 
     # Django fields
     # last_login, date_joined, is_active, is_staff, is_superuser
+
+    objects = UserManager.from_queryset(UserQuerySet)()
 
     def normalize_fields(self):
         for field_name in ["email", "username"]:

--- a/data/models/user.py
+++ b/data/models/user.py
@@ -242,6 +242,9 @@ class User(DirtyFieldsMixin, AbstractUser):
 
     objects = UserManager.from_queryset(UserQuerySet)()
 
+    def __str__(self):
+        return f"{self.get_full_name()} ({self.username})"
+
     def normalize_fields(self):
         for field_name in ["email", "username"]:
             if field_name in self.get_dirty_fields():
@@ -278,9 +281,6 @@ class User(DirtyFieldsMixin, AbstractUser):
     @property
     def has_mtm_data(self):
         return self.creation_mtm_source or self.creation_mtm_campaign or self.creation_mtm_medium
-
-    def __str__(self):
-        return f"{self.get_full_name()} ({self.username})"
 
     def canteens_count(self):
         return self.canteens.count()

--- a/data/models/vegetarianexpe.py
+++ b/data/models/vegetarianexpe.py
@@ -10,10 +10,6 @@ from .canteen import Canteen
 
 
 class VegetarianExpe(models.Model):
-    class Meta:
-        verbose_name = "expérimentation repas végétariens quotidiens"
-        verbose_name_plural = "expérimentations repas végétariens quotidiens"
-
     class MenuOptions(models.TextChoices):
         UNIQUE = "unique", "Un menu unique pour tous les convives"
         MULTIPLE = "multiple", "Une offre à choix multiples"
@@ -77,9 +73,6 @@ class VegetarianExpe(models.Model):
         CLIENTS = "clients", "Réaction des convives"
         OVERWORK = "overwork", "Surcharge de travail pour le personnel"
         OTHER = "other", "Autre"
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
 
     canteen = models.ForeignKey(Canteen, on_delete=models.CASCADE, verbose_name="cantine")
 
@@ -568,3 +561,10 @@ class VegetarianExpe(models.Model):
         blank=True,
         verbose_name="Precision sur les freins rencontrés à la mise en place de l’option végétarienne quotidienne",
     )
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "expérimentation repas végétariens quotidiens"
+        verbose_name_plural = "expérimentations repas végétariens quotidiens"

--- a/data/models/videotutorial.py
+++ b/data/models/videotutorial.py
@@ -11,13 +11,6 @@ class VideoTutorialCategory(models.TextChoices):
 
 
 class VideoTutorial(models.Model):
-    class Meta:
-        verbose_name = "tutoriel vidéo"
-        verbose_name_plural = "tutoriels vidéo"
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-
     title = models.TextField(verbose_name="titre")
     description = models.TextField(verbose_name="description")
     published = models.BooleanField(default=False, verbose_name="publié")
@@ -32,6 +25,13 @@ class VideoTutorial(models.Model):
         verbose_name="catégorie",
     )
     thumbnail = models.ImageField(null=True, blank=True, verbose_name="aperçu")
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "tutoriel vidéo"
+        verbose_name_plural = "tutoriels vidéo"
 
     def __str__(self):
         return self.title

--- a/data/models/wasteaction.py
+++ b/data/models/wasteaction.py
@@ -7,11 +7,6 @@ from data.fields import ChoiceArrayField
 
 
 class WasteAction(RevisionMixin, models.Model):
-    class Meta:
-        verbose_name = "Action anti-gaspi"
-        verbose_name_plural = "Actions anti-gaspi"
-        ordering = ["-modification_date"]
-
     class Effort(models.TextChoices):
         SMALL = "SMALL", "Petit pas"
         MEDIUM = "MEDIUM", "Moyen"
@@ -21,9 +16,6 @@ class WasteAction(RevisionMixin, models.Model):
         PREP = "PREP", "Préparation"
         UNSERVED = "UNSERVED", "Non servi"
         PLATE = "PLATE", "Retour assiette"
-
-    creation_date = models.DateTimeField(auto_now_add=True, verbose_name="Date de création")
-    modification_date = models.DateTimeField(auto_now=True, verbose_name="Date de dernière modification")
 
     title = models.TextField(verbose_name="Titre")
     subtitle = models.TextField(null=True, blank=True, verbose_name="Sous-titre")
@@ -44,9 +36,13 @@ class WasteAction(RevisionMixin, models.Model):
     # not using revisions directly in case we want to add custom logic in the property in the future
     _revisions = GenericRelation("wagtailcore.Revision", related_query_name="wasteaction")
 
-    @property
-    def revisions(self):
-        return self._revisions
+    creation_date = models.DateTimeField(auto_now_add=True, verbose_name="Date de création")
+    modification_date = models.DateTimeField(auto_now=True, verbose_name="Date de dernière modification")
+
+    class Meta:
+        verbose_name = "Action anti-gaspi"
+        verbose_name_plural = "Actions anti-gaspi"
+        ordering = ["-modification_date"]
 
     def __str__(self):
         return f'Action anti-gaspi "{self.title}"'
@@ -54,6 +50,10 @@ class WasteAction(RevisionMixin, models.Model):
     def save(self, *args, **kwargs):
         self.full_clean()
         super().save(*args, **kwargs)
+
+    @property
+    def revisions(self):
+        return self._revisions
 
     def effort_display(self):
         return dict(WasteAction.Effort.choices)[self.effort]

--- a/data/models/wastemeasurement.py
+++ b/data/models/wastemeasurement.py
@@ -15,14 +15,6 @@ def validate_before_today(value):
 
 
 class WasteMeasurement(models.Model):
-    class Meta:
-        verbose_name = "évaluation du gaspillage alimentaire"
-        verbose_name_plural = "évaluations du gaspillage alimentaire"
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-    history = HistoricalRecords()
-
     canteen = models.ForeignKey(Canteen, on_delete=models.CASCADE)
 
     period_start_date = models.DateField(verbose_name="date de début")
@@ -73,6 +65,23 @@ class WasteMeasurement(models.Model):
         verbose_name="restes assiette - masse non-comestible (kg)",
     )
 
+    history = HistoricalRecords()
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "évaluation du gaspillage alimentaire"
+        verbose_name_plural = "évaluations du gaspillage alimentaire"
+
+    def clean(self):
+        self.validate_dates()
+        return super().clean()
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
     @property
     def days_in_period(self):
         # + 1 because python is exclusive but period dates are inclusive
@@ -85,14 +94,6 @@ class WasteMeasurement(models.Model):
         if not canteen_yearly_meal_count or not self.meal_count or not has_total_mass:
             return None
         return self.total_mass / self.meal_count * canteen_yearly_meal_count
-
-    def clean(self):
-        self.validate_dates()
-        return super().clean()
-
-    def save(self, *args, **kwargs):
-        self.full_clean()
-        super().save(*args, **kwargs)
 
     def validate_dates(self):
         start_date = self.period_start_date


### PR DESCRIPTION
Bon, je continue mon ménage de printemps :)

Ordre de chaque modèle
- Enum & co
- "champs du modèle"
- history
- creation_date & modification_date
- objects
- class Meta
- def `__str__`
- def clean()
- def save()
- `@property`
- methods

Et 2 petites modifs pour utiliser `as_manager` au lieu de `from_queryset`