### PR TITLE
improve(Achats): séparer FRANCE de CIRCUIT_COURT & LOCAL dans les calculs d'aggrégation

### DIFF
--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -878,7 +878,8 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         body = response.json()
         self.assertEqual(body["valeurViandesVolailles"], 155.0)
         self.assertEqual(body["valeurViandesVolaillesEgalim"], 120.0)
-        self.assertEqual(body["valeurViandesVolaillesFrance"], 65.0)
+        self.assertEqual(body["valeurViandesVolaillesFrance"], 50.0 + 15.0)
+        self.assertEqual(body["valeurViandesVolaillesLocal"], 0)
 
     @authenticate
     def test_purchase_fish_totals(self):
@@ -894,9 +895,10 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
             characteristics=[
                 Purchase.Characteristic.BIO,
                 Purchase.Characteristic.LABEL_ROUGE,
+                Purchase.Characteristic.FRANCE,
             ],
             family=Purchase.Family.PRODUITS_DE_LA_MER,
-            price_ht=55,
+            price_ht=50,
         )
 
         # Should be counted on EGalim
@@ -926,7 +928,7 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
             price_ht=20,
         )
 
-        # Should not be counted as EGalim, only included in the total
+        # Should be counted on provenance france
         PurchaseFactory(
             canteen=canteen,
             date="2020-01-01",
@@ -950,8 +952,10 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(body["valeurProduitsDeLaMer"], 160.0)
-        self.assertEqual(body["valeurProduitsDeLaMerEgalim"], 125.0)
+        self.assertEqual(body["valeurProduitsDeLaMer"], 155.0)
+        self.assertEqual(body["valeurProduitsDeLaMerEgalim"], 120.0)
+        self.assertEqual(body["valeurProduitsDeLaMerFrance"], 50.0 + 15.0)
+        self.assertEqual(body["valeurProduitsDeLaMerLocal"], 0)
 
     @authenticate
     def test_get_multi_year_purchase_statistics(self):
@@ -1129,54 +1133,6 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
         self.assertIn(diag_cc.id, results)
         self.assertEqual(diag_cc.valeur_totale, 20)
         self.assertEqual(diag_cc.central_kitchen_diagnostic_mode, "APPRO")
-
-    @freeze_time("2025-03-30")  # after the 2024 campaign
-    @authenticate
-    def test_create_diagnostics_from_purchases_france_value(self):
-        """
-        Test that the france total value is calculated correctly
-        """
-        canteen_site = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[authenticate.user])
-        PurchaseFactory(
-            canteen=canteen_site,
-            date="2024-11-01",
-            price_ht=10,
-            characteristics=[Purchase.Characteristic.FRANCE],
-            family=Purchase.Family.BOULANGERIE,
-        )
-        PurchaseFactory(
-            canteen=canteen_site,
-            date="2024-11-01",
-            price_ht=50,
-            characteristics=[Purchase.Characteristic.CIRCUIT_COURT],
-            family=Purchase.Family.BOULANGERIE,
-        )
-        PurchaseFactory(
-            canteen=canteen_site,
-            date="2024-11-01",
-            price_ht=15,
-            characteristics=[Purchase.Characteristic.LOCAL],
-            family=Purchase.Family.BOULANGERIE,
-        )
-
-        year = 2024
-        self.assertEqual(Diagnostic.objects.filter(year=year, canteen__in=[canteen_site.id]).count(), 0)
-
-        response = self.client.post(
-            reverse("diagnostics_from_purchases", kwargs={"year": year}),
-            {"canteenIds": [canteen_site.id]},
-            format="json",
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        body = response.json()
-        results = body["results"]
-        diag_site = Diagnostic.objects.get(year=year, canteen=canteen_site)
-        self.assertIn(diag_site.id, results)
-        self.assertEqual(diag_site.valeur_totale, 75)
-        self.assertEqual(diag_site.valeur_boulangerie_france, 10 + 50 + 15)
-        self.assertEqual(diag_site.valeur_boulangerie_circuit_court, 50)
-        self.assertEqual(diag_site.valeur_boulangerie_local, 15)
 
 
 class PublicPurchasePercentageSummaryApiTest(APITestCase):

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -372,7 +372,7 @@ class Purchase(SoftDeletionModel):
         if int(year) == 2025:
             cls._complete_diag_appro_labels_france_circuit_court_local_2025(purchases, data)
         else:
-            cls._complete_diag_appro_labels_france_europe_circuit_court_local(purchases, data)
+            cls._complete_diag_appro_labels_france_circuit_court_local(purchases, data)
         cls._complete_diag_appro_labels_non_egalim(purchases, data)
 
     @classmethod
@@ -453,13 +453,13 @@ class Purchase(SoftDeletionModel):
             data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
 
     @classmethod
-    def _complete_diag_appro_labels_france_europe_circuit_court_local(cls, purchases, data):
+    def _complete_diag_appro_labels_france_circuit_court_local(cls, purchases, data):
         """
-        How we manage France/Europe/Circuit court/local:
+        How we manage France/Circuit court/local:
         - outside of APPRO_LABELS_EGALIM
         - products can be counted in multiple of these characteristics
         - NOTE: circuit_court & local are not counted as France
-        - NOTE: in 2026, Europe was added
+        - TODO: in 2026, Europe was added
         """
         from data.models import Diagnostic
 

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -369,8 +369,8 @@ class Purchase(SoftDeletionModel):
         """
         cls._complete_diag_data_appro_labels(purchases, data)
         cls._complete_diag_data_appro_label_bio_dont_commerce_equitable(purchases, data)
-        if int(year) < 2026:
-            cls._complete_diag_appro_labels_france_europe_circuit_court_local_before_2026(purchases, data)
+        if int(year) == 2025:
+            cls._complete_diag_appro_labels_france_circuit_court_local_2025(purchases, data)
         else:
             cls._complete_diag_appro_labels_france_europe_circuit_court_local(purchases, data)
         cls._complete_diag_appro_labels_non_egalim(purchases, data)
@@ -426,12 +426,13 @@ class Purchase(SoftDeletionModel):
             data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
 
     @classmethod
-    def _complete_diag_appro_labels_france_europe_circuit_court_local_before_2026(cls, purchases, data):
+    def _complete_diag_appro_labels_france_circuit_court_local_2025(cls, purchases, data):
         """
-        How we manage France/Europe/Circuit court/local:
+        How we manage France/Circuit court/local:
         - outside of APPRO_LABELS_EGALIM
         - products can be counted in multiple of these characteristics
-        - NOTE: before 2026, circuit_court & local were part of France, so we count them as France
+        - NOTE: in 2025, circuit_court & local were part of France, so we count them as France
+        - NOTE: in 2025, Europe did not exist yet
         """
         from data.models import Diagnostic
 
@@ -450,7 +451,6 @@ class Purchase(SoftDeletionModel):
             ).distinct()
             key = "valeur_" + family + "_france"
             data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
-            other_labels_characteristics.append(cls.Characteristic.FRANCE)
 
     @classmethod
     def _complete_diag_appro_labels_france_europe_circuit_court_local(cls, purchases, data):
@@ -459,6 +459,7 @@ class Purchase(SoftDeletionModel):
         - outside of APPRO_LABELS_EGALIM
         - products can be counted in multiple of these characteristics
         - NOTE: circuit_court & local are not counted as France
+        - NOTE: in 2026, Europe was added
         """
         from data.models import Diagnostic
 

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -299,7 +299,7 @@ class Purchase(SoftDeletionModel):
         purchases = cls.objects.filter_for_stats(canteen, year)
         data = {"year": year}
         cls._simple_diag_data(purchases, data)
-        cls._complete_diag_data(purchases, data)
+        cls._complete_diag_data(purchases, data, year)
         cls._misc_totals(purchases, data)
 
         return data
@@ -363,13 +363,16 @@ class Purchase(SoftDeletionModel):
         data["valeur_externalites_performance"] = stats["valeur_externalites_performance"] or 0
 
     @classmethod
-    def _complete_diag_data(cls, purchases, data):
+    def _complete_diag_data(cls, purchases, data, year):
         """
         Summary for detailed teledeclaration totals, by family and label.
         """
         cls._complete_diag_data_appro_labels(purchases, data)
         cls._complete_diag_data_appro_label_bio_dont_commerce_equitable(purchases, data)
-        cls._complete_diag_appro_labels_france_europe_circuit_court_local(purchases, data)
+        if int(year) < 2026:
+            cls._complete_diag_appro_labels_france_europe_circuit_court_local_before_2026(purchases, data)
+        else:
+            cls._complete_diag_appro_labels_france_europe_circuit_court_local(purchases, data)
         cls._complete_diag_appro_labels_non_egalim(purchases, data)
 
     @classmethod
@@ -423,12 +426,12 @@ class Purchase(SoftDeletionModel):
             data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
 
     @classmethod
-    def _complete_diag_appro_labels_france_europe_circuit_court_local(cls, purchases, data):
+    def _complete_diag_appro_labels_france_europe_circuit_court_local_before_2026(cls, purchases, data):
         """
         How we manage France/Europe/Circuit court/local:
         - outside of APPRO_LABELS_EGALIM
         - products can be counted in multiple of these characteristics
-        - before 2025, circuit_court & local were part of France
+        - NOTE: before 2026, circuit_court & local were part of France, so we count them as France
         """
         from data.models import Diagnostic
 
@@ -448,6 +451,24 @@ class Purchase(SoftDeletionModel):
             key = "valeur_" + family + "_france"
             data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
             other_labels_characteristics.append(cls.Characteristic.FRANCE)
+
+    @classmethod
+    def _complete_diag_appro_labels_france_europe_circuit_court_local(cls, purchases, data):
+        """
+        How we manage France/Europe/Circuit court/local:
+        - outside of APPRO_LABELS_EGALIM
+        - products can be counted in multiple of these characteristics
+        - NOTE: circuit_court & local are not counted as France
+        """
+        from data.models import Diagnostic
+
+        for family in Diagnostic.APPRO_FAMILIES:
+            purchase_family = purchases.filter(family=family.upper())
+            for label in cls.CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL:
+                characteristic = cls.Characteristic[label]
+                purchase_family_label = purchase_family.filter(Q(characteristics__contains=[characteristic]))
+                key = "valeur_" + family + "_" + label.lower()
+                data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
 
     @classmethod
     def _complete_diag_appro_labels_non_egalim(cls, purchases, data):

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -173,3 +173,58 @@ class PurchaseDeleteQuerySetAndPropertyTest(TestCase):
         self.purchase.delete()
 
         self.assertTrue(self.purchase.is_deleted)
+
+
+class PurchaseSummaryFranceTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        PurchaseFactory(
+            canteen=cls.canteen,
+            date="2026-11-01",
+            characteristics=[Purchase.Characteristic.FRANCE],
+            family=Purchase.Family.BOULANGERIE,
+            price_ht=10,
+        )
+        PurchaseFactory(
+            canteen=cls.canteen,
+            date="2026-11-01",
+            characteristics=[Purchase.Characteristic.CIRCUIT_COURT],
+            family=Purchase.Family.BOULANGERIE,
+            price_ht=50,
+        )
+        PurchaseFactory(
+            canteen=cls.canteen,
+            date="2026-11-01",
+            characteristics=[Purchase.Characteristic.EUROPE, Purchase.Characteristic.LOCAL],  # e.g. border
+            family=Purchase.Family.BOULANGERIE,
+            price_ht=15,
+        )
+        PurchaseFactory(
+            canteen=cls.canteen,
+            date="2026-11-01",
+            characteristics=[
+                Purchase.Characteristic.FRANCE,
+                Purchase.Characteristic.CIRCUIT_COURT,
+                Purchase.Characteristic.LOCAL,
+            ],
+            family=Purchase.Family.BOULANGERIE,
+            price_ht=15,
+        )
+
+    def test_canteen_summary_for_year_france_seperated(self):
+        result = Purchase.canteen_summary_for_year(self.canteen, 2026)
+
+        self.assertEqual(result["valeur_boulangerie_france"], 10 + 15)
+        self.assertEqual(result["valeur_boulangerie_circuit_court"], 50 + 15)
+        self.assertEqual(result["valeur_boulangerie_local"], 15 + 15)
+
+    def test_canteen_summary_for_year_france_before_2026(self):
+        # before 2026, circuit court and local were counted as France
+        Purchase.objects.filter(canteen=self.canteen).update(date="2025-11-01")
+
+        result = Purchase.canteen_summary_for_year(self.canteen, 2025)
+
+        self.assertEqual(result["valeur_boulangerie_france"], 10 + 50 + 15 + 15)
+        self.assertEqual(result["valeur_boulangerie_circuit_court"], 50 + 15)
+        self.assertEqual(result["valeur_boulangerie_local"], 15 + 15)


### PR DESCRIPTION
Suite au refacto dans #6784, on a maintenant une méthode `_complete_diag_appro_labels_france_europe_circuit_court_local`

Et dans l'interface de création/modification on a déjà séparé #6720

|Avant|Après|
|-|-|
|`_complete_diag_appro_labels_france_europe_circuit_court_local_before_2026`|`_complete_diag_appro_labels_france_europe_circuit_court_local`|
|Origine France / Origine France dont circuit court, Origine France dont local|Origine France, Circuit court, Local|

### Historique

en 2025, on a regroupé Local & Circuit court sous France. cf #5950, #5987 & #6532.
on revert ces changements pour 2026 et futur

### Todo après

- faire la même chose coté Diagnostic/tunnel (verbose_name aussi)
- gérer Europe : #6788