### PR TITLE
fix(Données Géo): PAT: enlever les caractères bizarres à la volée

### DIFF
--- a/2024-frontend/src/data/pats.json
+++ b/2024-frontend/src/data/pats.json
@@ -49,7 +49,7 @@
   },
   {
     "code": "1275",
-    "nom": "PAT de la Communauté dAgglomération Privas Centre Ardèche"
+    "nom": "PAT de la Communauté d'Agglomération Privas Centre Ardèche"
   },
   {
     "code": "1276",
@@ -165,7 +165,7 @@
   },
   {
     "code": "1304",
-    "nom": "PAT de la Communauté dagglomération du Puy-en-Velay"
+    "nom": "PAT de la Communauté d'agglomération du Puy-en-Velay"
   },
   {
     "code": "1305",
@@ -197,7 +197,7 @@
   },
   {
     "code": "1312",
-    "nom": "PAT de la Communauté dAgglomération de lOuest Rhodanien"
+    "nom": "PAT de la Communauté d'Agglomération de l'Ouest Rhodanien"
   },
   {
     "code": "1314",
@@ -225,7 +225,7 @@
   },
   {
     "code": "1320",
-    "nom": "PAT de la Communauté de Communes de Cur de Savoie"
+    "nom": "PAT de la Communauté de Communes de Cur de Savoie"
   },
   {
     "code": "1321",
@@ -301,7 +301,7 @@
   },
   {
     "code": "1340",
-    "nom": "PAT de la Communauté de communes Cur du Jura"
+    "nom": "PAT de la Communauté de communes Cur du Jura"
   },
   {
     "code": "1341",
@@ -353,7 +353,7 @@
   },
   {
     "code": "1353",
-    "nom": "PAT de la Communauté dAgglomération du Grand Sénonais"
+    "nom": "PAT de la Communauté d'Agglomération du Grand Sénonais"
   },
   {
     "code": "1354",
@@ -393,19 +393,19 @@
   },
   {
     "code": "1363",
-    "nom": "Communauté dAgglomération du Pays de Dreux"
+    "nom": "Communauté d'Agglomération du Pays de Dreux"
   },
   {
     "code": "1364",
-    "nom": "PAT du Syndicat mixte du Pays Dunois et de la Communauté de communes Cur de Beauce"
+    "nom": "PAT du Syndicat mixte du Pays Dunois et de la Communauté de communes Cur de Beauce"
   },
   {
     "code": "1365",
-    "nom": "Pays Castelroussin Val de lIndre"
+    "nom": "Pays Castelroussin Val de l'Indre"
   },
   {
     "code": "1366",
-    "nom": "Pays dIssoudun et de Champagne Berrichonne"
+    "nom": "Pays d'Issoudun et de Champagne Berrichonne"
   },
   {
     "code": "1367",
@@ -433,7 +433,7 @@
   },
   {
     "code": "1373",
-    "nom": "Communauté de communes Touraine Vallée de lIndre"
+    "nom": "Communauté de communes Touraine Vallée de l'Indre"
   },
   {
     "code": "1374",
@@ -461,7 +461,7 @@
   },
   {
     "code": "1380",
-    "nom": "PETR Forêt dOrléans Loire Sologne"
+    "nom": "PETR Forêt d'Orléans Loire Sologne"
   },
   {
     "code": "1381",
@@ -517,7 +517,7 @@
   },
   {
     "code": "1398",
-    "nom": "PAT du PETR Cur de Lorraine"
+    "nom": "PAT du PETR Cur de Lorraine"
   },
   {
     "code": "1399",
@@ -705,7 +705,7 @@
   },
   {
     "code": "1449",
-    "nom": "PAT de la commune de La Possession \"Cultiv' local, pou manj local\""
+    "nom": "PAT de la commune de La Possession \"Cultiv' local, pou manj' local\""
   },
   {
     "code": "1450",
@@ -745,7 +745,7 @@
   },
   {
     "code": "1460",
-    "nom": "PAT de la Communauté de Communes Cur Côte Fleurie"
+    "nom": "PAT de la Communauté de Communes Cur Côte Fleurie"
   },
   {
     "code": "1461",
@@ -849,7 +849,7 @@
   },
   {
     "code": "1488",
-    "nom": "PAT de la Communauté dAgglomération du Grand Cognac"
+    "nom": "PAT de la Communauté d'Agglomération du Grand Cognac"
   },
   {
     "code": "1489",
@@ -977,7 +977,7 @@
   },
   {
     "code": "1522",
-    "nom": "PAT du PETR de lAriège"
+    "nom": "PAT du PETR de l'Ariège"
   },
   {
     "code": "1523",
@@ -1017,7 +1017,7 @@
   },
   {
     "code": "1532",
-    "nom": "Projet alimentaire territorial de lOuest Aveyron"
+    "nom": "Projet alimentaire territorial de l'Ouest Aveyron"
   },
   {
     "code": "1533",
@@ -1137,7 +1137,7 @@
   },
   {
     "code": "1562",
-    "nom": "PAT du Syndicat mixte de développement local (SYDEL) du Pays Cur d'Hérault"
+    "nom": "PAT du Syndicat mixte de développement local (SYDEL) du Pays Cur d'Hérault"
   },
   {
     "code": "1563",
@@ -1413,7 +1413,7 @@
   },
   {
     "code": "1637",
-    "nom": "PAT de la Communauté de Communes Cur de Var"
+    "nom": "PAT de la Communauté de Communes Cur de Var"
   },
   {
     "code": "1639",
@@ -1505,7 +1505,7 @@
   },
   {
     "code": "1668",
-    "nom": "Politique Agricole et Alimentaire de la Communauté de Communes Côte dEmeraude"
+    "nom": "Politique Agricole et Alimentaire de la Communauté de Communes Côte d'Emeraude"
   },
   {
     "code": "1744",
@@ -1625,7 +1625,7 @@
   },
   {
     "code": "2001",
-    "nom": "PAT du Pays dEpinal Cur des Vosges"
+    "nom": "PAT du Pays d'Epinal Cur des Vosges"
   },
   {
     "code": "2008",
@@ -1697,7 +1697,7 @@
   },
   {
     "code": "3874",
-    "nom": "PAT d'Estérel Côte dAzur Agglomération"
+    "nom": "PAT d'Estérel Côte d'Azur Agglomération"
   },
   {
     "code": "3886",
@@ -1753,7 +1753,7 @@
   },
   {
     "code": "5187",
-    "nom": "PAT de la Communauté Urbaine dAlençon"
+    "nom": "PAT de la Communauté Urbaine d'Alençon"
   },
   {
     "code": "5481",

--- a/common/api/datagouv.py
+++ b/common/api/datagouv.py
@@ -52,6 +52,7 @@ MA_CANTINE_DATAGOUV_TELEDECLARATION_SCHEMA_URL = f"{settings.GITHUB_RAW_BASE_URL
 # URL: https://france-pat.fr/presentation-de-l-observatoire/
 # Note: data updated twice a year
 # Note: communes can belong to multiple PATs
+# Note: why do we use the ISO-8859-1 csv? because the other one contains even weirder characters like "AgglomÃ©ration"
 
 PAT_DATAGOUV_DATASET_ID = "pat-projets-alimentaires-territoriaux-description"
 PAT_DATAGOUV_URL = f"https://www.data.gouv.fr/datasets/{PAT_DATAGOUV_DATASET_ID}"

--- a/common/api/datagouv.py
+++ b/common/api/datagouv.py
@@ -55,6 +55,7 @@ PAT_DATAGOUV_DATASET_ID = "pat-projets-alimentaires-territoriaux-description"
 PAT_DATAGOUV_URL = f"https://www.data.gouv.fr/datasets/{PAT_DATAGOUV_DATASET_ID}"
 # PAT_DATAGOUV_RESOURCE_ID = "c85d08a7-ff12-4d31-bb11-27d37523bc7c"  # 20250710
 PAT_DATAGOUV_RESOURCE_ID = "0dc55455-022f-4885-8022-34f612aba59c"  # 20250710 (ISO-8859-1)
+# PAT_DATAGOUV_CSV_URL = "https://static.data.gouv.fr/resources/pat-projets-alimentaires-territoriaux-description/20250710-204351/pats-20250710.csv"
 PAT_DATAGOUV_CSV_URL = "https://static.data.gouv.fr/resources/pat-projets-alimentaires-territoriaux-description/20250710-204354/pats-20250710-win1252.csv"
 
 

--- a/common/api/datagouv.py
+++ b/common/api/datagouv.py
@@ -8,6 +8,8 @@ import requests
 from django.conf import settings
 from django.core.cache import cache
 
+from common.utils.utils import clean_unicode_string
+
 logger = logging.getLogger(__name__)
 
 # ------------------------------------------------------------------------------
@@ -173,7 +175,7 @@ def map_pat_list_to_communes_insee_code():
                 pat_mapping[city_insee_code].append(
                     {
                         "pat": pat["id"],
-                        "pat_lib": pat["nom_administratif"],
+                        "pat_lib": clean_unicode_string(pat["nom_administratif"]),
                     }
                 )
     except requests.HTTPError as e:

--- a/common/utils/tests/test_utils.py
+++ b/common/utils/tests/test_utils.py
@@ -16,3 +16,12 @@ class UtilsTest(TestCase):
         ]:
             with self.subTest(text=TUPLE):
                 self.assertEqual(utils_utils.normalize_string(TUPLE[0]), TUPLE[1])
