### PR TITLE
refactor(Achats): regrouper les stats d'aggrégation dans une queryset dédiée

### DIFF
--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -2,8 +2,6 @@ import logging
 from collections import OrderedDict
 
 from django.core.exceptions import BadRequest, ObjectDoesNotExist, ValidationError
-from django.db.models import Q, Sum
-from django.db.models.functions import ExtractYear
 from django.http import JsonResponse
 from django_filters import rest_framework as django_filters
 from rest_framework import status
@@ -172,7 +170,7 @@ class CanteenPurchasesSummaryView(APIView):
         canteen_id = kwargs.get("canteen_pk")
         canteen = self._get_canteen(canteen_id, self.request)
         year = request.query_params.get("year")
-        data = canteen_summary_for_year(canteen, year) if year else canteen_summary(canteen)
+        data = Purchase.canteen_summary_for_year(canteen, year) if year else Purchase.canteen_summary(canteen)
         return Response(PurchaseSummarySerializer(data).data if year else data)
 
     def _get_canteen(self, canteen_id, request):
@@ -202,7 +200,7 @@ class CanteenPurchasesPercentageSummaryView(APIView):
         if not ignore_redaction and year in canteen.redacted_appro_years:
             raise NotFound()
 
-        data = canteen_summary_for_year(canteen, year)
+        data = Purchase.canteen_summary_for_year(canteen, year)
         if data["valeur_totale"] == 0:
             raise NotFound()
 
@@ -219,156 +217,6 @@ class CanteenPurchasesPercentageSummaryView(APIView):
             return canteen
         except Canteen.DoesNotExist as e:
             raise NotFound() from e
