### PR TITLE
fix(Cantines): dans l'API canteenStatus, ne plus appeler l'API Adresse (répare le formulaire de création de cantines)

### DIFF
--- a/2024-frontend/src/components/CanteenEstablishmentCard.vue
+++ b/2024-frontend/src/components/CanteenEstablishmentCard.vue
@@ -31,7 +31,7 @@ const linkedCanteensLabel = computed(() => {
           <p class="fr-mb-0 fr-text--xs">{{ siret ? "SIRET" : "SIREN" }} : {{ siret || siren }}</p>
         </li>
         <li>
-          <p class="fr-mb-0 fr-text--xs">Ville : {{ city }} ({{ department }})</p>
+          <p class="fr-mb-0 fr-text--xs">Ville : {{ city }}<span v-if="department"> ({{ department }})</span></p>
         </li>
       </ul>
     </div>

--- a/api/tests/test_canteen_status.py
+++ b/api/tests/test_canteen_status.py
@@ -9,7 +9,6 @@ from rest_framework.test import APITestCase
 from api.tests.utils import authenticate
 from data.factories import CanteenFactory
 from common.api.recherche_entreprises import mock_fetch_geo_data_from_siret, mock_fetch_geo_data_from_siren
-from common.api.adresse import mock_fetch_geo_data_from_code
 
 
 class CanteenStatusBySiretApiTest(APITestCase):
@@ -75,7 +74,6 @@ class CanteenStatusBySiretApiTest(APITestCase):
     @authenticate
     def test_check_siret_new_canteen(self, mock):
         mock_fetch_geo_data_from_siret(mock, self.siret)
-        mock_fetch_geo_data_from_code(mock, self.insee_code)
 
         response = self.client.get(self.url)
 
@@ -87,7 +85,7 @@ class CanteenStatusBySiretApiTest(APITestCase):
         self.assertEqual(body["postalCode"], "59100")
         self.assertEqual(body["city"], "ROUBAIX")
         self.assertEqual(body["cityInseeCode"], "59512")
-        self.assertEqual(body["department"], "38")
+        # self.assertEqual(body["department"], "38")
 
     @requests_mock.Mocker()
     @authenticate
@@ -115,7 +113,7 @@ class CanteenStatusBySiretApiTest(APITestCase):
         self.assertNotIn("postalCode", body)
         self.assertNotIn("city", body)
         self.assertNotIn("cityInseeCode", body)
-        self.assertNotIn("department", body)
+        # self.assertNotIn("department", body)
 
 
 class CanteenStatusBySirenApiTest(APITestCase):
@@ -139,7 +137,7 @@ class CanteenStatusBySirenApiTest(APITestCase):
         self.assertEqual(body["postalCode"], "59100")
         self.assertEqual(body["city"], "ROUBAIX")
         self.assertEqual(body["cityInseeCode"], "59512")
-        self.assertEqual(body["department"], "59")
+        # self.assertEqual(body["department"], "59")
 
     @requests_mock.Mocker()
     @authenticate
@@ -170,4 +168,4 @@ class CanteenStatusBySirenApiTest(APITestCase):
         self.assertNotIn("postalCode", body)
         self.assertNotIn("city", body)
         self.assertNotIn("cityInseeCode", body)
-        self.assertNotIn("department", body)
+        # self.assertNotIn("department", body)

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -47,7 +47,6 @@ from api.serializers import (
     PublicCanteenSerializer,
 )
 from api.views.utils import update_change_reason_with_auth
-from common.api.adresse import fetch_geo_data_from_code
 from common.api.recherche_entreprises import fetch_geo_data_from_siren, fetch_geo_data_from_siret
 from common.utils import send_mail
 from data.models import Canteen, Diagnostic, ManagerInvitation, Sector, SectorM2M
@@ -444,11 +443,11 @@ class CanteenStatusBySiretView(APIView):
             response = fetch_geo_data_from_siret(siret)
             if not response:
                 return Response(None, status=status.HTTP_204_NO_CONTENT)
-            city = response.get("city", None)
-            city_insee_code = response.get("city_insee_code", None)
-            postcode = response.get("postal_code", None)
-            if city and postcode:
-                response = {**response, **fetch_geo_data_from_code(city_insee_code)}
+            # city = response.get("city", None)
+            # city_insee_code = response.get("city_insee_code", None)
+            # postcode = response.get("postal_code", None)
+            # if city and postcode:
+            #     response = {**response, **fetch_geo_data_from_code(city_insee_code)}
         return Response(response, status=status.HTTP_200_OK)
 
 

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -443,11 +443,6 @@ class CanteenStatusBySiretView(APIView):
             response = fetch_geo_data_from_siret(siret)
             if not response:
                 return Response(None, status=status.HTTP_204_NO_CONTENT)
-            # city = response.get("city", None)
-            # city_insee_code = response.get("city_insee_code", None)
-            # postcode = response.get("postal_code", None)
-            # if city and postcode:
-            #     response = {**response, **fetch_geo_data_from_code(city_insee_code)}
         return Response(response, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
`CanteenStatusBySiretView` : ne plus appeler `api.adresse.fetch_geo_data_from_code`
- c'était utile pour avoir la ville en minuscule + le département
- mini modif frontend pour cacher les parenthèses si le département n'est pas retourné
- ca sera le cas, car l'API Recherche Entreprise ne le renvoi pas...