+
+    def test_clean_unicode_string(self):
+        for TUPLE in [
+            ("Caf<U+00E9>", "Café"),
+            ("PAT dAzur", "PAT d'Azur"),
+            ("foo\x92bar\x07baz", "foo'barbaz"),
+        ]:
+            with self.subTest(text=TUPLE):
+                self.assertEqual(utils_utils.clean_unicode_string(TUPLE[0]), TUPLE[1])

--- a/common/utils/utils.py
+++ b/common/utils/utils.py
@@ -1,7 +1,39 @@
+import unicodedata
+import re
+
+
 def normalize_string(text) -> str:
     if text:
         return str(text).replace(" ", "").replace("\xa0", "")
     return text
+
+
+def clean_unicode_string(value):
+    """
+    Clean up problematic Unicode/control characters, including Windows-1252 smart quotes and invisible bytes.
+    """
+    if not isinstance(value, str):
+        return value
+
+    # Replace <U+XXXX> patterns
+    def replace_unicode_escape(match):
+        hex_code = match.group(1)
+        try:
+            return chr(int(hex_code, 16))
+        except Exception:
+            return ""
+
+    value = re.sub(r"<U\+([0-9A-Fa-f]{4})>", replace_unicode_escape, value)
+
+    # Replace Windows-1252 smart quotes and similar
+    value = value.replace("", "'").replace("", "'").replace("", '"').replace("", '"')
+
+    # Remove other control characters except \n, \t
+    value = re.sub(r"[\x00-\x08\x0b-\x0c\x0e-\x1f\x7f-\x9f]", "", value)
+
+    # Normalize accents, etc.
+    value = unicodedata.normalize("NFC", value)
+    return value
 
 
 def add_validation_error(dict, key, value):

