### PR TITLE
refactor(Diagnostics): améliorer le script pour remplir le nouveau champ warning_reason_list (seulement les bilans détaillés pour circuit court & local)

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -148,35 +148,40 @@ def incoherent_values_query():
 
 def circuit_court_sup_france_query():
     """
-    TDs 2025 avec une incohérence sur "origine France dont circuit_court"
+    TDs COMPLETE 2025 avec une incohérence sur "origine France dont circuit_court"
     - En 2025, circuit-court faisait partie d'origine France, mais à parfois été mal télédéclaré
     - A partir de 2026, circuit-court a été sorti d'origine France
 
     Note: requires with_label_sum("circuit_court") and with_label_sum("france") annotations
     """
-    return Q(year=2025, circuit_court_sum__gt=F("france_sum"))
+    return Q(year=2025, diagnostic_type=Diagnostic.DiagnosticType.COMPLETE, circuit_court_sum__gt=F("france_sum"))
 
 
 def local_sup_france_query():
     """
-    TDs 2025 avec une incohérence sur "origine France dont local"
+    TDs COMPLETE 2025 avec une incohérence sur "origine France dont local"
     - En 2025, local faisait partie d'origine France, mais à parfois été mal télédéclaré
     - A partir de 2026, local a été sorti d'origine France
 
     Note: requires with_label_sum("local") and with_label_sum("france") annotations
     """
-    return Q(year=2025, local_sum__gt=F("france_sum"))
+    return Q(year=2025, diagnostic_type=Diagnostic.DiagnosticType.COMPLETE, local_sum__gt=F("france_sum"))
 
 
 def commerce_equitable_sup_bio_query():
     """
-    TDs 2025 avec une incohérence sur "bio dont commerce équitable"
+    TDs SIMPLE & COMPLETE 2025 avec une incohérence sur "bio dont commerce équitable"
 
     Note: see validators/diagnostics.py#validate_valeur_bio
     Note: requires with_label_sum("bio_dont_commerce_equitable") and with_label_sum("bio") annotations
     """
-    # return Q(year=2025, valeur_bio_dont_commerce_equitable__gt=F("valeur_bio"))
-    return Q(year=2025, bio_dont_commerce_equitable_sum__gt=F("bio_sum"))
+    return Q(
+        year=2025,
+        diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+        valeur_bio_dont_commerce_equitable__gt=F("valeur_bio"),
+    ) | Q(
+        year=2025, diagnostic_type=Diagnostic.DiagnosticType.COMPLETE, bio_dont_commerce_equitable_sum__gt=F("bio_sum")
+    )
 
 
 class DiagnosticQuerySet(models.QuerySet):

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -806,7 +806,7 @@ class DiagnosticEgalimQuerySetAndPropertyTest(TestCase):
 
 class DiagnosticInvalidWarningQueriesTest(TestCase):
     def test_circuit_court_sup_france_query(self):
-        diagnostic = DiagnosticFactory(
+        diagnostic_complete = DiagnosticFactory(
             year=2025,
             canteen=CanteenFactory(),
             diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
@@ -821,10 +821,10 @@ class DiagnosticInvalidWarningQueriesTest(TestCase):
         )
 
         self.assertEqual(diagnostic_qs.count(), 1)
-        self.assertIn(diagnostic, diagnostic_qs)
+        self.assertIn(diagnostic_complete, diagnostic_qs)
 
     def test_local_sup_france_query(self):
-        diagnostic = DiagnosticFactory(
+        diagnostic_complete = DiagnosticFactory(
             year=2025,
             canteen=CanteenFactory(),
             diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
@@ -837,10 +837,17 @@ class DiagnosticInvalidWarningQueriesTest(TestCase):
         )
 
         self.assertEqual(diagnostic_qs.count(), 1)
-        self.assertIn(diagnostic, diagnostic_qs)
+        self.assertIn(diagnostic_complete, diagnostic_qs)
 
     def test_commerce_equitable_sup_bio_query(self):
-        diagnostic = DiagnosticFactory(
+        diagnostic_simple = DiagnosticFactory(
+            year=2025,
+            canteen=CanteenFactory(),
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+            valeur_bio=10,
+            valeur_bio_dont_commerce_equitable=15,
+        )
+        diagnostic_complete = DiagnosticFactory(
             year=2025,
             canteen=CanteenFactory(),
             diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
@@ -854,8 +861,9 @@ class DiagnosticInvalidWarningQueriesTest(TestCase):
             .filter(commerce_equitable_sup_bio_query())
         )
 
-        self.assertEqual(diagnostic_qs.count(), 1)
-        self.assertIn(diagnostic, diagnostic_qs)
+        self.assertEqual(diagnostic_qs.count(), 2)
+        self.assertIn(diagnostic_simple, diagnostic_qs)
+        self.assertIn(diagnostic_complete, diagnostic_qs)
 
 
 class DiagnosticModelDeleteTest(TestCase):


### PR DESCRIPTION
Suite à #6737

On ajuste les querysets
- circuit_court_sup_france_query : seulement COMPLETE
- local_sup_france_query : seulement COMPLETE
- commerce_equitable_sup_bio_query : différent si SIMPLE & COMPLETE