-
-
-def canteen_summary_for_year(canteen, year):
-    purchases = Purchase.objects.only("id", "family", "characteristics", "price_ht").filter(
-        canteen=canteen, date__year=year
-    )
-    data = {"year": year}
-    simple_diag_data(purchases, data)
-    complete_diag_data(purchases, data)
-    misc_totals(purchases, data)
-
-    return data
-
-
-def canteen_summary(canteen):
-    data = {"results": []}
-    years = (
-        Purchase.objects.filter(canteen=canteen).annotate(year=ExtractYear("date")).order_by("year").distinct("year")
-    )
-    years = [y["year"] for y in years.values()]
-    for year in years:
-        year_data = {"year": year}
-        purchases = Purchase.objects.only("id", "family", "characteristics", "price_ht").filter(
-            canteen=canteen, date__year=year
-        )
-        simple_diag_data(purchases, year_data)
-        data["results"].append(year_data)
-
-    return data
-
-
-def simple_diag_data(purchases, data):
-    bio_filter = Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_BIO)
-    bio_commerce_equitable_filter = bio_filter & Q(
-        characteristics__contains=[Purchase.Characteristic.COMMERCE_EQUITABLE]
-    )
-    siqo_filter = Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_SIQO)
-    egalim_autres_filter = Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EGALIM_AUTRES)
-    egalim_autres_commerce_equitable_filter = egalim_autres_filter & Q(
-        characteristics__contains=[Purchase.Characteristic.COMMERCE_EQUITABLE]
-    )
-    externalities_performance_filter = Q(
-        characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EXTERNALITES_PERFORMANCE
-    )
-
-    data["valeur_totale"] = purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-
-    bio_purchases = purchases.filter(bio_filter).distinct()
-    data["valeur_bio"] = bio_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-    data["valeur_bio_dont_commerce_equitable"] = (
-        bio_purchases.filter(bio_commerce_equitable_filter).aggregate(total=Sum("price_ht"))["total"] or 0
-    )
-
-    # the remaining stats should ignore any bio products
-    purchases_no_bio = purchases.exclude(bio_filter)
-    siqo_purchases = purchases_no_bio.filter(siqo_filter).distinct()
-    data["valeur_siqo"] = siqo_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-
-    # the remaining stats should also ignore any sustainable (SIQO) products
-    purchases_no_bio_no_siqo = purchases_no_bio.exclude(siqo_filter)
-    egalim_autres_purchases = purchases_no_bio_no_siqo.filter(egalim_autres_filter).distinct()
-    data["valeur_egalim_autres"] = egalim_autres_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-    data["valeur_egalim_autres_dont_commerce_equitable"] = (
-        egalim_autres_purchases.filter(egalim_autres_commerce_equitable_filter).aggregate(total=Sum("price_ht"))[
-            "total"
-        ]
-        or 0
-    )
-
-    # the remaining stats should also ignore any "other EGalim" products
-    purchases_no_bio_siqo_no_egalim_autres = purchases_no_bio_no_siqo.exclude(egalim_autres_filter)
-    externalities_performance_purchases = purchases_no_bio_siqo_no_egalim_autres.filter(
-        externalities_performance_filter
-    ).distinct()
-    data["valeur_externalites_performance"] = (
-        externalities_performance_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-    )
-
-
-def complete_diag_data(purchases, data):
-    """
-    summary for detailed teledeclaration totals, by family and label
-    Note: the order of Diagnostic.APPRO_LABELS_EGALIM is significant - determines which labels trump others when aggregating purchases
-    """
-    for family in Diagnostic.APPRO_FAMILIES:
-        purchase_family = purchases.filter(family=family.upper())
-        for label in Diagnostic.APPRO_LABELS_EGALIM:
-            if label.upper() == "AOCAOP_IGP_STG":
-                purchase_family_label = purchase_family.filter(
-                    characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_AOCAOP_IGP_STG
-                ).distinct()
-                # the remaining stats should ignore already counted labels
-                purchase_family = purchase_family.exclude(
-                    characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_AOCAOP_IGP_STG
-                ).distinct()
-            else:
-                purchase_family_label = purchase_family.filter(
-                    Q(characteristics__contains=[Purchase.Characteristic[label.upper()]])
-                ).distinct()
-                # the remaining stats should ignore already counted labels
-                purchase_family = purchase_family.exclude(
-                    Q(characteristics__contains=[Purchase.Characteristic[label.upper()]])
-                ).distinct()
-            key = "valeur_" + family + "_" + label
-            data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
-        # special case of bio_dont_commerce_equitable (products can be counted twice across characteristics)
-        purchase_family = purchases.filter(family=family.upper())
-        purchase_family_label = purchase_family.filter(
-            Q(characteristics__contains=[Purchase.Characteristic.BIO])
-            & Q(characteristics__contains=[Purchase.Characteristic.COMMERCE_EQUITABLE])
-        )
-        key = "valeur_" + family + "_" + "bio_dont_commerce_equitable"
-        data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
-        # outside of EGalim (products can be counted twice across characteristics)
-        purchase_family = purchases.filter(family=family.upper())
-        other_labels_characteristics = []
-        for label in Diagnostic.APPRO_LABELS_FRANCE_SUBCATEGORIES:
-            characteristic = Purchase.Characteristic[label.upper()]
-            purchase_family_label = purchase_family.filter(Q(characteristics__contains=[characteristic]))
-            key = "valeur_" + family + "_" + label
-            data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
-            other_labels_characteristics.append(characteristic)
-        # France total
-        purchase_family_label = purchase_family.filter(
-            characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL
-        ).distinct()
-        key = "valeur_" + family + "_france"
-        data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
-        other_labels_characteristics.append(Purchase.Characteristic.FRANCE)
-        # Non-EGalim totals (contains no labels or only one or more of other_labels)
-        non_egalim_purchases = purchase_family.filter(
-            Q(characteristics__contained_by=(other_labels_characteristics + [""])) | Q(characteristics__len=0)
-        ).distinct()
-        key = "valeur_" + family + "_non_egalim"
-        data[key] = non_egalim_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-
-
-def misc_totals(purchases, data):
-    # meat_poultry
-    meat_poultry_purchases = purchases.filter(family=Purchase.Family.VIANDES_VOLAILLES)
-    data["valeur_viandes_volailles"] = meat_poultry_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-    meat_poultry_egalim = meat_poultry_purchases.filter(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EGALIM)
-    data["valeur_viandes_volailles_egalim"] = meat_poultry_egalim.aggregate(total=Sum("price_ht"))["total"] or 0
-    meat_poultry_france = meat_poultry_purchases.filter(characteristics__contains=[Purchase.Characteristic.FRANCE])
-    data["valeur_viandes_volailles_france"] = meat_poultry_france.aggregate(total=Sum("price_ht"))["total"] or 0
-    # fish
-    fish_purchases = purchases.filter(family=Purchase.Family.PRODUITS_DE_LA_MER)
-    data["valeur_produits_de_la_mer"] = fish_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-    fish_egalim = fish_purchases.filter(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EGALIM)
-    data["valeur_produits_de_la_mer_egalim"] = fish_egalim.aggregate(total=Sum("price_ht"))["total"] or 0
 
 
 class DiagnosticsFromPurchasesView(APIView):
