### PR TITLE
refactor(Diagnostics): nouveaux querysets pour aider à filter les warning_reason_list

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -128,7 +128,7 @@ def canteen_has_siret_or_siren_unite_legale_query():
 
 def aberrant_values_query():
     """
-    Ici nous filtrons les TD dont les déclarations paraissent aberrantes et sont impactantes :
+    Ici nous filtrons les TDs dont les déclarations paraissent aberrantes et sont impactantes :
     - Coût denrées existe et > 20 euros ET valeur d'achat alimentaires > 1 million d'euros
     Dans le cas particulier où le nombre de repas annuel n'est pas renseigné,
     nous laissons la TD même si la valeur alimentaire est > 1 million d'euros)
@@ -140,10 +140,43 @@ def aberrant_values_query():
 
 def incoherent_values_query():
     """
-    Ici nous filtrons les TD dont les déclarations paraissent incohérentes et sont impactantes :
-    - Durant la campagne 2023, nous avons identifié deux TD dont les valeurs étaient incohérentes.
+    Ici nous filtrons les TDs dont les déclarations paraissent incohérentes et sont impactantes :
+    - Durant la campagne 2023, nous avons identifié deux TDs dont les valeurs étaient incohérentes.
     """
     return Q(year=2022, teledeclaration_id__in=[9656, 8037])
+
+
+def circuit_court_gt_france_query():
+    """
+    TDs 2025 avec une incohérence sur "origine France dont circuit_court"
+    - En 2025, circuit-court faisait partie d'origine France, mais à parfois été mal télédéclaré
+    - A partir de 2026, circuit-court a été sorti d'origine France
+
+    Note: requires with_label_sum("circuit_court") and with_label_sum("france") annotations
+    """
+    return Q(year=2025, circuit_court_sum__gt=F("france_sum"))
+
+
+def local_gt_france_query():
+    """
+    TDs 2025 avec une incohérence sur "origine France dont local"
+    - En 2025, local faisait partie d'origine France, mais à parfois été mal télédéclaré
+    - A partir de 2026, local a été sorti d'origine France
+
+    Note: requires with_label_sum("local") and with_label_sum("france") annotations
+    """
+    return Q(year=2025, local_sum__gt=F("france_sum"))
+
+
+def commerce_equitable_gt_bio_query():
+    """
+    TDs 2025 avec une incohérence sur "bio dont commerce équitable"
+
+    Note: see validators/diagnostics.py#validate_valeur_bio
+    Note: requires with_label_sum("bio_dont_commerce_equitable") and with_label_sum("bio") annotations
+    """
+    # return Q(year=2025, valeur_bio_dont_commerce_equitable__gt=F("valeur_bio"))
+    return Q(year=2025, bio_dont_commerce_equitable_sum__gt=F("bio_sum"))
 
 
 class DiagnosticQuerySet(models.QuerySet):

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -12,6 +12,9 @@ from data.models.diagnostic import (
     Diagnostic,
     canteen_has_siret_or_siren_unite_legale_query,
     canteen_soft_deleted_during_campaign_query,
+    circuit_court_gt_france_query,
+    local_gt_france_query,
+    commerce_equitable_gt_bio_query,
 )
 
 year_data = 2024
@@ -799,6 +802,60 @@ class DiagnosticEgalimQuerySetAndPropertyTest(TestCase):
                     valeur_totale=valeur_totale, valeur_egalim_hors_bio_agg=valeur_egalim_hors_bio_agg
                 )
                 self.assertEqual(diagnostic.compute_pourcentage_egalim_hors_bio(), pourcentage_egalim_hors_bio)
+
+
+class DiagnosticInvalidWarningQueriesTest(TestCase):
+    def test_circuit_court_gt_france_query(self):
+        diagnostic = DiagnosticFactory(
+            year=2025,
+            canteen=CanteenFactory(),
+            diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
+            valeur_viandes_volailles_france=20,
+            valeur_viandes_volailles_circuit_court=25,
+        )
+
+        diagnostic_qs = (
+            Diagnostic.objects.with_label_sum("france")
+            .with_label_sum("circuit_court")
+            .filter(circuit_court_gt_france_query())
+        )
+
+        self.assertEqual(diagnostic_qs.count(), 1)
+        self.assertIn(diagnostic, diagnostic_qs)
+
+    def test_local_gt_france_query(self):
+        diagnostic = DiagnosticFactory(
+            year=2025,
+            canteen=CanteenFactory(),
+            diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
+            valeur_produits_de_la_mer_france=25,
+            valeur_produits_de_la_mer_local=30,
+        )
+
+        diagnostic_qs = (
+            Diagnostic.objects.with_label_sum("france").with_label_sum("local").filter(local_gt_france_query())
+        )
+
+        self.assertEqual(diagnostic_qs.count(), 1)
+        self.assertIn(diagnostic, diagnostic_qs)
+
+    def test_commerce_equitable_gt_bio_query(self):
+        diagnostic = DiagnosticFactory(
+            year=2025,
+            canteen=CanteenFactory(),
+            diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
+            valeur_viandes_volailles_bio=10,
+            valeur_viandes_volailles_bio_dont_commerce_equitable=15,
+        )
+
+        diagnostic_qs = (
+            Diagnostic.objects.with_label_sum("bio")
+            .with_label_sum("bio_dont_commerce_equitable")
+            .filter(commerce_equitable_gt_bio_query())
+        )
+
+        self.assertEqual(diagnostic_qs.count(), 1)
+        self.assertIn(diagnostic, diagnostic_qs)
 
 
 class DiagnosticModelDeleteTest(TestCase):


### PR DESCRIPTION
Suite à #6732 (nouveau champ `Diagnostic.warning_reason_list`)
Et grâce à #6735 (nouveaux querysets `with_label_sum` & `with_family_sum`)

On peut enfin construire les queries utiles pour filtrer les TD concernées par les différents warning_reason_list
- 3 queries : circuit_court_gt_france_query, local_gt_france_query, commerce_equitable_gt_bio_query
- ajout de tests