### PR TITLE
feat(Achats): API: nouvel endpoint pour créer des achats (caractéristiques divisées en 4)

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -52,6 +52,7 @@ from .teledeclaration import (  # noqa: F401
     CampaignDatesFullSerializer,
 )  # noqa: F401
 from .purchase import (  # noqa: F401
+    PurchaseSerializer,
     PurchaseOldSerializer,
     PurchaseSummarySerializer,
     PurchasePercentageSummarySerializer,

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -1,6 +1,7 @@
 from drf_base64.fields import Base64FileField
 from rest_framework import serializers
 
+from api.serializers.utils import PurchaseField, choice_list_to_choices
 from data.models import Purchase
 
 
@@ -68,9 +69,95 @@ class PurchaseOldSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class PurchaseField(serializers.DecimalField):
-    def __init__(self):
-        super().__init__(max_digits=20, decimal_places=2, required=False)
+class PurchaseSerializer(serializers.ModelSerializer):
+    id = serializers.IntegerField(read_only=True)
+    canteen = serializers.PrimaryKeyRelatedField(read_only=True)
+    # caracteristiques is split into 4 fields
+    categories_egalim = serializers.MultipleChoiceField(
+        choices=choice_list_to_choices(Purchase.CHARACTERISTIC_LABELS_EGALIM)
+    )
+    origine = serializers.ChoiceField(
+        choices=choice_list_to_choices(Purchase.CHARACTERISTIC_LABELS_ORIGINE),
+        required=False,
+    )
+    est_local = serializers.BooleanField(required=False)
+    est_circuit_court = serializers.BooleanField(required=False)
+    creation_source = serializers.CharField(read_only=True)
+    import_source = serializers.CharField(read_only=True)
+    creation_date = serializers.DateTimeField(read_only=True)
+    modification_date = serializers.DateTimeField(read_only=True)
+
+    class Meta:
+        model = Purchase
+        fields = (
+            "id",
+            "canteen",
+            "description",
+            "fournisseur",
+            "date",
+            "prix_ht",
+            "famille_produits",
+            "categories_egalim",
+            "origine",
+            "est_local",
+            "est_circuit_court",
+            "definition_local",
+            # "facture",
+            "creation_source",
+            "import_source",
+            "creation_date",
+            "modification_date",
+        )
+
+    def to_representation(self, instance):
+        """
+        Useful for read operations (returning data)
+        """
+        representation = super().to_representation(instance)
+        representation["categories_egalim"] = [
+            characteristic
+            for characteristic in (instance.caracteristiques or [])
+            if characteristic in Purchase.CHARACTERISTIC_LABELS_EGALIM
+        ]
+        representation["origine"] = next(
+            (
+                characteristic
+                for characteristic in (instance.caracteristiques or [])
+                if characteristic in Purchase.CHARACTERISTIC_LABELS_ORIGINE
+            ),
+            "",
+        )
+        representation["est_local"] = any(
+            characteristic == Purchase.Characteristic.LOCAL for characteristic in (instance.caracteristiques or [])
+        )
+        representation["est_circuit_court"] = any(
+            characteristic == Purchase.Characteristic.CIRCUIT_COURT
+            for characteristic in (instance.caracteristiques or [])
+        )
+        return representation
+
+    def to_internal_value(self, data):
+        """
+        Useful for write operations (creating/updating data)
+        """
+        internal_value = super().to_internal_value(data)
+
+        caracteristiques = []
+
+        caracteristiques.extend(internal_value.pop("categories_egalim", []))
+
+        origine = internal_value.pop("origine", "")
+        if origine:
+            caracteristiques.append(origine)
+
+        if internal_value.pop("est_local", False):
+            caracteristiques.append(Purchase.Characteristic.LOCAL)
+
+        if internal_value.pop("est_circuit_court", False):
+            caracteristiques.append(Purchase.Characteristic.CIRCUIT_COURT)
+
+        internal_value["caracteristiques"] = caracteristiques
+        return internal_value
 
 
 # NB: these names reflect the names in the diagnostic model

--- a/api/serializers/utils.py
+++ b/api/serializers/utils.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+
+class PurchaseField(serializers.DecimalField):
+    def __init__(self):
+        super().__init__(max_digits=20, decimal_places=2, required=False)
+
+
+def choice_list_to_choices(choice_list):
+    return [(choice.value, choice.label) for choice in choice_list]

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -316,7 +316,7 @@ class PurchaseCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_create_empty_diagnostic_error(self):
+    def test_create_empty_purchase_error(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.post(self.url, {})
@@ -338,21 +338,14 @@ class PurchaseCreateApiTest(APITestCase):
         self.assertEqual(purchase.caracteristiques, [Purchase.Characteristic.BIO, Purchase.Characteristic.EUROPE])
         self.assertEqual(purchase.creation_user, authenticate.user)
 
-    def test_create_minimal_diagnostic_via_oauth2(self):
+    def test_cannot_create_minimal_purchase_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
         self.canteen.managers.add(user)
 
         self.client.credentials(Authorization=f"Bearer {token}")
         response = self.client.post(self.url, self.PURCHASE_MINIMAL_PAYLOAD)
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        purchase = Purchase.objects.first()
-        self.assertEqual(purchase.description, self.PURCHASE_MINIMAL_PAYLOAD["description"])
-        self.assertEqual(purchase.fournisseur, self.PURCHASE_MINIMAL_PAYLOAD["fournisseur"])
-        self.assertEqual(float(purchase.prix_ht), self.PURCHASE_MINIMAL_PAYLOAD["prix_ht"])
-        self.assertEqual(purchase.famille_produits, Purchase.Family.PRODUITS_DE_LA_MER)
-        self.assertEqual(purchase.caracteristiques, [Purchase.Characteristic.BIO, Purchase.Characteristic.EUROPE])
-        self.assertEqual(purchase.creation_user, user)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class PurchaseOldCreateApiTest(APITestCase):

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
-from api.tests.utils import authenticate
+from api.tests.utils import authenticate, get_oauth2_token
 from data.factories import CanteenFactory, DiagnosticFactory, PurchaseFactory, UserFactory
 from data.models import Canteen, Diagnostic, Purchase
 from data.models.creation_source import CreationSource
@@ -281,26 +281,105 @@ class PurchaseCreateApiTest(APITestCase):
     def setUpTestData(cls):
         cls.user = UserFactory()
         cls.canteen = CanteenFactory(managers=[cls.user])
-        cls.url = reverse("purchase_list_create")
-        cls.PURCHASE_PAYLOAD = {
-            "date": "2022-01-13",
-            "canteen": cls.canteen.id,
+        cls.url = reverse("canteen_purchase_create", kwargs={"canteen_pk": cls.canteen.id})
+        cls.PURCHASE_MINIMAL_PAYLOAD = {
+            # "canteen_id": cls.canteen.id,
             "description": "Saumon",
-            "provider": "Test fournisseur",
-            "family": "PRODUITS_DE_LA_MER",
-            "characteristics": ["BIO", "LOCAL"],
-            "local_definition": "AUTOUR_SERVICE",
-            "price_ht": 15.23,
+            "fournisseur": "Test fournisseur",
+            "date": "2022-01-13",
+            "prix_ht": 15.23,
+            "famille_produits": Purchase.Family.PRODUITS_DE_LA_MER,
+            "categories_egalim": [Purchase.Characteristic.BIO],
+            "origine": Purchase.Characteristic.EUROPE,
+            "est_local": False,
+            "est_circuit_court": False,
+            "definition_local": "",
         }
 
     def test_cannot_create_purchase_if_unauthenticated(self):
-        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
+        response = self.client.post(self.url, self.PURCHASE_MINIMAL_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_create_purchase_if_canteen_does_not_exist(self):
-        payload = {**self.PURCHASE_PAYLOAD, "canteen": 9999}
+        response = self.client.post(
+            reverse("canteen_purchase_create", kwargs={"canteen_pk": 999}), self.PURCHASE_MINIMAL_PAYLOAD
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_create_purchase_if_not_canteen_manager(self):
+        response = self.client.post(self.url, self.PURCHASE_MINIMAL_PAYLOAD)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_create_empty_diagnostic_error(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.post(self.url, {})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @authenticate
+    def test_create_minimal_purchase(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.post(self.url, self.PURCHASE_MINIMAL_PAYLOAD)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        purchase = Purchase.objects.first()
+        self.assertEqual(purchase.description, self.PURCHASE_MINIMAL_PAYLOAD["description"])
+        self.assertEqual(purchase.fournisseur, self.PURCHASE_MINIMAL_PAYLOAD["fournisseur"])
+        self.assertEqual(float(purchase.prix_ht), self.PURCHASE_MINIMAL_PAYLOAD["prix_ht"])
+        self.assertEqual(purchase.famille_produits, Purchase.Family.PRODUITS_DE_LA_MER)
+        self.assertEqual(purchase.caracteristiques, [Purchase.Characteristic.BIO, Purchase.Characteristic.EUROPE])
+        self.assertEqual(purchase.creation_user, authenticate.user)
+
+    def test_create_minimal_diagnostic_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:write")
+        self.canteen.managers.add(user)
+
+        self.client.credentials(Authorization=f"Bearer {token}")
+        response = self.client.post(self.url, self.PURCHASE_MINIMAL_PAYLOAD)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        purchase = Purchase.objects.first()
+        self.assertEqual(purchase.description, self.PURCHASE_MINIMAL_PAYLOAD["description"])
+        self.assertEqual(purchase.fournisseur, self.PURCHASE_MINIMAL_PAYLOAD["fournisseur"])
+        self.assertEqual(float(purchase.prix_ht), self.PURCHASE_MINIMAL_PAYLOAD["prix_ht"])
+        self.assertEqual(purchase.famille_produits, Purchase.Family.PRODUITS_DE_LA_MER)
+        self.assertEqual(purchase.caracteristiques, [Purchase.Characteristic.BIO, Purchase.Characteristic.EUROPE])
+        self.assertEqual(purchase.creation_user, user)
+
+
+class PurchaseOldCreateApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.url = reverse("purchase_list_create")
+        cls.PURCHASE_MINIMAL_PAYLOAD = {
+            "canteen": cls.canteen.id,
+            "description": "Saumon",
+            "provider": "Test fournisseur",
+            "date": "2022-01-13",
+            "price_ht": 15.23,
+            "family": "PRODUITS_DE_LA_MER",
+            "characteristics": ["BIO", "LOCAL"],
+            "local_definition": "AUTOUR_SERVICE",
+        }
+
+    def test_cannot_create_purchase_if_unauthenticated(self):
+        response = self.client.post(self.url, self.PURCHASE_MINIMAL_PAYLOAD)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_create_purchase_if_canteen_does_not_exist(self):
+        payload = {**self.PURCHASE_MINIMAL_PAYLOAD, "canteen": 9999}
 
         response = self.client.post(self.url, payload)
 
@@ -308,7 +387,7 @@ class PurchaseCreateApiTest(APITestCase):
 
     @authenticate
     def test_cannot_create_purchase_if_not_canteen_manager(self):
-        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
+        response = self.client.post(self.url, self.PURCHASE_MINIMAL_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -316,7 +395,7 @@ class PurchaseCreateApiTest(APITestCase):
     def test_create_purchase(self):
         self.canteen.managers.add(authenticate.user)
 
-        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
+        response = self.client.post(self.url, self.PURCHASE_MINIMAL_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         purchase = Purchase.objects.first()
@@ -329,7 +408,7 @@ class PurchaseCreateApiTest(APITestCase):
         self.canteen.managers.add(authenticate.user)
 
         # from the APP
-        payload = {**self.PURCHASE_PAYLOAD, "creation_source": CreationSource.APP}
+        payload = {**self.PURCHASE_MINIMAL_PAYLOAD, "creation_source": CreationSource.APP}
         response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
@@ -337,19 +416,19 @@ class PurchaseCreateApiTest(APITestCase):
         self.assertEqual(created_purchase.creation_source, CreationSource.APP)
 
         # defaults to API
-        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
+        response = self.client.post(self.url, self.PURCHASE_MINIMAL_PAYLOAD)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         created_purchase = Purchase.objects.get(pk=body["id"])
         self.assertEqual(created_purchase.creation_source, CreationSource.API)
 
         # returns a 404 if the creation_source is not valid
-        payload = {**self.PURCHASE_PAYLOAD, "creation_source": "UNKNOWN"}
+        payload = {**self.PURCHASE_MINIMAL_PAYLOAD, "creation_source": "UNKNOWN"}
         response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
-class PurchaseUpdateApiTest(APITestCase):
+class PurchaseOldUpdateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
@@ -460,7 +539,7 @@ class PurchaseUpdateApiTest(APITestCase):
         self.assertEqual(self.purchase.creation_source, CreationSource.APP)  # unchanged
 
 
-class PurchaseDeleteApiTest(APITestCase):
+class PurchaseOldDeleteApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()

--- a/api/urls.py
+++ b/api/urls.py
@@ -46,6 +46,7 @@ from api.views import (
     PublishedCanteensView,
     PurchaseListCreateView,
     UserCanteenListExportView,
+    PurchaseCreateView,
     PurchaseListExportView,
     PurchaseOptionsView,
     PurchaseRetrieveUpdateDestroyView,
@@ -103,6 +104,11 @@ urlpatterns = {
         name="user_canteen_list_export",
     ),
     path("canteens/<int:pk>", RetrieveUpdateUserCanteenView.as_view(), name="single_canteen"),
+    path(
+        "canteens/<int:canteen_pk>/purchases/",
+        PurchaseCreateView.as_view(),
+        name="canteen_purchase_create",
+    ),
     path(
         "canteens/<int:canteen_pk>/diagnostics/",
         DiagnosticCreateView.as_view(),

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -53,6 +53,7 @@ from .purchase import (  # noqa: F401
     CanteenPurchasesPercentageSummaryView,
     CanteenPurchasesSummaryView,
     DiagnosticsFromPurchasesView,
+    PurchaseCreateView,
     PurchaseListCreateView,
     PurchaseOptionsView,
     PurchaseRetrieveUpdateDestroyView,

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -4,24 +4,55 @@ from collections import OrderedDict
 from django.core.exceptions import BadRequest, ObjectDoesNotExist, ValidationError
 from django.http import JsonResponse
 from django_filters import rest_framework as django_filters
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status
 from rest_framework.exceptions import NotFound, PermissionDenied
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.generics import CreateAPIView, ListCreateAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from api.filters.utils import UnaccentSearchFilter
-from api.permissions import IsAuthenticated, IsCanteenManager, IsLinkedCanteenManager
+from api.permissions import (
+    IsAuthenticated,
+    IsAuthenticatedOrTokenHasResourceScope,
+    IsCanteenManager,
+    IsCanteenManagerUrlParam,
+    IsLinkedCanteenManager,
+)
 from api.serializers import (
     PurchaseOldSerializer,
     PurchasePercentageSummarySerializer,
+    PurchaseSerializer,
     PurchaseSummarySerializer,
 )
 from data.models import Canteen, Diagnostic, Purchase
 from data.models.creation_source import CreationSource
 
 logger = logging.getLogger(__name__)
+
+
+@extend_schema_view(
+    post=extend_schema(
+        summary="Créer un nouvel achat.",
+        description="Un achat doit être rattaché a une cantine.",
+    )
+)
+class PurchaseCreateView(CreateAPIView):
+    permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
+    required_scopes = ["canteen"]
+    model = Purchase
+    serializer_class = PurchaseSerializer
+
+    def _get_canteen(self):
+        # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
+        return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
+
+    def perform_create(self, serializer):
+        canteen = self._get_canteen()
+        creation_user = self.request.user
+        creation_source = serializer.validated_data.get("creation_source") or CreationSource.API
+        serializer.save(canteen=canteen, creation_user=creation_user, creation_source=creation_source)
 
 
 class PurchasesPagination(LimitOffsetPagination):

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 from django.core.exceptions import BadRequest, ObjectDoesNotExist, ValidationError
 from django.http import JsonResponse
 from django_filters import rest_framework as django_filters
-from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status
 from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.generics import CreateAPIView, ListCreateAPIView, RetrieveUpdateDestroyAPIView
@@ -15,7 +14,6 @@ from rest_framework.views import APIView
 from api.filters.utils import UnaccentSearchFilter
 from api.permissions import (
     IsAuthenticated,
-    IsAuthenticatedOrTokenHasResourceScope,
     IsCanteenManager,
     IsCanteenManagerUrlParam,
     IsLinkedCanteenManager,
@@ -32,15 +30,8 @@ from data.models.creation_source import CreationSource
 logger = logging.getLogger(__name__)
 
 
-@extend_schema_view(
-    post=extend_schema(
-        summary="Créer un nouvel achat.",
-        description="Un achat doit être rattaché a une cantine.",
-    )
-)
 class PurchaseCreateView(CreateAPIView):
-    permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
-    required_scopes = ["canteen"]
+    permission_classes = [IsAuthenticated, IsCanteenManagerUrlParam]
     model = Purchase
     serializer_class = PurchaseSerializer
 


### PR DESCRIPTION
- nouvel endpoint `canteens/<int:canteen_pk>/purchases`
- nouveau serializer `PurchaseSerializer`
- pour l'instant seulement possible de créer
- suite : #6810 (retrieve, update & delete)