### PR TITLE
refactor(Tests): API: homogénéisation suite aux changements récents

### DIFF
--- a/api/tests/test_canteen_action.py
+++ b/api/tests/test_canteen_action.py
@@ -28,13 +28,13 @@ class CanteenActionDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_retrieve_actionable_canteen_if_not_manager(self):
+    def test_cannot_retrieve_actionable_canteen_if_not_canteen_manager(self):
         canteen = CanteenFactory()
         response = self.client.get(reverse("retrieve_actionable_canteen", kwargs={"pk": canteen.id, "year": 2021}))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_retrieve_actionable_canteen_if_manager(self):
+    def test_retrieve_actionable_canteen_if_canteen_manager(self):
         canteen = CanteenFactory(managers=[authenticate.user])
         response = self.client.get(reverse("retrieve_actionable_canteen", kwargs={"pk": canteen.id, "year": 2021}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -9,7 +9,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from api.tests.utils import authenticate, get_oauth2_token
-from data.factories import CanteenFactory, DiagnosticFactory, ManagerInvitationFactory
+from data.factories import CanteenFactory, DiagnosticFactory, ManagerInvitationFactory, UserFactory
 from data.models import Canteen, Diagnostic, Sector, Teledeclaration
 from data.models.creation_source import CreationSource
 from common.api.datagouv import mock_get_pat_csv, mock_get_pat_dataset_resource
@@ -35,12 +35,15 @@ CANTEEN_SITE_DEFAULT_PAYLOAD = {
 class CanteenListApiTest(APITestCase):
     def test_cannot_get_user_canteens_unauthenticated(self):
         response = self.client.get(reverse("user_canteens"))
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_get_canteens_wrong_token(self):
         _, token = get_oauth2_token("user:read")
         self.client.credentials(Authorization=f"Bearer {token}")
+
         response = self.client.get(reverse("user_canteens"))
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_get_canteens_correct_token(self):
@@ -49,6 +52,7 @@ class CanteenListApiTest(APITestCase):
 
         self.client.credentials(Authorization=f"Bearer {token}")
         response = self.client.get(reverse("user_canteens"))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["count"], 1)
@@ -73,6 +77,7 @@ class CanteenListApiTest(APITestCase):
             canteen.managers.set([authenticate.user])
 
         response = self.client.get(reverse("user_canteens"))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json().get("results")
 
@@ -97,10 +102,11 @@ class CanteenListApiTest(APITestCase):
             creation_mtm_medium="mtm_medium_value",
             managers=[authenticate.user],
         )
+
         response = self.client.get(reverse("user_canteens"))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json().get("results")[0]
-
         self.assertNotIn("mtm_source_value", body)
         self.assertNotIn("mtm_campaign_value", body)
         self.assertNotIn("mtm_medium_value", body)
@@ -114,9 +120,9 @@ class CanteenListFilterApiTest(APITestCase):
         user_central_serving_cuisine = CanteenFactory(production_type="central_serving", managers=[authenticate.user])
 
         response = self.client.get(f"{reverse('user_canteens')}?production_type=central,central_serving")
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-
         self.assertEqual(body["count"], 2)
         ids = list(map(lambda x: x["id"], body["results"]))
         self.assertIn(user_central_cuisine.id, ids)
@@ -140,9 +146,9 @@ class CanteenListPreviewApiTest(APITestCase):
         ]
 
         response = self.client.get(reverse("user_canteen_previews"))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-
         self.assertEqual(len(body), 2)
         self.assertEqual(body[0].get("id"), user_canteens[1].id)
         self.assertEqual(body[1].get("id"), user_canteens[0].id)
@@ -153,6 +159,7 @@ class CanteenListPreviewApiTest(APITestCase):
 
         self.client.credentials(Authorization=f"Bearer {token}")
         response = self.client.get(reverse("user_canteen_previews"))
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_canteen_preview_correct_token(self):
@@ -161,6 +168,7 @@ class CanteenListPreviewApiTest(APITestCase):
 
         self.client.credentials(Authorization=f"Bearer {token}")
         response = self.client.get(reverse("user_canteen_previews"))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(len(body), 1)
@@ -237,6 +245,7 @@ class CanteenDetailApiTest(APITestCase):
 
         # make user the manager of the groupe canteen as well
         canteen_groupe.managers.add(authenticate.user)
+
         response = self.client.get(reverse("single_canteen", kwargs={"pk": canteen_groupe.id}))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -305,6 +314,7 @@ class CanteenDetailApiTest(APITestCase):
         teledeclaration = Teledeclaration.create_from_diagnostic(diagnostic, authenticate.user)
 
         response = self.client.get(reverse("user_canteens"))
+
         body = response.json().get("results")
         json_canteen = next(filter(lambda x: x["id"] == canteen.id, body))
         json_diagnostic = next(filter(lambda x: x["id"] == diagnostic.id, json_canteen["diagnostics"]))
@@ -314,6 +324,7 @@ class CanteenDetailApiTest(APITestCase):
         teledeclaration.cancel()
 
         response = self.client.get(reverse("user_canteens"))
+
         body = response.json().get("results")
         json_canteen = next(filter(lambda x: x["id"] == canteen.id, body))
         json_diagnostic = next(filter(lambda x: x["id"] == diagnostic.id, json_canteen["diagnostics"]))
@@ -361,6 +372,7 @@ class CanteenDetailApiTest(APITestCase):
         )
 
         response = self.client.get(reverse("single_canteen", kwargs={"pk": user_canteen.id}))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
 
@@ -397,18 +409,21 @@ class CanteenDetailApiTest(APITestCase):
         )
 
         response_canteen_199 = self.client.get(reverse("single_canteen", kwargs={"pk": canteen_199_daily_meals.id}))
+
         self.assertEqual(response_canteen_199.status_code, status.HTTP_200_OK)
         body = response_canteen_199.json()
         self.assertIs(body["dailyMealCount"], 199)
         self.assertIs(body["badges"]["diversification"], None)
 
         response_canteen_200 = self.client.get(reverse("single_canteen", kwargs={"pk": canteen_200_daily_meals.id}))
+
         self.assertEqual(response_canteen_200.status_code, status.HTTP_200_OK)
         body = response_canteen_200.json()
         self.assertIs(body["dailyMealCount"], 200)
         self.assertIs(body["badges"]["diversification"], True)
 
         response_canteen_201 = self.client.get(reverse("single_canteen", kwargs={"pk": canteen_201_daily_meals.id}))
+
         self.assertEqual(response_canteen_201.status_code, status.HTTP_200_OK)
         body = response_canteen_201.json()
         self.assertIs(body["dailyMealCount"], 201)
@@ -524,6 +539,7 @@ class CanteenCreateApiTest(APITestCase):
         response = self.client.post(
             reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "creation_source": "APP"}
         )
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         created_canteen = Canteen.objects.get(pk=body["id"])
@@ -532,6 +548,7 @@ class CanteenCreateApiTest(APITestCase):
 
         # defaults to API
         response = self.client.post(reverse("user_canteens"), CANTEEN_SITE_DEFAULT_PAYLOAD)
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         created_canteen = Canteen.objects.get(pk=body["id"])
@@ -542,6 +559,7 @@ class CanteenCreateApiTest(APITestCase):
         response = self.client.post(
             reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "creation_source": "UNKNOWN"}
         )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @authenticate
@@ -550,6 +568,7 @@ class CanteenCreateApiTest(APITestCase):
         del payload["siret"]
 
         response = self.client.post(reverse("user_canteens"), payload)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
         self.assertEqual(body["siret"], ["Champ requis."])
@@ -557,6 +576,7 @@ class CanteenCreateApiTest(APITestCase):
     @authenticate
     def test_cannot_create_canteen_with_bad_siret(self):
         response = self.client.post(reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "siret": "0123"})
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
         self.assertEqual(body["siret"], ["14 caractères numériques sont attendus"])
@@ -564,6 +584,7 @@ class CanteenCreateApiTest(APITestCase):
         response = self.client.post(
             reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "siret": "01234567891011"}
         )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
         self.assertEqual(
@@ -580,6 +601,7 @@ class CanteenCreateApiTest(APITestCase):
                 "centralProducerSiret": "01234567891011",
             },
         )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
         self.assertEqual(
@@ -597,6 +619,7 @@ class CanteenCreateApiTest(APITestCase):
         canteen = CanteenFactory(siret=siret)
 
         response = self.client.post(reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "siret": siret})
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
         self.assertEqual(body["name"], canteen.name)
