### PR TITLE
refactor(Diagnostic): plus besoin de meal_price_annotated, ménage

### DIFF
--- a/api/serializers/diagnostic_teledeclaration.py
+++ b/api/serializers/diagnostic_teledeclaration.py
@@ -16,7 +16,7 @@ class DiagnosticTeledeclaredAnalysisSerializer(serializers.ModelSerializer):
     siren_unite_legale = serializers.CharField(source="canteen_snapshot.siren_unite_legale", read_only=True)
     daily_meal_count = serializers.IntegerField(source="canteen_snapshot.daily_meal_count", read_only=True)
     yearly_meal_count = serializers.IntegerField(source="canteen_snapshot.yearly_meal_count", read_only=True)
-    cout_denrees = serializers.SerializerMethodField()
+    cout_denrees = serializers.FloatField(source="cout_repas", read_only=True)
     cuisine_centrale = serializers.SerializerMethodField()
     central_producer_siret = serializers.CharField(source="canteen_snapshot.central_producer_siret", read_only=True)
     code_insee_commune = serializers.CharField(source="canteen_snapshot.city_insee_code", read_only=True)
@@ -159,9 +159,6 @@ class DiagnosticTeledeclaredAnalysisSerializer(serializers.ModelSerializer):
             "genere_par_cuisine_centrale",
         )
         read_only_fields = fields
-
-    def get_cout_denrees(self, obj):
-        return obj.meal_price_annotated if obj.meal_price_annotated else -1
 
     def get_cuisine_centrale(self, obj):
         production_type = obj.canteen_snapshot.get("production_type", None)

--- a/api/views/diagnostic_teledeclaration.py
+++ b/api/views/diagnostic_teledeclaration.py
@@ -312,11 +312,7 @@ class DiagnosticTeledeclaredAnalysisListView(ListAPIView):
     ordering_fields = ["creation_date"]
 
     def get_queryset(self):
-        return (
-            Diagnostic.objects.with_meal_price()
-            .valid_td_all_years(CAMPAIGN_DATES.keys())
-            .order_by("teledeclaration_date")
-        )
+        return Diagnostic.objects.valid_td_all_years(CAMPAIGN_DATES.keys()).order_by("teledeclaration_date")
 
 
 class DiagnosticTeledeclaredOpenDataListView(ListAPIView):

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -5,10 +5,9 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator
 from django.db import models, transaction
-from django.db.models import Case, DecimalField, F, Func, IntegerField, Q, Sum, Value, When
+from django.db.models import DecimalField, F, Func, IntegerField, Q, Sum, Value
 from django.db.models.expressions import RawSQL
-from django.db.models.fields.json import KT
-from django.db.models.functions import Cast, Coalesce
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 from simple_history.models import HistoricalRecords
 
@@ -133,10 +132,8 @@ def aberrant_values_query():
     - Coût denrées existe et > 20 euros ET valeur d'achat alimentaires > 1 million d'euros
     Dans le cas particulier où le nombre de repas annuel n'est pas renseigné,
     nous laissons la TD même si la valeur alimentaire est > 1 million d'euros)
