### PR TITLE
improve(Cantines): Données Géo: script dédié à la màj des données PAT

### DIFF
--- a/common/api/datagouv.py
+++ b/common/api/datagouv.py
@@ -56,6 +56,7 @@ MA_CANTINE_DATAGOUV_TELEDECLARATION_SCHEMA_URL = f"{settings.GITHUB_RAW_BASE_URL
 
 PAT_DATAGOUV_DATASET_ID = "pat-projets-alimentaires-territoriaux-description"
 PAT_DATAGOUV_URL = f"https://www.data.gouv.fr/datasets/{PAT_DATAGOUV_DATASET_ID}"
+PAT_DATAGOUV_DATE = "20250710"
 # PAT_DATAGOUV_RESOURCE_ID = "c85d08a7-ff12-4d31-bb11-27d37523bc7c"  # 20250710
 PAT_DATAGOUV_RESOURCE_ID = "0dc55455-022f-4885-8022-34f612aba59c"  # 20250710 (ISO-8859-1)
 # PAT_DATAGOUV_CSV_URL = "https://static.data.gouv.fr/resources/pat-projets-alimentaires-territoriaux-description/20250710-204351/pats-20250710.csv"

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -444,23 +444,21 @@ class Canteen(DirtyFieldsMixin, SoftDeletionModel):
         SPORT = "sport", "Sport"
         TRAVAIL = "travail", "Travail"
 
+    GEO_PAT_FIELDS = ["pat_list", "pat_lib_list"]
     GEO_FIELDS = [
         "city_insee_code",
         "city",
         "postal_code",
         "epci",
         "epci_lib",
-        "pat_list",
-        "pat_lib_list",
+        *GEO_PAT_FIELDS,
         "department",
         "department_lib",
         "region",
         "region_lib",
     ]
     # not all city_insee_code are linked to a PAT