@@ -608,6 +631,7 @@ class CanteenCreateApiTest(APITestCase):
         canteen.managers.add(authenticate.user)
 
         response = self.client.post(reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "siret": siret})
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
         self.assertEqual(body["name"], canteen.name)
@@ -640,6 +664,7 @@ class CanteenCreateApiTest(APITestCase):
         ]
 
         response = self.client.post(reverse("user_canteens"), payload, format="json")
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         created_canteen = Canteen.objects.get(pk=body["id"])
@@ -663,6 +688,7 @@ class CanteenCreateApiTest(APITestCase):
         payload["creation_mtm_medium"] = "mtm_medium_value"
 
         response = self.client.post(reverse("user_canteens"), payload, format="json")
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         created_canteen = Canteen.objects.get(pk=body["id"])
@@ -674,7 +700,20 @@ class CanteenCreateApiTest(APITestCase):
 class CanteenUpdateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.canteen = CanteenFactory(**CANTEEN_SITE_DEFAULT_PAYLOAD)
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(
+            **CANTEEN_SITE_DEFAULT_PAYLOAD,
+            managers=[cls.user],
+            creation_user=cls.user,
+            creation_source=CreationSource.APP,
+        )
+
+    def test_cannot_update_canteen_if_unauthenticated(self):
+        payload = {"management_type": Canteen.ManagementType.CONCEDED}
+
+        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_update_canteen_with_put(self):
@@ -683,13 +722,6 @@ class CanteenUpdateApiTest(APITestCase):
         response = self.client.put(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)
 
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-
-    def test_cannot_update_canteen_if_unauthenticated(self):
-        payload = {"management_type": Canteen.ManagementType.CONCEDED}
-
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_update_canteen_if_not_manager(self):
@@ -712,13 +744,13 @@ class CanteenUpdateApiTest(APITestCase):
         self.assertEqual(self.canteen.siret, "92341284500011")
         self.assertEqual(self.canteen.city, "Roubaix")
         self.canteen.managers.add(authenticate.user)
-
         payload = {
             "siret": "21340172201787",
             "city": "Montpellier",  # siret changed, geo fields are reset and re-fetched
             "managementType": Canteen.ManagementType.CONCEDED,
             "reservationExpeParticipant": True,
         }
+
         response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -732,10 +764,10 @@ class CanteenUpdateApiTest(APITestCase):
     def test_update_canteen_production_type(self):
         self.assertEqual(self.canteen.production_type, Canteen.ProductionType.ON_SITE)
         self.canteen.managers.add(authenticate.user)
-
         payload = {
             "productionType": Canteen.ProductionType.ON_SITE_CENTRAL,
         }
+
         response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -749,6 +781,7 @@ class CanteenUpdateApiTest(APITestCase):
 
         for empty in ["", None]:
             payload = {"siret": empty, "siren_unite_legale": empty}
+
             response = self.client.patch(
                 reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json"
             )
@@ -772,8 +805,8 @@ class CanteenUpdateApiTest(APITestCase):
         canteen_2 = CanteenFactory(siret=siret_2)
         self.assertEqual(self.canteen.siret, "92341284500011")
         self.canteen.managers.add(authenticate.user)
-
         payload = {"siret": siret_2}
+
         response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -798,8 +831,8 @@ class CanteenUpdateApiTest(APITestCase):
     def test_update_canteen_with_own_siret(self):
         self.assertEqual(self.canteen.siret, "92341284500011")
         self.canteen.managers.add(authenticate.user)
-
         payload = {"siret": self.canteen.siret}
+
         response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -817,7 +850,6 @@ class CanteenUpdateApiTest(APITestCase):
         self.assertEqual(self.canteen.city, "Roubaix")
         # self.assertEqual(self.canteen.city_insee_code, "59512")  # ROUBAIX
         self.canteen.managers.add(authenticate.user)
-
         payload = {"siret": "21340172201787"}
 
         response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
@@ -834,7 +866,6 @@ class CanteenUpdateApiTest(APITestCase):
         image_base_64 = None
         with open(image_path, "rb") as image:
             image_base_64 = base64.b64encode(image.read()).decode("utf-8")
-
         payload = {
             "images": [
                 {
@@ -842,7 +873,9 @@ class CanteenUpdateApiTest(APITestCase):
                 }
             ]
         }
+
         response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.canteen.refresh_from_db()
         self.assertEqual(self.canteen.images.count(), 0)
@@ -865,41 +898,48 @@ class CanteenUpdateApiTest(APITestCase):
                 }
             ]
         }
-        self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
 
+        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.canteen.refresh_from_db()
         self.assertEqual(self.canteen.images.count(), 1)
 
         # Delete image
         payload = {"images": []}
-        self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
 
+        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.canteen.refresh_from_db()
         self.assertEqual(self.canteen.images.count(), 0)
 
     @authenticate
     def test_update_canteen_does_not_update_creation_user_and_source(self):
         self.canteen.managers.add(authenticate.user)
-        self.assertEqual(self.canteen.creation_user, None)
-        self.assertEqual(self.canteen.creation_source, None)
+        self.assertEqual(self.canteen.creation_user, self.user)
+        self.assertEqual(self.canteen.creation_source, CreationSource.APP)
 
-        payload = {"managementType": Canteen.ManagementType.CONCEDED}
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+        payload = {
+            "managementType": Canteen.ManagementType.CONCEDED,
+            "reservationExpeParticipant": True,
+        }
+
+        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.canteen.refresh_from_db()
-        self.assertEqual(self.canteen.creation_user, None)  # unchanged
-        self.assertEqual(self.canteen.creation_source, None)  # unchanged
+        self.assertEqual(self.canteen.management_type, Canteen.ManagementType.CONCEDED)
+        self.assertEqual(self.canteen.reservation_expe_participant, True)
+        self.assertEqual(self.canteen.creation_user, self.user)  # unchanged
+        self.assertEqual(self.canteen.creation_source, CreationSource.APP)  # unchanged
 
     @authenticate
-    def test_update_canteen_tracking_info(self):
-        """
-        The app should not allow the tracking info to be updated
-        """
+    def test_cannot_update_canteen_tracking_info(self):
+        self.canteen.managers.add(authenticate.user)
         self.assertEqual(self.canteen.creation_mtm_source, None)
         self.assertEqual(self.canteen.creation_mtm_campaign, None)
         self.assertEqual(self.canteen.creation_mtm_medium, None)
-        self.canteen.managers.add(authenticate.user)
 
         payload = {
             "managementType": Canteen.ManagementType.CONCEDED,
@@ -907,6 +947,7 @@ class CanteenUpdateApiTest(APITestCase):
             "creation_mtm_campaign": "mtm_campaign_value",
             "creation_mtm_medium": "mtm_medium_value",
         }
+
         response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -198,7 +198,7 @@ class CanteenDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_get_single_user_canteen_if_not_manager(self):