-
-    Note: requires meal_price annotation
     """
-    return Q(meal_price_annotated__isnull=False, meal_price_annotated__gt=20, valeur_totale__gt=1000000)
+    return Q(cout_repas__isnull=False, cout_repas__gt=20, valeur_totale__gt=1000000)
 
 
 def incoherent_values_query():
@@ -263,25 +260,6 @@ class DiagnosticQuerySet(models.QuerySet):
         )
         return self.annotate(**{f"{family}_sum": sum_expression})
 
-    def with_meal_price(self):
-        """
-        Le coût denrées est calculé en divisant la valeur d'achat alimentaire total par le nombre de repas annuels.
-        """
-        # Cast to FloatField first to handle legacy float values in JSON, then to IntegerField
-        return self.annotate(
-            canteen_yearly_meal_count_annotated=Cast(
-                KT("canteen_snapshot__yearly_meal_count"), output_field=IntegerField()
-            )
-        ).annotate(
-            meal_price_annotated=Case(
-                When(
-                    canteen_yearly_meal_count_annotated__gt=0,
-                    then=F("valeur_totale") / F("canteen_yearly_meal_count_annotated"),
-                ),
-                default=None,
-            )
-        )
-
     def with_satellites_snapshot_stats(self):
         return self.annotate(
             satellites_snapshot_count_annotated=Func(
@@ -294,9 +272,6 @@ class DiagnosticQuerySet(models.QuerySet):
                 output_field=IntegerField(),
             )
         )
-
-    def exclude_aberrant_values(self):
-        return self.with_meal_price().exclude(aberrant_values_query())
 
     def canteen_for_stat(self, year):
         return (
@@ -315,7 +290,7 @@ class DiagnosticQuerySet(models.QuerySet):
                 .exclude(teledeclaration_mode_satellite_without_appro_query())
                 .filter(valeur_bio_agg_is_filled_query())  # Chaîne de traitement n°5
                 .canteen_for_stat(year)  # Chaîne de traitement n°6 & n°7
-                .exclude_aberrant_values()  # Chaîne de traitement n°8
+                .exclude(aberrant_values_query())  # Chaîne de traitement n°8
                 .exclude(incoherent_values_query())  # Chaîne de traitement n°8
             )
         else:

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -5,12 +5,12 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
 from freezegun import freeze_time
-from api.tests.utils import assert_almost_equal
 
 from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 from data.models import Canteen, Sector
 from data.models.diagnostic import (
     Diagnostic,
+    aberrant_values_query,
     canteen_has_siret_or_siren_unite_legale_query,
     canteen_soft_deleted_during_campaign_query,
     circuit_court_sup_france_query,
@@ -381,7 +381,7 @@ class DiagnosticQuerySetTest(TestCase):
         cls.canteen_missing_siret.siret = ""  # missing data
         cls.canteen_missing_siret.save(skip_validations=True)
         cls.canteen_missing_siret.refresh_from_db()
-        cls.canteen_meal_price_aberrant = CanteenFactory(siret="21670482500019", yearly_meal_count=1000)
+        cls.canteen_cout_repas_aberrant = CanteenFactory(siret="21670482500019", yearly_meal_count=1000)
         cls.canteen_valeur_totale_aberrant = CanteenFactory(siret="21630113500010", yearly_meal_count=100000)
         cls.canteen_aberrant = CanteenFactory(siret="21130055300016", yearly_meal_count=1000)
         cls.canteen_deleted = CanteenFactory(
@@ -439,24 +439,24 @@ class DiagnosticQuerySetTest(TestCase):
         with freeze_time(date_in_teledeclaration_campaign):
             cls.diagnostic_canteen_missing_siret.teledeclare(applicant=UserFactory(), skip_validations=True)
 
-        cls.diagnostic_canteen_meal_price_aberrant = DiagnosticFactory(
+        cls.diagnostic_canteen_cout_repas_aberrant = DiagnosticFactory(
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
             year=year_data,
             creation_date=date_in_teledeclaration_campaign,
-            canteen=cls.canteen_meal_price_aberrant,
-            valeur_totale=1000000.00,  # meal_price > 20
+            canteen=cls.canteen_cout_repas_aberrant,
+            valeur_totale=1000000.00,  # cout_repas > 20
             valeur_bio=200.00,
             invalid_reason_list=[Diagnostic.InvalidReason.VALEURS_ABERRANTES],
         )
         with freeze_time(date_in_teledeclaration_campaign):
-            cls.diagnostic_canteen_meal_price_aberrant.teledeclare(applicant=UserFactory())
+            cls.diagnostic_canteen_cout_repas_aberrant.teledeclare(applicant=UserFactory())
 
         cls.diagnostic_canteen_valeur_totale_aberrant = DiagnosticFactory(
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
             year=year_data,
             creation_date=date_in_teledeclaration_campaign,
             canteen=cls.canteen_valeur_totale_aberrant,
-            valeur_totale=1000001.00,  # aberrant but meal_price < 20
+            valeur_totale=1000001.00,  # aberrant but cout_repas < 20
             valeur_bio=200.00,
             invalid_reason_list=[],
         )
@@ -468,7 +468,7 @@ class DiagnosticQuerySetTest(TestCase):
             year=year_data,
             creation_date=date_in_teledeclaration_campaign,
             canteen=cls.canteen_aberrant,
-            valeur_totale=1000001.00,  # aberrant AND meal_price > 20
+            valeur_totale=1000001.00,  # aberrant AND cout_repas > 20
             valeur_bio=200.00,
             invalid_reason_list=[Diagnostic.InvalidReason.VALEURS_ABERRANTES],
         )
@@ -558,20 +558,9 @@ class DiagnosticQuerySetTest(TestCase):
         diagnostics = Diagnostic.all_objects.valid_td_site_all_years([year_data, year_data - 1])
         self.assertEqual(diagnostics.count(), 6 + 6)
 
-    def test_with_meal_price(self):
-        self.assertEqual(Diagnostic.objects.count(), 17)
-        diagnostics = Diagnostic.objects.with_meal_price()
-        self.assertEqual(diagnostics.count(), 17)
-        self.assertEqual(
-            diagnostics.get(id=self.diagnostic_canteen_valid_1.id).canteen_yearly_meal_count_annotated, 1000
-        )
-        self.assertEqual(diagnostics.get(id=self.diagnostic_canteen_valid_1.id).meal_price_annotated, 1.0)
-        self.assertEqual(diagnostics.get(id=self.diagnostic_canteen_valid_4.id).canteen_yearly_meal_count_annotated, 0)
-        self.assertEqual(diagnostics.get(id=self.diagnostic_canteen_valid_4.id).meal_price_annotated, None)
-
     def test_exclude_aberrant_values(self):
         self.assertEqual(Diagnostic.objects.count(), 17)
-        diagnostics = Diagnostic.objects.exclude_aberrant_values()
+        diagnostics = Diagnostic.objects.exclude(aberrant_values_query())
         self.assertEqual(diagnostics.count(), 16)
         self.assertNotIn(self.diagnostic_canteen_aberrant, diagnostics)
 
@@ -915,29 +904,6 @@ class DiagnosticMealPriceQuerySetAndPropertyTest(TestCase):
             cls.diagnostic_satellite_draft = DiagnosticFactory(
                 canteen=cls.canteen_satellite_draft, year=year_data, valeur_totale=None
             )
-
-    def test_with_meal_price_queryset(self):
-        diagnostics = Diagnostic.objects.with_meal_price()
-
-        diagnostic_draft_canteen_empty = diagnostics.get(id=self.diagnostic_draft_canteen_empty.id)
-        self.assertEqual(diagnostic_draft_canteen_empty.canteen_yearly_meal_count_annotated, None)
-        self.assertEqual(diagnostic_draft_canteen_empty.meal_price_annotated, None)
-        diagnostic_draft_empty = diagnostics.get(id=self.diagnostic_draft_empty.id)
-        self.assertEqual(diagnostic_draft_empty.canteen_yearly_meal_count_annotated, None)
-        self.assertEqual(diagnostic_draft_empty.meal_price_annotated, None)
-        diagnostic_draft_filled = diagnostics.get(id=self.diagnostic_draft_filled.id)
-        self.assertEqual(
-            diagnostic_draft_filled.canteen_yearly_meal_count_annotated, None
-        )  # only if teledeclared (canteen_snapshot)
-        self.assertEqual(diagnostic_draft_filled.meal_price_annotated, None)  # only if teledeclared (canteen_snapshot)
-        diagnostic_groupe_teledeclared = diagnostics.get(id=self.diagnostic_groupe_teledeclared.id)
-        self.assertEqual(diagnostic_groupe_teledeclared.canteen_yearly_meal_count_annotated, 2000)
-        assert_almost_equal(
-            self, diagnostic_groupe_teledeclared.meal_price_annotated, Decimal("50.00025")
-        )  # annotate not rounded
-        diagnostic_satellite_teledeclared = diagnostics.get(id=self.diagnostic_satellite_teledeclared.id)
-        self.assertEqual(diagnostic_satellite_teledeclared.canteen_yearly_meal_count_annotated, 1300)
-        self.assertEqual(diagnostic_satellite_teledeclared.meal_price_annotated, None)  # valeur_totale is None
 
     def test_canteen_yearly_meal_count_property(self):
         self.assertEqual(self.diagnostic_draft_canteen_empty.canteen_yearly_meal_count, None)

--- a/macantine/management/commands/diagnostic_fill_invalid_warning_reason_list.py
+++ b/macantine/management/commands/diagnostic_fill_invalid_warning_reason_list.py
@@ -223,7 +223,7 @@ def fill_invalid_reason_VALEURS_ABERRANTES(diagnostic_qs, apply):
         _remove_reason_item("invalid", reason_item)
 
     # Step 2: queryset
-    diagnostic_qs = diagnostic_qs.with_meal_price().filter(aberrant_values_query())
+    diagnostic_qs = diagnostic_qs.filter(aberrant_values_query())
     logger.info(f"Found {diagnostic_qs.count()} diagnostics with aberrant values")
 
     # Step 3: update

--- a/macantine/tests/test_etl_analysis.py
+++ b/macantine/tests/test_etl_analysis.py
@@ -269,7 +269,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
                 }
 
                 self.serializer = DiagnosticTeledeclaredAnalysisSerializer(
-                    instance=Diagnostic.objects.with_meal_price().get(id=diagnostic.id)
+                    instance=Diagnostic.objects.get(id=diagnostic.id)
                 )
                 data = self.serializer.data
                 self.assertEqual(data["ratio_egalim_sans_bio"], tc["expected_outcome"])
@@ -329,7 +329,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
                 "valeur_totale": diagnostic.valeur_totale,
             }
             self.serializer = DiagnosticTeledeclaredAnalysisSerializer(
-                instance=Diagnostic.objects.with_meal_price().get(id=diagnostic.id)
+                instance=Diagnostic.objects.get(id=diagnostic.id)
             )
             data = self.serializer.data
 
@@ -348,11 +348,11 @@ class TeledeclarationETLAnalysisTest(TestCase):
                 "valeur_totale": diagnostic.valeur_totale,
             }
             self.serializer = DiagnosticTeledeclaredAnalysisSerializer(
-                instance=Diagnostic.objects.with_meal_price().get(id=diagnostic.id)
+                instance=Diagnostic.objects.get(id=diagnostic.id)
             )
             data = self.serializer.data
 
-            self.assertEqual(data["cout_denrees"], -1)
+            self.assertIsNone(data["cout_denrees"])
 
     def test_geo_columns(self):
         with freeze_time("2023-03-30"):  # during the 2022 campaign
@@ -372,9 +372,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
             diagnostic = DiagnosticFactory(canteen=canteen_with_geo_data, year=2022)
             diagnostic.teledeclare(applicant=UserFactory())
 
-        self.serializer = DiagnosticTeledeclaredAnalysisSerializer(
-            instance=Diagnostic.objects.with_meal_price().get(id=diagnostic.id)
-        )
+        self.serializer = DiagnosticTeledeclaredAnalysisSerializer(instance=Diagnostic.objects.get(id=diagnostic.id))
         data = self.serializer.data
 
         self.assertEqual(data["epci"], "200040715")
@@ -399,7 +397,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
             diagnostic_half_geo.teledeclare(applicant=UserFactory())
 
         self.serializer_half_geo = DiagnosticTeledeclaredAnalysisSerializer(
-            instance=Diagnostic.objects.with_meal_price().get(id=diagnostic_half_geo.id)
+            instance=Diagnostic.objects.get(id=diagnostic_half_geo.id)
         )
         data = self.serializer_half_geo.data
 
@@ -425,7 +423,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
             diagnostic_without_geo.teledeclare(applicant=UserFactory())
 
         self.serializer_without_geo = DiagnosticTeledeclaredAnalysisSerializer(
-            instance=Diagnostic.objects.with_meal_price().get(id=diagnostic_without_geo.id)
+            instance=Diagnostic.objects.get(id=diagnostic_without_geo.id)
         )
         data_no_geo = self.serializer_without_geo.data
 
@@ -446,9 +444,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
             diagnostic = DiagnosticFactory(canteen=canteen_with_line_ministry, year=2022)
             diagnostic.teledeclare(applicant=UserFactory())
 
-        self.serializer = DiagnosticTeledeclaredAnalysisSerializer(
-            instance=Diagnostic.objects.with_meal_price().get(id=diagnostic.id)
-        )
+        self.serializer = DiagnosticTeledeclaredAnalysisSerializer(instance=Diagnostic.objects.get(id=diagnostic.id))
         data = self.serializer.data
 
         self.assertEqual(data["line_ministry"], Canteen.Ministries.AGRICULTURE)
@@ -460,7 +456,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
             diagnostic_without_line_ministry.teledeclare(applicant=UserFactory())
 
         self.serializer_without_line_ministry = DiagnosticTeledeclaredAnalysisSerializer(
-            instance=Diagnostic.objects.with_meal_price().get(id=diagnostic_without_line_ministry.id)
+            instance=Diagnostic.objects.get(id=diagnostic_without_line_ministry.id)
         )
         data_without_line_ministry = self.serializer_without_line_ministry.data
 


### PR DESCRIPTION
### Quoi

Suite à #6753 & #6754 (nouveau champ `Diagnostic.cout_repas` calculé au save sur tous les bilans, et remplis)

On n'a plus besoin du queryset `meal_price`

### Pourquoi

- faire le ménage
- prochaine PR qui rajoute des règles de filtrage "aberrant" pour la campagne 2025