@@ -391,7 +239,7 @@ class DiagnosticsFromPurchasesView(APIView):
             if request.user not in canteen.managers.all():
                 errors.append(f"Vous ne gérez pas la cantine : {canteen_id}")
                 continue
-            values_dict = canteen_summary_for_year(canteen, year)
+            values_dict = Purchase.canteen_summary_for_year(canteen, year)
             valeur_totale = values_dict["valeur_totale"]
             if valeur_totale == 0 or valeur_totale is None:
                 errors.append(f"Aucun achat trouvé pour la cantine : {canteen_id}")

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -12,7 +12,79 @@ from data.models import Canteen
 from data.models.creation_source import CreationSource
 from data.validators import purchase as purchase_validators
 
-from .softdeletionmodel import SoftDeletionModel
+from .softdeletionmodel import SoftDeletionManager, SoftDeletionModel, SoftDeletionQuerySet
+
+
+def bio_query():
+    return Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_BIO)
+
+
+def siqo_query():
+    return Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_SIQO)
+
+
+def egalim_autres_query():
+    return Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EGALIM_AUTRES)
+
+
+def valeur_externalites_performance_query():
+    return Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EXTERNALITES_PERFORMANCE)
+
+
+class PurchaseQuerySet(SoftDeletionQuerySet):
+    def filter_for_stats(self, canteen, year):
+        return self.only("id", "family", "characteristics", "price_ht").filter(canteen=canteen, date__year=year)
+
+    def aggregated_stats(self):
+        return self.aggregate(
+            valeur_totale=Sum("price_ht"),
+            valeur_bio=Sum("price_ht", filter=bio_query()),
+            valeur_bio_dont_commerce_equitable=Sum(
+                "price_ht",
+                filter=bio_query() & Q(characteristics__contains=[Purchase.Characteristic.COMMERCE_EQUITABLE]),
+            ),
+            # valeur_siqo should ignore any bio products
+            valeur_siqo=Sum("price_ht", filter=~bio_query() & siqo_query()),
+            # valeur_egalim_autres & valeur_egalim_autres_dont_commerce_equitable should ignore any bio & siqo products
+            valeur_egalim_autres=Sum(
+                "price_ht",
+                filter=~bio_query() & ~siqo_query() & egalim_autres_query(),
+            ),
+            valeur_egalim_autres_dont_commerce_equitable=Sum(
+                "price_ht",
+                filter=~bio_query()
+                & ~siqo_query()
+                & egalim_autres_query()
+                & Q(characteristics__contains=[Purchase.Characteristic.COMMERCE_EQUITABLE]),
+            ),
+            # valeur_externalites_performance should ignore any bio, siqo, and egalim_autres products
+            valeur_externalites_performance=Sum(
+                "price_ht",
+                filter=~bio_query() & ~siqo_query() & ~egalim_autres_query() & valeur_externalites_performance_query(),
+            ),
+            # misc totals
+            valeur_viandes_volailles=Sum("price_ht", filter=Q(family=Purchase.Family.VIANDES_VOLAILLES)),
+            valeur_viandes_volailles_egalim=Sum(
+                "price_ht",
+                filter=Q(family=Purchase.Family.VIANDES_VOLAILLES)
+                & Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EGALIM),
+            ),
+            valeur_viandes_volailles_france=Sum(
+                "price_ht",
+                filter=Q(family=Purchase.Family.VIANDES_VOLAILLES)
+                & Q(characteristics__contains=[Purchase.Characteristic.FRANCE]),
+            ),
+            valeur_produits_de_la_mer=Sum("price_ht", filter=Q(family=Purchase.Family.PRODUITS_DE_LA_MER)),
+            valeur_produits_de_la_mer_egalim=Sum(
+                "price_ht",
+                filter=Q(family=Purchase.Family.PRODUITS_DE_LA_MER)
+                & Q(characteristics__overlap=Purchase.CHARACTERISTIC_LABELS_EGALIM),
+            ),
+        )
+
+
+class PurchaseManager(SoftDeletionManager):
+    queryset_model = PurchaseQuerySet
 
 
 class Purchase(SoftDeletionModel):