+    def test_cannot_get_single_user_canteen_if_not_canteen_manager(self):
         """
         Users cannot access the full representation of a single
         canteen if they do not manage it.
@@ -724,7 +724,7 @@ class CanteenUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     @authenticate
-    def test_cannot_update_canteen_if_not_manager(self):
+    def test_cannot_update_canteen_if_not_canteen_manager(self):
         payload = {"management_type": Canteen.ManagementType.CONCEDED}
 
         response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)
@@ -861,7 +861,7 @@ class CanteenUpdateApiTest(APITestCase):
         self.assertEqual(self.canteen.city_insee_code, "34172")
 
     @authenticate
-    def test_cannot_update_canteen_image_if_not_manager(self):
+    def test_cannot_update_canteen_image_if_not_canteen_manager(self):
         image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
         image_base_64 = None
         with open(image_path, "rb") as image:
@@ -881,7 +881,7 @@ class CanteenUpdateApiTest(APITestCase):
         self.assertEqual(self.canteen.images.count(), 0)
 
     @authenticate
-    def test_update_canteen_image_if_manager(self):
+    def test_update_canteen_image_if_canteen_manager(self):
         self.canteen.managers.add(authenticate.user)
         self.assertEqual(self.canteen.images.count(), 0)
 
@@ -958,12 +958,33 @@ class CanteenUpdateApiTest(APITestCase):
 
 
 class CanteenDeleteApiTest(APITestCase):
-    @authenticate
-    def test_soft_delete(self):
-        canteen = CanteenFactory(managers=[authenticate.user])
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.url = reverse("single_canteen", kwargs={"pk": cls.canteen.id})
 
-        response = self.client.delete(reverse("single_canteen", kwargs={"pk": canteen.id}))
+    def test_cannot_delete_canteen_if_unauthenticated(self):
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_cannot_delete_canteen_if_not_canteen_manager(self):
+        authenticate(self.client)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_delete_canteen(self):
+        self.canteen.managers.add(authenticate.user)
+        self.assertEqual(Canteen.objects.count(), 1)
+
+        response = self.client.delete(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Canteen.objects.count(), 0)
+        self.assertEqual(Canteen.all_objects.count(), 1)
         # Model was only soft-deleted but remains in the DB
-        self.assertIsNotNone(Canteen.all_objects.get(pk=canteen.id).deletion_date)
+        self.assertIsNotNone(Canteen.all_objects.get(pk=self.canteen.id).deletion_date)

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -8,7 +8,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from api.tests.utils import authenticate, get_oauth2_token
-from data.factories import CanteenFactory, DiagnosticFactory
+from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 from data.models import Diagnostic
 from data.models.creation_source import CreationSource
 
@@ -16,8 +16,8 @@ from data.models.creation_source import CreationSource
 class DiagnosticCreateApiTest(APITestCase):
     def test_cannot_create_diagnostic_if_unauthenticated(self):
         canteen = CanteenFactory()
-
         payload = {"year": 2020}
+
         response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -25,16 +25,20 @@ class DiagnosticCreateApiTest(APITestCase):
     @authenticate
     def test_cannot_create_diagnostic_if_canteen_does_not_exist(self):
         payload = {"year": 2020}
+
         response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": 999}), payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_cannot_create_diagnostic_if_not_canteen_manager(self):
-        canteen = CanteenFactory()
-
+        other_user = UserFactory()
+        other_user_canteen = CanteenFactory(managers=[other_user])
         payload = {"year": 2020}
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
+
+        response = self.client.post(
+            reverse("diagnostic_creation", kwargs={"canteen_pk": other_user_canteen.id}), payload
+        )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -45,8 +49,8 @@ class DiagnosticCreateApiTest(APITestCase):
         we need to provide the required field(s)
         """
         canteen = CanteenFactory(managers=[authenticate.user])
-
         payload = {}
+
         response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -59,8 +63,8 @@ class DiagnosticCreateApiTest(APITestCase):
         (minimal required fields)
         """
         canteen = CanteenFactory(managers=[authenticate.user])
-
         payload = {"year": 2020}
+
         response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -72,8 +76,8 @@ class DiagnosticCreateApiTest(APITestCase):
     def test_create_minimal_diagnostic_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
         canteen = CanteenFactory(managers=[user])
-
         payload = {"year": 2020}
+
         self.client.credentials(Authorization=f"Bearer {token}")
         response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
 
@@ -273,11 +277,11 @@ class DiagnosticCreateApiTest(APITestCase):
             "valeur_autres_local": 10,
             # end of detailed value fields
         }
+
         response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
         diagnostic = Diagnostic.objects.get(canteen__id=canteen.id)
-
         self.assertEqual(diagnostic.year, 2020)
         self.assertTrue(diagnostic.cooking_plastic_substituted)
         self.assertFalse(diagnostic.has_donation_agreement)
@@ -326,28 +330,26 @@ class DiagnosticCreateApiTest(APITestCase):
         On CREATE, total_leftovers should be converted from kg to ton
         """
         canteen = CanteenFactory(managers=[authenticate.user])
-
         payload = {
             "year": 2020,
             "total_leftovers": 1234.56,
         }
-        response = self.client.post(
-            reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload, format="json"
-        )
+
+        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         diagnostic = Diagnostic.objects.get(canteen__id=canteen.id)
         self.assertEqual(diagnostic.total_leftovers, Decimal("1.23456"))
 
     @authenticate
-    def test_create_duplicate_diagnostic(self):
+    def test_cannot_create_duplicate_diagnostic(self):
         """
         Shouldn't be able to add a diagnostic with the same canteen, year and value for generated_from_groupe_diagnostic"
         as an existing diagnostic
         """
         canteen = CanteenFactory(managers=[authenticate.user])
-
         payload = {"year": 2020, "generated_from_groupe_diagnostic": False, "valeur_bio": 10}
+
         self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
 
         try:
@@ -365,12 +367,11 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(diagnostic.valeur_bio, 10)
 
     @authenticate
-    def test_create_diagnostic_bad_total(self):
+    def test_cannot_create_diagnostic_with_bad_total(self):
         """
         Do not create a diagnostic where the sum of the values is > total
         """
         canteen = CanteenFactory(managers=[authenticate.user])
-
         payload = {
             "year": 2020,
             "valeur_bio": 1000,
@@ -378,123 +379,95 @@ class DiagnosticCreateApiTest(APITestCase):
             "valeur_egalim_autres": 1000,
             "valeur_totale": 2000,
         }
+
         response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class DiagnosticUpdateApiTest(APITestCase):
