### PR TITLE
improve(Diagnostics): améliore la commande pour remplir les champs "calculés" (dont le nouveau `cout_repas`)

### DIFF
--- a/macantine/management/commands/diagnostic_fill_computed_fields.py
+++ b/macantine/management/commands/diagnostic_fill_computed_fields.py
@@ -1,0 +1,56 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from data.models import Diagnostic
+
+logger = logging.getLogger(__name__)
+
+
+FIELD_LIST = Diagnostic.AGGREGATED_APPRO_FIELDS + Diagnostic.COMPUTED_EGALIM_FIELDS + Diagnostic.OTHER_COMPUTED_FIELDS
+
+
+class Command(BaseCommand):
+    """
+    Goal: command to fill Diagnostic "computed" fields (see FIELD_LIST)
+
+    Usage:
+    - python manage.py diagnostic_fill_computed_fields --year 2025
+    """
+
+    help = "Fill diagnostic teledeclared egalim fields for a given year"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--year",
+            type=int,
+            required=True,
+            help="Year of the teledeclaration campaign to process",
+        )
+
+    def handle(self, *args, **options):
+        year = options["year"]
+        logger.info(f"Start task: diagnostic_fill_computed_fields for year {year}")
+
+        qs = Diagnostic.objects.in_year(year)
+
+        logger.info("Step 1: find the diagnostics for the specified year")
+        logger.info(f"Found {qs.count()} diagnostics for year {year}")
+
+        logger.info(
+            "Step 2: reset the fields for all the diagnostics (both draft & teledeclared) for the specified year"
+        )
+        qs.update(**{field_name: None for field_name in FIELD_LIST})
+
+        logger.info("Step 3: fill the fields (and save)")
+        for index, diagnostic in enumerate(qs):
+            # called in save()
+            # diagnostic.populate_aggregated_values()
+            # diagnostic.populate_egalim_stats()
+            # diagnostic.populate_cout_repas()
+            diagnostic.save(update_fields=FIELD_LIST)
+            if index % 5000 == 0:
+                logger.info(f"Updated {index} diagnostics")
+
+        # Done!
+        logger.info(f"Task completed: updated {qs.count()} diagnostics for year {year}")

--- a/macantine/management/commands/diagnostic_fill_computed_fields.py
+++ b/macantine/management/commands/diagnostic_fill_computed_fields.py
@@ -7,7 +7,7 @@ from data.models import Diagnostic
 logger = logging.getLogger(__name__)
 
 
-FIELD_LIST = Diagnostic.AGGREGATED_APPRO_FIELDS + Diagnostic.COMPUTED_EGALIM_FIELDS + Diagnostic.OTHER_COMPUTED_FIELDS
+FIELD_LIST = Diagnostic.AGGREGATED_APPRO_FIELDS + Diagnostic.EGALIM_STATS_FIELDS + Diagnostic.OTHER_COMPUTED_FIELDS
 
 
 class Command(BaseCommand):

--- a/macantine/tests/test_diagnostic_fill_computed_fields.py
+++ b/macantine/tests/test_diagnostic_fill_computed_fields.py
@@ -23,6 +23,10 @@ class DiagnosticFillComputedFieldsCommandTest(TestCase):
         self.assertEqual(diagnostic.valeur_egalim_autres, 300)
         self.assertEqual(diagnostic.canteen_snapshot["yearly_meal_count"], 500)
 
+        # simulate the fact that these fields were empty for non-teledeclared diagnostics
+        for field_name in self.FIELD_LIST:
+            setattr(diagnostic, field_name, None)
+
         call_command("diagnostic_fill_computed_fields", "--year", 2022)
 
         diagnostic.refresh_from_db()

--- a/macantine/tests/test_diagnostic_fill_computed_fields.py
+++ b/macantine/tests/test_diagnostic_fill_computed_fields.py
@@ -5,12 +5,12 @@ from data.models import Diagnostic
 from macantine.tests.test_etl_common import setUpTestData as ETLCommonSetUpTestData
 
 
-class TeledeclarationFillEgalimFieldsCommandTest(TestCase):
+class DiagnosticFillComputedFieldsCommandTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         ETLCommonSetUpTestData(cls, with_diagnostics=True)
         cls.FIELD_LIST = (
-            Diagnostic.AGGREGATED_APPRO_FIELDS + Diagnostic.COMPUTED_EGALIM_FIELDS + Diagnostic.OTHER_COMPUTED_FIELDS
+            Diagnostic.AGGREGATED_APPRO_FIELDS + Diagnostic.EGALIM_STATS_FIELDS + Diagnostic.OTHER_COMPUTED_FIELDS
         )
 
     def test_run_on_diagnostic_teledeclared(self):