@@ -151,6 +223,9 @@ class Purchase(SoftDeletionModel):
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
 
+    objects = PurchaseManager()
+    all_objects = PurchaseManager(alive_only=False)
+
     class Meta:
         verbose_name = "achat"
         verbose_name_plural = "achats"
@@ -194,9 +269,7 @@ class Purchase(SoftDeletionModel):
 
     @classmethod
     def canteen_summary_for_year(cls, canteen, year):
-        purchases = cls.objects.only("id", "family", "characteristics", "price_ht").filter(
-            canteen=canteen, date__year=year
-        )
+        purchases = cls.objects.filter_for_stats(canteen, year)
         data = {"year": year}
         cls._simple_diag_data(purchases, data)
         cls._complete_diag_data(purchases, data)
@@ -213,9 +286,7 @@ class Purchase(SoftDeletionModel):
         years = [y["year"] for y in years.values()]
         for year in years:
             year_data = {"year": year}
-            purchases = cls.objects.only("id", "family", "characteristics", "price_ht").filter(
-                canteen=canteen, date__year=year
-            )
+            purchases = cls.objects.filter_for_stats(canteen, year)
             cls._simple_diag_data(purchases, year_data)
             data["results"].append(year_data)
 
@@ -223,51 +294,16 @@ class Purchase(SoftDeletionModel):
 
     @classmethod
     def _simple_diag_data(cls, purchases, data):
-        bio_filter = Q(characteristics__overlap=cls.CHARACTERISTIC_LABELS_BIO)
-        bio_commerce_equitable_filter = bio_filter & Q(
-            characteristics__contains=[cls.Characteristic.COMMERCE_EQUITABLE]
-        )
-        siqo_filter = Q(characteristics__overlap=cls.CHARACTERISTIC_LABELS_SIQO)
-        egalim_autres_filter = Q(characteristics__overlap=cls.CHARACTERISTIC_LABELS_EGALIM_AUTRES)
-        egalim_autres_commerce_equitable_filter = egalim_autres_filter & Q(
-            characteristics__contains=[cls.Characteristic.COMMERCE_EQUITABLE]
-        )
-        externalities_performance_filter = Q(
-            characteristics__overlap=cls.CHARACTERISTIC_LABELS_EXTERNALITES_PERFORMANCE
-        )
-
-        data["valeur_totale"] = purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-
-        bio_purchases = purchases.filter(bio_filter).distinct()
-        data["valeur_bio"] = bio_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-        data["valeur_bio_dont_commerce_equitable"] = (
-            bio_purchases.filter(bio_commerce_equitable_filter).aggregate(total=Sum("price_ht"))["total"] or 0
-        )
-
-        # the remaining stats should ignore any bio products
-        purchases_no_bio = purchases.exclude(bio_filter)
-        siqo_purchases = purchases_no_bio.filter(siqo_filter).distinct()
-        data["valeur_siqo"] = siqo_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-
-        # the remaining stats should also ignore any sustainable (SIQO) products
-        purchases_no_bio_no_siqo = purchases_no_bio.exclude(siqo_filter)
-        egalim_autres_purchases = purchases_no_bio_no_siqo.filter(egalim_autres_filter).distinct()
-        data["valeur_egalim_autres"] = egalim_autres_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
+        stats = purchases.aggregated_stats()
+        data["valeur_totale"] = stats["valeur_totale"] or 0
+        data["valeur_bio"] = stats["valeur_bio"] or 0
+        data["valeur_bio_dont_commerce_equitable"] = stats["valeur_bio_dont_commerce_equitable"] or 0
+        data["valeur_siqo"] = stats["valeur_siqo"] or 0
+        data["valeur_egalim_autres"] = stats["valeur_egalim_autres"] or 0
         data["valeur_egalim_autres_dont_commerce_equitable"] = (
-            egalim_autres_purchases.filter(egalim_autres_commerce_equitable_filter).aggregate(total=Sum("price_ht"))[
-                "total"
-            ]
-            or 0
+            stats["valeur_egalim_autres_dont_commerce_equitable"] or 0
         )