-    @authenticate
-    def test_edit_diagnostic_unauthorized(self):
-        """
-        The user can only edit diagnostics of canteens they manage
-        """
-        diagnostic = DiagnosticFactory(year=2019)
-
-        payload = {"year": 2020}
-
-        response = self.client.patch(
-            reverse(
-                "diagnostic_update",
-                kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
-            ),
-            payload,
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.diagnostic = DiagnosticFactory(
+            year=2019, canteen=cls.canteen, creation_user=cls.user, creation_source=CreationSource.APP
         )
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        diagnostic.refresh_from_db()
-        self.assertEqual(diagnostic.year, 2019)
+        cls.url = reverse(
+            "diagnostic_update",
+            kwargs={"canteen_pk": cls.diagnostic.canteen.id, "pk": cls.diagnostic.id},
+        )
 
     @authenticate
     def test_cannot_update_diagnostic_with_put(self):
-        """
-        A user cannot update the data from a diagnostic object with PUT
-        """
-        diagnostic = DiagnosticFactory(year=2019)
-        diagnostic.canteen.managers.add(authenticate.user)
-
+        self.diagnostic.canteen.managers.add(authenticate.user)
         payload = {"year": 2020}
-        response = self.client.put(
-            reverse(
-                "diagnostic_update",
-                kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
-            ),
-            payload,
-        )
+
+        response = self.client.put(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    @authenticate
-    def test_edit_diagnostic(self):
-        """
-        The user can edit a diagnostic of a canteen they manage
-        """
-        diagnostic = DiagnosticFactory(year=2019)
-        diagnostic.canteen.managers.add(authenticate.user)
-
+    def test_cannot_update_diagnostic_if_unauthenticated(self):
         payload = {"year": 2020}
-        response = self.client.patch(
-            reverse(
-                "diagnostic_update",
-                kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
-            ),
-            payload,
-        )
+
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.diagnostic.refresh_from_db()
+        self.assertEqual(self.diagnostic.year, 2019)
+
+    @authenticate
+    def test_cannot_update_diagnostic_if_not_canteen_manager(self):
+        payload = {"year": 2020}
+
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.diagnostic.refresh_from_db()
+        self.assertEqual(self.diagnostic.year, 2019)
+
+    @authenticate
+    def test_update_diagnostic(self):
+        self.diagnostic.canteen.managers.add(authenticate.user)
+        payload = {"year": 2020}
+
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        diagnostic.refresh_from_db()
-        self.assertEqual(diagnostic.year, 2020)
+        self.diagnostic.refresh_from_db()
+        self.assertEqual(self.diagnostic.year, 2020)
 
-    def test_edit_diagnostic_via_oauth2(self):
+    def test_update_diagnostic_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
-        diagnostic = DiagnosticFactory(year=2019)
-        diagnostic.canteen.managers.add(user)
-
+        self.diagnostic.canteen.managers.add(user)
         payload = {"year": 2020}
+
         self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.patch(
-            reverse(
-                "diagnostic_update",
-                kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
-            ),
-            payload,
-        )
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @authenticate
     def test_update_diagnostic_does_not_update_creation_user_and_source(self):
-        diagnostic = DiagnosticFactory(year=2019)
-        diagnostic.canteen.managers.add(authenticate.user)
-        self.assertEqual(diagnostic.creation_user, None)
-        self.assertEqual(diagnostic.creation_source, None)
+        self.diagnostic.canteen.managers.add(authenticate.user)
+        self.assertEqual(self.diagnostic.creation_user, self.user)
+        self.assertEqual(self.diagnostic.creation_source, CreationSource.APP)
 
         payload = {"year": 2020}
-        response = self.client.patch(
-            reverse(
-                "diagnostic_update",
-                kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
-            ),
-            payload,
-        )
+
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        diagnostic.refresh_from_db()
-        self.assertEqual(diagnostic.creation_user, None)  # unchanged
-        self.assertEqual(diagnostic.creation_source, None)  # unchanged
+        self.diagnostic.refresh_from_db()
+        self.assertEqual(self.diagnostic.creation_user, self.user)  # unchanged
+        self.assertEqual(self.diagnostic.creation_source, CreationSource.APP)  # unchanged
 
     @authenticate
-    def test_edit_diagnostic_tracking_info(self):
-        """
-        Diagnostic creation campaign info cannot be updated
-        """
-        diagnostic = DiagnosticFactory(
-            year=2019,
-            creation_mtm_source=None,
-            creation_mtm_campaign=None,
-            creation_mtm_medium=None,
-        )
-        diagnostic.canteen.managers.add(authenticate.user)
+    def test_cannot_update_diagnostic_tracking_info(self):
+        self.diagnostic.canteen.managers.add(authenticate.user)
+        self.assertEqual(self.diagnostic.creation_mtm_source, None)
+        self.assertEqual(self.diagnostic.creation_mtm_campaign, None)
+        self.assertEqual(self.diagnostic.creation_mtm_medium, None)
 
         payload = {
             "year": 2020,
@@ -502,30 +475,25 @@ class DiagnosticUpdateApiTest(APITestCase):
             "creation_mtm_campaign": "mtm_campaign_value",
             "creation_mtm_medium": "mtm_medium_value",
         }
-        response = self.client.patch(
-            reverse(
-                "diagnostic_update",
-                kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
-            ),
-            payload,
-        )
+
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        diagnostic.refresh_from_db()
-        self.assertEqual(diagnostic.year, 2020)
-        self.assertIsNone(diagnostic.creation_mtm_source)
-        self.assertIsNone(diagnostic.creation_mtm_campaign)
-        self.assertIsNone(diagnostic.creation_mtm_medium)
+        self.diagnostic.refresh_from_db()
+        self.assertEqual(self.diagnostic.year, 2020)
+        self.assertIsNone(self.diagnostic.creation_mtm_source)
+        self.assertIsNone(self.diagnostic.creation_mtm_campaign)
+        self.assertIsNone(self.diagnostic.creation_mtm_medium)
 
     @authenticate
-    def test_edit_diagnostic_bad_total(self):
+    def test_cannot_update_diagnostic_with_bad_total(self):
         """
         Do not save edits to a diagnostic which make the sum of the values > total
         """
         diagnostic = DiagnosticFactory(year=2019, valeur_totale=10, valeur_bio=5, valeur_siqo=2)
         diagnostic.canteen.managers.add(authenticate.user)
-
         payload = {"valeur_siqo": 999}
+
         response = self.client.patch(
             reverse(
                 "diagnostic_update",
@@ -545,17 +513,16 @@ class DiagnosticUpdateApiTest(APITestCase):
         """
         canteen = CanteenFactory(managers=[authenticate.user])
         diagnostic = DiagnosticFactory(canteen=canteen, total_leftovers=Decimal("1.23456"))
-
         payload = {
             "total_leftovers": 6666.66,
         }
+
         response = self.client.patch(
             reverse(
                 "diagnostic_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
-            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -569,17 +536,16 @@ class DiagnosticUpdateApiTest(APITestCase):
         """
         canteen = CanteenFactory(managers=[authenticate.user])
         diagnostic = DiagnosticFactory(canteen=canteen, total_leftovers=Decimal("1.23456"))
-
         payload = {
             "bread_leftovers": 100,
         }
+
         response = self.client.patch(
             reverse(
                 "diagnostic_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
-            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -594,17 +560,16 @@ class DiagnosticUpdateApiTest(APITestCase):
         """
         canteen = CanteenFactory(managers=[authenticate.user])
         diagnostic = DiagnosticFactory(canteen=canteen, total_leftovers=Decimal("1.23456"))
-
         payload = {
             "total_leftovers": 6666.666,
         }
+
         response = self.client.patch(
             reverse(
                 "diagnostic_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
-            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -618,13 +583,13 @@ class DiagnosticUpdateApiTest(APITestCase):
         payload = {
             "total_leftovers": "this shouldn't be a string",
         }
+
         response = self.client.patch(
             reverse(
                 "diagnostic_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
-            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -634,17 +599,14 @@ class DiagnosticUpdateApiTest(APITestCase):
         self.assertEqual(diagnostic.total_leftovers, Decimal("1.23456"))
 
     @authenticate
-    def test_edit_submitted_diagnostic(self):
-        """
-        A diagnostic cannot be edited if it has been teledeclared
-        """
+    def test_cannot_update_diagnostic_teledeclared(self):
         date_in_2022_teledeclaration_campaign = "2022-08-30"
         diagnostic = DiagnosticFactory(year=2021)
         diagnostic.canteen.managers.add(authenticate.user)
         with freeze_time(date_in_2022_teledeclaration_campaign):
             diagnostic.teledeclare(applicant=authenticate.user)
-
         payload = {"year": 2020}
+
         response = self.client.patch(
             reverse(
                 "diagnostic_update",
@@ -658,18 +620,15 @@ class DiagnosticUpdateApiTest(APITestCase):
         self.assertEqual(diagnostic.year, 2021)
 
     @authenticate
-    def test_edit_cancelled_diagnostic(self):
-        """
-        A diagnostic can be edited if its teledeclaration has been cancelled
-        """
+    def test_update_diagnostic_cancelled(self):
         date_in_2022_teledeclaration_campaign = "2022-08-30"
         diagnostic = DiagnosticFactory(year=2021)
         diagnostic.canteen.managers.add(authenticate.user)
         with freeze_time(date_in_2022_teledeclaration_campaign):
             diagnostic.teledeclare(applicant=authenticate.user)
             diagnostic.cancel()
-
         payload = {"year": 2020}
+
         response = self.client.patch(
             reverse(
                 "diagnostic_update",
@@ -683,7 +642,7 @@ class DiagnosticUpdateApiTest(APITestCase):
         self.assertEqual(diagnostic.year, 2020)
 
     @authenticate
-    def test_edit_cancelled_diagnostic_during_correction_campaign(self):
+    def test_update_cancelled_diagnostic_during_correction_campaign(self):
         """
         A diagnostic can be edited during the correction campaign if its teledeclaration has been cancelled
         """
@@ -697,6 +656,7 @@ class DiagnosticUpdateApiTest(APITestCase):
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
             payload = {"service_type": Diagnostic.ServiceType.MULTIPLE_SELF}
+
             response = self.client.patch(
                 reverse(
                     "diagnostic_update",
@@ -722,4 +682,5 @@ class DiagnosticDeleteApiTest(APITestCase):
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             )
         )
+
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -14,31 +14,29 @@ from data.models.creation_source import CreationSource
 
 
 class DiagnosticCreateApiTest(APITestCase):
-    def test_cannot_create_diagnostic_if_unauthenticated(self):
-        canteen = CanteenFactory()
-        payload = {"year": 2020}
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.url = reverse("diagnostic_creation", kwargs={"canteen_pk": cls.canteen.id})
+        cls.DIAGNOSTIC_PAYLOAD = {"year": 2020}
 
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
+    def test_cannot_create_diagnostic_if_unauthenticated(self):
+        response = self.client.post(self.url, self.DIAGNOSTIC_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_create_diagnostic_if_canteen_does_not_exist(self):
-        payload = {"year": 2020}
-
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": 999}), payload)
+        response = self.client.post(
+            reverse("diagnostic_creation", kwargs={"canteen_pk": 999}), self.DIAGNOSTIC_PAYLOAD
+        )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_cannot_create_diagnostic_if_not_canteen_manager(self):
-        other_user = UserFactory()
-        other_user_canteen = CanteenFactory(managers=[other_user])
-        payload = {"year": 2020}
-
-        response = self.client.post(
-            reverse("diagnostic_creation", kwargs={"canteen_pk": other_user_canteen.id}), payload
-        )
+        response = self.client.post(self.url, self.DIAGNOSTIC_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -48,10 +46,9 @@ class DiagnosticCreateApiTest(APITestCase):
         When calling this API on a canteen that the user manages
         we need to provide the required field(s)
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        payload = {}
+        self.canteen.managers.add(authenticate.user)
 
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
+        response = self.client.post(self.url, {})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -62,56 +59,50 @@ class DiagnosticCreateApiTest(APITestCase):
         we expect a diagnostic to be created
         (minimal required fields)
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        payload = {"year": 2020}
+        self.canteen.managers.add(authenticate.user)
 
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
+        response = self.client.post(self.url, self.DIAGNOSTIC_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         diagnostic = Diagnostic.objects.first()
-        self.assertEqual(diagnostic.canteen, canteen)
+        self.assertEqual(diagnostic.canteen, self.canteen)
         self.assertEqual(diagnostic.year, 2020)
         self.assertEqual(diagnostic.creation_user, authenticate.user)
 
     def test_create_minimal_diagnostic_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
-        canteen = CanteenFactory(managers=[user])
-        payload = {"year": 2020}
+        self.canteen.managers.add(user)
 
         self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
+        response = self.client.post(self.url, self.DIAGNOSTIC_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         diagnostic = Diagnostic.objects.first()
-        self.assertEqual(diagnostic.canteen, canteen)
+        self.assertEqual(diagnostic.canteen, self.canteen)
         self.assertEqual(diagnostic.year, 2020)
         self.assertEqual(diagnostic.creation_user, user)
 
     @authenticate
     def test_create_diagnostic_creation_source(self):
-        canteen = CanteenFactory()
-        canteen.managers.add(authenticate.user)
+        self.canteen.managers.add(authenticate.user)
 
         # from the APP
-        payload = {"year": 2020, "creation_source": "APP"}
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
-
+        payload = {**self.DIAGNOSTIC_PAYLOAD, "creation_source": "APP"}
+        response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        diagnostic = Diagnostic.objects.get(canteen__id=canteen.id)
+        diagnostic = Diagnostic.objects.get(canteen__id=self.canteen.id)
         self.assertEqual(diagnostic.creation_source, CreationSource.APP)
 
         # defaults to API
         payload = {"year": 2021}
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
-
+        response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        diagnostic = Diagnostic.objects.get(canteen__id=canteen.id, year=2021)
+        diagnostic = Diagnostic.objects.get(canteen__id=self.canteen.id, year=2021)
         self.assertEqual(diagnostic.creation_source, CreationSource.API)
 
         # returns a 404 if the creation_source is not valid
         payload = {"year": 2022, "creation_source": "UNKNOWN"}
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
-
+        response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @authenticate
@@ -120,7 +111,7 @@ class DiagnosticCreateApiTest(APITestCase):
         When calling this API on a canteen that the user manages
         we expect a diagnostic to be created
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
 
         payload = {
             "year": 2020,
@@ -278,10 +269,10 @@ class DiagnosticCreateApiTest(APITestCase):
             # end of detailed value fields
         }
 
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        diagnostic = Diagnostic.objects.get(canteen__id=canteen.id)
+        diagnostic = Diagnostic.objects.get(canteen__id=self.canteen.id)
         self.assertEqual(diagnostic.year, 2020)
         self.assertTrue(diagnostic.cooking_plastic_substituted)
         self.assertFalse(diagnostic.has_donation_agreement)
@@ -329,16 +320,16 @@ class DiagnosticCreateApiTest(APITestCase):
         """
         On CREATE, total_leftovers should be converted from kg to ton
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
         payload = {
-            "year": 2020,
+            **self.DIAGNOSTIC_PAYLOAD,
             "total_leftovers": 1234.56,
         }
 
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
+        response = self.client.post(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        diagnostic = Diagnostic.objects.get(canteen__id=canteen.id)
+        diagnostic = Diagnostic.objects.get(canteen__id=self.canteen.id)
         self.assertEqual(diagnostic.total_leftovers, Decimal("1.23456"))
 
     @authenticate
@@ -347,23 +338,20 @@ class DiagnosticCreateApiTest(APITestCase):
         Shouldn't be able to add a diagnostic with the same canteen, year and value for generated_from_groupe_diagnostic"
         as an existing diagnostic
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        payload = {"year": 2020, "generated_from_groupe_diagnostic": False, "valeur_bio": 10}
+        self.canteen.managers.add(authenticate.user)
+        payload = {**self.DIAGNOSTIC_PAYLOAD, "generated_from_groupe_diagnostic": False, "valeur_bio": 10}
 
-        self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
+        self.client.post(self.url, payload)
 
         try:
             with transaction.atomic():
-                payload = {"year": 2020, "generated_from_groupe_diagnostic": False, "valeur_bio": 1000}
-                response = self.client.post(
-                    reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}),
-                    payload,
-                )
+                payload = {**self.DIAGNOSTIC_PAYLOAD, "generated_from_groupe_diagnostic": False, "valeur_bio": 1000}
+                response = self.client.post(self.url, payload)
         except BadRequest:
             pass
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        diagnostic = Diagnostic.objects.get(canteen__id=canteen.id)
+        diagnostic = Diagnostic.objects.get(canteen__id=self.canteen.id)
         self.assertEqual(diagnostic.valeur_bio, 10)
 
     @authenticate
@@ -371,16 +359,16 @@ class DiagnosticCreateApiTest(APITestCase):
         """
         Do not create a diagnostic where the sum of the values is > total
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
         payload = {
-            "year": 2020,
+            **self.DIAGNOSTIC_PAYLOAD,
             "valeur_bio": 1000,
             "valeur_siqo": 1000,
             "valeur_egalim_autres": 1000,
             "valeur_totale": 2000,
         }
 
-        response = self.client.post(reverse("diagnostic_creation", kwargs={"canteen_pk": canteen.id}), payload)
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -523,6 +511,7 @@ class DiagnosticUpdateApiTest(APITestCase):
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
+            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -570,6 +559,7 @@ class DiagnosticUpdateApiTest(APITestCase):
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
+            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -239,6 +239,7 @@ class PurchaseDetailApiTest(APITestCase):
         """
         purchase = PurchaseFactory()
         response = self.client.get(reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}))
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
@@ -251,6 +252,7 @@ class PurchaseDetailApiTest(APITestCase):
         purchase = PurchaseFactory(canteen=other_user_canteen)
 
         response = self.client.get(reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}))
+
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
@@ -262,57 +264,60 @@ class PurchaseDetailApiTest(APITestCase):
         purchase = PurchaseFactory(canteen=canteen)
 
         response = self.client.get(reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["id"], purchase.id)
 
 
 class PurchaseCreateApiTest(APITestCase):
-    def test_cannot_create_purchase_if_unauthenticated(self):
-        payload = {
+    @classmethod
+    def setUpTestData(cls):
+        cls.PURCHASE_PAYLOAD = {
             "date": "2022-01-13",
-            "canteen_id": 1,
+            # "canteen_id": 1,
             "description": "Saumon",
             "provider": "Test provider",
             "family": "PRODUITS_DE_LA_MER",
-            "characteristics": ["BIO"],
+            "characteristics": ["BIO", "LOCAL"],
+            "local_definition": "AUTOUR_SERVICE",
             "price_ht": 15.23,
         }
-        response = self.client.post(reverse("purchase_list_create"), payload, format="json")
+
+    def test_cannot_create_purchase_if_unauthenticated(self):
+        canteen = CanteenFactory()
+        payload = {**self.PURCHASE_PAYLOAD, "canteen": canteen.id}
+
+        response = self.client.post(reverse("purchase_list_create"), payload)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_create_purchase_if_canteen_does_not_exist(self):
+        CanteenFactory(managers=[authenticate.user])
+        payload = {**self.PURCHASE_PAYLOAD, "canteen": 9999}
+
+        response = self.client.post(reverse("purchase_list_create"), payload)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_cannot_create_purchase_if_not_canteen_manager(self):
         other_user = UserFactory()
         other_user_canteen = CanteenFactory(managers=[other_user])
+        payload = {**self.PURCHASE_PAYLOAD, "canteen": other_user_canteen.id}
 
-        payload = {
-            "date": "2022-01-13",
-            "canteen": other_user_canteen.id,
-            "description": "Saumon",
-            "provider": "Test provider",
-            "family": "PRODUITS_DE_LA_MER",
-            "characteristics": ["BIO"],
-            "price_ht": 15.23,
-        }
-        response = self.client.post(reverse("purchase_list_create"), payload, format="json")
+        response = self.client.post(reverse("purchase_list_create"), payload)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_create_purchase(self):
         canteen = CanteenFactory(managers=[authenticate.user])
+        payload = {**self.PURCHASE_PAYLOAD, "canteen": canteen.id}
 
-        payload = {
-            "date": "2022-01-13",
-            "canteen": canteen.id,
-            "description": "Saumon",
-            "provider": "Test provider",
-            "family": "PRODUITS_DE_LA_MER",
-            "characteristics": ["BIO", "LOCAL"],
-            "price_ht": 15.23,
-            "local_definition": "AUTOUR_SERVICE",
-        }
-        response = self.client.post(reverse("purchase_list_create"), payload, format="json")
+        response = self.client.post(reverse("purchase_list_create"), payload)
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         purchase = Purchase.objects.first()
         self.assertEqual(purchase.local_definition, Purchase.Local.AUTOUR_SERVICE)
@@ -322,17 +327,7 @@ class PurchaseCreateApiTest(APITestCase):
     @authenticate
     def test_create_purchase_creation_source(self):
         canteen = CanteenFactory(managers=[authenticate.user])
-
-        payload = {
-            "date": "2022-01-13",
-            "canteen": canteen.id,
-            "description": "Saumon",
-            "provider": "Test provider",
-            "family": "PRODUITS_DE_LA_MER",
-            "characteristics": ["BIO", "LOCAL"],
-            "price_ht": 15.23,
-            "local_definition": "AUTOUR_SERVICE",
-        }
+        payload = {**self.PURCHASE_PAYLOAD, "canteen": canteen.id}
 
         # from the APP
         response = self.client.post(reverse("purchase_list_create"), {**payload, "creation_source": "APP"})
@@ -352,148 +347,116 @@ class PurchaseCreateApiTest(APITestCase):
         response = self.client.post(reverse("purchase_list_create"), {**payload, "creation_source": "UNKNOWN"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    @authenticate
-    def test_create_purchase_nonexistent_canteen(self):
-        """
-        A user cannot create a purchase for an nonexistent canteen
-        """
-        CanteenFactory(managers=[authenticate.user])
-
-        payload = {
-            "date": "2022-01-13",
-            "canteen": "9999",
-            "description": "Saumon",
-            "provider": "Test provider",
-            "family": "PRODUITS_DE_LA_MER",
-            "characteristics": ["BIO"],
-            "price_ht": 15.23,
-        }
-        response = self.client.post(reverse("purchase_list_create"), payload, format="json")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
 
 class PurchaseUpdateApiTest(APITestCase):
-    def test_update_purchases_unauthenticated(self):
-        """
-        The purchase update is only available when logged in
-        """
-        purchase = PurchaseFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.purchase = PurchaseFactory(canteen=cls.canteen, creation_user=cls.user, creation_source=CreationSource.APP)
+        cls.url = reverse("purchase_retrieve_update_destroy", kwargs={"pk": cls.purchase.id})
+
+    def test_cannot_update_purchase_if_unauthenticated(self):
         payload = {
-            "id": purchase.id,
             "price_ht": 15.23,
         }
-        response = self.client.patch(
-            reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}), payload, format="json"
-        )
+
+        response = self.client.patch(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_update_purchase_with_put(self):
-        """
-        A user cannot update the data from a purchase object with PUT
-        """
-        purchase = PurchaseFactory()
-        purchase.canteen.managers.add(authenticate.user)
-
+        self.purchase.canteen.managers.add(authenticate.user)
         payload = {
-            "id": purchase.id,
             "description": "Saumon",
             "provider": "Test provider",
             "price_ht": 15.23,
         }
 
-        response = self.client.put(
-            reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}), payload, format="json"
-        )
+        response = self.client.put(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     @authenticate
-    def test_update_purchase(self):
-        """
-        A user can update the data from a purchase object
-        """
-        purchase = PurchaseFactory()
-        purchase.canteen.managers.add(authenticate.user)
-        new_canteen = CanteenFactory(managers=[authenticate.user])
-
+    def test_cannot_update_someone_elses_purchase(self):
         payload = {
-            "id": purchase.id,
-            "canteen": new_canteen.id,
             "description": "Saumon",
             "provider": "Test provider",
             "price_ht": 15.23,
         }
 
-        response = self.client.patch(
-            reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}), payload, format="json"
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.patch(self.url, payload)
 
-        purchase.refresh_from_db()
-        self.assertEqual(purchase.canteen, new_canteen)
-        self.assertEqual(purchase.description, "Saumon")
-        self.assertEqual(purchase.provider, "Test provider")
-        self.assertEqual(float(purchase.price_ht), 15.23)
-
-    @authenticate
-    def test_update_someone_elses_purchase(self):
-        """
-        A user should not be able to update someone else's purchase object
-        """
-        purchase = PurchaseFactory()
-
-        payload = {
-            "id": purchase.id,
-            "description": "Saumon",
-            "provider": "Test provider",
-            "price_ht": 15.23,
-        }
-
-        response = self.client.patch(
-            reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}), payload, format="json"
-        )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_update_someone_elses_canteen(self):
-        """
-        A user should not be able to set someone else's canteen in a purchase update
-        """
-        purchase = PurchaseFactory()
-        purchase.canteen.managers.add(authenticate.user)
-        new_canteen = CanteenFactory()
+    def test_cannot_update_to_someone_elses_canteen(self):
+        self.purchase.canteen.managers.add(authenticate.user)
+        canteen_not_manager = CanteenFactory()
 
         payload = {
-            "id": purchase.id,
-            "canteen": new_canteen.id,
+            "canteen": canteen_not_manager.id,
         }
