### PR TITLE
refactor(Achats): renommer l'ancien serializer à PurchaseOldSerializer

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -52,7 +52,7 @@ from .teledeclaration import (  # noqa: F401
     CampaignDatesFullSerializer,
 )  # noqa: F401
 from .purchase import (  # noqa: F401
-    PurchaseSerializer,
+    PurchaseOldSerializer,
     PurchaseSummarySerializer,
     PurchasePercentageSummarySerializer,
     PurchaseExportSerializer,

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 from data.models import Purchase
 
 
-class PurchaseSerializer(serializers.ModelSerializer):
+class PurchaseOldSerializer(serializers.ModelSerializer):
     canteen = serializers.PrimaryKeyRelatedField(read_only=True)
     provider = serializers.CharField(source="fournisseur", required=False, allow_blank=True)
     family = serializers.ChoiceField(

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -14,8 +14,8 @@ from rest_framework.views import APIView
 from api.filters.utils import UnaccentSearchFilter
 from api.permissions import IsAuthenticated, IsCanteenManager, IsLinkedCanteenManager
 from api.serializers import (
+    PurchaseOldSerializer,
     PurchasePercentageSummarySerializer,
-    PurchaseSerializer,
     PurchaseSummarySerializer,
 )
 from data.models import Canteen, Diagnostic, Purchase
@@ -91,7 +91,7 @@ class PurchaseFilterSet(django_filters.FilterSet):
 class PurchaseListCreateView(ListCreateAPIView):
     permission_classes = [IsAuthenticated, IsLinkedCanteenManager]
     model = Purchase
-    serializer_class = PurchaseSerializer
+    serializer_class = PurchaseOldSerializer
     pagination_class = PurchasesPagination
     filter_backends = [
         UnaccentSearchFilter,
@@ -142,7 +142,7 @@ class PurchaseRetrieveUpdateDestroyView(RetrieveUpdateDestroyAPIView):
     permission_classes = [IsAuthenticated, IsLinkedCanteenManager]
     http_method_names = ["get", "patch", "delete"]  # disable "put"
     model = Purchase
-    serializer_class = PurchaseSerializer
+    serializer_class = PurchaseOldSerializer
 
     def get_queryset(self):
         return Purchase.objects.for_user(self.request.user)

--- a/api/views/purchase_import.py
+++ b/api/views/purchase_import.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 
-from api.serializers import PurchaseSerializer
+from api.serializers import PurchaseOldSerializer
 from api.views.base_import import BaseImportView
 from common.utils import file_import
 from common.utils import utils as utils_utils
@@ -14,7 +14,6 @@ from data.models import Canteen, ImportType, Purchase
 from data.models.creation_source import CreationSource
 
 from .utils import camelize
-
 
 PURCHASE_SIRET_SCHEMA_FILE_NAME = "achats_siret.json"
 PURCHASE_SIRET_SCHEMA_FILE_PATH = f"data/schemas/imports/{PURCHASE_SIRET_SCHEMA_FILE_NAME}"
@@ -187,7 +186,7 @@ class PurchasesImportView(BaseImportView):
         """Return purchase-specific response data"""
         return {
             "count": len(self.purchases),
-            "duplicatePurchases": camelize(PurchaseSerializer(self.duplicate_purchases, many=True).data),
+            "duplicatePurchases": camelize(PurchaseOldSerializer(self.duplicate_purchases, many=True).data),
             "duplicateFile": self.is_duplicate_file,
             "duplicatePurchaseCount": self.duplicate_purchase_count,
         }


### PR DESCRIPTION
préparer la création du nouveau Serializer. au lieu de tout faire dans la même PR, je préfère avoir un commit dédié au renommage à "Old" de l'ancienne. vu que les 2 vont cohabiter...