-
-        # the remaining stats should also ignore any "other EGalim" products
-        purchases_no_bio_siqo_no_egalim_autres = purchases_no_bio_no_siqo.exclude(egalim_autres_filter)
-        externalities_performance_purchases = purchases_no_bio_siqo_no_egalim_autres.filter(
-            externalities_performance_filter
-        ).distinct()
-        data["valeur_externalites_performance"] = (
-            externalities_performance_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-        )
+        data["valeur_externalites_performance"] = stats["valeur_externalites_performance"] or 0
 
     @classmethod
     def _complete_diag_data(cls, purchases, data):
@@ -332,15 +368,9 @@ class Purchase(SoftDeletionModel):
 
     @classmethod
     def _misc_totals(cls, purchases, data):
-        # meat_poultry
-        meat_poultry_purchases = purchases.filter(family=cls.Family.VIANDES_VOLAILLES)
-        data["valeur_viandes_volailles"] = meat_poultry_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-        meat_poultry_egalim = meat_poultry_purchases.filter(characteristics__overlap=cls.CHARACTERISTIC_LABELS_EGALIM)
-        data["valeur_viandes_volailles_egalim"] = meat_poultry_egalim.aggregate(total=Sum("price_ht"))["total"] or 0
-        meat_poultry_france = meat_poultry_purchases.filter(characteristics__contains=[cls.Characteristic.FRANCE])
-        data["valeur_viandes_volailles_france"] = meat_poultry_france.aggregate(total=Sum("price_ht"))["total"] or 0
-        # fish
-        fish_purchases = purchases.filter(family=cls.Family.PRODUITS_DE_LA_MER)
-        data["valeur_produits_de_la_mer"] = fish_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
-        fish_egalim = fish_purchases.filter(characteristics__overlap=cls.CHARACTERISTIC_LABELS_EGALIM)
-        data["valeur_produits_de_la_mer_egalim"] = fish_egalim.aggregate(total=Sum("price_ht"))["total"] or 0
+        result = purchases.aggregated_stats()
+        data["valeur_viandes_volailles"] = result["valeur_viandes_volailles"] or 0
+        data["valeur_viandes_volailles_egalim"] = result["valeur_viandes_volailles_egalim"] or 0
+        data["valeur_viandes_volailles_france"] = result["valeur_viandes_volailles_france"] or 0
+        data["valeur_produits_de_la_mer"] = result["valeur_produits_de_la_mer"] or 0
+        data["valeur_produits_de_la_mer_egalim"] = result["valeur_produits_de_la_mer_egalim"] or 0

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 
 from django.core.validators import MinValueValidator, ValidationError
 from django.db import models
+from django.db.models import Q, Sum
+from django.db.models.functions import ExtractYear
 
 from common.utils import utils as utils_utils
 from data.fields import ChoiceArrayField
@@ -189,3 +191,156 @@ class Purchase(SoftDeletionModel):
             except Exception:
                 pass
         return ", ".join(valid_characteristics) if valid_characteristics else None