+        response = self.client.patch(self.url, payload)
 
-        response = self.client.patch(
-            reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}), payload, format="json"
-        )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_update_purchase_does_not_update_creation_user_and_source(self):
-        purchase = PurchaseFactory()
-        purchase.canteen.managers.add(authenticate.user)
-        self.assertEqual(purchase.creation_user, None)
-        self.assertEqual(purchase.creation_source, None)
-
+    def test_update_purchase(self):
+        self.purchase.canteen.managers.add(authenticate.user)
+        new_canteen = CanteenFactory(managers=[authenticate.user])
         payload = {
-            "id": purchase.id,
+            "canteen": new_canteen.id,
             "description": "Saumon",
             "provider": "Test provider",
             "price_ht": 15.23,
         }
 
-        response = self.client.patch(
-            reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}), payload, format="json"
-        )
+        response = self.client.patch(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        purchase.refresh_from_db()
-        self.assertEqual(purchase.creation_user, None)  # unchanged
-        self.assertEqual(purchase.creation_source, None)  # unchanged
+        self.purchase.refresh_from_db()
+        self.assertEqual(self.purchase.canteen, new_canteen)
+        self.assertEqual(self.purchase.description, "Saumon")
+        self.assertEqual(self.purchase.provider, "Test provider")
+        self.assertEqual(float(self.purchase.price_ht), 15.23)
+
+    @authenticate
+    def test_update_purchase_does_not_update_creation_user(self):
+        self.purchase.canteen.managers.add(authenticate.user)
+        payload = {
+            "description": "Saumon",
+            "provider": "Test provider",
+            "price_ht": 15.23,
+            "creation_source": CreationSource.API,
+        }
+
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.purchase.refresh_from_db()
+        self.assertEqual(self.purchase.creation_user, self.user)  # unchanged
+        # self.assertEqual(self.purchase.creation_source, CreationSource.APP)  # TODO: should not be possible
+
+    @authenticate
+    def test_update_purchase_does_not_update_creation_user_and_source(self):
+        self.purchase.canteen.managers.add(authenticate.user)
+        self.assertEqual(self.purchase.creation_user, self.user)
+        self.assertEqual(self.purchase.creation_source, CreationSource.APP)
+
+        payload = {
+            "description": "Saumon",
+            "provider": "Test provider",
+            "price_ht": 15.23,
+        }
+
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.purchase.refresh_from_db()
+        self.assertEqual(self.purchase.creation_user, self.user)  # unchanged
+        self.assertEqual(self.purchase.creation_source, CreationSource.APP)  # unchanged
 
 
 class PurchaseDeleteApiTest(APITestCase):
@@ -506,8 +469,8 @@ class PurchaseDeleteApiTest(APITestCase):
         purchase.canteen.managers.add(authenticate.user)
 
         response = self.client.delete(reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}))
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(Purchase.objects.filter(pk=purchase.id).count(), 0)
 
     @authenticate
