### PR TITLE
refactor(Diagnostics): nouveaux querysets with_label_sum & with_family_sum (on va en avoir besoin pour warning_reason_list)

### DIFF
--- a/api/tests/test_canteen_published.py
+++ b/api/tests/test_canteen_published.py
@@ -932,12 +932,12 @@ class PublishedCanteenDetailApiTest(APITestCase):
         DiagnosticFactory(
             canteen=canteen,
             year=2021,
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
             valeur_viandes_volailles=None,
             valeur_viandes_volailles_egalim=100,
             valeur_viandes_volailles_france=100,
             valeur_produits_de_la_mer=None,
             valeur_produits_de_la_mer_egalim=100,
-            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
         )
 
         response = self.client.get(reverse("single_published_canteen", kwargs={"pk": canteen.id}))

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1,11 +1,14 @@
+import operator
+from functools import reduce
+
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator
 from django.db import models, transaction
-from django.db.models import Case, F, Func, IntegerField, Q, Sum, When
+from django.db.models import Case, DecimalField, F, Func, IntegerField, Q, Sum, Value, When
 from django.db.models.expressions import RawSQL
 from django.db.models.fields.json import KT
-from django.db.models.functions import Cast
+from django.db.models.functions import Cast, Coalesce
 from django.utils import timezone
 from simple_history.models import HistoricalRecords
 
@@ -183,6 +186,36 @@ class DiagnosticQuerySet(models.QuerySet):
                 ]
             )
         )