+
+    @classmethod
+    def canteen_summary_for_year(cls, canteen, year):
+        purchases = cls.objects.only("id", "family", "characteristics", "price_ht").filter(
+            canteen=canteen, date__year=year
+        )
+        data = {"year": year}
+        cls._simple_diag_data(purchases, data)
+        cls._complete_diag_data(purchases, data)
+        cls._misc_totals(purchases, data)
+
+        return data
+
+    @classmethod
+    def canteen_summary(cls, canteen):
+        data = {"results": []}
+        years = (
+            cls.objects.filter(canteen=canteen).annotate(year=ExtractYear("date")).order_by("year").distinct("year")
+        )
+        years = [y["year"] for y in years.values()]
+        for year in years:
+            year_data = {"year": year}
+            purchases = cls.objects.only("id", "family", "characteristics", "price_ht").filter(
+                canteen=canteen, date__year=year
+            )
+            cls._simple_diag_data(purchases, year_data)
+            data["results"].append(year_data)
+
+        return data
+
+    @classmethod
+    def _simple_diag_data(cls, purchases, data):
+        bio_filter = Q(characteristics__overlap=cls.CHARACTERISTIC_LABELS_BIO)
+        bio_commerce_equitable_filter = bio_filter & Q(
+            characteristics__contains=[cls.Characteristic.COMMERCE_EQUITABLE]
+        )
+        siqo_filter = Q(characteristics__overlap=cls.CHARACTERISTIC_LABELS_SIQO)
+        egalim_autres_filter = Q(characteristics__overlap=cls.CHARACTERISTIC_LABELS_EGALIM_AUTRES)
+        egalim_autres_commerce_equitable_filter = egalim_autres_filter & Q(
+            characteristics__contains=[cls.Characteristic.COMMERCE_EQUITABLE]
+        )
+        externalities_performance_filter = Q(
+            characteristics__overlap=cls.CHARACTERISTIC_LABELS_EXTERNALITES_PERFORMANCE
+        )
+
+        data["valeur_totale"] = purchases.aggregate(total=Sum("price_ht"))["total"] or 0
+
+        bio_purchases = purchases.filter(bio_filter).distinct()
+        data["valeur_bio"] = bio_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
+        data["valeur_bio_dont_commerce_equitable"] = (
+            bio_purchases.filter(bio_commerce_equitable_filter).aggregate(total=Sum("price_ht"))["total"] or 0
+        )
+
+        # the remaining stats should ignore any bio products
+        purchases_no_bio = purchases.exclude(bio_filter)
+        siqo_purchases = purchases_no_bio.filter(siqo_filter).distinct()
+        data["valeur_siqo"] = siqo_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
+
+        # the remaining stats should also ignore any sustainable (SIQO) products
+        purchases_no_bio_no_siqo = purchases_no_bio.exclude(siqo_filter)
+        egalim_autres_purchases = purchases_no_bio_no_siqo.filter(egalim_autres_filter).distinct()
+        data["valeur_egalim_autres"] = egalim_autres_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
+        data["valeur_egalim_autres_dont_commerce_equitable"] = (
+            egalim_autres_purchases.filter(egalim_autres_commerce_equitable_filter).aggregate(total=Sum("price_ht"))[
+                "total"
+            ]
+            or 0
+        )
+
+        # the remaining stats should also ignore any "other EGalim" products
+        purchases_no_bio_siqo_no_egalim_autres = purchases_no_bio_no_siqo.exclude(egalim_autres_filter)
+        externalities_performance_purchases = purchases_no_bio_siqo_no_egalim_autres.filter(
+            externalities_performance_filter
+        ).distinct()
+        data["valeur_externalites_performance"] = (
+            externalities_performance_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
+        )
+
+    @classmethod
+    def _complete_diag_data(cls, purchases, data):
+        """
+        Summary for detailed teledeclaration totals, by family and label.
+        Note: the order of APPRO_LABELS_EGALIM is significant - determines which
+        labels trump others when aggregating purchases.
+        """
+        from data.models import Diagnostic
+
+        for family in Diagnostic.APPRO_FAMILIES:
+            purchase_family = purchases.filter(family=family.upper())
+            for label in Diagnostic.APPRO_LABELS_EGALIM:
+                if label.upper() == "AOCAOP_IGP_STG":
+                    purchase_family_label = purchase_family.filter(
+                        characteristics__overlap=cls.CHARACTERISTIC_LABELS_AOCAOP_IGP_STG
+                    ).distinct()
+                    # the remaining stats should ignore already counted labels
+                    purchase_family = purchase_family.exclude(
+                        characteristics__overlap=cls.CHARACTERISTIC_LABELS_AOCAOP_IGP_STG
+                    ).distinct()
+                else:
+                    purchase_family_label = purchase_family.filter(
+                        Q(characteristics__contains=[cls.Characteristic[label.upper()]])
+                    ).distinct()
+                    # the remaining stats should ignore already counted labels
+                    purchase_family = purchase_family.exclude(
+                        Q(characteristics__contains=[cls.Characteristic[label.upper()]])
+                    ).distinct()
+                key = "valeur_" + family + "_" + label
+                data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
+            # special case of bio_dont_commerce_equitable (products can be counted twice across characteristics)
+            purchase_family = purchases.filter(family=family.upper())
+            purchase_family_label = purchase_family.filter(
+                Q(characteristics__contains=[cls.Characteristic.BIO])
+                & Q(characteristics__contains=[cls.Characteristic.COMMERCE_EQUITABLE])
+            )
+            key = "valeur_" + family + "_" + "bio_dont_commerce_equitable"
+            data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
+            # outside of EGalim (products can be counted twice across characteristics)
+            purchase_family = purchases.filter(family=family.upper())
+            other_labels_characteristics = []
+            for label in Diagnostic.APPRO_LABELS_FRANCE_SUBCATEGORIES:
+                characteristic = cls.Characteristic[label.upper()]
+                purchase_family_label = purchase_family.filter(Q(characteristics__contains=[characteristic]))
+                key = "valeur_" + family + "_" + label
+                data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
+                other_labels_characteristics.append(characteristic)
+            # France total
+            purchase_family_label = purchase_family.filter(
+                characteristics__overlap=cls.CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL
+            ).distinct()
+            key = "valeur_" + family + "_france"
+            data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
+            other_labels_characteristics.append(cls.Characteristic.FRANCE)
+            # Non-EGalim totals (contains no labels or only one or more of other_labels)
+            non_egalim_purchases = purchase_family.filter(
+                Q(characteristics__contained_by=(other_labels_characteristics + [""])) | Q(characteristics__len=0)
+            ).distinct()
+            key = "valeur_" + family + "_non_egalim"
+            data[key] = non_egalim_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
+
+    @classmethod
+    def _misc_totals(cls, purchases, data):
+        # meat_poultry
+        meat_poultry_purchases = purchases.filter(family=cls.Family.VIANDES_VOLAILLES)
+        data["valeur_viandes_volailles"] = meat_poultry_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
+        meat_poultry_egalim = meat_poultry_purchases.filter(characteristics__overlap=cls.CHARACTERISTIC_LABELS_EGALIM)
+        data["valeur_viandes_volailles_egalim"] = meat_poultry_egalim.aggregate(total=Sum("price_ht"))["total"] or 0
+        meat_poultry_france = meat_poultry_purchases.filter(characteristics__contains=[cls.Characteristic.FRANCE])
+        data["valeur_viandes_volailles_france"] = meat_poultry_france.aggregate(total=Sum("price_ht"))["total"] or 0
+        # fish
+        fish_purchases = purchases.filter(family=cls.Family.PRODUITS_DE_LA_MER)
+        data["valeur_produits_de_la_mer"] = fish_purchases.aggregate(total=Sum("price_ht"))["total"] or 0
+        fish_egalim = fish_purchases.filter(characteristics__overlap=cls.CHARACTERISTIC_LABELS_EGALIM)
+        data["valeur_produits_de_la_mer_egalim"] = fish_egalim.aggregate(total=Sum("price_ht"))["total"] or 0

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -223,8 +223,8 @@ class Purchase(SoftDeletionModel):
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
 
