### PR TITLE
refactor(Achats): ajout de 2 nouveaux querysets (for_user & for_year)

### DIFF
--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -111,7 +111,7 @@ class PurchaseListCreateView(ListCreateAPIView):
     filterset_class = PurchaseFilterSet
 
     def get_queryset(self):
-        return Purchase.objects.select_related("canteen").filter(canteen__in=self.request.user.canteens.all())
+        return Purchase.objects.for_user(self.request.user)
 
     def perform_create(self, serializer):
         canteen_id = self.request.data.get("canteen")
@@ -142,7 +142,7 @@ class PurchaseRetrieveUpdateDestroyView(RetrieveUpdateDestroyAPIView):
     serializer_class = PurchaseSerializer
 
     def get_queryset(self):
-        return Purchase.objects.filter(canteen__in=self.request.user.canteens.all())
+        return Purchase.objects.for_user(self.request.user)
 
     def perform_update(self, serializer):
         canteen_id = self.request.data.get("canteen")
@@ -261,7 +261,7 @@ class PurchaseOptionsView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
-        purchases = Purchase.objects.filter(canteen__in=self.request.user.canteens.all())
+        purchases = Purchase.objects.for_user(request.user)
         products = list(
             purchases.filter(description__isnull=False)
             .order_by("description")
@@ -282,7 +282,7 @@ class PurchasesDeleteView(APIView):
 
     def post(self, request):
         purchase_ids = request.data.get("ids")
-        purchases = Purchase.objects.filter(canteen__in=self.request.user.canteens.all(), id__in=purchase_ids)
+        purchases = Purchase.objects.for_user(request.user).filter(id__in=purchase_ids)
         deleted_count = purchases.delete()
         return JsonResponse({"count": deleted_count}, status=status.HTTP_200_OK)
 
@@ -292,8 +292,6 @@ class PurchasesRestoreView(APIView):
 
     def post(self, request):
         purchase_ids = request.data.get("ids")
-        purchases_to_restore = Purchase.all_objects.filter(
-            canteen__in=self.request.user.canteens.all(), id__in=purchase_ids
-        )
+        purchases_to_restore = Purchase.all_objects.for_user(request.user).filter(id__in=purchase_ids)
         restored_count = purchases_to_restore.update(deletion_date=None)
         return JsonResponse({"count": restored_count}, status=status.HTTP_200_OK)

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -206,7 +206,7 @@ class CanteenPurchasesPercentageSummaryView(APIView):
 
         if is_canteen_manager:
             data["last_purchase_date"] = (
-                Purchase.objects.only("date").filter(canteen=canteen, date__year=year).latest("date").date
+                Purchase.objects.only("date").filter(canteen=canteen).for_year(year).latest("date").date
             )
 
         return Response(PurchasePercentageSummarySerializer(data).data)

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -171,7 +171,7 @@ class CanteenQuerySet(SoftDeletionQuerySet):
     def annotate_with_purchases_for_year(self, year):
         from data.models import Purchase
 
-        purchases_for_year = Purchase.objects.filter(canteen=OuterRef("pk"), date__year=year)
+        purchases_for_year = Purchase.objects.filter(canteen=OuterRef("pk")).for_year(year)
         return self.annotate(has_purchases_for_year=Exists(purchases_for_year))
 
     def annotate_with_diagnostic_for_year(self, year):

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -32,6 +32,9 @@ def valeur_externalites_performance_query():
 
 
 class PurchaseQuerySet(SoftDeletionQuerySet):
+    def for_user(self, user):
+        return self.select_related("canteen").filter(canteen__managers=user)
+
     def filter_for_stats(self, canteen, year):
         return self.only("id", "family", "characteristics", "price_ht").filter(canteen=canteen, date__year=year)
 

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -35,8 +35,11 @@ class PurchaseQuerySet(SoftDeletionQuerySet):
     def for_user(self, user):
         return self.select_related("canteen").filter(canteen__managers=user)
 
+    def for_year(self, year):
+        return self.filter(date__year=year)
+
     def filter_for_stats(self, canteen, year):
-        return self.only("id", "family", "characteristics", "price_ht").filter(canteen=canteen, date__year=year)
+        return self.only("id", "family", "characteristics", "price_ht").filter(canteen=canteen).for_year(year)
 
     def aggregated_stats(self):
         return self.aggregate(

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from django.test import TransactionTestCase, TestCase
 from django.core.exceptions import ValidationError
 
-from data.factories import PurchaseFactory
+from data.factories import PurchaseFactory, CanteenFactory, UserFactory
 from data.models import Purchase
 
 
@@ -126,6 +126,22 @@ class PurchaseModelDeleteTest(TestCase):
 
         self.assertEqual(Purchase.objects.count(), 0)
         self.assertEqual(Purchase.all_objects.count(), 0)
+
+
+class PurchaseQuerySetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory()
+        cls.purchase = PurchaseFactory(canteen=cls.canteen)
+
+    def test_for_user_queryset(self):
+        self.assertEqual(Purchase.objects.for_user(self.user).count(), 0)
+
+        self.canteen.managers.add(self.user)
+        self.canteen.save()
+
+        self.assertEqual(Purchase.objects.for_user(self.user).count(), 1)
 
 
 class PurchaseDeleteQuerySetAndPropertyTest(TestCase):

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -133,7 +133,8 @@ class PurchaseQuerySetTest(TestCase):
     def setUpTestData(cls):
         cls.user = UserFactory()
         cls.canteen = CanteenFactory()
-        cls.purchase = PurchaseFactory(canteen=cls.canteen)
+        cls.purchase_2023_canteen = PurchaseFactory(canteen=cls.canteen, date="2023-01-01")
+        cls.purchase_2024 = PurchaseFactory(date="2024-01-01")
 
     def test_for_user_queryset(self):
         self.assertEqual(Purchase.objects.for_user(self.user).count(), 0)
@@ -142,6 +143,11 @@ class PurchaseQuerySetTest(TestCase):
         self.canteen.save()
 
         self.assertEqual(Purchase.objects.for_user(self.user).count(), 1)
+
+    def test_for_year_queryset(self):
+        self.assertEqual(Purchase.objects.for_year(2022).count(), 0)
+        self.assertEqual(Purchase.objects.for_year(2023).count(), 1)
+        self.assertEqual(Purchase.objects.for_year(2024).count(), 1)
 
 
 class PurchaseDeleteQuerySetAndPropertyTest(TestCase):


### PR DESCRIPTION
Quand j'ai fait #6706 je me suis rendu compte de quelques querysets `Purchase` qui se répetaient
- `for_user`
- `for_year`
- et ajout de tests pour les 2