+
+    def with_label_sum(self, label: str):
+        """
+        Sum all appro fields of a given label
+
+        Note: see also label_sum method
+        """
+        sum_expression = reduce(
+            operator.add,
+            (
+                Coalesce(F(f"valeur_{family}_{label}"), Value(0), output_field=DecimalField())
+                for family in Diagnostic.APPRO_FAMILIES
+            ),
+        )
+        return self.annotate(**{f"{label}_sum": sum_expression})
+
+    def with_family_sum(self, family: str):
+        """
+        Sum all appro fields of a given family
+
+        Note: see also family_sum method
+        """
+        sum_expression = reduce(
+            operator.add,
+            (
+                Coalesce(F(f"valeur_{family}_{label}"), Value(0), output_field=DecimalField())
+                for label in Diagnostic.APPRO_LABELS
+            ),
+        )
+        return self.annotate(**{f"{family}_sum": sum_expression})
 
     def with_meal_price(self):
         """

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -659,7 +659,19 @@ class DiagnosticIsFilledQuerySetAndPropertyTest(TestCase):
 class DiagnosticLabelFamilySumQuerySetAndPropertyTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.diagnostic_1 = DiagnosticFactory(
+        cls.diagnostic_simple = DiagnosticFactory(
+            year=2025,
+            canteen=CanteenFactory(),
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+            valeur_totale=1000,
+            valeur_bio=200,
+            valeur_bio_dont_commerce_equitable=50,
+            valeur_viandes_volailles=100,
+            valeur_viandes_volailles_egalim=50,
+            valeur_viandes_volailles_france=20,
+            valeur_autres_france=30,
+        )
+        cls.diagnostic_complete_1 = DiagnosticFactory(
             year=2025,
             canteen=CanteenFactory(),
             diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
@@ -672,7 +684,7 @@ class DiagnosticLabelFamilySumQuerySetAndPropertyTest(TestCase):
             valeur_produits_de_la_mer_label_rouge=8,
             valeur_produits_de_la_mer_france=25,
         )
-        cls.diagnostic_2 = DiagnosticFactory(
+        cls.diagnostic_complete_2 = DiagnosticFactory(
             year=2025,
             canteen=CanteenFactory(),
             diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
@@ -693,39 +705,57 @@ class DiagnosticLabelFamilySumQuerySetAndPropertyTest(TestCase):
             .with_label_sum("label_rouge")
             .with_label_sum("france")
         )
-        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_1.id).bio_sum, 10 + 15)
-        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_1.id).bio_dont_commerce_equitable_sum, 5 + 0)
-        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_1.id).label_rouge_sum, 7 + 8)
-        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_1.id).france_sum, 20 + 25)
-        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).bio_sum, 10 + 15)
-        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).bio_dont_commerce_equitable_sum, 0 + 10)
-        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).label_rouge_sum, 7 + 8)
-        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).france_sum, 20 + 25)
+        diagnostic_simple = diagnostic_qs.get(id=self.diagnostic_simple.id)
+        self.assertEqual(diagnostic_simple.bio_sum, 0)
+        self.assertEqual(diagnostic_simple.bio_dont_commerce_equitable_sum, 0)
+        self.assertEqual(diagnostic_simple.label_rouge_sum, 0)
+        self.assertEqual(diagnostic_simple.france_sum, 20 + 30)
+        diagnostic_complete_1 = diagnostic_qs.get(id=self.diagnostic_complete_1.id)
+        self.assertEqual(diagnostic_complete_1.bio_sum, 10 + 15)
+        self.assertEqual(diagnostic_complete_1.bio_dont_commerce_equitable_sum, 5 + 0)
+        self.assertEqual(diagnostic_complete_1.label_rouge_sum, 7 + 8)
+        self.assertEqual(diagnostic_complete_1.france_sum, 20 + 25)
+        diagnostic_complete_2 = diagnostic_qs.get(id=self.diagnostic_complete_2.id)
+        self.assertEqual(diagnostic_complete_2.bio_sum, 10 + 15)
+        self.assertEqual(diagnostic_complete_2.bio_dont_commerce_equitable_sum, 0 + 10)
+        self.assertEqual(diagnostic_complete_2.label_rouge_sum, 7 + 8)
+        self.assertEqual(diagnostic_complete_2.france_sum, 20 + 25)
 
     def test_label_sum_property(self):
-        self.assertEqual(self.diagnostic_1.label_sum("bio"), 10 + 15)
-        self.assertEqual(self.diagnostic_1.label_sum("bio_dont_commerce_equitable"), 5 + 0)
-        self.assertEqual(self.diagnostic_1.label_sum("label_rouge"), 7 + 8)
-        self.assertEqual(self.diagnostic_1.label_sum("france"), 20 + 25)
-        self.assertEqual(self.diagnostic_2.label_sum("bio"), 10 + 15)
-        self.assertEqual(self.diagnostic_2.label_sum("bio_dont_commerce_equitable"), 0 + 10)
-        self.assertEqual(self.diagnostic_2.label_sum("label_rouge"), 7 + 8)
-        self.assertEqual(self.diagnostic_2.label_sum("france"), 20 + 25)
+        self.assertEqual(self.diagnostic_simple.label_sum("bio"), None)
+        self.assertEqual(self.diagnostic_simple.label_sum("bio_dont_commerce_equitable"), None)
+        self.assertEqual(self.diagnostic_simple.label_sum("label_rouge"), None)
+        self.assertEqual(self.diagnostic_simple.label_sum("france"), 20 + 30)
+        self.assertEqual(self.diagnostic_complete_1.label_sum("bio"), 10 + 15)
+        self.assertEqual(self.diagnostic_complete_1.label_sum("bio_dont_commerce_equitable"), 5 + 0)
+        self.assertEqual(self.diagnostic_complete_1.label_sum("label_rouge"), 7 + 8)
+        self.assertEqual(self.diagnostic_complete_1.label_sum("france"), 20 + 25)
+        self.assertEqual(self.diagnostic_complete_2.label_sum("bio"), 10 + 15)
+        self.assertEqual(self.diagnostic_complete_2.label_sum("bio_dont_commerce_equitable"), 0 + 10)
+        self.assertEqual(self.diagnostic_complete_2.label_sum("label_rouge"), 7 + 8)
+        self.assertEqual(self.diagnostic_complete_2.label_sum("france"), 20 + 25)
 
     def test_with_family_sum_queryset(self):
         diagnostic_qs = Diagnostic.objects.with_family_sum("viandes_volailles").with_family_sum("produits_de_la_mer")
+        diagnostic_simple = diagnostic_qs.get(id=self.diagnostic_simple.id)
+        self.assertEqual(diagnostic_simple.viandes_volailles_sum, 0)
+        self.assertEqual(diagnostic_simple.produits_de_la_mer_sum, 0)
+        diagnostic_complete_1 = diagnostic_qs.get(id=self.diagnostic_complete_1.id)
         self.assertEqual(
-            diagnostic_qs.get(id=self.diagnostic_1.id).viandes_volailles_sum, 10 + 7
+            diagnostic_complete_1.viandes_volailles_sum, 10 + 7
         )  # bio_dont_commerce_equitable & france are not included
-        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_1.id).produits_de_la_mer_sum, 15 + 8)
-        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).viandes_volailles_sum, 10 + 7)
-        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).produits_de_la_mer_sum, 15 + 8)
+        self.assertEqual(diagnostic_complete_1.produits_de_la_mer_sum, 15 + 8)
+        diagnostic_complete_2 = diagnostic_qs.get(id=self.diagnostic_complete_2.id)
+        self.assertEqual(diagnostic_complete_2.viandes_volailles_sum, 10 + 7)
+        self.assertEqual(diagnostic_complete_2.produits_de_la_mer_sum, 15 + 8)
 
     def test_family_sum_property(self):
-        self.assertEqual(self.diagnostic_1.family_sum("viandes_volailles"), 10 + 7)
-        self.assertEqual(self.diagnostic_1.family_sum("produits_de_la_mer"), 15 + 8)
-        self.assertEqual(self.diagnostic_2.family_sum("viandes_volailles"), 10 + 7)
-        self.assertEqual(self.diagnostic_2.family_sum("produits_de_la_mer"), 15 + 8)
+        self.assertEqual(self.diagnostic_simple.family_sum("viandes_volailles"), 0)
+        self.assertEqual(self.diagnostic_simple.family_sum("produits_de_la_mer"), 0)
+        self.assertEqual(self.diagnostic_complete_1.family_sum("viandes_volailles"), 10 + 7)
+        self.assertEqual(self.diagnostic_complete_1.family_sum("produits_de_la_mer"), 15 + 8)
+        self.assertEqual(self.diagnostic_complete_2.family_sum("viandes_volailles"), 10 + 7)
+        self.assertEqual(self.diagnostic_complete_2.family_sum("produits_de_la_mer"), 15 + 8)
 
 
 class DiagnosticEgalimQuerySetAndPropertyTest(TestCase):

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -656,6 +656,78 @@ class DiagnosticIsFilledQuerySetAndPropertyTest(TestCase):
                 self.assertFalse(diagnostic.is_filled)
 
 
+class DiagnosticLabelFamilySumQuerySetAndPropertyTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.diagnostic_1 = DiagnosticFactory(
+            year=2025,
+            canteen=CanteenFactory(),
+            diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
+            valeur_viandes_volailles_bio=10,
+            valeur_viandes_volailles_bio_dont_commerce_equitable=5,
+            valeur_viandes_volailles_label_rouge=7,
+            valeur_viandes_volailles_france=20,
+            valeur_produits_de_la_mer_bio=15,
+            valeur_produits_de_la_mer_bio_dont_commerce_equitable=None,
+            valeur_produits_de_la_mer_label_rouge=8,
+            valeur_produits_de_la_mer_france=25,
+        )
+        cls.diagnostic_2 = DiagnosticFactory(
+            year=2025,
+            canteen=CanteenFactory(),
+            diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
+            valeur_viandes_volailles_bio=10,
+            valeur_viandes_volailles_bio_dont_commerce_equitable=None,
+            valeur_viandes_volailles_label_rouge=7,
+            valeur_viandes_volailles_france=20,
+            valeur_produits_de_la_mer_bio=15,
+            valeur_produits_de_la_mer_bio_dont_commerce_equitable=10,
+            valeur_produits_de_la_mer_label_rouge=8,
+            valeur_produits_de_la_mer_france=25,
+        )
+
+    def test_with_label_sum_queryset(self):
+        diagnostic_qs = (
+            Diagnostic.objects.with_label_sum("bio")
+            .with_label_sum("bio_dont_commerce_equitable")
+            .with_label_sum("label_rouge")
+            .with_label_sum("france")
+        )
+        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_1.id).bio_sum, 10 + 15)
+        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_1.id).bio_dont_commerce_equitable_sum, 5 + 0)
+        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_1.id).label_rouge_sum, 7 + 8)
+        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_1.id).france_sum, 20 + 25)
+        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).bio_sum, 10 + 15)
+        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).bio_dont_commerce_equitable_sum, 0 + 10)
+        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).label_rouge_sum, 7 + 8)
+        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).france_sum, 20 + 25)
+
+    def test_label_sum_property(self):
+        self.assertEqual(self.diagnostic_1.label_sum("bio"), 10 + 15)
+        self.assertEqual(self.diagnostic_1.label_sum("bio_dont_commerce_equitable"), 5 + 0)
+        self.assertEqual(self.diagnostic_1.label_sum("label_rouge"), 7 + 8)
+        self.assertEqual(self.diagnostic_1.label_sum("france"), 20 + 25)
+        self.assertEqual(self.diagnostic_2.label_sum("bio"), 10 + 15)
+        self.assertEqual(self.diagnostic_2.label_sum("bio_dont_commerce_equitable"), 0 + 10)
+        self.assertEqual(self.diagnostic_2.label_sum("label_rouge"), 7 + 8)
+        self.assertEqual(self.diagnostic_2.label_sum("france"), 20 + 25)
+
+    def test_with_family_sum_queryset(self):
+        diagnostic_qs = Diagnostic.objects.with_family_sum("viandes_volailles").with_family_sum("produits_de_la_mer")
+        self.assertEqual(
+            diagnostic_qs.get(id=self.diagnostic_1.id).viandes_volailles_sum, 10 + 7
+        )  # bio_dont_commerce_equitable & france are not included
+        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_1.id).produits_de_la_mer_sum, 15 + 8)
+        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).viandes_volailles_sum, 10 + 7)
+        self.assertEqual(diagnostic_qs.get(id=self.diagnostic_2.id).produits_de_la_mer_sum, 15 + 8)
+
+    def test_family_sum_property(self):
+        self.assertEqual(self.diagnostic_1.family_sum("viandes_volailles"), 10 + 7)
+        self.assertEqual(self.diagnostic_1.family_sum("produits_de_la_mer"), 15 + 8)
+        self.assertEqual(self.diagnostic_2.family_sum("viandes_volailles"), 10 + 7)
+        self.assertEqual(self.diagnostic_2.family_sum("produits_de_la_mer"), 15 + 8)
+
+
 class DiagnosticEgalimQuerySetAndPropertyTest(TestCase):
     def test_compute_pourcentage_bio_method(self):
         for valeur_totale, valeur_bio_agg, pourcentage_bio in [


### PR DESCRIPTION
### Quoi

2 nouveaux querysets `with_label_sum` & `with_family_sum`
- des annotate
- même fonctionnement que les méthodes actuelles `label_sum` & `family_sum`
- ajout de tests

### Pourquoi

- pour warning_reason_list (#6732), et comparer par exemple "circuit_court" avec "france", on a besoin d'avoir les sommes.
- utile dans tous les cas et rajouter des tests