-    objects = PurchaseManager()
-    all_objects = PurchaseManager(alive_only=False)
+    objects = PurchaseManager.from_queryset(PurchaseQuerySet)()
+    all_objects = PurchaseManager.from_queryset(PurchaseQuerySet)(alive_only=False)
 
     class Meta:
         verbose_name = "achat"
@@ -368,9 +368,9 @@ class Purchase(SoftDeletionModel):
 
     @classmethod
     def _misc_totals(cls, purchases, data):
-        result = purchases.aggregated_stats()
-        data["valeur_viandes_volailles"] = result["valeur_viandes_volailles"] or 0
-        data["valeur_viandes_volailles_egalim"] = result["valeur_viandes_volailles_egalim"] or 0
-        data["valeur_viandes_volailles_france"] = result["valeur_viandes_volailles_france"] or 0
-        data["valeur_produits_de_la_mer"] = result["valeur_produits_de_la_mer"] or 0
-        data["valeur_produits_de_la_mer_egalim"] = result["valeur_produits_de_la_mer_egalim"] or 0
+        stats = purchases.aggregated_stats()
+        data["valeur_viandes_volailles"] = stats["valeur_viandes_volailles"] or 0
+        data["valeur_viandes_volailles_egalim"] = stats["valeur_viandes_volailles_egalim"] or 0
+        data["valeur_viandes_volailles_france"] = stats["valeur_viandes_volailles_france"] or 0
+        data["valeur_produits_de_la_mer"] = stats["valeur_produits_de_la_mer"] or 0
+        data["valeur_produits_de_la_mer_egalim"] = stats["valeur_produits_de_la_mer_egalim"] or 0


### PR DESCRIPTION
Suite de #6702

- on bascule la logique "stats achat par cantine & year" de `views/purchase.py` dans `models/purchase.py`
- on transforme ensuite la moitié des stats en queryset d'aggregate

pas de tests encore, mais ceux actuels passent.
et je vais faire une PR par la suite pour regrouper & blinder les tests (entre modèle et view) (et avec les différents cas de figure d'aggrégation)