### PR TITLE
refactor(Cantines): API: ajout d'un test sur la création avec oauth2

### DIFF
--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -489,6 +489,27 @@ class CanteenCreateApiTest(APITestCase):
         self.assertIn(authenticate.user, created_canteen.managers.all())
 
     @requests_mock.Mocker()
+    def test_create_canteen_via_oauth2(self, mock):
+        mock_fetch_geo_data_from_siret(mock, siret="92341284500011", success=True)
+        mock_fetch_communes(mock)
+        mock_fetch_epcis(mock)
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        user, token = get_oauth2_token("canteen:write")
+
+        self.client.credentials(Authorization=f"Bearer {token}")
+        response = self.client.post(reverse("user_canteens"), CANTEEN_SITE_DEFAULT_PAYLOAD)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        created_canteen = Canteen.objects.get(pk=body["id"])
+        self.assertEqual(created_canteen.siret, "92341284500011")
+        self.assertEqual(created_canteen.city, "Roubaix")  # ROUBAIX
+        self.assertEqual(created_canteen.management_type, Canteen.ManagementType.DIRECT)
+        self.assertIn(user, created_canteen.managers.all())
+
+    @requests_mock.Mocker()
     @authenticate
     def test_create_canteen_creation_source(self, mock):
         mock_fetch_geo_data_from_siret(mock, siret="92341284500011", success=True)

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -280,7 +280,8 @@ class UserCanteensFilterSet(django_filters.FilterSet):
 )
 class UserCanteensView(ListCreateAPIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope]
-    queryset = Canteen.objects.none()
+    required_scopes = ["canteen"]
+    queryset = Canteen.objects.none()  # see get_queryset
     serializer_class = FullCanteenSerializer
     pagination_class = UserCanteensPagination
     filter_backends = [
@@ -289,7 +290,6 @@ class UserCanteensView(ListCreateAPIView):
         MaCantineOrderingFilter,
     ]
     filterset_class = UserCanteensFilterSet
-    required_scopes = ["canteen"]
     search_fields = ["name", "siret"]
     ordering_fields = ["name", "creation_date", "modification_date", "daily_meal_count"]
 
@@ -343,20 +343,20 @@ class UserCanteensView(ListCreateAPIView):
     ),
 )
 class UserCanteenPreviews(ListAPIView):
-    queryset = Canteen.objects.none()
-    serializer_class = CanteenPreviewSerializer
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope]
     required_scopes = ["canteen"]
+    queryset = Canteen.objects.none()  # see get_queryset
+    serializer_class = CanteenPreviewSerializer
 
     def get_queryset(self):
         return self.request.user.canteens.all()
 
 
 class UserCanteenSummaries(ListAPIView):
-    queryset = Canteen.objects.none()
-    serializer_class = CanteenSummarySerializer
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope]
     required_scopes = ["canteen"]
+    queryset = Canteen.objects.none()  # see get_queryset
+    serializer_class = CanteenSummarySerializer
     pagination_class = UserCanteensPagination
     filter_backends = [
         django_filters.DjangoFilterBackend,
@@ -401,9 +401,9 @@ class UserCanteenActions(ListAPIView):
 )
 class RetrieveUpdateUserCanteenView(RetrieveUpdateDestroyAPIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManager]
+    required_scopes = ["canteen"]
     queryset = Canteen.objects.all()
     serializer_class = FullCanteenSerializer
-    required_scopes = ["canteen"]
 
     def put(self, request, *args, **kwargs):
         return JsonResponse(
@@ -770,9 +770,9 @@ class ActionableCanteensListView(ListAPIView):
 
 class ActionableCanteenRetrieveView(RetrieveAPIView):
     permission_classes = [IsAuthenticated, IsCanteenManager]
+    required_scopes = ["canteen"]
     model = Canteen
     serializer_class = CanteenActionsSerializer
-    required_scopes = ["canteen"]
 
     def get_queryset(self):
         year = self.request.parser_context.get("kwargs").get("year")


### PR DESCRIPTION
Je me suis rendu compte
- qu'il était possible de créer des cantines via oauth2
- mais qu'il n'y avait pas de tests (comme c'est déjà le cas coté Diagnostic)
- un peu en lien avec #6750