### PR TITLE
refactor(API Validata): Open Data: checker si les fichiers sont valides avant d'exporter

### DIFF
--- a/common/api/validata.py
+++ b/common/api/validata.py
@@ -23,6 +23,7 @@ Possible error keys:
 """
 
 import requests
+import mimetypes
 
 FRICTIONLESS_SCHEMA_URL = "https://frictionlessdata.io/schemas/table-schema.json"
 VALIDATA_PREPROD_API_URL = "https://preprod-api-validata.dataeng.etalab.studio/validate"
@@ -33,16 +34,18 @@ def validate_file_against_schema(file, schema_url):
     try:
         # Reset the file pointer to the beginning
         file.seek(0)
+        filename = getattr(file, "name", "upload.csv")
+        content_type = getattr(file, "content_type", None) or mimetypes.guess_type(filename)[0] or "text/csv"
         response = requests.post(
             VALIDATA_PROD_API_URL,
             files={
-                "file": (file.name, file.read(), file.content_type),
+                "file": (filename, file.read(), content_type),
             },
             data={"schema": schema_url, "ignore_header_case": True, "include_resource_data": True},
         )
         return response.json()
-    except Exception:
-        raise Exception("Erreur lors de la validation du fichier (Validata). Merci de réessayer plus tard.")
+    except Exception as e:
+        raise Exception("Erreur lors de la validation du fichier (Validata). Merci de réessayer plus tard.") from e
 
 
 def process_errors(report):

--- a/common/api/validata.py
+++ b/common/api/validata.py
@@ -141,3 +141,13 @@ def get_specific_error_informations(error):
         "cell": error["cell"],
         "has_doc": True,
     }
+
+
+def mock_post_validate_file_against_schema(mock, success=True):
+    if not success:
+        pass
+    mock.post(
+        "https://api.validata.etalab.studio/validate",
+        json={"report": {"errors": [], "stats": {"errors": 0}, "tasks": []}},
+        status_code=200,
+    )

--- a/macantine/etl/etl.py
+++ b/macantine/etl/etl.py
@@ -1,14 +1,11 @@
-import csv
-import json
 import logging
-import os
 import time
 from abc import ABC, abstractmethod
 
 import pandas as pd
-import requests
 from django.core.files.storage import default_storage
 
+from common.api import validata
 from data.models.geo import Department, Region
 from macantine.etl.utils import format_geo_name
 
@@ -55,24 +52,26 @@ class ETL(ABC):
             return 0
 
     def is_valid(self, filepath) -> bool:
-        # In order to validate the dataset with the validata api, must first convert to CSV then save online
-        with default_storage.open(filepath + "_to_validate.csv", "w") as file:
-            self.df.to_csv(
+        """
+        Validates the dataset against the schema using Validata API.
+        It creates a temporary csv file with only 1000 rows (to avoid sending too big files to Validata) and checks the response.
+        """
+        to_validate_path = f"{filepath}_to_validate.csv"
+        df_to_validate = self.df.head(1000).copy()
+        with default_storage.open(to_validate_path, "w") as file:
+            df_to_validate.to_csv(
                 file,
                 sep=";",
                 index=False,
                 na_rep="",
                 encoding="utf_8_sig",
-                quoting=csv.QUOTE_NONE,
             )
-        dataset_to_validate_url = (
-            f"{os.environ['CELLAR_HOST']}/{os.environ['CELLAR_BUCKET_NAME']}/media/{filepath}_to_validate.csv"
-        )
-
-        res = requests.get(
-            f"https://api.validata.etalab.studio/validate?schema={self.schema_url}&url={dataset_to_validate_url}&header_case=true"
-        )
-        report = json.loads(res.text)["report"]
+        with default_storage.open(to_validate_path, "rb") as file:
+            validata_response = validata.validate_file_against_schema(file, self.schema_url)
+        if "error" in validata_response:
+            logger.error(validata_response["error"])
+            return False
+        report = validata_response["report"]
         if len(report["errors"]) > 0 or report["stats"]["errors"] > 0:
             logger.error(f"The dataset {self.dataset_name} extraction has errors : ")
             logger.error(report["errors"])

--- a/macantine/etl/open_data.py
+++ b/macantine/etl/open_data.py
@@ -1,5 +1,4 @@
 import json
-import os
 from io import BytesIO
 
 import pandas as pd
@@ -122,23 +121,18 @@ class OPEN_DATA(etl.TRANSFORMER_LOADER):
         with default_storage.open(filename + ".xlsx", "wb") as f:
             f.write(output.getvalue())
 
-    def load_dataset(self, datagouv=True):
+    def load_dataset(self, datagouv=False):
         filepath = f"open_data/{self.dataset_name}"
-        if (
-            os.environ.get("STATICFILES_STORAGE") == "storages.backends.s3.S3Storage"
-            and os.environ.get("DEFAULT_FILE_STORAGE") == "storages.backends.s3.S3Storage"
-        ):
-            if not self.is_valid():
-                logger.error(f"The dataset {self.name} is invalid and therefore will not be exported to s3")
-                return
+        if not self.is_valid(filepath):
+            logger.error(f"The dataset {self.dataset_name} is invalid and therefore will not be exported to s3")
+            raise Exception(f"Le dataset {self.dataset_name} est invalide et ne peut pas être exporté.")
         try:
             self._load_data_csv(filepath)
             self._load_data_xlsx(filepath)
-
             if datagouv:
                 update_dataset_resources(self.datagouv_dataset_id)
         except Exception as e:
-            logger.error(f"Error saving validated data: {e}")
+            raise Exception(f"Erreur lors de l'export du dataset {self.dataset_name}") from e
 
 
 class ETL_OPEN_DATA_CANTEEN(etl.EXTRACTOR, OPEN_DATA):

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -248,7 +248,7 @@ def export_datasets(datasets: dict):
         logger.info(f"Starting {key} dataset extraction")
         etl.extract_dataset()
         etl.transform_dataset()
-        etl.load_dataset()
+        etl.load_dataset(datagouv=True)
 
     end = time.time()
     result = f"Exported {len(datasets)} datasets in {end - start:.2f} seconds"

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 import pandas as pd
 import requests_mock
 from django.core.files.storage import default_storage
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from freezegun import freeze_time
 
 from common.api.datagouv import mock_get_pat_csv, mock_get_pat_dataset_resource
@@ -81,9 +81,13 @@ class CanteenETLOpenDataTest(TestCase):
         canteen_satellite = etl.df[etl.df.id == self.canteen_satellite.id].iloc[0]
         self.assertEqual(canteen_satellite["groupe_id"], self.canteen_groupe.id)
 
-    @override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
     def test_canteen_load_dataset(self, mock):
-        # Making sure the code will not enter online dataset validation by forcing local filesystem management
+        mock.post(
+            "https://api.validata.etalab.studio/validate",
+            json={"report": {"errors": [], "stats": {"errors": 0}, "tasks": []}},
+            status_code=200,
+        )
+
         test_cases = [
             {
                 "name": " Load valid dataset",
@@ -96,8 +100,8 @@ class CanteenETLOpenDataTest(TestCase):
                 "expected_length": 1,
             },
         ]
+
         etl = ETL_OPEN_DATA_CANTEEN()
-        etl.dataset_name += "_test"  # Avoid interferring with other files
 
         for tc in test_cases:
             etl.df = tc["data"]

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -11,6 +11,7 @@ from freezegun import freeze_time
 from common.api.datagouv import mock_get_pat_csv, mock_get_pat_dataset_resource
 from common.api.decoupage_administratif import mock_fetch_communes, mock_fetch_epcis
 from common.api.datagouv import update_dataset_resources
+from common.api.validata import mock_post_validate_file_against_schema
 from data.models import Canteen, Diagnostic
 from macantine.etl.open_data import ETL_OPEN_DATA_CANTEEN, ETL_OPEN_DATA_TELEDECLARATIONS
 from macantine.tests.test_etl_common import setUpTestData as ETLCommonSetUpTestData
@@ -82,11 +83,7 @@ class CanteenETLOpenDataTest(TestCase):
         self.assertEqual(canteen_satellite["groupe_id"], self.canteen_groupe.id)
 
     def test_canteen_load_dataset(self, mock):
-        mock.post(
-            "https://api.validata.etalab.studio/validate",
-            json={"report": {"errors": [], "stats": {"errors": 0}, "tasks": []}},
-            status_code=200,
-        )
+        mock_post_validate_file_against_schema(mock)
 
         test_cases = [
             {

--- a/macantine/tests/test_etl_open_data.py
+++ b/macantine/tests/test_etl_open_data.py
@@ -99,6 +99,7 @@ class CanteenETLOpenDataTest(TestCase):
         ]
 
         etl = ETL_OPEN_DATA_CANTEEN()
+        etl.dataset_name += "_test"  # Avoid interferring with other files
 
         for tc in test_cases:
             etl.df = tc["data"]
@@ -106,7 +107,6 @@ class CanteenETLOpenDataTest(TestCase):
             with default_storage.open(f"open_data/{etl.dataset_name}.csv", "r") as csv_file:
                 output_dataframe = pd.read_csv(csv_file, sep=";")
             self.assertEqual(tc["expected_length"], len(output_dataframe))
-
             self.assertTrue(default_storage.exists(f"open_data/{etl.dataset_name}.xlsx"))
 
             # Cleaning files


### PR DESCRIPTION
Quelques améliorations en lien avec Validata
- exceptions: renvoyer `from e` pour avoir la stacktrace coté Sentry
- etl `is_valid` : l'appeller dans tous les cas & utiliser la méthode existante `validate_file_against_schema`
- tests : ajouter un mock dans la lib validata.py