### PR TITLE
improve(Achats): diverses améliorations sur le formulaire (wording, champs obligatoires, explications)

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -171,7 +171,7 @@ export default Object.freeze({
         "Produit acquis sur la base de ses performances en matière de protection de l'environnement et d'approvisionnement direct",
     },
   },
-  PurchasesOrigines: {
+  PurchasesOriginesCategories: {
     EUROPE: { text: "Origine Europe" },
     FRANCE: { text: "Origine France" },
   },

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -175,11 +175,9 @@ export default Object.freeze({
     EUROPE: { text: "Origine Europe" },
     FRANCE: { text: "Origine France" },
   },
-  PurchasesLocal: {
-    LOCAL: { text: "Cocher la case si l'achat est 'Local'" },
-  },
-  PurchasesCircuitCourt: {
-    CIRCUIT_COURT: { text: "Cocher la case si l'achat est en 'Circuit court'" },
+  PurchasesNotEgalimCategories: {
+    CIRCUIT_COURT: { text: "Commercialisation en circuit-court" },
+    LOCAL: { text: "Produit local" },
   },
   TeledeclarationCharacteristics: {
     // NB: the order of these can affect the aesthetics of the display on PurchasePage, esp for long texts

--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -175,7 +175,7 @@
             </v-row>
           </fieldset>
           <fieldset class="mx-4 mb-4" style="width: 100%">
-            <legend class="body-2 my-1">Catégories d'Origine</legend>
+            <legend class="body-2 my-1">Catégories d'origine</legend>
             <v-row class="mb-4">
               <v-col cols="12" sm="4" class="py-0" v-for="characteristic in originesCategories" :key="characteristic">
                 <v-checkbox

--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -24,7 +24,7 @@
             <v-row class="mb-4">
               <v-col cols="12">
                 <label class="body-2" for="description">
-                  Description du produit
+                  Description du produit *
                 </label>
                 <DsfrCombobox
                   validate-on-blur
@@ -39,7 +39,7 @@
               </v-col>
               <v-col cols="12" sm="8">
                 <label class="body-2" for="provider">
-                  Fournisseur
+                  Fournisseur *
                 </label>
                 <DsfrCombobox
                   validate-on-blur
@@ -52,7 +52,7 @@
                 ></DsfrCombobox>
               </v-col>
               <v-col cols="12" sm="4">
-                <label class="body-2" for="price">Prix HT</label>
+                <label class="body-2" for="price">Prix HT *</label>
                 <DsfrTextField
                   validate-on-blur
                   hide-details="auto"
@@ -65,7 +65,7 @@
               </v-col>
 
               <v-col cols="12" sm="8">
-                <label class="body-2" for="canteen">Cantine</label>
+                <label class="body-2" for="canteen">Cantine *</label>
                 <DsfrAutocomplete
                   hide-details="auto"
                   :items="userCanteens"
@@ -82,7 +82,7 @@
               </v-col>
 
               <v-col cols="12" sm="4">
-                <label class="body-2" for="date">Date d'achat</label>
+                <label class="body-2" for="date">Date d'achat *</label>
 
                 <v-menu
                   v-model="menu"
@@ -115,7 +115,7 @@
               </v-col>
             </v-row>
             <DsfrRadio
-              label="Famille de produit"
+              label="Famille de produit *"
               v-model="purchase.family"
               :items="productFamilies"
               @change="familyChange"
@@ -217,7 +217,7 @@
               </v-col>
               <v-col cols="12" sm="4" class="pb-0">
                 <div v-show="showLocalDefinition" class="mt-2">
-                  <label class="body-2" for="local-definition">Quelle est votre définition de "Local" ?</label>
+                  <label class="body-2" for="local-definition">Quelle est votre définition de "Local" ? *</label>
                   <DsfrSelect
                     hide-details="auto"
                     :items="localDefinitions"

--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -195,12 +195,17 @@
             </v-row>
           </fieldset>
           <fieldset class="mx-4 mb-4" style="width: 100%">
-            <legend class="body-2 my-1">Hors EGalim : critère local</legend>
-            <!--<span class="body-2 my-3 grey--text text--darken-1">
-              Phrase explicative de la définition de local.... curabitur blandit tempus porttitor.
-            </span>-->
+            <v-row>
+              <v-col cols="12" sm="8" class="pb-0">
+                <legend class="body-2">Hors EGalim</legend>
+                <span class="body-2 grey--text text--darken-1">
+                  Ces informations ne sont pas demandées pour la télédéclaration EGalim mais permettent d’enrichir votre
+                  synthèse d’achats et vos supports de communication.
+                </span>
+              </v-col>
+            </v-row>
             <v-row class="mb-4">
-              <v-col cols="12" sm="4" class="py-0" v-for="characteristic in local" :key="characteristic">
+              <v-col cols="12" sm="4" class="py-0" v-for="characteristic in notEgalimCategories" :key="characteristic">
                 <v-checkbox
                   hide-details="auto"
                   v-model="purchase.characteristics"
@@ -210,13 +215,13 @@
                 >
                   <template v-slot:label>
                     <span class="body-2 grey--text text--darken-4">
-                      {{ getCharacteristicDisplayText(characteristic, "PurchasesLocal") }}
+                      {{ getCharacteristicDisplayText(characteristic, "PurchasesNotEgalimCategories") }}
                     </span>
                   </template>
                 </v-checkbox>
               </v-col>
               <v-col cols="12" sm="4" class="pb-0">
-                <div v-show="showLocalDefinition" class="mt-2">
+                <div v-show="showLocalDefinition">
                   <label class="body-2" for="local-definition">Quelle est votre définition de "Local" ? *</label>
                   <DsfrSelect
                     hide-details="auto"
@@ -228,26 +233,6 @@
                     no-data-text="Pas de résultats"
                   />
                 </div>
-              </v-col>
-            </v-row>
-          </fieldset>
-          <fieldset class="mx-4 mb-0" style="width: 100%">
-            <legend class="body-2 my-1">Hors EGalim : commercialisation en circuit court</legend>
-            <v-row class="mb-4">
-              <v-col cols="12" sm="4" class="py-0" v-for="characteristic in circuitCourt" :key="characteristic">
-                <v-checkbox
-                  hide-details="auto"
-                  v-model="purchase.characteristics"
-                  :multiple="true"
-                  :key="characteristic"
-                  :value="characteristic"
-                >
-                  <template v-slot:label>
-                    <span class="body-2 grey--text text--darken-4">
-                      {{ getCharacteristicDisplayText(characteristic, "PurchasesCircuitCourt") }}
-                    </span>
-                  </template>
-                </v-checkbox>
               </v-col>
             </v-row>
           </fieldset>

--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -34,6 +34,7 @@
                   id="description"
                   :items="productDescriptions"
                   :rules="[validators.required]"
+                  placeholder="Ex : Yaourts bio, légumes bio de juin..."
                 ></DsfrCombobox>
               </v-col>
               <v-col cols="12" sm="8">

--- a/frontend/src/views/PurchasePage.vue
+++ b/frontend/src/views/PurchasePage.vue
@@ -175,9 +175,9 @@
             </v-row>
           </fieldset>
           <fieldset class="mx-4 mb-4" style="width: 100%">
-            <legend class="body-2 my-1">Origine</legend>
+            <legend class="body-2 my-1">Catégories d'Origine</legend>
             <v-row class="mb-4">
-              <v-col cols="12" sm="4" class="py-0" v-for="characteristic in origines" :key="characteristic">
+              <v-col cols="12" sm="4" class="py-0" v-for="characteristic in originesCategories" :key="characteristic">
                 <v-checkbox
                   hide-details="auto"
                   v-model="purchase.characteristics"
@@ -355,9 +355,8 @@ export default {
       })),
       characteristics: Object.keys(Constants.Characteristics),
       egalimCategories: Object.keys(Constants.PurchasesEGalimCategories),
-      origines: Object.keys(Constants.PurchasesOrigines),
-      local: Object.keys(Constants.PurchasesLocal),
-      circuitCourt: Object.keys(Constants.PurchasesCircuitCourt),
+      originesCategories: Object.keys(Constants.PurchasesOriginesCategories),
+      notEgalimCategories: Object.keys(Constants.PurchasesNotEgalimCategories),
       backLink: { name: "PurchasesHome" },
       localDefinitions: Object.values(Constants.LocalDefinitions),
       productDescriptions: [],


### PR DESCRIPTION
Suite de #6720 (4 catégories)

Ticket : https://www.notion.so/incubateur-masa/Ajouter-phrase-explicative-pour-les-achats-Local-364de24614be80f18694c5e801e86a95

|Avant|Après|
|--|--|
| <img width="3420" height="3709" alt="avant" src="https://github.com/user-attachments/assets/6f8cb4c2-a9d2-4e82-85c8-9bf4e03a8fe5" /> | <img width="3420" height="3909" alt="Apres" src="https://github.com/user-attachments/assets/7549c707-9a9c-4105-bb73-ea772e3094ba" /> |