@@ -518,8 +481,8 @@ class PurchaseDeleteApiTest(APITestCase):
         purchase = PurchaseFactory()
 
         response = self.client.delete(reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(Purchase.objects.filter(pk=purchase.id).count(), 1)
 
     def test_delete_unauthenticated(self):
@@ -529,8 +492,8 @@ class PurchaseDeleteApiTest(APITestCase):
         purchase = PurchaseFactory()
 
         response = self.client.delete(reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}))
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(Purchase.objects.filter(pk=purchase.id).count(), 1)  #
 
     @authenticate
@@ -543,9 +506,8 @@ class PurchaseDeleteApiTest(APITestCase):
         purchase_2 = PurchaseFactory(deletion_date=None)
         purchase_2.canteen.managers.add(authenticate.user)
 
-        response = self.client.post(
-            reverse("delete_purchases"), {"ids": [purchase_1.id, purchase_2.id]}, format="json"
-        )
+        response = self.client.post(reverse("delete_purchases"), {"ids": [purchase_1.id, purchase_2.id]})
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         purchase_1.refresh_from_db()
         purchase_2.refresh_from_db()
@@ -567,7 +529,8 @@ class PurchaseDeleteApiTest(APITestCase):
         not_mine = PurchaseFactory(deletion_date=None)
         ids = [purchase_should_delete.id, purchase_already_deleted.id, invalid_id, not_mine.id]
 
