### PR TITLE
refactor(API Adresse): rendre l'appel à la fonction indépendant de l'objet 'response'

### DIFF
--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -444,9 +444,10 @@ class CanteenStatusBySiretView(APIView):
             if not response:
                 return Response(None, status=status.HTTP_204_NO_CONTENT)
             city = response.get("city", None)
+            city_insee_code = response.get("city_insee_code", None)
             postcode = response.get("postal_code", None)
             if city and postcode:
-                response = fetch_geo_data_from_code(response)
+                response = {**response, **fetch_geo_data_from_code(city_insee_code)}
         return Response(response, status=status.HTTP_200_OK)
 
 

--- a/common/api/adresse.py
+++ b/common/api/adresse.py
@@ -12,20 +12,21 @@ ADRESSE_API_URL = "https://api-adresse.data.gouv.fr/search"
 ADRESSE_CSV_API_URL = "https://api-adresse.data.gouv.fr/search/csv"
 
 
-def fetch_geo_data_from_code(response):
+def fetch_geo_data_from_code(city_insee_code):
+    response = {}
+    response["city_insee_code"] = city_insee_code
     try:
-        location_response = requests.get(
-            f"{ADRESSE_API_URL}/?q={response['city_insee_code']}&citycode={response['city_insee_code']}&type=municipality&autocomplete=1"
-        )
-        if location_response.ok:
-            location_response = location_response.json()
+        api_url = f"{ADRESSE_API_URL}/?q={city_insee_code}&citycode={city_insee_code}&type=municipality&autocomplete=1"
+        api_response = requests.get(api_url)
+        if api_response.ok:
+            location_response = api_response.json()
             results = location_response["features"]
             if results and results[0]:
                 try:
                     result = results[0]["properties"]
                     if result:
                         response["city"] = result["label"]
-                        response["city_insee_code"] = result["citycode"]
+                        # response["city_insee_code"] = result["citycode"]
                         response["postal_code"] = result["postcode"]
                         response["department"] = result["context"].split(",")[0]
                         response["department_lib"] = result["context"].split(", ")[1]
@@ -39,9 +40,7 @@ def fetch_geo_data_from_code(response):
                     f"features array for city '{response['city']}' in location response format is non-existant or empty : {location_response}"
                 )
         else:
-            logger.warning(
-                f"location fetching failed, code {location_response.status_code} : {location_response.json()}"
-            )
+            logger.warning(f"location fetching failed, code {api_response.status_code} : {api_response.json()}")
     except Exception as e:
         logger.exception(f"Error completing location data with SIRET for city: {response['city']}")
         logger.exception(e)
@@ -49,8 +48,11 @@ def fetch_geo_data_from_code(response):
 
 
 def fetch_geo_data_from_code_csv(csv_str, timeout=4):
-    # NB: max size of a csv file is 50 MB
-    response = requests.post(
+    """
+    Header of the csv_str must be: "siret,citycode,postcode"
+    The csv must not be larger than 50 MB (max size accepted by the adresse API)
+    """
+    api_response = requests.post(
         ADRESSE_CSV_API_URL,
         files={
             "data": ("locations.csv", csv_str),
@@ -62,8 +64,8 @@ def fetch_geo_data_from_code_csv(csv_str, timeout=4):
         },
         timeout=timeout,
     )
-    response.raise_for_status()
-    return response.text
+    api_response.raise_for_status()
+    return api_response.text
 
 
 def mock_fetch_geo_data_from_code(mock, city_insee_code):

--- a/common/api/datagouv.py
+++ b/common/api/datagouv.py
@@ -67,9 +67,10 @@ CACHE_TIMEOUT = 60 * 60 * 24 * 7  # 7 days
 
 def get_dataset(dataset_id):
     try:
-        response = requests.get(f"{DATAGOUV_API_URL}/datasets/{dataset_id}")
-        response.raise_for_status()
-        return response.json()
+        api_url = f"{DATAGOUV_API_URL}/datasets/{dataset_id}"
+        api_response = requests.get(api_url)
+        api_response.raise_for_status()
+        return api_response.json()
     except requests.HTTPError as e:
         logger.error(f"Datagouv dataset get: Error while getting dataset: {dataset_id}")
         logger.exception(e)
@@ -79,9 +80,10 @@ def get_dataset(dataset_id):
 
 def get_dataset_resource(dataset_id, resource_id):
     try:
-        response = requests.get(f"{DATAGOUV_API_URL}/datasets/{dataset_id}/resources/{resource_id}")
-        response.raise_for_status()
-        return response.json()
+        api_url = f"{DATAGOUV_API_URL}/datasets/{dataset_id}/resources/{resource_id}"
+        api_response = requests.get(api_url)
+        api_response.raise_for_status()
+        return api_response.json()
     except requests.HTTPError as e:
         logger.error(
             f"Datagouv dataset resource get: Error while getting dataset resource: {dataset_id} / {resource_id}"
@@ -111,12 +113,9 @@ def update_dataset_resources(dataset_id):
             if resource["format"] in ["xlsx", "csv"]:
                 now = datetime.now()
                 updated_url = resource["url"].split("?v=")[0] + "?v=" + now.strftime("%Y%m%d%H%M")
-                response = requests.put(
-                    f"{DATAGOUV_API_URL}/datasets/{dataset_id}/resources/{resource['id']}",
-                    headers=DATAGOUV_API_HEADER,
-                    json={"url": updated_url},
-                )
-                response.raise_for_status()
+                api_url = f"{DATAGOUV_API_URL}/datasets/{dataset_id}/resources/{resource['id']}"
+                api_response = requests.put(api_url, headers=DATAGOUV_API_HEADER, json={"url": updated_url})
+                api_response.raise_for_status()
                 count_updated_resources += 1
         logger.info(f"{count_updated_resources} datagouv's ressources have been updated")
         return count_updated_resources
@@ -140,10 +139,10 @@ def fetch_pats():
         return cached_response
 
     try:
-        pat_dataset_resource = get_dataset_resource(PAT_DATAGOUV_DATASET_ID, PAT_DATAGOUV_RESOURCE_ID)
-        response = requests.get(pat_dataset_resource["url"])
-        response.raise_for_status()
-        reader = csv.DictReader(response.iter_lines(decode_unicode=True), delimiter=";")
+        api_url = get_dataset_resource(PAT_DATAGOUV_DATASET_ID, PAT_DATAGOUV_RESOURCE_ID)
+        api_response = requests.get(api_url["url"])
+        api_response.raise_for_status()
+        reader = csv.DictReader(api_response.iter_lines(decode_unicode=True), delimiter=";")
         # the csv is BIG (4+ MB). So we only keep the fields we need.
         pat_list_filtered = [{field: row[field] for field in FIELDS_TO_KEEP} for row in reader]
         # cache mechanism: store the result


### PR DESCRIPTION
Suite du ménage de printemps autour des API géo (après #6710)

Ici on change un peu le comportement de `fetch_geo_data_from_code`
- avant : envoyer un dict `response`
- après : envoyer seulement un `city_insee_code`, pour rendre la méthode d'avantage claire & réutilisable