--- a/data/utils.py
+++ b/data/utils.py
@@ -1,8 +1,6 @@
 import csv
 import datetime
 import json
-import re
-import unicodedata
 from decimal import Decimal
 from io import BytesIO
 
@@ -148,29 +146,6 @@ def sum_int_with_potential_null(values_to_sum):
         return 0
     else:
         return sum(value for value in values_to_sum if value is not None)
-
-
-def clean_unicode_string(value):
-    """
-    Convert malformed Unicode escape sequences like <U+009C> to actual characters
-    Examples:
-    - "Caf<U+009C>" -> "Café" (if U+009C → é)
-    - "d<U+0092>Azur" -> "d'Azur" (if U+0092 → ')
-    """
-    if not isinstance(value, str):
-        return value
-
-    # Replace <U+XXXX> with the actual Unicode character
-    def replace_unicode_escape(match):
-        hex_code = match.group(1)
-        try:
-            return chr(int(hex_code, 16))
-        except (ValueError, OverflowError):
-            return ""  # Remove if invalid
-
-    value = re.sub(r"<U\+([0-9A-Fa-f]{4})>", replace_unicode_escape, value)
-    value = unicodedata.normalize("NFC", value)
-    return value
 
 
 def read_csv(filepath, delimiter=","):

--- a/data/utils.py
+++ b/data/utils.py
@@ -1,8 +1,10 @@
+import csv
 import datetime
+import json
+import re
+import unicodedata
 from decimal import Decimal
 from io import BytesIO
-import csv
-import json
 
 from django.core.files.base import ContentFile
 from django.core.serializers.json import DjangoJSONEncoder
@@ -146,6 +148,29 @@ def sum_int_with_potential_null(values_to_sum):
         return 0
     else:
         return sum(value for value in values_to_sum if value is not None)
+
+
+def clean_unicode_string(value):
+    """
+    Convert malformed Unicode escape sequences like <U+009C> to actual characters
+    Examples:
+    - "Caf<U+009C>" -> "Café" (if U+009C → é)
+    - "d<U+0092>Azur" -> "d'Azur" (if U+0092 → ')
+    """
+    if not isinstance(value, str):
+        return value
+
+    # Replace <U+XXXX> with the actual Unicode character
+    def replace_unicode_escape(match):
+        hex_code = match.group(1)
+        try:
+            return chr(int(hex_code, 16))
+        except (ValueError, OverflowError):
+            return ""  # Remove if invalid
+
+    value = re.sub(r"<U\+([0-9A-Fa-f]{4})>", replace_unicode_escape, value)
+    value = unicodedata.normalize("NFC", value)
+    return value
 
 
 def read_csv(filepath, delimiter=","):

--- a/macantine/management/commands/generate_geo_data_to_json.py
+++ b/macantine/management/commands/generate_geo_data_to_json.py
@@ -2,6 +2,7 @@ import json
 
 from django.core.management.base import BaseCommand
 
+from data.utils import clean_unicode_string
 from common.api.datagouv import fetch_pats
 from common.api.decoupage_administratif import (
     fetch_communes,
@@ -62,7 +63,7 @@ class Command(BaseCommand):
             pat_list_filtered = [
                 {
                     "code": pat["id"],
-                    "nom": pat["nom_administratif"],
+                    "nom": clean_unicode_string(pat["nom_administratif"]),
                 }
                 for pat in pat_list
             ]

--- a/macantine/management/commands/generate_geo_data_to_json.py
+++ b/macantine/management/commands/generate_geo_data_to_json.py
@@ -2,7 +2,7 @@ import json
 
 from django.core.management.base import BaseCommand
 
-from data.utils import clean_unicode_string
+from common.utils.utils import clean_unicode_string
 from common.api.datagouv import fetch_pats
 from common.api.decoupage_administratif import (
     fetch_communes,


### PR DESCRIPTION
Nouveau utils `clean_unicode_string`
Ce qui permet de gérer les charactères spéciaux contenus dans les données PAT
- regénère `pats.json` :heavy_check_mark: 
- utilisé aussi dans `map_pat_list_to_communes_insee_code`