-        response = self.client.post(reverse("delete_purchases"), {"ids": ids}, format="json")
+        response = self.client.post(reverse("delete_purchases"), {"ids": ids})
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         purchase_should_delete.refresh_from_db()
@@ -593,8 +556,9 @@ class PurchaseRestoreApiTest(APITestCase):
         not_my_purchase = PurchaseFactory(deletion_date=date)
 
         response = self.client.post(
-            reverse("restore_purchases"), {"ids": [purchase_1.id, purchase_2.id, not_my_purchase.id]}, format="json"
+            reverse("restore_purchases"), {"ids": [purchase_1.id, purchase_2.id, not_my_purchase.id]}
         )
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["count"], 2)
@@ -616,11 +580,13 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         response = self.client.get(
             reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
         )
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_purchase_nonexistent_canteen(self):
         response = self.client.get(reverse("canteen_purchases_summary", kwargs={"canteen_pk": 999999}), {"year": 2020})
+
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
@@ -708,8 +674,8 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         response = self.client.get(
             reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["valeurTotale"], 1075.0)
         self.assertEqual(body["valeurBio"], 220.0)
@@ -816,6 +782,7 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         response = self.client.get(
             reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
         )
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["valeurTotale"], 590.0)
@@ -834,9 +801,11 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
 
     def test_purchase_summary_unauthenticated(self):
         canteen = CanteenFactory()
+
         response = self.client.get(
             reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
         )
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
@@ -907,8 +876,8 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         response = self.client.get(
             reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["valeurViandesVolailles"], 155.0)
         self.assertEqual(body["valeurViandesVolaillesEgalim"], 120.0)
@@ -981,8 +950,8 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         response = self.client.get(
             reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["valeurProduitsDeLaMer"], 160.0)
         self.assertEqual(body["valeurProduitsDeLaMerEgalim"], 125.0)
