### PR TITLE
fix(Achats): divers correctifs suite au recettage avant mise en ligne

### DIFF
--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -75,9 +75,7 @@ const rules = {
     required,
     maxDate: helpers.withMessage(
       "La date d'achat ne peut pas être dans le futur",
-      (date) => {
-        return new Date(date) < new Date()
-      }
+      (date) => new Date(date) < new Date()
     )
   },
   family: { required },

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -252,6 +252,7 @@ const formatPayload = (form) => {
     <div class="fr-mt-6w ma-cantine--flex-end">
       <DsfrButton
         v-if="showDeleteButton"
+        :disabled="isSaving"
         label="Supprimer"
         icon="fr-icon-delete-bin-line"
         tertiary

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -130,7 +130,7 @@ const formatPayload = (form) => {
 </script>
 
 <template>
-  <form class="purchase-form fr-p-2w fr-p-md-7w fr-col-12 fr-col-lg-8 fr-background-default--grey fr-mt-4w" @submit.prevent="">
+  <form class="purchase-form fr-p-2w fr-p-md-7w fr-col-12 fr-col-lg-7 fr-background-default--grey fr-mt-4w" @submit.prevent="">
     <DsfrInputGroup
       v-model="form.description"
       label="Description du produit *"
@@ -252,7 +252,7 @@ const formatPayload = (form) => {
     <div class="fr-mt-6w ma-cantine--flex-end">
       <DsfrButton
         v-if="showDeleteButton"
-        label="Supprimer l'achat"
+        label="Supprimer"
         icon="fr-icon-delete-bin-line"
         tertiary
         @click="emit('delete')"
@@ -260,7 +260,7 @@ const formatPayload = (form) => {
       <DsfrButton
         v-if="showCancelButton"
         :disabled="isSaving"
-        label="Annuler la modification"
+        label="Annuler"
         secondary
         @click="emit('cancel')"
       />

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -173,18 +173,23 @@ const formatPayload = (form) => {
         />
       </div>
     </div>
-    <div>
+    <div class="fr-mb-3w">
       <p class="fr-legend-text fr-mb-1w">Facture</p>
-      <p v-if="form.invoiceUrl" class="fr-mb-2w">Vous avez déjà importé une facture pour cet achat, accéder au fichier en <a :href="form.invoiceUrl" target="_blank">cliquant ici</a>.</p>
-      <DsfrFileUpload
-        v-model="invoiceFileInputValue"
-        :label="form.invoiceUrl ? 'Télécharger un nouveau fichier' : 'Télécharger un fichier'"
-        hint="PDF ou image (JPEG, PNG) — 10 Mo maximum"
-        accept="image/jpeg,image/png,application/pdf"
-        :error="invoiceFileError"
-        class="fr-mb-3w"
-        @change="onInvoiceFileChange"
-      />
+      <div class="fr-grid-row fr-grid-row--top fr-grid-row--gutters">
+        <div v-if="form.invoiceUrl" class="fr-col-12 fr-col-md-6">
+          <p class="fr-mb-2w">Vous avez déjà importé une facture pour cet achat, accéder au fichier en <a :href="form.invoiceUrl" target="_blank">cliquant ici</a>.</p>
+        </div>
+        <div class="fr-col-12" :class="{ 'fr-col-md-6': form.invoiceUrl }">
+          <DsfrFileUpload
+            v-model="invoiceFileInputValue"
+            :label="form.invoiceUrl ? 'Télécharger un nouveau fichier' : 'Télécharger un fichier'"
+            hint="PDF ou image (JPEG, PNG) — 10 Mo maximum"
+            accept="image/jpeg,image/png,application/pdf"
+            :error="invoiceFileError"
+            @change="onInvoiceFileChange"
+          />
+        </div>
+      </div>
     </div>
     <DsfrRadioButtonSet
       v-model="form.family"

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -112,7 +112,7 @@ const isSaving = ref(false)
 const validateForm = async (action) => {
   const isValid = await v$.value.$validate()
   if (!isValid || invoiceFileError.value) return
-
+  isSaving.value = true
   const payload = formatPayload(form)
   if (invoiceFile.value) payload.invoiceFile = await toBase64(invoiceFile.value)
   emit("sendForm", { form: payload, action })

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -31,7 +31,7 @@ const form = reactive({
   characteristicsOrigines: [],
   characteristicsCircuitCourt: [],
   characteristicsLocal: [],
-  localDefinition: null,
+  localDefinition: "",
 })
 
 const familleProduitOptions = Object.values(achats.familleProduit)
@@ -53,7 +53,7 @@ const prefillFields = () => {
   form.priceHt = hasPriceHt ? Number(props.purchaseData.priceHt) : null
   form.date = props.purchaseData.date
   form.family = props.purchaseData.family
-  form.localDefinition = props.purchaseData.localDefinition
+  form.localDefinition = props.purchaseData.localDefinition || ""
   const characteristics = props.purchaseData.characteristics || []
   form.characteristicsEgalim = characteristics.filter((c) => egalimValues.includes(c))
   form.characteristicsOrigines = characteristics.filter((c) => originesValues.includes(c))

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -144,21 +144,27 @@ const formatPayload = (form) => {
     <datalist id="providers">
       <option v-for="provider in autocompleteOptions.providers" :key="provider" :value="provider"></option>
     </datalist>
-    <DsfrInputGroup
-      v-model.number="form.priceHt"
-      type="number"
-      label="Prix HT (€) *"
-      label-visible
-      :error-message="formatError(v$.priceHt)"
-    />
-    <DsfrInputGroup
-      v-model="form.date"
-      type="date"
-      label="Date d'achat *"
-      label-visible
-      :max="today"
-      :error-message="formatError(v$.date)"
-    />
+    <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
+      <div class="fr-col-12 fr-col-md-6">
+        <DsfrInputGroup
+          v-model.number="form.priceHt"
+          type="number"
+          label="Prix HT (€) *"
+          label-visible
+          :error-message="formatError(v$.priceHt)"
+        />
+      </div>
+      <div class="fr-col-12 fr-col-md-6">
+        <DsfrInputGroup
+          v-model="form.date"
+          type="date"
+          label="Date d'achat *"
+          label-visible
+          :max="today"
+          :error-message="formatError(v$.date)"
+        />
+      </div>
+    </div>
     <DsfrFileUpload
       v-model="invoiceFileInputValue"
       label="Facture"

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -3,6 +3,7 @@ import { reactive, ref, computed } from "vue"
 import { computedAsync } from "@vueuse/core"
 import { useVuelidate } from "@vuelidate/core"
 import { useValidators } from "@/validators.js"
+import { helpers } from "@vuelidate/validators"
 import { formatError, toBase64 } from "@/utils.js"
 import achats from "@/data/achats.json"
 import purchases from "@/services/purchases.js"
@@ -70,7 +71,15 @@ const rules = {
   description: { required },
   provider: { required },
   priceHt: { required, decimal, minValue: minValue(0.01) },
-  date: { required },
+  date: {
+    required,
+    maxDate: helpers.withMessage(
+      "La date d'achat ne peut pas être dans le futur",
+      (date) => {
+        return new Date(date) < new Date()
+      }
+    )
+  },
   family: { required },
   localDefinition: { required: requiredIf(showLocalDefinition) },
 }

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -60,6 +60,7 @@ const prefillFields = () => {
   form.characteristicsOrigines = characteristics.filter((c) => originesValues.includes(c))
   form.characteristicsCircuitCourt = characteristics.filter((c) => circuitCourtValues.includes(c))
   form.characteristicsLocal = characteristics.filter((c) => localValues.includes(c))
+  form.invoiceUrl = props.purchaseData.invoiceFile
 }
 
 if (props.purchaseData) prefillFields()
@@ -172,15 +173,19 @@ const formatPayload = (form) => {
         />
       </div>
     </div>
-    <DsfrFileUpload
-      v-model="invoiceFileInputValue"
-      label="Facture"
-      hint="PDF ou image (JPEG, PNG) — 10 Mo maximum"
-      accept="image/jpeg,image/png,application/pdf"
-      :error="invoiceFileError"
-      class="fr-mb-3w"
-      @change="onInvoiceFileChange"
-    />
+    <div>
+      <p class="fr-legend-text fr-mb-1w">Facture</p>
+      <p v-if="form.invoiceUrl" class="fr-mb-2w">Vous avez déjà importé une facture pour cet achat, accéder au fichier en <a :href="form.invoiceUrl" target="_blank">cliquant ici</a>.</p>
+      <DsfrFileUpload
+        v-model="invoiceFileInputValue"
+        :label="form.invoiceUrl ? 'Télécharger un nouveau fichier' : 'Télécharger un fichier'"
+        hint="PDF ou image (JPEG, PNG) — 10 Mo maximum"
+        accept="image/jpeg,image/png,application/pdf"
+        :error="invoiceFileError"
+        class="fr-mb-3w"
+        @change="onInvoiceFileChange"
+      />
+    </div>
     <DsfrRadioButtonSet
       v-model="form.family"
       legend="Famille de produit *"

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -9,8 +9,8 @@ import achats from "@/data/achats.json"
 import purchases from "@/services/purchases.js"
 
 /* Props and emits */
-const props = defineProps(["purchaseData", "showCreateButton", "showCancelButton"])
-const emit = defineEmits(["sendForm", "cancel"])
+const props = defineProps(["purchaseData", "showCreateButton", "showCancelButton", "showDeleteButton"])
+const emit = defineEmits(["sendForm", "cancel", "delete"])
 
 /* Form fields */
 const today = computed(() => new Date().toISOString().split("T")[0])
@@ -130,7 +130,7 @@ const formatPayload = (form) => {
 </script>
 
 <template>
-  <form class="purchase-form fr-p-2w fr-p-md-7w fr-col-12 fr-col-lg-7 fr-background-default--grey fr-mt-4w" @submit.prevent="">
+  <form class="purchase-form fr-p-2w fr-p-md-7w fr-col-12 fr-col-lg-8 fr-background-default--grey fr-mt-4w" @submit.prevent="">
     <DsfrInputGroup
       v-model="form.description"
       label="Description du produit *"
@@ -249,14 +249,19 @@ const formatPayload = (form) => {
       :options="definitionLocalOptions"
       :error-message="formatError(v$.localDefinition)"
     />
-
-    <div class="fr-grid-row fr-grid-row--right fr-grid-row--gutters fr-mt-4w">
+    <div class="fr-mt-6w ma-cantine--flex-end">
+      <DsfrButton
+        v-if="showDeleteButton"
+        label="Supprimer l'achat"
+        icon="fr-icon-delete-bin-line"
+        tertiary
+        @click="emit('delete')"
+      />
       <DsfrButton
         v-if="showCancelButton"
         :disabled="isSaving"
-        label="Annuler"
-        tertiary
-        class="fr-mr-1w"
+        label="Annuler la modification"
+        secondary
         @click="emit('cancel')"
       />
       <DsfrButton
@@ -264,7 +269,6 @@ const formatPayload = (form) => {
         :disabled="isSaving"
         label="Enregistrer et ajouter un nouvel achat"
         secondary
-        class="fr-mr-1w"
         @click="validateForm('stay-on-creation-page')"
       />
       <DsfrButton

--- a/2024-frontend/src/css/global.css
+++ b/2024-frontend/src/css/global.css
@@ -143,6 +143,13 @@ address {
     flex-grow: 1 !important;
 }
 
+.ma-cantine--flex-end {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
 /* BACKGROUND */
 .ma-cantine--bg-blue {
     position: relative;

--- a/2024-frontend/src/services/purchases.js
+++ b/2024-frontend/src/services/purchases.js
@@ -52,9 +52,21 @@ const fetchPurchasesOptions = () => {
     .then((response) => response)
 }
 
+const deletePurchase = (id) => {
+  return fetch(`/api/v1/purchases/${id}`, {
+    method: "DELETE",
+    headers: {
+      "X-CSRFToken": window.CSRF_TOKEN || "",
+    },
+  })
+    .then(verifyResponse)
+    .then((response) => response)
+}
+
 export default {
   createPurchase,
   fetchPurchase,
   updatePurchase,
   fetchPurchasesOptions,
+  deletePurchase,
 }

--- a/2024-frontend/src/services/purchases.js
+++ b/2024-frontend/src/services/purchases.js
@@ -66,7 +66,7 @@ const deletePurchase = (id) => {
 export default {
   createPurchase,
   fetchPurchase,
-  updatePurchase,
   fetchPurchasesOptions,
+  updatePurchase,
   deletePurchase,
 }

--- a/2024-frontend/src/services/purchases.js
+++ b/2024-frontend/src/services/purchases.js
@@ -63,10 +63,24 @@ const deletePurchase = (id) => {
     .then((response) => response)
 }
 
+const restorePurchases = (ids) => {
+  return fetch(`/api/v1/purchases/restore/`, {
+    method: "POST",
+    headers: {
+      "X-CSRFToken": window.CSRF_TOKEN || "",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ ids }),
+  })
+    .then(verifyResponse)
+    .then((response) => response)
+}
+
 export default {
   createPurchase,
   fetchPurchase,
   fetchPurchasesOptions,
   updatePurchase,
   deletePurchase,
+  restorePurchases,
 }

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -113,29 +113,14 @@ const goToPurchasesList = () => {
         :key="forceRerender"
         :purchase-data="purchaseData"
         :showCancelButton="true"
+        :showDeleteButton="true"
         @sendForm="(payload) => savePurchase(payload)"
         @cancel="goToPurchasesList"
+        @delete="deletePurchase"
       />
       <p v-else class="fr-mb-0" >
         Aucun achat trouvé avec le numéro d'identification « {{ purchaseId }} » pour la cantine « {{ canteenName }} ».
       </p>
-    </section>
-    <section v-if="purchaseData.id" class="fr-background-alt--red-marianne fr-p-3w fr-mt-3w fr-grid-row fr-grid-row--center">
-      <div class="fr-col-12 fr-col-lg-7 fr-background-default--grey fr-p-2w fr-p-md-7w">
-        <h2 class="fr-h5 fr-text-default--error">
-          <span class="fr-icon-delete-bin-line"></span>
-          Supprimer cet achat
-        </h2>
-        <p>
-          Vous ne souhaitez plus faire apparaître l'achat « {{ purchaseData.description }} » de l'établissement « {{ canteenName }} »,
-          vous pouvez le supprimer en cliquant sur le bouton ci-dessous.
-        </p>
-        <DsfrButton
-          label="Supprimer l'achat"
-          tertiary
-          @click="deletePurchase"
-        />
-      </div>
     </section>
 
   </template>

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -8,12 +8,14 @@ import purchasesService from "@/services/purchases.js"
 import AppLoader from "@/components/AppLoader.vue"
 import AppRessources from "@/components/AppRessources.vue"
 import PurchaseForm from "@/components/PurchaseForm.vue"
+import AppLinkRouter from "@/components/AppLinkRouter.vue"
 
 /* Router and store */
 const route = useRoute()
 const router = useRouter()
 const store = useRootStore()
 const forceRerender = ref(0)
+const purchaseDeleted = ref(false)
 
 /* Canteen */
 const canteenName = urlService.getCanteenName(route.params.canteenUrlComponent)
@@ -64,13 +66,7 @@ const savePurchase = async (props) => {
 const deletePurchase = async () => {
   if (!purchaseId) return
   purchasesService.deletePurchase(purchaseId).then( () => {
-    purchaseData.value = {}
-    forceRerender.value++
-    store.notify({
-      title: "Achat supprimé",
-      message: `L'achat a bien été supprimé pour la cantine « ${canteenName} ».`,
-      status: "success",
-    })
+    purchaseDeleted.value = true
   }).catch(error => {
     store.notifyServerError(error)
   })
@@ -83,55 +79,64 @@ const goToPurchasesList = () => {
 </script>
 
 <template>
-  <section class="fr-grid-row fr-grid-row--bottom">
-    <div class="fr-col-12 fr-col-md-6 fr-mb-4w fr-mb-md-0">
-      <h1>{{ route.meta.title }} pour la cantine «&nbsp;{{ canteenName }}&nbsp;»</h1>
-    </div>
-    <div class="fr-col-offset-md-1"></div>
-    <AppRessources>
-      <li>
-        <a :href="documentation.ajouterAchat" target="_blank">
-          Tutoriel pour ajouter un achat manuellement
-        </a>
-      </li>
-      <li>
-        <a :href="documentation.critèresQualiteDurabiliteProduits" target="_blank">
-          Comprendre les critères de qualité et durabilité des produits
-        </a>
-      </li>
-    </AppRessources>
-  </section>
-  <section
-    class="fr-background-alt--blue-france fr-p-3w fr-mt-4w fr-grid-row fr-grid-row--center"
-  >
-    <AppLoader v-if="isLoading" />
-    <PurchaseForm
-      v-else-if="purchaseData.id"
-      :key="forceRerender"
-      :purchase-data="purchaseData"
-      :showCancelButton="true"
-      @sendForm="(payload) => savePurchase(payload)"
-      @cancel="goToPurchasesList"
-    />
-    <p v-else class="fr-mb-0" >
-      Aucun achat trouvé avec le numéro d'identification « {{ purchaseId }} » pour la cantine « {{ canteenName }} ».
+  <DsfrAlert v-if="purchaseDeleted" class="fr-mt-4w" title="Achat supprimé" type="success">
+    <p>
+      L'achat a bien été supprimé pour la cantine « {{ canteenName }} ».
+      <AppLinkRouter :to="{ name: 'PurchasesHome' }" title="Retourner à la liste des achats" />.
     </p>
-  </section>
-  <section v-if="purchaseData.id" class="fr-background-alt--red-marianne fr-p-3w fr-mt-3w fr-grid-row fr-grid-row--center">
-    <div class="fr-col-12 fr-col-lg-7 fr-background-default--grey fr-p-2w fr-p-md-7w">
-      <h2 class="fr-h5 fr-text-default--error">
-        <span class="fr-icon-delete-bin-line"></span>
-        Supprimer cet achat
-      </h2>
-      <p>
-        Vous ne souhaitez plus faire apparaître l'achat « {{ purchaseData.description }} » de l'établissement « {{ canteenName }} »,
-        vous pouvez le supprimer en cliquant sur le bouton ci-dessous.
-      </p>
-      <DsfrButton
-        label="Supprimer l'achat"
-        tertiary
-        @click="deletePurchase"
+  </DsfrAlert>
+  <template v-else>
+    <section class="fr-grid-row fr-grid-row--bottom">
+      <div class="fr-col-12 fr-col-md-6 fr-mb-4w fr-mb-md-0">
+        <h1>{{ route.meta.title }} pour la cantine «&nbsp;{{ canteenName }}&nbsp;»</h1>
+      </div>
+      <div class="fr-col-offset-md-1"></div>
+      <AppRessources>
+        <li>
+          <a :href="documentation.ajouterAchat" target="_blank">
+            Tutoriel pour ajouter un achat manuellement
+          </a>
+        </li>
+        <li>
+          <a :href="documentation.critèresQualiteDurabiliteProduits" target="_blank">
+            Comprendre les critères de qualité et durabilité des produits
+          </a>
+        </li>
+      </AppRessources>
+    </section>
+    <section
+      class="fr-background-alt--blue-france fr-p-3w fr-mt-4w fr-grid-row fr-grid-row--center"
+    >
+      <AppLoader v-if="isLoading" />
+      <PurchaseForm
+        v-else-if="purchaseData.id"
+        :key="forceRerender"
+        :purchase-data="purchaseData"
+        :showCancelButton="true"
+        @sendForm="(payload) => savePurchase(payload)"
+        @cancel="goToPurchasesList"
       />
-    </div>
-  </section>
+      <p v-else class="fr-mb-0" >
+        Aucun achat trouvé avec le numéro d'identification « {{ purchaseId }} » pour la cantine « {{ canteenName }} ».
+      </p>
+    </section>
+    <section v-if="purchaseData.id" class="fr-background-alt--red-marianne fr-p-3w fr-mt-3w fr-grid-row fr-grid-row--center">
+      <div class="fr-col-12 fr-col-lg-7 fr-background-default--grey fr-p-2w fr-p-md-7w">
+        <h2 class="fr-h5 fr-text-default--error">
+          <span class="fr-icon-delete-bin-line"></span>
+          Supprimer cet achat
+        </h2>
+        <p>
+          Vous ne souhaitez plus faire apparaître l'achat « {{ purchaseData.description }} » de l'établissement « {{ canteenName }} »,
+          vous pouvez le supprimer en cliquant sur le bouton ci-dessous.
+        </p>
+        <DsfrButton
+          label="Supprimer l'achat"
+          tertiary
+          @click="deletePurchase"
+        />
+      </div>
+    </section>
+
+  </template>
 </template>

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -65,11 +65,17 @@ const savePurchase = async (props) => {
 /* Delete */
 const deletePurchase = async () => {
   if (!purchaseId) return
-  purchasesService.deletePurchase(purchaseId).then( () => {
-    purchaseDeleted.value = true
-  }).catch(error => {
-    store.notifyServerError(error)
-  })
+  purchasesService.deletePurchase(purchaseId)
+    .then(() => {
+      purchaseDeleted.value = true
+      purchaseData.value = {}
+      forceRerender.value++
+    })
+    .catch(error => {
+      store.notifyServerError(error)
+    })
+}
+
 }
 
 /* Redirect */

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -62,7 +62,7 @@ const savePurchase = async (props) => {
 }
 
 /* Delete */
-const deletePurchase = async () => {
+const deletePurchase = () => {
   if (!purchaseId) return
   purchasesService.deletePurchase(purchaseId)
     .then(() => {
@@ -76,7 +76,7 @@ const deletePurchase = async () => {
 }
 
 /* Restore */
-const restorePurchase = async () => {
+const restorePurchase = () => {
   if (!purchaseId) return
   purchasesService.restorePurchases([purchaseId])
     .then(() => {

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -60,13 +60,25 @@ const savePurchase = async (props) => {
   window.scrollTo(0, 0)
 }
 
-const goToPurchasesList = () => {
-  router.push({ name: "PurchasesHome" })
+/* Delete */
+const deletePurchase = async () => {
+  if (!purchaseId) return
+  purchasesService.deletePurchase(purchaseId).then( () => {
+    purchaseData.value = {}
+    forceRerender.value++
+    store.notify({
+      title: "Achat supprimé",
+      message: `L'achat a bien été supprimé pour la cantine « ${canteenName} ».`,
+      status: "success",
+    })
+  }).catch(error => {
+    store.notifyServerError(error)
+  })
 }
 
-/* Delete */
-const deletePurchase = (id) => {
-  console.log("deletePurchase", id)
+/* Redirect */
+const goToPurchasesList = () => {
+  router.push({ name: "PurchasesHome" })
 }
 </script>
 

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -63,6 +63,11 @@ const savePurchase = async (props) => {
 const goToPurchasesList = () => {
   router.push({ name: "PurchasesHome" })
 }
+
+/* Delete */
+const deletePurchase = (id) => {
+  console.log("deletePurchase", id)
+}
 </script>
 
 <template>
@@ -99,5 +104,22 @@ const goToPurchasesList = () => {
     <p v-else class="fr-mb-0" >
       Aucun achat trouvé avec le numéro d'identification « {{ purchaseId }} » pour la cantine « {{ canteenName }} ».
     </p>
+  </section>
+  <section class="fr-background-alt--red-marianne fr-p-3w fr-mt-3w fr-grid-row fr-grid-row--center">
+    <div class="fr-col-12 fr-col-lg-7 fr-background-default--grey fr-p-2w fr-p-md-7w">
+      <h2 class="fr-h5 fr-text-default--error">
+        <span class="fr-icon-delete-bin-line"></span>
+        Supprimer cet achat
+      </h2>
+      <p>
+        Vous ne souhaitez plus faire apparaître l'achat « {{ purchaseData.description }} » de l'établissement « {{ canteenName }} »,
+        vous pouvez le supprimer en cliquant sur le bouton ci-dessous.
+      </p>
+      <DsfrButton
+        label="Supprimer l'achat"
+        tertiary
+        @click="deletePurchase"
+      />
+    </div>
   </section>
 </template>

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -28,11 +28,9 @@ const purchaseData = ref({})
 const loadPurchase = async () => {
   isLoading.value = true
   const response = await purchasesService.fetchPurchase(purchaseId)
-  if (!response?.id || response.canteen !== Number(canteenId)) {
-    purchaseData.value = {}
-  } else {
-    purchaseData.value = response
-  }
+  const noPurchase = !response?.id
+  const notSameCanteen = response?.canteen !== Number(canteenId)
+  purchaseData.value = noPurchase || notSameCanteen ? {} : response
   isLoading.value = false
 }
 

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -8,7 +8,6 @@ import purchasesService from "@/services/purchases.js"
 import AppLoader from "@/components/AppLoader.vue"
 import AppRessources from "@/components/AppRessources.vue"
 import PurchaseForm from "@/components/PurchaseForm.vue"
-import AppLinkRouter from "@/components/AppLinkRouter.vue"
 
 /* Router and store */
 const route = useRoute()
@@ -76,6 +75,22 @@ const deletePurchase = async () => {
     })
 }
 
+/* Restore */
+const restorePurchase = async () => {
+  if (!purchaseId) return
+  purchasesService.restorePurchases([purchaseId])
+    .then(() => {
+      purchaseDeleted.value = false
+      loadPurchase()
+      store.notify({
+        title: "Achat restauré",
+        message: `L'achat a bien été restauré pour la cantine « ${canteenName} ».`,
+        status: "success",
+      })
+    })
+    .catch(error => {
+      store.notifyServerError(error)
+    })
 }
 
 /* Redirect */
@@ -85,37 +100,28 @@ const goToPurchasesList = () => {
 </script>
 
 <template>
-  <DsfrAlert v-if="purchaseDeleted" class="fr-mt-4w" title="Achat supprimé" type="success">
-    <p>
-      L'achat a bien été supprimé pour la cantine « {{ canteenName }} ».
-      <AppLinkRouter :to="{ name: 'PurchasesHome' }" title="Retourner à la liste des achats" />.
-    </p>
-  </DsfrAlert>
-  <template v-else>
-    <section class="fr-grid-row fr-grid-row--bottom">
-      <div class="fr-col-12 fr-col-md-6 fr-mb-4w fr-mb-md-0">
-        <h1>{{ route.meta.title }} pour la cantine «&nbsp;{{ canteenName }}&nbsp;»</h1>
-      </div>
-      <div class="fr-col-offset-md-1"></div>
-      <AppRessources>
-        <li>
-          <a :href="documentation.ajouterAchat" target="_blank">
-            Tutoriel pour ajouter un achat manuellement
-          </a>
-        </li>
-        <li>
-          <a :href="documentation.critèresQualiteDurabiliteProduits" target="_blank">
-            Comprendre les critères de qualité et durabilité des produits
-          </a>
-        </li>
-      </AppRessources>
-    </section>
-    <section
-      class="fr-background-alt--blue-france fr-p-3w fr-mt-4w fr-grid-row fr-grid-row--center"
-    >
-      <AppLoader v-if="isLoading" />
+  <section class="fr-grid-row fr-grid-row--bottom">
+    <div class="fr-col-12 fr-col-md-6 fr-mb-4w fr-mb-md-0">
+      <h1>{{ route.meta.title }} pour la cantine «&nbsp;{{ canteenName }}&nbsp;»</h1>
+    </div>
+    <div class="fr-col-offset-md-1"></div>
+    <AppRessources>
+      <li>
+        <a :href="documentation.ajouterAchat" target="_blank">
+          Tutoriel pour ajouter un achat manuellement
+        </a>
+      </li>
+      <li>
+        <a :href="documentation.critèresQualiteDurabiliteProduits" target="_blank">
+          Comprendre les critères de qualité et durabilité des produits
+        </a>
+      </li>
+    </AppRessources>
+  </section>
+  <section class="fr-mt-4w">
+    <AppLoader v-if="isLoading" />
+    <div v-else-if="purchaseData.id" class="fr-background-alt--blue-france fr-p-3w fr-grid-row fr-grid-row--center">
       <PurchaseForm
-        v-else-if="purchaseData.id"
         :key="forceRerender"
         :purchase-data="purchaseData"
         :showCancelButton="true"
@@ -124,10 +130,20 @@ const goToPurchasesList = () => {
         @cancel="goToPurchasesList"
         @delete="deletePurchase"
       />
-      <p v-else class="fr-mb-0" >
-        Aucun achat trouvé avec le numéro d'identification « {{ purchaseId }} » pour la cantine « {{ canteenName }} ».
+    </div>
+    <div v-else-if="purchaseDeleted" class="fr-col-12 fr-col-lg-7">
+      <p>
+        L'achat a bien été supprimé pour la cantine « {{ canteenName }} ». <br />
+        Il s'agit d'une erreur ? Vous pouvez le restaurer en cliquant sur le bouton ci-dessous.
       </p>
-    </section>
-
-  </template>
+      <DsfrButton
+        label="Annuler la suppression et restaurer l'achat"
+        tertiary
+        @click="restorePurchase"
+      />
+    </div>
+    <p v-else class="fr-mb-0" >
+      Aucun achat trouvé avec le numéro d'identification « {{ purchaseId }} » pour la cantine « {{ canteenName }} ».
+    </p>
+  </section>
 </template>

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -1,6 +1,5 @@
 <script setup>
-import { ref } from "vue"
-import { computedAsync } from "@vueuse/core"
+import { ref, onMounted } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import { useRootStore } from "@/stores/root"
 import documentation from "@/data/documentation.json"
@@ -14,6 +13,7 @@ import PurchaseForm from "@/components/PurchaseForm.vue"
 const route = useRoute()
 const router = useRouter()
 const store = useRootStore()
+const forceRerender = ref(0)
 
 /* Canteen */
 const canteenName = urlService.getCanteenName(route.params.canteenUrlComponent)
@@ -22,14 +22,20 @@ const canteenId = urlService.getCanteenId(route.params.canteenUrlComponent)
 /* Purchase */
 const isLoading = ref(true)
 const purchaseId = route.params.id
+const purchaseData = ref({})
 
-const purchaseData = computedAsync(async () => {
+const loadPurchase = async () => {
+  isLoading.value = true
   const response = await purchasesService.fetchPurchase(purchaseId)
+  if (!response?.id || response.canteen !== Number(canteenId)) {
+    purchaseData.value = {}
+  } else {
+    purchaseData.value = response
+  }
   isLoading.value = false
-  if (!response?.id) return {}
-  else if (response.canteen !== Number(canteenId)) return {}
-  else return response
-}, {})
+}
+
+onMounted(loadPurchase)
 
 /* Save */
 const savePurchase = async (props) => {
@@ -40,6 +46,9 @@ const savePurchase = async (props) => {
     store.notifyServerError(response)
     return
   }
+
+  purchaseData.value = response
+  forceRerender.value++
 
   store.notify({
     title: "Achat mis à jour",
@@ -81,6 +90,7 @@ const goToPurchasesList = () => {
     <AppLoader v-if="isLoading" />
     <PurchaseForm
       v-else-if="purchaseData.id"
+      :key="forceRerender"
       :purchase-data="purchaseData"
       :showCancelButton="true"
       @sendForm="(payload) => savePurchase(payload)"

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -105,7 +105,7 @@ const deletePurchase = (id) => {
       Aucun achat trouvé avec le numéro d'identification « {{ purchaseId }} » pour la cantine « {{ canteenName }} ».
     </p>
   </section>
-  <section class="fr-background-alt--red-marianne fr-p-3w fr-mt-3w fr-grid-row fr-grid-row--center">
+  <section v-if="purchaseData.id" class="fr-background-alt--red-marianne fr-p-3w fr-mt-3w fr-grid-row fr-grid-row--center">
     <div class="fr-col-12 fr-col-lg-7 fr-background-default--grey fr-p-2w fr-p-md-7w">
       <h2 class="fr-h5 fr-text-default--error">
         <span class="fr-icon-delete-bin-line"></span>

--- a/frontend/src/views/PurchasesHome.vue
+++ b/frontend/src/views/PurchasesHome.vue
@@ -296,6 +296,7 @@
       >
         <template v-slot:[`item.description`]="{ item }">
           <router-link
+            v-if="item.canteenUrlComponent"
             :to="{
               name: 'GestionnaireAchatsModifier',
               params: { id: item.id, canteenUrlComponent: item.canteenUrlComponent },
@@ -304,6 +305,10 @@
             {{ item.description || "[sans description]" }}
             <span class="d-sr-only">, {{ item.date }}</span>
           </router-link>
+          <p v-else>
+            {{ item.description || "[sans description]" }}
+            <span class="d-sr-only">, {{ item.date }}</span>
+          </p>
         </template>
         <template v-slot:[`item.family`]="{ item }">
           <v-chip outlined small :color="getProductFamilyDisplayValue(item.family).color" dark class="font-weight-bold">


### PR DESCRIPTION
Ticket : https://app.notion.com/p/incubateur-masa/Formulaire-achat-app-migration-en-vue3-V1-364de24614be80b0a390c8852f7436a7

Ce qui a été corrigé : 
- ajout de l'action de suppression depuis le formulaire de modification
- champs sur une même ligne
- ne pas rendre cliquable un achat pour une cantine supprimée
- afficher la facture déjà enregistrée


<img width="363" height="707" alt="Capture d’écran 2026-06-08 à 17 19 22" src="https://github.com/user-attachments/assets/2763917e-b9e4-43ad-80b3-702c8937799d" />

