### PR TITLE
refactor(API Recherche Entreprises): ne pas utiliser de camelCase dans la transformation des résultats (city_insee_code & postal_code)

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -444,7 +444,7 @@ class CanteenStatusBySiretView(APIView):
             if not response:
                 return Response(None, status=status.HTTP_204_NO_CONTENT)
             city = response.get("city", None)
-            postcode = response.get("postalCode", None)
+            postcode = response.get("postal_code", None)
             if city and postcode:
                 response = fetch_geo_data_from_code(response)
         return Response(response, status=status.HTTP_200_OK)

--- a/common/api/adresse.py
+++ b/common/api/adresse.py
@@ -15,7 +15,7 @@ ADRESSE_CSV_API_URL = "https://api-adresse.data.gouv.fr/search/csv"
 def fetch_geo_data_from_code(response):
     try:
         location_response = requests.get(
-            f"{ADRESSE_API_URL}/?q={response['cityInseeCode']}&citycode={response['cityInseeCode']}&type=municipality&autocomplete=1"
+            f"{ADRESSE_API_URL}/?q={response['city_insee_code']}&citycode={response['city_insee_code']}&type=municipality&autocomplete=1"
         )
         if location_response.ok:
             location_response = location_response.json()
@@ -72,12 +72,11 @@ def mock_fetch_geo_data_from_code(mock, city_insee_code):
         api_url,
         text=json.dumps(
             {
-                # city_insee_code: 59512
                 "features": [
                     {
                         "properties": {
                             "label": "ROUBAIX",
-                            "citycode": "59512",
+                            "citycode": "59512",  # city_insee_code
                             "postcode": "59100",
                             "context": "38, Isère, Auvergne-Rhône-Alpes",
                         }

--- a/common/api/recherche_entreprises.py
+++ b/common/api/recherche_entreprises.py
@@ -69,8 +69,8 @@ def fetch_geo_data_from_siren(siren):
             try:
                 etablissement = result["siege"]
                 response["name"] = get_enseigne_name(etablissement) or result["nom_complet"]
-                response["cityInseeCode"] = etablissement["commune"]
-                response["postalCode"] = etablissement["code_postal"]
+                response["city_insee_code"] = etablissement["commune"]
+                response["postal_code"] = etablissement["code_postal"]
                 response["city"] = etablissement["libelle_commune"]
                 response["epci"] = etablissement["epci"]
                 response["department"] = etablissement["departement"]
@@ -124,8 +124,8 @@ def fetch_geo_data_from_siret(siret):
             try:
                 etablissement = result["matching_etablissements"][0]
                 response["name"] = get_enseigne_name(etablissement) or result["nom_complet"]
-                response["cityInseeCode"] = etablissement["commune"]
-                response["postalCode"] = etablissement["code_postal"]
+                response["city_insee_code"] = etablissement["commune"]
+                response["postal_code"] = etablissement["code_postal"]
                 response["city"] = etablissement["libelle_commune"]  # en majuscules
                 response["epci"] = etablissement["epci"]
                 # response["department"] = etablissement["departement"]  # not in response

--- a/common/api/tests/test_recherche_entreprises.py
+++ b/common/api/tests/test_recherche_entreprises.py
@@ -35,8 +35,8 @@ class TestRechercheEntrepriseAPI(unittest.TestCase):
                 "expected_outcome": {
                     "siret": canteen_siret,
                     "name": "Foo",
-                    "cityInseeCode": "12345",
-                    "postalCode": "75001",
+                    "city_insee_code": "12345",
+                    "postal_code": "75001",
                     "city": "PARIS",
                 },
             },
@@ -65,8 +65,8 @@ class TestRechercheEntrepriseAPI(unittest.TestCase):
                 "expected_outcome": {
                     "siret": canteen_siret,
                     "name": "Foo",
-                    "cityInseeCode": "12345",
-                    "postalCode": "75001",
+                    "city_insee_code": "12345",
+                    "postal_code": "75001",
                     "city": "PARIS",
                 },
             },

--- a/macantine/management/commands/canteen_siret_recherche_entreprises_cache_csv.py
+++ b/macantine/management/commands/canteen_siret_recherche_entreprises_cache_csv.py
@@ -192,7 +192,7 @@ class Command(BaseCommand):
     def _get_response_status(api_response):
         if not api_response:
             return "not_found"
-        if api_response.get("cityInseeCode"):
+        if api_response.get("city_insee_code"):
             return "ok"
         return "error"
 
@@ -210,8 +210,8 @@ class Command(BaseCommand):
             "canteen_count": canteen_count,
             "status": status,
             "name": api_response.get("name") if api_response else None,
-            "city_insee_code": api_response.get("cityInseeCode") if api_response else None,
-            "postal_code": api_response.get("postalCode") if api_response else None,
+            "city_insee_code": api_response.get("city_insee_code") if api_response else None,
+            "postal_code": api_response.get("postal_code") if api_response else None,
             "city": api_response.get("city") if api_response else None,
             "epci": api_response.get("epci") if api_response else None,
             "department": api_response.get("department") if api_response else None,

--- a/macantine/management/commands/canteen_update_geolocation_data_using_siret.py
+++ b/macantine/management/commands/canteen_update_geolocation_data_using_siret.py
@@ -79,8 +79,8 @@ class Command(BaseCommand):
                     pending_changes["siret_etat_administratif"] = None
                 results["canteen_siret_unknown"].append(canteen.id)
             else:
-                city_insee_code = response.get("cityInseeCode")
-                postal_code = response.get("postalCode")
+                city_insee_code = response.get("city_insee_code")
+                postal_code = response.get("postal_code")
                 etat_administratif = response.get("etat_administratif")
 
                 # check if city_insee_code from API matches canteen city_insee_code
@@ -175,8 +175,8 @@ class Command(BaseCommand):
         status = cache_row.get("status")
         if status == "ok" and cache_row.get("city_insee_code"):
             return {
-                "cityInseeCode": cache_row.get("city_insee_code"),
-                "postalCode": cache_row.get("postal_code"),
+                "city_insee_code": cache_row.get("city_insee_code"),
+                "postal_code": cache_row.get("postal_code"),
                 "etat_administratif": cache_row.get("etat_administratif"),
             }
         if status == "not_found":

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -125,8 +125,8 @@ def update_canteen_geo_fields_from_siret(canteen):
         response = fetch_geo_data_from_siret(canteen.siret)
         if response:
             try:
-                if "cityInseeCode" in response.keys():
-                    canteen.city_insee_code = response["cityInseeCode"]
+                if "city_insee_code" in response.keys():
+                    canteen.city_insee_code = response["city_insee_code"]
                     canteen.siret_etat_administratif = response["etat_administratif"]
                     update = True
             except Exception as e:


### PR DESCRIPTION
Chantier données géo : petit ménage coté Recherche Entreprises
- on renvoyait en camelCase les cityInseeCode & postalCode
- mais plus simple de mettre du snake_case

Simplifie au passage le code de #6550 (j'avais fait les changements là-bas initialement)