@@ -1003,6 +972,7 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         PurchaseFactory(canteen=other_canteen, price_ht=999, date="2021-01-01")
 
         response = self.client.get(reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertIn("results", body)
@@ -1017,6 +987,7 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
 class PurchaseCanteenOptionsApiTest(APITestCase):
     def test_get_purchase_options_unauthenticated(self):
         response = self.client.get(reverse("purchase_options"))
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
@@ -1034,6 +1005,7 @@ class PurchaseCanteenOptionsApiTest(APITestCase):
         PurchaseFactory(description="secret product", provider="secret provider")
 
         response = self.client.get(f"{reverse('purchase_options')}")
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(len(body["products"]), 2)
@@ -1050,6 +1022,7 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
         If not logged in, throw a 403
         """
         response = self.client.post(reverse("diagnostics_from_purchases", kwargs={"year": 2020}), {})
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
@@ -1057,7 +1030,8 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
         """
         If canteen ids are missing, throw a 400
         """
-        response = self.client.post(reverse("diagnostics_from_purchases", kwargs={"year": 2021}), {}, format="json")
+        response = self.client.post(reverse("diagnostics_from_purchases", kwargs={"year": 2021}), {})
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @freeze_time("2024-02-10")  # during the 2023 campaign
@@ -1087,8 +1061,7 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
                     canteen_without_purchases.id,
                     canteen_ok.id,
                 ]
-            },
-            format="json",
+            }
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -1140,8 +1113,7 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
 
         response = self.client.post(
             reverse("diagnostics_from_purchases", kwargs={"year": year}),
-            {"canteenIds": [canteen_site.id, central_groupe.id]},
-            format="json",
+            {"canteenIds": [canteen_site.id, central_groupe.id]}
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -1197,7 +1169,6 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
         response = self.client.post(
             reverse("diagnostics_from_purchases", kwargs={"year": year}),
             {"canteenIds": [canteen_site.id]},
-            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -1292,7 +1263,6 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-
         self.assertNotIn("valeurTotale", body)
         self.assertNotIn("lastPurchaseDate", body)
         self.assertEqual(body["percentageValeurTotale"], 1)

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -243,7 +243,7 @@ class PurchaseDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_get_someone_elses_purchase(self):
+    def test_cannot_get_if_not_canteen_manager(self):
         """
         This endpoint can only return the purchase of canteens the logged user manages
         """
@@ -273,9 +273,12 @@ class PurchaseDetailApiTest(APITestCase):
 class PurchaseCreateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.url = reverse("purchase_list_create")
         cls.PURCHASE_PAYLOAD = {
             "date": "2022-01-13",
-            # "canteen_id": 1,
+            "canteen": cls.canteen.id,
             "description": "Saumon",
             "provider": "Test provider",
             "family": "PRODUITS_DE_LA_MER",
@@ -285,38 +288,29 @@ class PurchaseCreateApiTest(APITestCase):
         }
 
     def test_cannot_create_purchase_if_unauthenticated(self):
-        canteen = CanteenFactory()
-        payload = {**self.PURCHASE_PAYLOAD, "canteen": canteen.id}
-
-        response = self.client.post(reverse("purchase_list_create"), payload)
+        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_create_purchase_if_canteen_does_not_exist(self):
-        CanteenFactory(managers=[authenticate.user])
         payload = {**self.PURCHASE_PAYLOAD, "canteen": 9999}
 
-        response = self.client.post(reverse("purchase_list_create"), payload)
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_cannot_create_purchase_if_not_canteen_manager(self):
-        other_user = UserFactory()
-        other_user_canteen = CanteenFactory(managers=[other_user])
-        payload = {**self.PURCHASE_PAYLOAD, "canteen": other_user_canteen.id}
-
-        response = self.client.post(reverse("purchase_list_create"), payload)
+        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_create_purchase(self):
-        canteen = CanteenFactory(managers=[authenticate.user])
-        payload = {**self.PURCHASE_PAYLOAD, "canteen": canteen.id}
+        self.canteen.managers.add(authenticate.user)
 
-        response = self.client.post(reverse("purchase_list_create"), payload)
+        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         purchase = Purchase.objects.first()
@@ -326,25 +320,26 @@ class PurchaseCreateApiTest(APITestCase):
 
     @authenticate
     def test_create_purchase_creation_source(self):
-        canteen = CanteenFactory(managers=[authenticate.user])
-        payload = {**self.PURCHASE_PAYLOAD, "canteen": canteen.id}
+        self.canteen.managers.add(authenticate.user)
 
         # from the APP
-        response = self.client.post(reverse("purchase_list_create"), {**payload, "creation_source": "APP"})
+        payload = {**self.PURCHASE_PAYLOAD, "creation_source": CreationSource.APP}
+        response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         created_purchase = Purchase.objects.get(pk=body["id"])
         self.assertEqual(created_purchase.creation_source, CreationSource.APP)
 
         # defaults to API
-        response = self.client.post(reverse("purchase_list_create"), payload)
+        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         created_purchase = Purchase.objects.get(pk=body["id"])
         self.assertEqual(created_purchase.creation_source, CreationSource.API)
 
         # returns a 404 if the creation_source is not valid
-        response = self.client.post(reverse("purchase_list_create"), {**payload, "creation_source": "UNKNOWN"})
+        payload = {**self.PURCHASE_PAYLOAD, "creation_source": "UNKNOWN"}
+        response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
@@ -379,7 +374,7 @@ class PurchaseUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     @authenticate
-    def test_cannot_update_someone_elses_purchase(self):
+    def test_cannot_update_if_not_canteen_manager(self):
         payload = {
             "description": "Saumon",
             "provider": "Test provider",
@@ -391,7 +386,7 @@ class PurchaseUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_update_to_someone_elses_canteen(self):
+    def test_cannot_update_to_another_canteen_if_not_canteen_manager(self):
         self.purchase.canteen.managers.add(authenticate.user)
         canteen_not_manager = CanteenFactory()
 
@@ -460,59 +455,70 @@ class PurchaseUpdateApiTest(APITestCase):
 
 
 class PurchaseDeleteApiTest(APITestCase):
-    @authenticate
-    def test_delete_purchase(self):
-        """
-        A user can delete a purchase object
-        """
-        purchase = PurchaseFactory()
-        purchase.canteen.managers.add(authenticate.user)
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.purchase = PurchaseFactory(canteen=cls.canteen, creation_user=cls.user)
+        cls.url = reverse("purchase_retrieve_update_destroy", kwargs={"pk": cls.purchase.id})
 
-        response = self.client.delete(reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}))
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(Purchase.objects.filter(pk=purchase.id).count(), 0)
-
-    @authenticate
-    def test_delete_unauthorized(self):
-        """
-        A user cannot delete a purchase object of a canteen they don't manage
-        """
-        purchase = PurchaseFactory()
-
-        response = self.client.delete(reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}))
-
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(Purchase.objects.filter(pk=purchase.id).count(), 1)
-
-    def test_delete_unauthenticated(self):
-        """
-        A user cannot delete a purchase object of a canteen if they're not authenticated
-        """
-        purchase = PurchaseFactory()
-
-        response = self.client.delete(reverse("purchase_retrieve_update_destroy", kwargs={"pk": purchase.id}))
+    def test_cannot_delete_if_unauthenticated(self):
+        response = self.client.delete(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(Purchase.objects.filter(pk=purchase.id).count(), 1)  #
+        self.assertEqual(Purchase.objects.count(), 1)
+
+    @authenticate
+    def test_cannot_delete_if_not_canteen_manager(self):
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(Purchase.objects.count(), 1)
+
+    @authenticate
+    def test_delete_purchase(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Purchase.objects.count(), 0)
+        self.assertEqual(Purchase.all_objects.count(), 1)
+
+
+class PurchaseDeleteMultipleApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.purchase_1 = PurchaseFactory(canteen=cls.canteen)
+        cls.purchase_2 = PurchaseFactory(canteen=cls.canteen)
+
+    def test_cannot_delete_multiple_if_unauthenticated(self):
+        response = self.client.post(
+            reverse("delete_purchases"), {"ids": [self.purchase_1.id, self.purchase_2.id]}, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(Purchase.objects.count(), 2)
 
     @authenticate
     def test_delete_multiple_purchases(self):
-        """
-        Given a list of purchase ids, soft delete those purchases
-        """
-        purchase_1 = PurchaseFactory(deletion_date=None)
-        purchase_1.canteen.managers.add(authenticate.user)
-        purchase_2 = PurchaseFactory(deletion_date=None)
-        purchase_2.canteen.managers.add(authenticate.user)
+        self.assertIsNone(self.purchase_1.deletion_date)
+        self.assertIsNone(self.purchase_2.deletion_date)
+        self.canteen.managers.add(authenticate.user)
 
-        response = self.client.post(reverse("delete_purchases"), {"ids": [purchase_1.id, purchase_2.id]})
+        response = self.client.post(
+            reverse("delete_purchases"), {"ids": [self.purchase_1.id, self.purchase_2.id]}, format="json"
+        )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        purchase_1.refresh_from_db()
-        purchase_2.refresh_from_db()
-        self.assertIsNotNone(purchase_1.deletion_date)
-        self.assertIsNotNone(purchase_2.deletion_date)
+        self.assertEqual(Purchase.objects.count(), 0)
+        self.assertEqual(Purchase.all_objects.count(), 2)
+        self.purchase_1.refresh_from_db()
+        self.purchase_2.refresh_from_db()
+        self.assertIsNotNone(self.purchase_1.deletion_date)
+        self.assertIsNotNone(self.purchase_2.deletion_date)
 
     @authenticate
     def test_delete_invalid_purchases(self):
@@ -529,7 +535,7 @@ class PurchaseDeleteApiTest(APITestCase):
         not_mine = PurchaseFactory(deletion_date=None)
         ids = [purchase_should_delete.id, purchase_already_deleted.id, invalid_id, not_mine.id]
 
-        response = self.client.post(reverse("delete_purchases"), {"ids": ids})
+        response = self.client.post(reverse("delete_purchases"), {"ids": ids}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
@@ -556,7 +562,7 @@ class PurchaseRestoreApiTest(APITestCase):
         not_my_purchase = PurchaseFactory(deletion_date=date)
 
         response = self.client.post(
-            reverse("restore_purchases"), {"ids": [purchase_1.id, purchase_2.id, not_my_purchase.id]}
+            reverse("restore_purchases"), {"ids": [purchase_1.id, purchase_2.id, not_my_purchase.id]}, format="json"
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -574,7 +580,7 @@ class PurchaseRestoreApiTest(APITestCase):
 
 class PurchaseCanteenSummaryApiTest(APITestCase):
     @authenticate
-    def test_purchase_not_authorized(self):
+    def test_cannot_purchase_canteen_summary_if_unauthenticated(self):
         canteen = CanteenFactory()
 
         response = self.client.get(
@@ -584,7 +590,7 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_purchase_nonexistent_canteen(self):
+    def test_cannot_purchase_canteen_summary_if_canteen_unknown(self):
         response = self.client.get(reverse("canteen_purchases_summary", kwargs={"canteen_pk": 999999}), {"year": 2020})
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -799,15 +805,6 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         self.assertEqual(body["valeurViandesVolaillesNonEgalim"], 90.0)
         self.assertEqual(body["valeurExternalitesPerformance"], 0.0)
 
-    def test_purchase_summary_unauthenticated(self):
-        canteen = CanteenFactory()
-
-        response = self.client.get(
-            reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
     @authenticate
     def test_purchase_meat_totals(self):
         """
@@ -985,7 +982,7 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
 
 
 class PurchaseCanteenOptionsApiTest(APITestCase):
-    def test_get_purchase_options_unauthenticated(self):
+    def test_cannot_get_purchase_options_if_unauthenticated(self):
         response = self.client.get(reverse("purchase_options"))
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -1017,10 +1014,7 @@ class PurchaseCanteenOptionsApiTest(APITestCase):
 
 
 class DiagnosticsFromPurchasesApiTest(APITestCase):
-    def test_unauthorised_create_diagnostics_from_purchases(self):
-        """
-        If not logged in, throw a 403
-        """
+    def test_cannot_create_diagnostics_from_purchases_if_unauthenticated(self):
         response = self.client.post(reverse("diagnostics_from_purchases", kwargs={"year": 2020}), {})
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -1061,7 +1055,8 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
                     canteen_without_purchases.id,
                     canteen_ok.id,
                 ]
-            }
+            },
+            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -1113,7 +1108,8 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
 
         response = self.client.post(
             reverse("diagnostics_from_purchases", kwargs={"year": year}),
-            {"canteenIds": [canteen_site.id, central_groupe.id]}
+            {"canteenIds": [canteen_site.id, central_groupe.id]},
+            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -1169,6 +1165,7 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
         response = self.client.post(
             reverse("diagnostics_from_purchases", kwargs={"year": year}),
             {"canteenIds": [canteen_site.id]},
+            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -1305,7 +1302,7 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_get_last_purchase_date_in_public_summary_if_manager(self):
+    def test_get_last_purchase_date_in_public_summary_if_canteen_manager(self):
         """
         The purchases summary should return the last purchase date if the user
         is the manager of the canteen
@@ -1322,7 +1319,7 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         self.assertEqual(body["lastPurchaseDate"], "2024-12-01")
 
     @authenticate
-    def test_dont_get_last_purchase_date_in_public_summary_if_not_manager(self):
+    def test_dont_get_last_purchase_date_in_public_summary_if_not_canteen_manager(self):
         """
         The purchases summary should not return the last purchase date if the user
         is not the manager of the canteen, even if authenticated


### PR DESCRIPTION
Modifications apportées
- saut à la ligne pour avoir bien les 3 blocs setup / test / assert
- utiliser setUpTestData pour les update de Canteen, Purchase & Diagnostic
- ordonner par fail d'abord, puis success
- clarifier le nommage de certains des tests
- ajouter certains tests manquants (if_unauthenticated, if not_canteen_manager)