### PR TITLE
feat(Diagnostics): script pour remplir le nouveau champ `warning_reason_list`

### DIFF
--- a/macantine/management/commands/diagnostic_fill_invalid_reason_list.py
+++ b/macantine/management/commands/diagnostic_fill_invalid_reason_list.py
@@ -3,45 +3,55 @@ import logging
 from django.core.management.base import BaseCommand
 from django.db.models import F, Func, Value
 
-from data.utils import has_arrayfield_missing_query
 from data.models import Diagnostic
 from data.models.diagnostic import (
+    aberrant_values_query,
     canteen_deleted_query,
     canteen_has_siret_or_siren_unite_legale_query,
     canteen_soft_deleted_during_campaign_query,
-    teledeclaration_mode_satellite_without_appro_query,
-    aberrant_values_query,
+    circuit_court_gt_france_query,
+    commerce_equitable_gt_bio_query,
     incoherent_values_query,
+    local_gt_france_query,
+    teledeclaration_mode_satellite_without_appro_query,
     valeur_bio_agg_is_filled_query,
     valeur_totale_is_filled_query,
 )
+from data.utils import has_arrayfield_missing_query
 
 logger = logging.getLogger(__name__)
 
 
-def _remove_invalid_reason_item(invalid_reason):
-    Diagnostic.objects.filter(invalid_reason_list__contains=[invalid_reason]).update(
-        invalid_reason_list=Func(
-            F("invalid_reason_list"),
-            Value(invalid_reason),
-            function="array_remove",
-        )
+def _remove_reason_item(field_prefix, reason_item):
+    """
+    field: "invalid" or "warning"
+    """
+    Diagnostic.objects.filter(**{f"{field_prefix}_reason_list__contains": [reason_item]}).update(
+        **{
+            f"{field_prefix}_reason_list": Func(
+                F(f"{field_prefix}_reason_list"),
+                Value(reason_item),
+                function="array_remove",
+            )
+        }
     )
 
 
-def _append_invalid_reason_item(qs, invalid_reason):
+def _append_reason_item(qs, field_prefix, reason_item):
     qs.update(
-        invalid_reason_list=Func(
-            F("invalid_reason_list"),
-            Value(invalid_reason),
-            function="array_append",
-        )
+        **{
+            f"{field_prefix}_reason_list": Func(
+                F(f"{field_prefix}_reason_list"),
+                Value(reason_item),
+                function="array_append",
+            )
+        }
     )
 
 
 class Command(BaseCommand):
     """
-    Goal: fill the invalid_reason_list field
+    Goal: fill the invalid_reason_list & warning_reason_list fields
 
     Usage:
     - python manage.py diagnostic_fill_invalid_reason_list --year 2024
@@ -74,6 +84,8 @@ class Command(BaseCommand):
             generated_from_groupe_diagnostic=False
         )
 
+        #########################################################
+        # invalid_reason_list
         fill_invalid_reason_CANTINE_SUPPRIMEE(diagnostic_qs, apply)
         fill_invalid_reason_CANTINE_SOFT_SUPPRIMEE_PENDANT_CAMPAGNE(diagnostic_qs, year, apply)
         fill_invalid_reason_CANTINE_SANS_SIRET_OU_SIREN(diagnostic_qs, apply)
@@ -84,18 +96,26 @@ class Command(BaseCommand):
         fill_invalid_reason_VALEURS_INCOHERENTES(diagnostic_qs, apply)
         # fill_invalid_reason_DOUBLON_1TD1SITE()  # done in teledeclaration_generate_1td1site.py
 
-        diagnostic_qs = diagnostic_qs.exclude(has_arrayfield_missing_query("invalid_reason_list"))
+        #########################################################
+        # warning_reason_list
+        fill_warning_reason_CIRCUIT_COURT_GT_FRANCE(diagnostic_qs, apply)
+        fill_warning_reason_LOCAL_GT_FRANCE(diagnostic_qs, apply)
+        fill_warning_reason_COMMERCE_EQUITABLE_GT_BIO(diagnostic_qs, apply)
+
         logger.info("Task completed: diagnostic_fill_invalid_reason_list")
-        logger.info(f"Found {diagnostic_qs.count()} diagnostics with an invalid reason")
+        diagnostic_invalid_qs = diagnostic_qs.exclude(has_arrayfield_missing_query("invalid_reason_list"))
+        logger.info(f"Found {diagnostic_invalid_qs.count()} diagnostics with an invalid reason")
+        diagnostic_warning_qs = diagnostic_qs.exclude(has_arrayfield_missing_query("warning_reason_list"))
+        logger.info(f"Found {diagnostic_warning_qs.count()} diagnostics with a warning reason")
 
 
 def fill_invalid_reason_CANTINE_SUPPRIMEE(diagnostic_qs, apply):
-    logger.info("fill_invalid_reason: CANTINE_SUPPRIMEE")
-    invalid_reason = Diagnostic.InvalidReason.CANTINE_SUPPRIMEE
+    reason_item = Diagnostic.InvalidReason.CANTINE_SUPPRIMEE
+    logger.info(f"fill_invalid_reason: {reason_item}")
 
     # Step 1: cleanup
     if apply:
-        _remove_invalid_reason_item(invalid_reason)
+        _remove_reason_item("invalid", reason_item)
 
     # Step 2: queryset
     diagnostic_qs = diagnostic_qs.filter(canteen_deleted_query())
@@ -103,16 +123,16 @@ def fill_invalid_reason_CANTINE_SUPPRIMEE(diagnostic_qs, apply):
 
     # Step 3: update
     if apply:
-        _append_invalid_reason_item(diagnostic_qs, invalid_reason)
+        _append_reason_item(diagnostic_qs, "invalid", reason_item)
 
 
 def fill_invalid_reason_CANTINE_SOFT_SUPPRIMEE_PENDANT_CAMPAGNE(diagnostic_qs, year, apply):
-    logger.info("fill_invalid_reason: CANTINE_SOFT_SUPPRIMEE_PENDANT_CAMPAGNE")
-    invalid_reason = Diagnostic.InvalidReason.CANTINE_SOFT_SUPPRIMEE_PENDANT_CAMPAGNE
+    reason_item = Diagnostic.InvalidReason.CANTINE_SOFT_SUPPRIMEE_PENDANT_CAMPAGNE
+    logger.info(f"fill_invalid_reason: {reason_item}")
 
     # Step 1: cleanup
     if apply:
-        _remove_invalid_reason_item(invalid_reason)
+        _remove_reason_item("invalid", reason_item)
 
     # Step 2: queryset
     diagnostic_qs = diagnostic_qs.filter(canteen_soft_deleted_during_campaign_query(year))
@@ -120,16 +140,16 @@ def fill_invalid_reason_CANTINE_SOFT_SUPPRIMEE_PENDANT_CAMPAGNE(diagnostic_qs, y
 
     # Step 3: update
     if apply:
-        _append_invalid_reason_item(diagnostic_qs, invalid_reason)
+        _append_reason_item(diagnostic_qs, "invalid", reason_item)
 
 
 def fill_invalid_reason_CANTINE_SANS_SIRET_OU_SIREN(diagnostic_qs, apply):
-    logger.info("fill_invalid_reason: CANTINE_SANS_SIRET_OU_SIREN")
-    invalid_reason = Diagnostic.InvalidReason.CANTINE_SANS_SIRET_OU_SIREN
+    reason_item = Diagnostic.InvalidReason.CANTINE_SANS_SIRET_OU_SIREN
+    logger.info(f"fill_invalid_reason: {reason_item}")
 
     # Step 1: cleanup
     if apply:
-        _remove_invalid_reason_item(invalid_reason)
+        _remove_reason_item("invalid", reason_item)
 
     # Step 2: queryset
     diagnostic_qs = diagnostic_qs.exclude(canteen_has_siret_or_siren_unite_legale_query())
@@ -137,16 +157,16 @@ def fill_invalid_reason_CANTINE_SANS_SIRET_OU_SIREN(diagnostic_qs, apply):
 
     # Step 3: update
     if apply:
-        _append_invalid_reason_item(diagnostic_qs, invalid_reason)
+        _append_reason_item(diagnostic_qs, "invalid", reason_item)
 
 
 def fill_invalid_reason_TELEDECLARATION_MODE_SATELLITE_WITHOUT_APPRO(diagnostic_qs, apply):
-    logger.info("fill_invalid_reason: TELEDECLARATION_MODE_SATELLITE_WITHOUT_APPRO")
-    invalid_reason = Diagnostic.InvalidReason.TELEDECLARATION_MODE_SATELLITE_WITHOUT_APPRO
+    reason_item = Diagnostic.InvalidReason.TELEDECLARATION_MODE_SATELLITE_WITHOUT_APPRO
+    logger.info(f"fill_invalid_reason: {reason_item}")
 
     # Step 1: cleanup
     if apply:
-        _remove_invalid_reason_item(invalid_reason)
+        _remove_reason_item("invalid", reason_item)
 
     # Step 2: queryset
     diagnostic_qs = diagnostic_qs.filter(teledeclaration_mode_satellite_without_appro_query())
@@ -154,16 +174,16 @@ def fill_invalid_reason_TELEDECLARATION_MODE_SATELLITE_WITHOUT_APPRO(diagnostic_
 
     # Step 3: update
     if apply:
-        _append_invalid_reason_item(diagnostic_qs, invalid_reason)
+        _append_reason_item(diagnostic_qs, "invalid", reason_item)
 
 
 def fill_invalid_reason_VALEUR_TOTALE_VIDE(diagnostic_qs, apply):
-    logger.info("fill_invalid_reason: VALEUR_TOTALE_VIDE")
-    invalid_reason = Diagnostic.InvalidReason.VALEUR_TOTALE_VIDE
+    reason_item = Diagnostic.InvalidReason.VALEUR_TOTALE_VIDE
+    logger.info(f"fill_invalid_reason: {reason_item}")
 
     # Step 1: cleanup
     if apply:
-        _remove_invalid_reason_item(invalid_reason)
+        _remove_reason_item("invalid", reason_item)
 
     # Step 2: queryset
     diagnostic_qs = diagnostic_qs.exclude(valeur_totale_is_filled_query())
@@ -171,16 +191,16 @@ def fill_invalid_reason_VALEUR_TOTALE_VIDE(diagnostic_qs, apply):
 
     # Step 3: update
     if apply:
-        _append_invalid_reason_item(diagnostic_qs, invalid_reason)
+        _append_reason_item(diagnostic_qs, "invalid", reason_item)
 
 
 def fill_invalid_reason_VALEUR_BIO_AGG_VIDE(diagnostic_qs, apply):
-    logger.info("fill_invalid_reason: VALEUR_BIO_AGG_VIDE")
-    invalid_reason = Diagnostic.InvalidReason.VALEUR_BIO_AGG_VIDE
+    reason_item = Diagnostic.InvalidReason.VALEUR_BIO_AGG_VIDE
+    logger.info(f"fill_invalid_reason: {reason_item}")
 
     # Step 1: cleanup
     if apply:
-        _remove_invalid_reason_item(invalid_reason)
+        _remove_reason_item("invalid", reason_item)
 
     # Step 2: queryset
     diagnostic_qs = diagnostic_qs.exclude(valeur_bio_agg_is_filled_query())
@@ -188,16 +208,16 @@ def fill_invalid_reason_VALEUR_BIO_AGG_VIDE(diagnostic_qs, apply):
 
     # Step 3: update
     if apply:
-        _append_invalid_reason_item(diagnostic_qs, invalid_reason)
+        _append_reason_item(diagnostic_qs, "invalid", reason_item)
 
 
 def fill_invalid_reason_VALEURS_ABERRANTES(diagnostic_qs, apply):
-    logger.info("fill_invalid_reason: VALEURS_ABERRANTES")
-    invalid_reason = Diagnostic.InvalidReason.VALEURS_ABERRANTES
+    reason_item = Diagnostic.InvalidReason.VALEURS_ABERRANTES
+    logger.info(f"fill_invalid_reason: {reason_item}")
 
     # Step 1: cleanup
     if apply:
-        _remove_invalid_reason_item(invalid_reason)
+        _remove_reason_item("invalid", reason_item)
 
     # Step 2: queryset
     diagnostic_qs = diagnostic_qs.with_meal_price().filter(aberrant_values_query())
@@ -205,16 +225,16 @@ def fill_invalid_reason_VALEURS_ABERRANTES(diagnostic_qs, apply):
 
     # Step 3: update
     if apply:
-        _append_invalid_reason_item(diagnostic_qs, invalid_reason)
+        _append_reason_item(diagnostic_qs, "invalid", reason_item)
 
 
 def fill_invalid_reason_VALEURS_INCOHERENTES(diagnostic_qs, apply):
-    logger.info("fill_invalid_reason: VALEURS_INCOHERENTES")
-    invalid_reason = Diagnostic.InvalidReason.VALEURS_INCOHERENTES
+    reason_item = Diagnostic.InvalidReason.VALEURS_INCOHERENTES
+    logger.info(f"fill_invalid_reason: {reason_item}")
 
     # Step 1: cleanup
     if apply:
-        _remove_invalid_reason_item(invalid_reason)
+        _remove_reason_item("invalid", reason_item)
 
     # Step 2: queryset
     diagnostic_qs = diagnostic_qs.filter(incoherent_values_query())
@@ -222,4 +242,55 @@ def fill_invalid_reason_VALEURS_INCOHERENTES(diagnostic_qs, apply):
 
     # Step 3: update
     if apply:
-        _append_invalid_reason_item(diagnostic_qs, invalid_reason)
+        _append_reason_item(diagnostic_qs, "invalid", reason_item)
+
+
+def fill_warning_reason_CIRCUIT_COURT_GT_FRANCE(diagnostic_qs, apply):
+    reason_item = Diagnostic.WarningReason.CIRCUIT_COURT_GT_FRANCE
+    logger.info(f"fill_warning_reason: {reason_item}")
+
+    # Step 1: cleanup
+    if apply:
+        _remove_reason_item("warning", reason_item)
+
+    # Step 2: queryset
+    diagnostic_qs = diagnostic_qs.filter(circuit_court_gt_france_query())
+    logger.info(f"Found {diagnostic_qs.count()} diagnostics with circuit court > origine France")
+
+    # Step 3: update
+    if apply:
+        _append_reason_item(diagnostic_qs, "warning", reason_item)
+
+
+def fill_warning_reason_LOCAL_GT_FRANCE(diagnostic_qs, apply):
+    reason_item = Diagnostic.WarningReason.LOCAL_GT_FRANCE
+    logger.info(f"fill_warning_reason: {reason_item}")
+
+    # Step 1: cleanup
+    if apply:
+        _remove_reason_item("warning", reason_item)
+
+    # Step 2: queryset
+    diagnostic_qs = diagnostic_qs.filter(local_gt_france_query())
+    logger.info(f"Found {diagnostic_qs.count()} diagnostics with local > origine France")
+
+    # Step 3: update
+    if apply:
+        _append_reason_item(diagnostic_qs, "warning", reason_item)
+
+
+def fill_warning_reason_COMMERCE_EQUITABLE_GT_BIO(diagnostic_qs, apply):
+    reason_item = Diagnostic.WarningReason.COMMERCE_EQUITABLE_GT_BIO
+    logger.info(f"fill_warning_reason: {reason_item}")
+
+    # Step 1: cleanup
+    if apply:
+        _remove_reason_item("warning", reason_item)
+
+    # Step 2: queryset
+    diagnostic_qs = diagnostic_qs.filter(commerce_equitable_gt_bio_query())
+    logger.info(f"Found {diagnostic_qs.count()} diagnostics with commerce equitable > bio")
+
+    # Step 3: update
+    if apply:
+        _append_reason_item(diagnostic_qs, "warning", reason_item)


### PR DESCRIPTION
Suite à #6732 (nouveau champ `Diagnostic.warning_reason_list`)
Et grâce à #6735 (nouveaux querysets `with_label_sum` & `with_family_sum`) & #6736 (`circuit_court_gt_france_query`, `local_gt_france_query`, `commerce_equitable_gt_bio_query`)

On réutilise le script `diagnostic_fill_invalid_reason_list` créé dans #6455
- ajout de la logique liée à `warning_reason_list`
- on renommera à `diagnostic_fill_invalid_warning_reason_list` dans #6738

