### PR TITLE
improve(Bandeau démo): mise à jour du texte explicatif

### DIFF
--- a/2024-frontend/src/components/BannerEnv.vue
+++ b/2024-frontend/src/components/BannerEnv.vue
@@ -3,5 +3,5 @@ import { computed } from 'vue'
 const displayBanner = computed(() => window.ENVIRONMENT !== "prod")
 </script>
 <template>
-  <DsfrNotice v-if="displayBanner" type="warning" title="Environnement de démonstration : toutes les actions sont sans conséquence." />
+  <DsfrNotice v-if="displayBanner" type="warning" title="Environnement de démonstration : toutes les actions sont sans conséquence." desc="Le comportement est figé sur la période de télédéclaration (possibilité de créer un bilan de l'année n-1 et de le télédéclarer/corriger jusqu'à la fin de l'année n)" />
 </template>

--- a/frontend/src/components/AppBannerDemo.vue
+++ b/frontend/src/components/AppBannerDemo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="app-banner-env">
+  <div class="app-banner-env text-left">
     <div v-if="show" class="fr-notice fr-notice--info">
       <div class="fr-container">
         <div class="fr-notice__body">
@@ -7,6 +7,10 @@
             <v-icon class="fr-notice__icon mr-2 mb-1">mdi-information</v-icon>
             <span class="fr-notice__title">
               Environnement de démonstration : toutes les actions sont sans conséquence.
+            </span>
+            <span class="fr-notice__desc">
+              Le comportement est figé sur la période de télédéclaration (possibilité de créer un bilan de l'année n-1
+              et de le télédéclarer/corriger jusqu'à la fin de l'année n)
             </span>
           </p>
         </div>


### PR DESCRIPTION
Ticket : https://www.notion.so/incubateur-masa/Changer-le-wording-du-bandeau-de-d-mo-35ede24614be805680c9c07b1a6a87a0

<img width="1416" height="409" alt="Capture d’écran 2026-05-18 à 16 49 38" src="https://github.com/user-attachments/assets/8dedd446-93ae-42a6-84b6-0230da49dbd0" />
