### PR TITLE
refactor(Achats): ajouter des tests sur all_objects & is_deleted

### DIFF
--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -126,3 +126,28 @@ class PurchaseModelDeleteTest(TestCase):
 
         self.assertEqual(Purchase.objects.count(), 0)
         self.assertEqual(Purchase.all_objects.count(), 0)
+
+
+class PurchaseDeleteQuerySetAndPropertyTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.purchase = PurchaseFactory()
+
+    def test_all_objects_queryset(self):
+        """
+        The delete method should "soft delete" a purchase and have it hidden by default
+        from querysets, unless specifically asked for
+        """
+        self.assertEqual(Purchase.objects.count(), 1)
+
+        self.purchase.delete()
+
+        self.assertEqual(Purchase.objects.all().count(), 0)
+        self.assertEqual(Purchase.all_objects.all().count(), 1)
+
+    def test_is_deleted_property(self):
+        self.assertFalse(self.purchase.is_deleted)
+
+        self.purchase.delete()
+
+        self.assertTrue(self.purchase.is_deleted)


### PR DESCRIPTION
Dans #6706 on a du créer `PurchaseManager` (à cause de soft-delete / simple history)
Et re-ajouter la ligne `all_objects = `

Donc j'en profite pour rajouter des tests (similaire à ce qu'il existe déjà coté cantines)