### PR TITLE
improve(Achats): nouvelles properties categories_egalim, origine, est_local & est_circuit_court

### DIFF
--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -284,7 +284,26 @@ class Purchase(SoftDeletionModel):
         super().save(**kwargs)
 
     @property
-    def famille_produits_display(self):
+    def categories_egalim(self) -> list[str]:
+        return [c for c in (self.caracteristiques or []) if c in Purchase.CHARACTERISTIC_LABELS_EGALIM]
+
+    @property
+    def origine(self) -> str | None:
+        for origine in Purchase.CHARACTERISTIC_LABELS_ORIGINE:
+            if origine in (self.caracteristiques or []):
+                return origine
+        return None
+
+    @property
+    def est_local(self) -> bool:
+        return Purchase.Characteristic.LOCAL in (self.caracteristiques or [])
+
+    @property
+    def est_circuit_court(self) -> bool:
+        return Purchase.Characteristic.CIRCUIT_COURT in (self.caracteristiques or [])
+
+    @property
+    def famille_produits_display(self) -> str | None:
         if not self.famille_produits:
             return None
         try:
@@ -293,7 +312,7 @@ class Purchase(SoftDeletionModel):
             return None
 
     @property
-    def caracteristiques_display(self):
+    def caracteristiques_display(self) -> str | None:
         if not self.caracteristiques:
             return None
         caracteristiques_display = []

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -303,25 +303,21 @@ class Purchase(SoftDeletionModel):
         return Purchase.Characteristic.CIRCUIT_COURT in (self.caracteristiques or [])
 
     @property
-    def famille_produits_display(self) -> str | None:
-        if not self.famille_produits:
-            return None
+    def famille_produits_display(self) -> str:
         try:
             return Purchase.Family(self.famille_produits).label
         except Exception:
-            return None
+            return ""
 
     @property
-    def caracteristiques_display(self) -> str | None:
-        if not self.caracteristiques:
-            return None
+    def caracteristiques_display(self) -> str:
         caracteristiques_display = []
-        for c in self.caracteristiques:
+        for c in self.caracteristiques or []:
             try:
                 caracteristiques_display.append(Purchase.Characteristic(c).label)
             except Exception:
                 pass
-        return ", ".join(caracteristiques_display) if caracteristiques_display else None
+        return ", ".join(caracteristiques_display) if caracteristiques_display else ""
 
     @classmethod
     def canteen_summary_for_year(cls, canteen, year):

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -203,7 +203,9 @@ class PurchaseModelPropertiesTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.canteen = CanteenFactory()
-        cls.purchase_empty = PurchaseFactory(canteen=cls.canteen, date="2026-01-01", caracteristiques=[], prix_ht=15)
+        cls.purchase_empty = PurchaseFactory(
+            canteen=cls.canteen, date="2026-01-01", caracteristiques=[], famille_produits=None, prix_ht=15
+        )
         cls.purchase = PurchaseFactory(
             canteen=cls.canteen,
             date="2026-01-01",
@@ -232,6 +234,17 @@ class PurchaseModelPropertiesTest(TestCase):
     def test_purchase_est_circuit_court_property(self):
         self.assertFalse(self.purchase_empty.est_circuit_court)
         self.assertTrue(self.purchase.est_circuit_court)
+
+    def test_purchase_famille_produits_display_property(self):
+        self.assertEqual(self.purchase_empty.famille_produits_display, None)
+        self.assertEqual(self.purchase.famille_produits_display, "Boulangerie/Pâtisserie fraîches et surgelées")
+
+    def test_purchase_caracteristiques_display_property(self):
+        self.assertEqual(self.purchase_empty.caracteristiques_display, None)
+        self.assertEqual(
+            self.purchase.caracteristiques_display,
+            "Bio, Origine France, Circuit-court, Produit local",
+        )
 
 
 class PurchaseSummaryFranceTest(TestCase):

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -236,11 +236,11 @@ class PurchaseModelPropertiesTest(TestCase):
         self.assertTrue(self.purchase.est_circuit_court)
 
     def test_purchase_famille_produits_display_property(self):
-        self.assertEqual(self.purchase_empty.famille_produits_display, None)
+        self.assertEqual(self.purchase_empty.famille_produits_display, "")
         self.assertEqual(self.purchase.famille_produits_display, "Boulangerie/Pâtisserie fraîches et surgelées")
 
     def test_purchase_caracteristiques_display_property(self):
-        self.assertEqual(self.purchase_empty.caracteristiques_display, None)
+        self.assertEqual(self.purchase_empty.caracteristiques_display, "")
         self.assertEqual(
             self.purchase.caracteristiques_display,
             "Bio, Origine France, Circuit-court, Produit local",

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -199,6 +199,41 @@ class PurchaseDeleteQuerySetAndPropertyTest(TestCase):
         self.assertTrue(self.purchase.is_deleted)
 
 
+class PurchaseModelPropertiesTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.purchase_empty = PurchaseFactory(canteen=cls.canteen, date="2026-01-01", caracteristiques=[], prix_ht=15)
+        cls.purchase = PurchaseFactory(
+            canteen=cls.canteen,
+            date="2026-01-01",
+            caracteristiques=[
+                Purchase.Characteristic.BIO,
+                Purchase.Characteristic.FRANCE,
+                Purchase.Characteristic.CIRCUIT_COURT,
+                Purchase.Characteristic.LOCAL,
+            ],
+            famille_produits=Purchase.Family.BOULANGERIE,
+            prix_ht=15,
+        )
+
+    def test_purchase_categories_egalim_property(self):
+        self.assertEqual(self.purchase_empty.categories_egalim, [])
+        self.assertEqual(self.purchase.categories_egalim, [Purchase.Characteristic.BIO])
+
+    def test_purchase_origine_property(self):
+        self.assertEqual(self.purchase_empty.origine, None)
+        self.assertEqual(self.purchase.origine, Purchase.Characteristic.FRANCE)
+
+    def test_purchase_est_local_property(self):
+        self.assertFalse(self.purchase_empty.est_local)
+        self.assertTrue(self.purchase.est_local)
+
+    def test_purchase_est_circuit_court_property(self):
+        self.assertFalse(self.purchase_empty.est_circuit_court)
+        self.assertTrue(self.purchase.est_circuit_court)
+
+
 class PurchaseSummaryFranceTest(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
Commencer le travail de la nouvelle API

### Quoi

Ici on rajoute seulement de nouvelles proporties au modèle
- categories_egalim, origine, est_local, est_circuit_court
- ajout de tests
- mini améliorations des 2 properties "display" existantes (renvoyer string vide au lieu de None)

### Pourquoi

Rendre visible ce split de caractéristiques coté modèle, vu qu'on garde un seul ArrayField.
ca pourra être utile dans l'admin ou ailleurs.
et ca permettra de visibiliser ces nouveaux wordings