### PR TITLE
fix(ETL): répare l'export open data (fix sur le paramètre datagouv)

### DIFF
--- a/macantine/etl/open_data.py
+++ b/macantine/etl/open_data.py
@@ -121,7 +121,7 @@ class OPEN_DATA(etl.TRANSFORMER_LOADER):
         with default_storage.open(filename + ".xlsx", "wb") as f:
             f.write(output.getvalue())
 
-    def load_dataset(self, datagouv=False):
+    def load_dataset(self, datagouv=True):
         filepath = f"open_data/{self.dataset_name}"
         if not self.is_valid(filepath):
             logger.error(f"The dataset {self.dataset_name} is invalid and therefore will not be exported to s3")

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -248,7 +248,7 @@ def export_datasets(datasets: dict):
         logger.info(f"Starting {key} dataset extraction")
         etl.extract_dataset()
         etl.transform_dataset()
-        etl.load_dataset(datagouv=True)
+        etl.load_dataset()
 
     end = time.time()
     result = f"Exported {len(datasets)} datasets in {end - start:.2f} seconds"


### PR DESCRIPTION
Dans le refactoring #6713 j'avais fait une modif sur le paramètre `datagouv=True` dans `tasks.py` que j'aurais pas du...
Je revert.
Ca répare les exports