### PR TITLE
improve(Achats): gérer EUROPE dans les calculs d'aggrégation

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -538,13 +538,11 @@ class Diagnostic(models.Model):
     APPRO_LABELS_NON_EGALIM = [
         "non_egalim",
     ]
-    APPRO_LABELS_FRANCE_SUBCATEGORIES = [
-        "circuit_court",
-        "local",
-    ]
-    APPRO_LABELS_FRANCE = ["france"] + APPRO_LABELS_FRANCE_SUBCATEGORIES
+    APPRO_LABELS_ORIGINE = ["europe", "france"]
     APPRO_LABELS = APPRO_LABELS_EGALIM + APPRO_LABELS_NON_EGALIM
-    APPRO_LABELS_ALL = APPRO_LABELS + ["bio_dont_commerce_equitable"] + APPRO_LABELS_FRANCE
+    APPRO_LABELS_ALL = (
+        APPRO_LABELS + ["bio_dont_commerce_equitable"] + APPRO_LABELS_ORIGINE + ["circuit_court", "local"]
+    )
     APPRO_LABELS_GROUPS_MAPPING = {
         "bio": ["bio"],
         "siqo": ["label_rouge", "aocaop_igp_stg"],
@@ -1789,8 +1787,8 @@ class Diagnostic(models.Model):
             family = "produits_de_la_mer"
             total_fish_egalim = total_fish_egalim + (getattr(self, f"valeur_{family}_{label}") or 0)
 
-        # NOTE: stop populating france from APPRO_LABELS_FRANCE
-        # for label in Diagnostic.APPRO_LABELS_FRANCE:
+        # NOTE: stop populating france from ["france", "circuit_court", "local"]
+        # for label in ["france", "circuit_court", "local"]:
         #     family = "viandes_volailles"
         #     total_meat_france = total_meat_france + (getattr(self, f"valeur_{family}_{label}") or 0)
 
@@ -1844,7 +1842,7 @@ class Diagnostic(models.Model):
 
     def family_sum(self, family: str):
         """
-        NOTE: APPRO_LABELS does not include APPRO_LABELS_FRANCE
+        NOTE: APPRO_LABELS does not include APPRO_LABELS_ORIGINE & circuit_court & local
         """
         sum = 0
         for label in Diagnostic.APPRO_LABELS:

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -538,7 +538,7 @@ class Diagnostic(models.Model):
     APPRO_LABELS_NON_EGALIM = [
         "non_egalim",
     ]
-    APPRO_LABELS_ORIGINE = ["europe", "france"]
+    APPRO_LABELS_ORIGINE = ["france"]  # TODO: add "europe" before
     APPRO_LABELS = APPRO_LABELS_EGALIM + APPRO_LABELS_NON_EGALIM
     APPRO_LABELS_ALL = (
         APPRO_LABELS + ["bio_dont_commerce_equitable"] + APPRO_LABELS_ORIGINE + ["circuit_court", "local"]

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -463,7 +463,7 @@ class Purchase(SoftDeletionModel):
 
         for family in Diagnostic.APPRO_FAMILIES:
             purchase_family = purchases.filter(family=family.upper())
-            for label in ["france", "circuit_court", "local"]:
+            for label in ["circuit_court", "local"]:  # "france" is done just after
                 purchase_family_label = purchase_family.filter(
                     Q(characteristics__contains=[cls.Characteristic[label.upper()]])
                 )

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -180,19 +180,21 @@ class Purchase(SoftDeletionModel):
         Characteristic.COMMERCE_EQUITABLE,
     ]
 
-    CHARACTERISTIC_LABELS_ORIGINE = [Characteristic.EUROPE, Characteristic.FRANCE]
-
-    CHARACTERISTIC_LABELS_ORIGINE_CIRCUIT_COURT_LOCAL = CHARACTERISTIC_LABELS_ORIGINE + [
-        Characteristic.CIRCUIT_COURT,
-        Characteristic.LOCAL,
-    ]
-
+    # when transformed into diagnostics, only the top label will be counted
     CHARACTERISTIC_LABELS_EGALIM = (
         CHARACTERISTIC_LABELS_BIO
         + CHARACTERISTIC_LABELS_SIQO
         + CHARACTERISTIC_LABELS_EXTERNALITES_PERFORMANCE
         + CHARACTERISTIC_LABELS_EGALIM_AUTRES
     )
+
+    CHARACTERISTIC_LABELS_ORIGINE = [Characteristic.EUROPE, Characteristic.FRANCE]
+
+    # when transformed into diagnostics, all labels will be counted
+    CHARACTERISTIC_LABELS_INFO = CHARACTERISTIC_LABELS_ORIGINE + [
+        Characteristic.CIRCUIT_COURT,
+        Characteristic.LOCAL,
+    ]
 
     CREATION_META_FIELDS = [
         "creation_date",
@@ -417,7 +419,7 @@ class Purchase(SoftDeletionModel):
         """
         How we manage bio_dont_commerce_equitable:
         - outside of APPRO_LABELS_EGALIM
-        - products can be counted twice across characteristics
+        - products can be counted twice across caracteristiques
         """
         from data.models import Diagnostic
 
@@ -435,48 +437,45 @@ class Purchase(SoftDeletionModel):
         """
         How we manage France/Circuit court/local:
         - outside of APPRO_LABELS_EGALIM
-        - products can be counted in multiple of these characteristics
+        - products can be counted in multiple of these caracteristiques
         - NOTE: before 2025, circuit_court & local are not counted as France
         - NOTE: before 2025, Europe did not exist yet
         """
         from data.models import Diagnostic
 
         for family in Diagnostic.APPRO_FAMILIES:
-            purchase_family = purchases.filter(family=family.upper())
+            purchase_family = purchases.filter(famille_produits=family.upper())
             for label in ["france", "circuit_court", "local"]:
                 purchase_family_label = purchase_family.filter(
-                    Q(characteristics__contains=[cls.Characteristic[label.upper()]])
+                    Q(caracteristiques__contains=[cls.Characteristic[label.upper()]])
                 )
                 key = "valeur_" + family + "_" + label.lower()
-                data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
+                data[key] = purchase_family_label.aggregate(total=Sum("prix_ht"))["total"] or 0
 
     @classmethod
     def _complete_diag_appro_labels_origine_circuit_court_local_2025(cls, purchases, data):
         """
         How we manage France/Circuit court/local:
         - outside of APPRO_LABELS_EGALIM
-        - products can be counted in multiple of these characteristics
+        - products can be counted in multiple of these caracteristiques
         - NOTE: in 2025, circuit_court & local were part of France, so we count them as France
         - NOTE: in 2025, Europe did not exist yet
         """
         from data.models import Diagnostic
 
         for family in Diagnostic.APPRO_FAMILIES:
-            purchase_family = purchases.filter(family=family.upper())
+            purchase_family = purchases.filter(famille_produits=family.upper())
             for label in ["circuit_court", "local"]:  # "france" is done just after
                 purchase_family_label = purchase_family.filter(
-                    Q(characteristics__contains=[cls.Characteristic[label.upper()]])
+                    Q(caracteristiques__contains=[cls.Characteristic[label.upper()]])
                 )
                 key = "valeur_" + family + "_" + label
-                data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
+                data[key] = purchase_family_label.aggregate(total=Sum("prix_ht"))["total"] or 0
             # France total
-            CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL = [
-                cls.Characteristic.FRANCE,
-                cls.Characteristic.CIRCUIT_COURT,
-                cls.Characteristic.LOCAL,
-            ]
             purchase_family_label = purchase_family.filter(
-                caracteristiques__overlap=CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL
+                caracteristiques__overlap=[
+                    cls.Characteristic(label.upper()) for label in ["france", "circuit_court", "local"]
+                ]
             ).distinct()
             key = "valeur_" + family + "_france"
             data[key] = purchase_family_label.aggregate(total=Sum("prix_ht"))["total"] or 0
@@ -486,17 +485,17 @@ class Purchase(SoftDeletionModel):
         """
         How we manage France/Europe/Circuit court/local:
         - outside of APPRO_LABELS_EGALIM
-        - products can be counted in multiple of these characteristics
+        - products can be counted in multiple of these caracteristiques
         - NOTE: circuit_court & local are not counted as France
         - NOTE: in 2026, Europe was added
         """
         from data.models import Diagnostic
 
         for family in Diagnostic.APPRO_FAMILIES:
-            purchase_family = purchases.filter(family=family.upper())
-            for label in cls.CHARACTERISTIC_LABELS_ORIGINE_CIRCUIT_COURT_LOCAL:
+            purchase_family = purchases.filter(famille_produits=family.upper())
+            for label in cls.CHARACTERISTIC_LABELS_INFO:
                 purchase_family_label = purchase_family.filter(
-                    Q(characteristics__contains=[cls.Characteristic[label]])
+                    Q(caracteristiques__contains=[cls.Characteristic[label]])
                 )
                 key = "valeur_" + family + "_" + label.lower()
                 data[key] = purchase_family_label.aggregate(total=Sum("prix_ht"))["total"] or 0

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -180,8 +180,9 @@ class Purchase(SoftDeletionModel):
         Characteristic.COMMERCE_EQUITABLE,
     ]
 
-    CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL = [
-        Characteristic.FRANCE,
+    CHARACTERISTIC_LABELS_ORIGINE = [Characteristic.EUROPE, Characteristic.FRANCE]
+
+    CHARACTERISTIC_LABELS_ORIGINE_CIRCUIT_COURT_LOCAL = CHARACTERISTIC_LABELS_ORIGINE + [
         Characteristic.CIRCUIT_COURT,
         Characteristic.LOCAL,
     ]
@@ -371,10 +372,12 @@ class Purchase(SoftDeletionModel):
         """
         cls._complete_diag_data_appro_labels(purchases, data)
         cls._complete_diag_data_appro_label_bio_dont_commerce_equitable(purchases, data)
-        if int(year) == 2025:
-            cls._complete_diag_appro_labels_france_circuit_court_local_2025(purchases, data)
+        if int(year) < 2025:
+            cls._complete_diag_appro_labels_origine_circuit_court_local_before_2025(purchases, data)
+        elif int(year) == 2025:
+            cls._complete_diag_appro_labels_origine_circuit_court_local_2025(purchases, data)
         else:
-            cls._complete_diag_appro_labels_france_circuit_court_local(purchases, data)
+            cls._complete_diag_appro_labels_origine_circuit_court_local(purchases, data)
         cls._complete_diag_appro_labels_non_egalim(purchases, data)
 
     @classmethod
@@ -428,7 +431,27 @@ class Purchase(SoftDeletionModel):
             data[key] = purchase_family_label.aggregate(total=Sum("prix_ht"))["total"] or 0
 
     @classmethod
-    def _complete_diag_appro_labels_france_circuit_court_local_2025(cls, purchases, data):
+    def _complete_diag_appro_labels_origine_circuit_court_local_before_2025(cls, purchases, data):
+        """
+        How we manage France/Circuit court/local:
+        - outside of APPRO_LABELS_EGALIM
+        - products can be counted in multiple of these characteristics
+        - NOTE: before 2025, circuit_court & local are not counted as France
+        - NOTE: before 2025, Europe did not exist yet
+        """
+        from data.models import Diagnostic
+
+        for family in Diagnostic.APPRO_FAMILIES:
+            purchase_family = purchases.filter(family=family.upper())
+            for label in ["france", "circuit_court", "local"]:
+                purchase_family_label = purchase_family.filter(
+                    Q(characteristics__contains=[cls.Characteristic[label.upper()]])
+                )
+                key = "valeur_" + family + "_" + label.lower()
+                data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
+
+    @classmethod
+    def _complete_diag_appro_labels_origine_circuit_court_local_2025(cls, purchases, data):
         """
         How we manage France/Circuit court/local:
         - outside of APPRO_LABELS_EGALIM
@@ -439,37 +462,42 @@ class Purchase(SoftDeletionModel):
         from data.models import Diagnostic
 
         for family in Diagnostic.APPRO_FAMILIES:
-            purchase_family = purchases.filter(famille_produits=family.upper())
-            other_labels_characteristics = []
-            for label in Diagnostic.APPRO_LABELS_FRANCE_SUBCATEGORIES:
-                characteristic = cls.Characteristic[label.upper()]
-                purchase_family_label = purchase_family.filter(Q(caracteristiques__contains=[characteristic]))
+            purchase_family = purchases.filter(family=family.upper())
+            for label in ["france", "circuit_court", "local"]:
+                purchase_family_label = purchase_family.filter(
+                    Q(characteristics__contains=[cls.Characteristic[label.upper()]])
+                )
                 key = "valeur_" + family + "_" + label
-                data[key] = purchase_family_label.aggregate(total=Sum("prix_ht"))["total"] or 0
-                other_labels_characteristics.append(characteristic)
+                data[key] = purchase_family_label.aggregate(total=Sum("price_ht"))["total"] or 0
             # France total
+            CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL = [
+                cls.Characteristic.FRANCE,
+                cls.Characteristic.CIRCUIT_COURT,
+                cls.Characteristic.LOCAL,
+            ]
             purchase_family_label = purchase_family.filter(
-                caracteristiques__overlap=cls.CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL
+                caracteristiques__overlap=CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL
             ).distinct()
             key = "valeur_" + family + "_france"
             data[key] = purchase_family_label.aggregate(total=Sum("prix_ht"))["total"] or 0
 
     @classmethod
-    def _complete_diag_appro_labels_france_circuit_court_local(cls, purchases, data):
+    def _complete_diag_appro_labels_origine_circuit_court_local(cls, purchases, data):
         """
-        How we manage France/Circuit court/local:
+        How we manage France/Europe/Circuit court/local:
         - outside of APPRO_LABELS_EGALIM
         - products can be counted in multiple of these characteristics
         - NOTE: circuit_court & local are not counted as France
-        - TODO: in 2026, Europe was added
+        - NOTE: in 2026, Europe was added
         """
         from data.models import Diagnostic
 
         for family in Diagnostic.APPRO_FAMILIES:
-            purchase_family = purchases.filter(famille_produits=family.upper())
-            for label in cls.CHARACTERISTIC_LABELS_FRANCE_CIRCUIT_COURT_LOCAL:
-                characteristic = cls.Characteristic[label]
-                purchase_family_label = purchase_family.filter(Q(caracteristiques__contains=[characteristic]))
+            purchase_family = purchases.filter(family=family.upper())
+            for label in cls.CHARACTERISTIC_LABELS_ORIGINE_CIRCUIT_COURT_LOCAL:
+                purchase_family_label = purchase_family.filter(
+                    Q(characteristics__contains=[cls.Characteristic[label]])
+                )
                 key = "valeur_" + family + "_" + label.lower()
                 data[key] = purchase_family_label.aggregate(total=Sum("prix_ht"))["total"] or 0
 

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -214,19 +214,33 @@ class PurchaseSummaryFranceTest(TestCase):
             prix_ht=15,
         )
 
-    def test_canteen_summary_for_year_france_seperated(self):
+    def test_canteen_summary_for_year_france_2026(self):
+        # in 2026, Europe was added
         result = Purchase.canteen_summary_for_year(self.canteen, 2026)
 
+        self.assertEqual(result["valeur_boulangerie_europe"], 15)
         self.assertEqual(result["valeur_boulangerie_france"], 10 + 15)
         self.assertEqual(result["valeur_boulangerie_circuit_court"], 50 + 15)
         self.assertEqual(result["valeur_boulangerie_local"], 15 + 15)
 
-    def test_canteen_summary_for_year_france_before_2026(self):
-        # before 2026, circuit court and local were counted as France
+    def test_canteen_summary_for_year_france_2025(self):
+        # in 2025, circuit court and local were counted as France
         Purchase.objects.filter(canteen=self.canteen).update(date="2025-11-01")
 
         result = Purchase.canteen_summary_for_year(self.canteen, 2025)
 
+        self.assertNotIn("valeur_boulangerie_europe", result)
         self.assertEqual(result["valeur_boulangerie_france"], 10 + 50 + 15 + 15)
+        self.assertEqual(result["valeur_boulangerie_circuit_court"], 50 + 15)
+        self.assertEqual(result["valeur_boulangerie_local"], 15 + 15)
+
+    def test_canteen_summary_for_year_france_2024(self):
+        # before 2025, circuit court and local were seperated from France (like 2026)
+        Purchase.objects.filter(canteen=self.canteen).update(date="2024-11-01")
+
+        result = Purchase.canteen_summary_for_year(self.canteen, 2024)
+
+        self.assertNotIn("valeur_boulangerie_europe", result)
+        self.assertEqual(result["valeur_boulangerie_france"], 10 + 15)
         self.assertEqual(result["valeur_boulangerie_circuit_court"], 50 + 15)
         self.assertEqual(result["valeur_boulangerie_local"], 15 + 15)

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -213,12 +213,28 @@ class PurchaseSummaryFranceTest(TestCase):
             famille_produits=Purchase.Family.BOULANGERIE,
             prix_ht=15,
         )