--- a/macantine/tests/test_diagnostic_fill_computed_fields.py
+++ b/macantine/tests/test_diagnostic_fill_computed_fields.py
@@ -1,0 +1,61 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from data.models import Diagnostic
+from macantine.tests.test_etl_common import setUpTestData as ETLCommonSetUpTestData
+
+
+class TeledeclarationFillEgalimFieldsCommandTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        ETLCommonSetUpTestData(cls, with_diagnostics=True)
+        cls.FIELD_LIST = (
+            Diagnostic.AGGREGATED_APPRO_FIELDS + Diagnostic.COMPUTED_EGALIM_FIELDS + Diagnostic.OTHER_COMPUTED_FIELDS
+        )
+
+    def test_run_on_diagnostic_teledeclared(self):
+        diagnostic = self.canteen_site_diagnostic_2022
+        diagnostic_modification_date_before = diagnostic.modification_date
+        self.assertEqual(diagnostic.valeur_totale, 1000)
+        self.assertEqual(diagnostic.valeur_bio, 200)
+        self.assertEqual(diagnostic.valeur_siqo, 0)
+        self.assertEqual(diagnostic.valeur_externalites_performance, 0)
+        self.assertEqual(diagnostic.valeur_egalim_autres, 300)
+        self.assertEqual(diagnostic.canteen_snapshot["yearly_meal_count"], 500)
+
+        call_command("diagnostic_fill_computed_fields", "--year", 2022)
+
+        diagnostic.refresh_from_db()
+        self.assertIsNotNone(diagnostic.valeur_bio_agg)
+        self.assertIsNotNone(diagnostic.pourcentage_bio)
+        self.assertIsNotNone(diagnostic.pourcentage_egalim)
+        self.assertIsNotNone(diagnostic.pourcentage_egalim_hors_bio)
+        self.assertTrue(diagnostic.objectifs_egalim_atteints)
+        self.assertIsNotNone(diagnostic.cout_repas)
+        self.assertEqual(diagnostic.modification_date, diagnostic_modification_date_before)  # unchanged
+
+    def test_run_on_diagnostic_draft(self):
+        diagnostic = self.canteen_site_diagnostic_2023
+        diagnostic_modification_date_before = diagnostic.modification_date
+        self.assertEqual(diagnostic.valeur_totale, 1000)
+        self.assertEqual(diagnostic.valeur_bio, 200)
+        self.assertEqual(diagnostic.valeur_siqo, 0)
+        self.assertEqual(diagnostic.valeur_externalites_performance, 0)
+        self.assertEqual(diagnostic.valeur_egalim_autres, 300)
+        self.assertIsNone(diagnostic.canteen_snapshot)  # not teledeclared
+
+        # simulate the fact that these fields were empty for non-teledeclared diagnostics
+        for field_name in self.FIELD_LIST:
+            setattr(diagnostic, field_name, None)
+
+        call_command("diagnostic_fill_computed_fields", "--year", 2023)
+
+        # should stay unchanged
+        diagnostic.refresh_from_db()
+        self.assertIsNotNone(diagnostic.valeur_bio_agg)
+        self.assertIsNotNone(diagnostic.pourcentage_bio)
+        self.assertIsNotNone(diagnostic.pourcentage_egalim)
+        self.assertIsNotNone(diagnostic.pourcentage_egalim_hors_bio)
+        self.assertTrue(diagnostic.objectifs_egalim_atteints)
+        self.assertIsNotNone(diagnostic.cout_repas)
+        self.assertEqual(diagnostic.modification_date, diagnostic_modification_date_before)  # unchanged

--- a/macantine/tests/test_etl_common.py
+++ b/macantine/tests/test_etl_common.py
@@ -38,6 +38,7 @@ def setUpTestData(cls, with_diagnostics=False):
         declaration_donnees_2024=True,
         declaration_donnees_2025=False,
         managers=[cls.canteen_site_manager_1, cls.canteen_site_manager_2],
+        yearly_meal_count=500,
     )
     cls.canteen_site_without_manager = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[])
     cls.canteen_site_earlier = CanteenFactory(
@@ -100,6 +101,7 @@ def setUpTestData(cls, with_diagnostics=False):
                 valeur_totale=1000,
                 valeur_bio=200,
                 valeur_siqo=0,
+                valeur_externalites_performance=0,
                 valeur_egalim_autres=300,
             )
         with freeze_time("2023-05-15"):  # during the 2022 campaign (1 day later)
@@ -128,6 +130,7 @@ def setUpTestData(cls, with_diagnostics=False):
                 valeur_totale=1000,
                 valeur_bio=200,
                 valeur_siqo=0,
+                valeur_externalites_performance=0,
                 valeur_egalim_autres=300,
             )
             cls.canteen_site_diagnostic_2023.teledeclare(cls.canteen_site_manager_1)
@@ -155,6 +158,7 @@ def setUpTestData(cls, with_diagnostics=False):
                 valeur_totale=1000,
                 valeur_bio=400,
                 valeur_siqo=100,
+                valeur_externalites_performance=0,
                 valeur_egalim_autres=200,
             )
             cls.canteen_site_diagnostic_2024.teledeclare(cls.canteen_site_manager_1)


### PR DESCRIPTION
Dans #6481 on avait créé la commande `teledeclaration_fill_egalim_fields.py`

Suite à #6752 & #6753 on a besoin d'améliorer cette commande pour
- pouvoir la faire tourner sur TOUS les diagnostics (pas seulement ceux télédéclarés)
- mettre à jour d'avantage de champs

Modifications apportées
- renommé la commande à `diagnostic_fill_computed_fields.py`
- ajout de tests