-    GEO_FIELDS_WITHOUT_PAT = [
-        field_name for field_name in GEO_FIELDS if field_name not in ("pat_list", "pat_lib_list")
-    ]
+    GEO_FIELDS_WITHOUT_PAT = list(set(GEO_FIELDS) - set(GEO_PAT_FIELDS))
 
     TD_FIELDS = [
         "declaration_donnees_2021",

--- a/docs/geo.md
+++ b/docs/geo.md
@@ -79,4 +79,6 @@ voir [common/api/decoupage_administratif.py](../common/api/decoupage_administrat
 
 voir [common/api/datagouv.py](../common/api/datagouv.py)
 
-à compléter
+* mettre à jour le fichier source
+* reset le cache (`cache.clear()`)
+* lancer la commande de mise à jour des cantines : `python manage.py canteen_update_pat_data_using_city_insee_code` ("apply")

--- a/macantine/management/commands/canteen_update_pat_data_using_city_insee_code.py
+++ b/macantine/management/commands/canteen_update_pat_data_using_city_insee_code.py
@@ -1,0 +1,64 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from common.api.datagouv import fetch_commune_pat_list, map_pat_list_to_communes_insee_code, PAT_DATAGOUV_DATE
+from data.models import Canteen
+from data.utils import has_charfield_missing_query
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Usage:
+    - python manage.py canteen_update_pat_data_using_city_insee_code
+    - python manage.py canteen_update_pat_data_using_city_insee_code --apply
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="To apply changes, otherwise just show what would be done (dry run).",
+            default=False,
+        )
+
+    def handle(self, *args, **options):
+        logger.info("Start task: canteen_update_pat_data_using_city_insee_code")
+        apply = options["apply"]
+
+        if not apply:
+            logger.info("Dry run mode, no changes will be applied.")
+
+        pat_mapping = map_pat_list_to_communes_insee_code()
+        logger.info(
+            f"Fetched PAT mapping for {len(pat_mapping)} communes from data.gouv.fr dataset (PAT_DATAGOUV_DATE={PAT_DATAGOUV_DATE})"
+        )
+
+        results = {"canteen_updated": 0, "pat_list_updated": 0, "pat_lib_list_updated": 0}
+
+        canteen_qs = Canteen.all_objects.exclude(has_charfield_missing_query("city_insee_code"))
+        logger.info(f"Found {canteen_qs.count()} canteens with a city_insee_code")
+
+        for index, canteen in enumerate(canteen_qs):
+            expected_pat_list = fetch_commune_pat_list(canteen.city_insee_code, pat_mapping, "id") or []
+            expected_pat_lib_list = fetch_commune_pat_list(canteen.city_insee_code, pat_mapping, "lib") or []
+            if (canteen.pat_list != expected_pat_list) or (canteen.pat_lib_list != expected_pat_lib_list):
+                if canteen.pat_list != expected_pat_list:
+                    canteen.pat_list = expected_pat_list
+                    results["pat_list_updated"] += 1
+                if canteen.pat_lib_list != expected_pat_lib_list:
+                    canteen.pat_lib_list = expected_pat_lib_list
+                    results["pat_lib_list_updated"] += 1
+                results["canteen_updated"] += 1
+                if apply:
+                    canteen._change_reason = (
+                        f"Données PAT MAJ ({PAT_DATAGOUV_DATE}) (canteen_update_pat_data_using_city_insee_code)"
+                    )
+                    canteen.save(skip_validations=True, update_fields=Canteen.GEO_PAT_FIELDS)
+
+        logger.info(f"Finished processing {canteen_qs.count()} canteens")
+        logger.info(f"Canteens updated: {results['canteen_updated']}")
+        logger.info(f"Updated pat_list: {results['pat_list_updated']}")
+        logger.info(f"Updated pat_lib_list: {results['pat_lib_list_updated']}")

--- a/macantine/tests/test_canteen_update_pat_data_using_city_insee_code.py
+++ b/macantine/tests/test_canteen_update_pat_data_using_city_insee_code.py
@@ -1,0 +1,97 @@
+import requests_mock
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from common.api.datagouv import mock_get_pat_csv, mock_get_pat_dataset_resource
+from data.factories import CanteenFactory
+from data.models import Canteen
+
+
+@requests_mock.Mocker()
+class CanteenUpdatePATDataUsingCityInseeCodeCommandTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen_with_pat = CanteenFactory(
+            city_insee_code="38039",
+            pat_list=["1294", "1295"],
+            pat_lib_list=[
+                "PAT du Département de l'Isère",
+                "Projet Alimentaire inter Territorial de la Grande région grenobloise",
+            ],
+        )
+        cls.canteen_with_pat_lib_missing = CanteenFactory(
+            city_insee_code="38039", pat_list=["1294", "1295"], pat_lib_list=[]
+        )
+        cls.canteen_with_pat_half_missing = CanteenFactory(
+            city_insee_code="38039", pat_list=["1294"], pat_lib_list=["PAT du Département de l'Isère"]
+        )
+        cls.canteen_with_pat_missing = CanteenFactory(city_insee_code="38039", pat_list=[], pat_lib_list=[])
+        cls.canteen_with_pat_wrong = CanteenFactory(
+            city_insee_code="38039", pat_list=["9999"], pat_lib_list=["PAT Inconnu"]
+        )
+        cls.canteen_without_pat = CanteenFactory(city_insee_code="13209", pat_list=[], pat_lib_list=[])
+        cls.canteen_wit_pat_to_remove = CanteenFactory(
+            city_insee_code="13209", pat_list=["1294"], pat_lib_list=["PAT du Département de l'Isère"]
+        )
+        cls.canteen_with_no_city_insee_code = CanteenFactory(city_insee_code=None, pat_list=[], pat_lib_list=[])
+        cls.canteen_with_pat_missing_deleted = CanteenFactory(
+            city_insee_code="38039", pat_list=[], pat_lib_list=[], deletion_date=timezone.now()
+        )
+
+    def test_command(self, mock):
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        self.assertEqual(Canteen.all_objects.count(), 9)
+        self.assertEqual(Canteen.objects.count(), 8)
+
+        self.assertEqual(len(self.canteen_with_pat.pat_lib_list), 2)
+        self.assertEqual(len(self.canteen_with_pat.pat_lib_list), 2)
+        self.assertEqual(len(self.canteen_with_pat_lib_missing.pat_list), 2)
+        self.assertEqual(len(self.canteen_with_pat_lib_missing.pat_lib_list), 0)
+        self.assertEqual(len(self.canteen_with_pat_half_missing.pat_list), 1)
+        self.assertEqual(len(self.canteen_with_pat_half_missing.pat_lib_list), 1)
+        self.assertEqual(len(self.canteen_with_pat_missing.pat_list), 0)
+        self.assertEqual(len(self.canteen_with_pat_missing.pat_lib_list), 0)
+        self.assertEqual(len(self.canteen_with_pat_wrong.pat_list), 1)
+        self.assertEqual(len(self.canteen_with_pat_wrong.pat_lib_list), 1)
+        self.assertEqual(len(self.canteen_without_pat.pat_list), 0)
+        self.assertEqual(len(self.canteen_without_pat.pat_lib_list), 0)
+        self.assertEqual(len(self.canteen_wit_pat_to_remove.pat_list), 1)
+        self.assertEqual(len(self.canteen_wit_pat_to_remove.pat_lib_list), 1)
+        self.assertEqual(len(self.canteen_with_no_city_insee_code.pat_list), 0)
+        self.assertEqual(len(self.canteen_with_no_city_insee_code.pat_lib_list), 0)
+        self.assertEqual(len(self.canteen_with_pat_missing_deleted.pat_list), 0)
+        self.assertEqual(len(self.canteen_with_pat_missing_deleted.pat_lib_list), 0)
+
+        call_command("canteen_update_pat_data_using_city_insee_code", apply=True)
+
+        self.canteen_with_pat.refresh_from_db()
+        self.canteen_with_pat_lib_missing.refresh_from_db()
+        self.canteen_with_pat_half_missing.refresh_from_db()
+        self.canteen_with_pat_missing.refresh_from_db()
+        self.canteen_with_pat_wrong.refresh_from_db()
+        self.canteen_without_pat.refresh_from_db()
+        self.canteen_wit_pat_to_remove.refresh_from_db()
+        self.canteen_with_no_city_insee_code.refresh_from_db()
+        self.canteen_with_pat_missing_deleted.refresh_from_db()
+
+        self.assertEqual(len(self.canteen_with_pat.pat_lib_list), 2)
+        self.assertEqual(len(self.canteen_with_pat.pat_lib_list), 2)
+        self.assertEqual(len(self.canteen_with_pat_lib_missing.pat_list), 2)
+        self.assertEqual(len(self.canteen_with_pat_lib_missing.pat_lib_list), 2)  # updated
+        self.assertEqual(len(self.canteen_with_pat_half_missing.pat_list), 2)  # updated
+        self.assertEqual(len(self.canteen_with_pat_half_missing.pat_lib_list), 2)  # updated
+        self.assertEqual(len(self.canteen_with_pat_missing.pat_list), 2)  # updated
+        self.assertEqual(len(self.canteen_with_pat_missing.pat_lib_list), 2)  # updated
+        self.assertEqual(len(self.canteen_with_pat_wrong.pat_list), 2)  # updated
+        self.assertEqual(len(self.canteen_with_pat_wrong.pat_lib_list), 2)  # updated
+        self.assertEqual(len(self.canteen_without_pat.pat_list), 0)
+        self.assertEqual(len(self.canteen_without_pat.pat_lib_list), 0)
+        self.assertEqual(len(self.canteen_wit_pat_to_remove.pat_list), 0)  # updated
+        self.assertEqual(len(self.canteen_wit_pat_to_remove.pat_lib_list), 0)  # updated
+        self.assertEqual(len(self.canteen_with_no_city_insee_code.pat_list), 0)
+        self.assertEqual(len(self.canteen_with_no_city_insee_code.pat_lib_list), 0)
+        self.assertEqual(len(self.canteen_with_pat_missing_deleted.pat_list), 2)  # updated
+        self.assertEqual(len(self.canteen_with_pat_missing_deleted.pat_lib_list), 2)  # updated

--- a/macantine/tests/test_canteen_update_pat_data_using_city_insee_code.py
+++ b/macantine/tests/test_canteen_update_pat_data_using_city_insee_code.py
@@ -5,14 +5,15 @@ from django.utils import timezone
 
 from common.api.datagouv import mock_get_pat_csv, mock_get_pat_dataset_resource
 from data.factories import CanteenFactory
-from data.models import Canteen
 
 
 @requests_mock.Mocker()
 class CanteenUpdatePATDataUsingCityInseeCodeCommandTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.canteen_with_pat = CanteenFactory(
+    def test_canteen_ok(self, mock):
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        canteen = CanteenFactory(
             city_insee_code="38039",
             pat_list=["1294", "1295"],
             pat_lib_list=[
@@ -20,78 +21,145 @@ class CanteenUpdatePATDataUsingCityInseeCodeCommandTest(TestCase):
                 "Projet Alimentaire inter Territorial de la Grande région grenobloise",
             ],
         )
-        cls.canteen_with_pat_lib_missing = CanteenFactory(
-            city_insee_code="38039", pat_list=["1294", "1295"], pat_lib_list=[]
-        )
-        cls.canteen_with_pat_half_missing = CanteenFactory(
-            city_insee_code="38039", pat_list=["1294"], pat_lib_list=["PAT du Département de l'Isère"]
-        )
-        cls.canteen_with_pat_missing = CanteenFactory(city_insee_code="38039", pat_list=[], pat_lib_list=[])
-        cls.canteen_with_pat_wrong = CanteenFactory(
-            city_insee_code="38039", pat_list=["9999"], pat_lib_list=["PAT Inconnu"]
-        )
-        cls.canteen_without_pat = CanteenFactory(city_insee_code="13209", pat_list=[], pat_lib_list=[])
-        cls.canteen_wit_pat_to_remove = CanteenFactory(
-            city_insee_code="13209", pat_list=["1294"], pat_lib_list=["PAT du Département de l'Isère"]
-        )
-        cls.canteen_with_no_city_insee_code = CanteenFactory(city_insee_code=None, pat_list=[], pat_lib_list=[])
-        cls.canteen_with_pat_missing_deleted = CanteenFactory(
-            city_insee_code="38039", pat_list=[], pat_lib_list=[], deletion_date=timezone.now()
-        )
 
-    def test_command(self, mock):
-        mock_get_pat_dataset_resource(mock)
-        mock_get_pat_csv(mock)
-
-        self.assertEqual(Canteen.all_objects.count(), 9)
-        self.assertEqual(Canteen.objects.count(), 8)
-
-        self.assertEqual(len(self.canteen_with_pat.pat_lib_list), 2)
-        self.assertEqual(len(self.canteen_with_pat.pat_lib_list), 2)
-        self.assertEqual(len(self.canteen_with_pat_lib_missing.pat_list), 2)
-        self.assertEqual(len(self.canteen_with_pat_lib_missing.pat_lib_list), 0)
-        self.assertEqual(len(self.canteen_with_pat_half_missing.pat_list), 1)
-        self.assertEqual(len(self.canteen_with_pat_half_missing.pat_lib_list), 1)
-        self.assertEqual(len(self.canteen_with_pat_missing.pat_list), 0)
-        self.assertEqual(len(self.canteen_with_pat_missing.pat_lib_list), 0)
-        self.assertEqual(len(self.canteen_with_pat_wrong.pat_list), 1)
-        self.assertEqual(len(self.canteen_with_pat_wrong.pat_lib_list), 1)
-        self.assertEqual(len(self.canteen_without_pat.pat_list), 0)
-        self.assertEqual(len(self.canteen_without_pat.pat_lib_list), 0)
-        self.assertEqual(len(self.canteen_wit_pat_to_remove.pat_list), 1)
-        self.assertEqual(len(self.canteen_wit_pat_to_remove.pat_lib_list), 1)
-        self.assertEqual(len(self.canteen_with_no_city_insee_code.pat_list), 0)
-        self.assertEqual(len(self.canteen_with_no_city_insee_code.pat_lib_list), 0)
-        self.assertEqual(len(self.canteen_with_pat_missing_deleted.pat_list), 0)
-        self.assertEqual(len(self.canteen_with_pat_missing_deleted.pat_lib_list), 0)
+        self.assertEqual(len(canteen.pat_list), 2)
+        self.assertEqual(len(canteen.pat_lib_list), 2)
 
         call_command("canteen_update_pat_data_using_city_insee_code", apply=True)
 
-        self.canteen_with_pat.refresh_from_db()
-        self.canteen_with_pat_lib_missing.refresh_from_db()
-        self.canteen_with_pat_half_missing.refresh_from_db()
-        self.canteen_with_pat_missing.refresh_from_db()
-        self.canteen_with_pat_wrong.refresh_from_db()
-        self.canteen_without_pat.refresh_from_db()
-        self.canteen_wit_pat_to_remove.refresh_from_db()
-        self.canteen_with_no_city_insee_code.refresh_from_db()
-        self.canteen_with_pat_missing_deleted.refresh_from_db()
+        canteen.refresh_from_db()
 
-        self.assertEqual(len(self.canteen_with_pat.pat_lib_list), 2)
-        self.assertEqual(len(self.canteen_with_pat.pat_lib_list), 2)
-        self.assertEqual(len(self.canteen_with_pat_lib_missing.pat_list), 2)
-        self.assertEqual(len(self.canteen_with_pat_lib_missing.pat_lib_list), 2)  # updated
-        self.assertEqual(len(self.canteen_with_pat_half_missing.pat_list), 2)  # updated
-        self.assertEqual(len(self.canteen_with_pat_half_missing.pat_lib_list), 2)  # updated
-        self.assertEqual(len(self.canteen_with_pat_missing.pat_list), 2)  # updated
-        self.assertEqual(len(self.canteen_with_pat_missing.pat_lib_list), 2)  # updated
-        self.assertEqual(len(self.canteen_with_pat_wrong.pat_list), 2)  # updated
-        self.assertEqual(len(self.canteen_with_pat_wrong.pat_lib_list), 2)  # updated
-        self.assertEqual(len(self.canteen_without_pat.pat_list), 0)
-        self.assertEqual(len(self.canteen_without_pat.pat_lib_list), 0)
-        self.assertEqual(len(self.canteen_wit_pat_to_remove.pat_list), 0)  # updated
-        self.assertEqual(len(self.canteen_wit_pat_to_remove.pat_lib_list), 0)  # updated
-        self.assertEqual(len(self.canteen_with_no_city_insee_code.pat_list), 0)
-        self.assertEqual(len(self.canteen_with_no_city_insee_code.pat_lib_list), 0)
-        self.assertEqual(len(self.canteen_with_pat_missing_deleted.pat_list), 2)  # updated
-        self.assertEqual(len(self.canteen_with_pat_missing_deleted.pat_lib_list), 2)  # updated
+        self.assertEqual(len(canteen.pat_list), 2)
+        self.assertEqual(len(canteen.pat_lib_list), 2)
+
+    def test_canteen_with_pat_lib_missing(self, mock):
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        canteen = CanteenFactory(city_insee_code="38039", pat_list=["1294", "1295"], pat_lib_list=[])
+
+        self.assertEqual(len(canteen.pat_list), 2)
+        self.assertEqual(len(canteen.pat_lib_list), 0)
+
+        call_command("canteen_update_pat_data_using_city_insee_code", apply=True)
+
+        canteen.refresh_from_db()
+
+        self.assertEqual(len(canteen.pat_list), 2)
+        self.assertEqual(len(canteen.pat_lib_list), 2)  # updated
+
+    def test_canteen_with_pat_half_missing(self, mock):
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        canteen = CanteenFactory(
+            city_insee_code="38039", pat_list=["1294"], pat_lib_list=["PAT du Département de l'Isère"]
+        )
+
+        self.assertEqual(len(canteen.pat_list), 1)
+        self.assertEqual(len(canteen.pat_lib_list), 1)
+
+        call_command("canteen_update_pat_data_using_city_insee_code", apply=True)
+
+        canteen.refresh_from_db()
+
+        self.assertEqual(len(canteen.pat_list), 2)  # updated
+        self.assertEqual(len(canteen.pat_lib_list), 2)  # updated
+
+    def test_canteen_with_pat_missing(self, mock):
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        canteen = CanteenFactory(city_insee_code="38039", pat_list=[], pat_lib_list=[])
+
+        self.assertEqual(len(canteen.pat_list), 0)
+        self.assertEqual(len(canteen.pat_lib_list), 0)
+
+        call_command("canteen_update_pat_data_using_city_insee_code", apply=True)
+
+        canteen.refresh_from_db()
+
+        self.assertEqual(len(canteen.pat_list), 2)  # updated
+        self.assertEqual(len(canteen.pat_lib_list), 2)  # updated
+
+    def test_canteen_with_pat_wrong(self, mock):
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        canteen = CanteenFactory(city_insee_code="38039", pat_list=["9999"], pat_lib_list=["PAT Inconnu"])
+
+        self.assertEqual(len(canteen.pat_list), 1)
+        self.assertEqual(len(canteen.pat_lib_list), 1)
+
+        call_command("canteen_update_pat_data_using_city_insee_code", apply=True)
+
+        canteen.refresh_from_db()
+
+        self.assertEqual(len(canteen.pat_list), 2)  # updated
+        self.assertEqual(len(canteen.pat_lib_list), 2)  # updated
+
+    def test_canteen_without_pat(self, mock):
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        canteen = CanteenFactory(city_insee_code="13209", pat_list=[], pat_lib_list=[])
+
+        self.assertEqual(len(canteen.pat_list), 0)
+        self.assertEqual(len(canteen.pat_lib_list), 0)
+
+        call_command("canteen_update_pat_data_using_city_insee_code", apply=True)
+
+        canteen.refresh_from_db()
+
+        self.assertEqual(len(canteen.pat_list), 0)
+        self.assertEqual(len(canteen.pat_lib_list), 0)
+
+    def test_canteen_with_pat_to_remove(self, mock):
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        canteen = CanteenFactory(
+            city_insee_code="13209", pat_list=["1294"], pat_lib_list=["PAT du Département de l'Isère"]
+        )
+
+        self.assertEqual(len(canteen.pat_list), 1)
+        self.assertEqual(len(canteen.pat_lib_list), 1)
+
+        call_command("canteen_update_pat_data_using_city_insee_code", apply=True)
+
+        canteen.refresh_from_db()
+
+        self.assertEqual(len(canteen.pat_list), 0)  # updated
+        self.assertEqual(len(canteen.pat_lib_list), 0)  # updated
+
+    def test_canteen_with_no_city_insee_code(self, mock):
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        canteen = CanteenFactory(city_insee_code=None, pat_list=[], pat_lib_list=[])
+
+        self.assertEqual(len(canteen.pat_list), 0)
+        self.assertEqual(len(canteen.pat_lib_list), 0)
+
+        call_command("canteen_update_pat_data_using_city_insee_code", apply=True)
+
+        canteen.refresh_from_db()
+
+        self.assertEqual(len(canteen.pat_list), 0)
+        self.assertEqual(len(canteen.pat_lib_list), 0)
+
+    def test_canteen_with_pat_missing_deleted(self, mock):
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        canteen = CanteenFactory(city_insee_code="38039", pat_list=[], pat_lib_list=[], deletion_date=timezone.now())
+
+        self.assertEqual(len(canteen.pat_list), 0)
+        self.assertEqual(len(canteen.pat_lib_list), 0)
+
+        call_command("canteen_update_pat_data_using_city_insee_code", apply=True)
+
+        canteen.refresh_from_db()
+
+        self.assertEqual(len(canteen.pat_list), 2)  # updated
+        self.assertEqual(len(canteen.pat_lib_list), 2)  # updated


### PR DESCRIPTION
v2 de #6716 
Et suite à #6693

Modifications apportées
- nouvelle commande `canteen_update_pat_data_using_city_insee_code`
- ajout de tests
- mise à jour de la doc `geo.md`