+        PurchaseFactory(
+            canteen=cls.canteen,
+            date="2026-11-01",
+            caracteristiques=[Purchase.Characteristic.EUROPE],
+            famille_produits=Purchase.Family.BOULANGERIE,
+            prix_ht=5,
+        )
+        PurchaseFactory(
+            canteen=cls.canteen,
+            date="2026-11-01",
+            caracteristiques=[],
+            famille_produits=Purchase.Family.BOULANGERIE,
+            prix_ht=5,
+        )
 
-    def test_canteen_summary_for_year_france_2026(self):
-        # in 2026, Europe was added
-        result = Purchase.canteen_summary_for_year(self.canteen, 2026)
+    def test_canteen_summary_for_year_france_2024(self):
+        # before 2025, circuit court and local were seperated from France (like 2026)
+        Purchase.objects.filter(canteen=self.canteen).update(date="2024-11-01")
 
-        self.assertEqual(result["valeur_boulangerie_europe"], 15)
+        result = Purchase.canteen_summary_for_year(self.canteen, 2024)
+
+        self.assertNotIn("valeur_boulangerie_europe", result)
         self.assertEqual(result["valeur_boulangerie_france"], 10 + 15)
         self.assertEqual(result["valeur_boulangerie_circuit_court"], 50 + 15)
         self.assertEqual(result["valeur_boulangerie_local"], 15 + 15)
