### PR TITLE
docs: ajouter une page pour expliquer les commandes en lien avec une campagne de télédéclaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Ressources :
 * **Achats:** regrouper les stats d'aggrégation dans une queryset dédiée ([#6706](https://github.com/betagouv/ma-cantine/issues/6706)) ([3b0d3c1](https://github.com/betagouv/ma-cantine/commit/3b0d3c14a3a65f71450fa417a27acef33dd1967b))
 * **deps:** bump django from 5.2.13 to 5.2.14 ([#6697](https://github.com/betagouv/ma-cantine/issues/6697)) ([d6547b8](https://github.com/betagouv/ma-cantine/commit/d6547b83e372bbc550a30284e011dead1e3053e5))
 * **deps:** bump wagtail from 7.0.5 to 7.0.7 ([#6696](https://github.com/betagouv/ma-cantine/issues/6696)) ([42b3509](https://github.com/betagouv/ma-cantine/commit/42b35098f1bbd4e40a59f7a9dd427da582bad32a))
-* **Diagnostics:** améliorer la commande diagnostic_fill_invalid_reason_list (apply, stats recap) ([#6700](https://github.com/betagouv/ma-cantine/issues/6700)) ([b8bdfa6](https://github.com/betagouv/ma-cantine/commit/b8bdfa66b2901df312086398cc6729533ff53634))
+* **Diagnostics:** améliorer la commande diagnostic_fill_invalid_warning_reason_list (apply, stats recap) ([#6700](https://github.com/betagouv/ma-cantine/issues/6700)) ([b8bdfa6](https://github.com/betagouv/ma-cantine/commit/b8bdfa66b2901df312086398cc6729533ff53634))
 * réorganise les champs dans les modèles (Meta & timestamps en bas) ([#6703](https://github.com/betagouv/ma-cantine/issues/6703)) ([7a57abb](https://github.com/betagouv/ma-cantine/commit/7a57abb6f5854190297c1d786c54384c66cd59cb))
 
 ## [2026.33.1](https://github.com/betagouv/ma-cantine/compare/v2026.33.0...v2026.33.1) (2026-05-04)

--- a/docs/teledeclaration_campaign.md
+++ b/docs/teledeclaration_campaign.md
@@ -6,13 +6,13 @@
 
 voir [macantine/utils.py](../macantine/utils.py) et la constante `CAMPAIGN_DATES`
 
-### Pendant la campagne
+## Pendant la campagne
 
-## Exports
+### Exports
 
 Modifier la fréquence des exports Metabase & Open Data, voir [macantine/celery.py](../macantine/celery.py)
 
-## 1TD1Site
+### 1TD1Site
 
 1. remplir les champs `invalid_warning_reason_list` &  `warning_reason_list`
     ```
@@ -25,6 +25,6 @@ Modifier la fréquence des exports Metabase & Open Data, voir [macantine/celery.
 
 TODO: temps réel au moment du save/cancel des TD
 
-### Après la campagne
+## Après la campagne
 
 TODO (dbt)

--- a/docs/teledeclaration_campaign.md
+++ b/docs/teledeclaration_campaign.md
@@ -1,0 +1,30 @@
+# Campagne de télédéclaration
+
+## Avant la campagne
+
+### Définir les dates
+
+voir [macantine/utils.py](../macantine/utils.py) et la constante `CAMPAIGN_DATES`
+
+### Pendant la campagne
+
+## Exports
+
+Modifier la fréquence des exports Metabase & Open Data, voir [macantine/celery.py](../macantine/celery.py)
+
+## 1TD1Site
+
+1. remplir les champs `invalid_warning_reason_list` &  `warning_reason_list`
+    ```
+    python manage.py diagnostic_fill_invalid_warning_reason_list --year YYYY --apply
+    ```
+2. créer les TD "fantômes" pour les cantines RSAT
+    ```
+    python manage.py teledeclaration_generate_1td1site --year YYYY --apply
+    ```
+
+TODO: temps réel au moment du save/cancel des TD
+
+### Après la campagne
+
+TODO (dbt)

--- a/macantine/management/commands/diagnostic_fill_invalid_warning_reason_list.py
+++ b/macantine/management/commands/diagnostic_fill_invalid_warning_reason_list.py
@@ -54,8 +54,8 @@ class Command(BaseCommand):
     Goal: fill the invalid_reason_list & warning_reason_list fields
 
     Usage:
-    - python manage.py diagnostic_fill_invalid_reason_list --year 2024
-    - python manage.py diagnostic_fill_invalid_reason_list --year 2024 --apply
+    - python manage.py diagnostic_fill_invalid_warning_reason_list --year 2024
+    - python manage.py diagnostic_fill_invalid_warning_reason_list --year 2024 --apply
     """
 
     def add_arguments(self, parser):
@@ -76,7 +76,7 @@ class Command(BaseCommand):
         year = options["year"]
         apply = options["apply"]
 
-        logger.info(f"Starting task: diagnostic_fill_invalid_reason_list, campaign {year}")
+        logger.info(f"Starting task: diagnostic_fill_invalid_warning_reason_list, campaign {year}")
         if not apply:
             logger.info("Dry run mode, no changes will be applied.")
 
@@ -102,7 +102,7 @@ class Command(BaseCommand):
         fill_warning_reason_LOCAL_GT_FRANCE(diagnostic_qs, apply)
         fill_warning_reason_COMMERCE_EQUITABLE_GT_BIO(diagnostic_qs, apply)
 
-        logger.info("Task completed: diagnostic_fill_invalid_reason_list")
+        logger.info("Task completed: diagnostic_fill_invalid_warning_reason_list")
         diagnostic_invalid_qs = diagnostic_qs.exclude(has_arrayfield_missing_query("invalid_reason_list"))
         logger.info(f"Found {diagnostic_invalid_qs.count()} diagnostics with an invalid reason")
         diagnostic_warning_qs = diagnostic_qs.exclude(has_arrayfield_missing_query("warning_reason_list"))


### PR DESCRIPTION
Nouveau bout de doc `docs/teledeclaration_campaign.md`

Surtout pour expliquer
- avant la campagne : CAMPAIGN_DATES
- pendant la campagne : diagnostic_fill_invalid_warning_reason_list & teledeclaration_generate_1td1site

J'ai aussi renommé la commande `diagnostic_fill_invalid_warning_reason_list` suite à #6737