@@ -234,13 +250,11 @@ class PurchaseSummaryFranceTest(TestCase):
         self.assertEqual(result["valeur_boulangerie_circuit_court"], 50 + 15)
         self.assertEqual(result["valeur_boulangerie_local"], 15 + 15)
 
-    def test_canteen_summary_for_year_france_2024(self):
-        # before 2025, circuit court and local were seperated from France (like 2026)
-        Purchase.objects.filter(canteen=self.canteen).update(date="2024-11-01")
+    def test_canteen_summary_for_year_france_2026(self):
+        # in 2026, Europe was added
+        result = Purchase.canteen_summary_for_year(self.canteen, 2026)
 
-        result = Purchase.canteen_summary_for_year(self.canteen, 2024)
-
-        self.assertNotIn("valeur_boulangerie_europe", result)
+        self.assertEqual(result["valeur_boulangerie_europe"], 15 + 5)
         self.assertEqual(result["valeur_boulangerie_france"], 10 + 15)
         self.assertEqual(result["valeur_boulangerie_circuit_court"], 50 + 15)
         self.assertEqual(result["valeur_boulangerie_local"], 15 + 15)


### PR DESCRIPTION
Suite à #6708 (nouveau `Characterist.EUROPE`) & #6731 (nouvelle gestion des aggrégations France)

A partir de 2026, on gère maintenant EUROPE

La PR coté Diagnostic - #6790 - viendra plus tard quand on s'attaquera au chantier TD 2026