### PR TITLE
refactor(API): renvoyer proprement un 404 quand la cantine est inconnue

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -2,6 +2,7 @@ from django.contrib.auth import get_user_model
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from oauth2_provider.contrib.rest_framework.permissions import TokenHasResourceScope
 from rest_framework import permissions
+from rest_framework.generics import get_object_or_404
 
 from data.models import Canteen
 
@@ -68,11 +69,8 @@ class IsCanteenManagerUrlParam(permissions.BasePermission):
         canteen_pk = view.kwargs.get("canteen_pk", None)
         if not canteen_pk:
             return False
-        try:
-            canteen = Canteen.objects.only("managers").get(pk=canteen_pk)
-            return canteen.managers.filter(id=request.user.id).exists()
-        except Canteen.DoesNotExist:
-            return False
+        canteen = get_object_or_404(Canteen.objects.only("managers"), pk=canteen_pk)
+        return canteen.managers.filter(id=request.user.id).exists()
 
 
 class IsLinkedCanteenManager(permissions.BasePermission):

--- a/api/tests/test_canteen_groupe.py
+++ b/api/tests/test_canteen_groupe.py
@@ -48,7 +48,7 @@ class CanteenGroupeSatellitesListApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_list_if_group_does_not_exist(self):
+    def test_cannot_list_if_group_unknown(self):
         url = reverse(
             "canteen_groupe_satellites_list",
             kwargs={"canteen_pk": 9999},
@@ -56,7 +56,7 @@ class CanteenGroupeSatellitesListApiTest(APITestCase):
         self.client.force_authenticate(user=authenticate.user)
         response = self.client.get(url)
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)  # should be 404
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_cannot_list_if_user_not_group_manager(self):
@@ -188,7 +188,7 @@ class CanteenGroupeSatelliteLinkUnlinkApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_link_unlink_satellite_if_group_does_not_exist(self):
+    def test_cannot_link_unlink_satellite_if_group_unknown(self):
         # self.canteen_satellite_0 is not linked yet
         url = reverse(
             "canteen_groupe_satellite_link",
@@ -196,7 +196,7 @@ class CanteenGroupeSatelliteLinkUnlinkApiTest(APITestCase):
         )
         response = self.client.post(url)
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)  # should be 404
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         # self.canteen_satellite_11 is linked to groupe_1
         url = reverse(
@@ -205,7 +205,7 @@ class CanteenGroupeSatelliteLinkUnlinkApiTest(APITestCase):
         )
         response = self.client.post(url)
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)  # should be 404
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_cannot_link_unlink_satellite_if_user_not_group_manager(self):


### PR DESCRIPTION
### Quoi

Dans nos views, on jongle actuellement entre IsCanteenManagerUrlParam, IsLinkedCanteenManager, et des try/catch un peu partout

Dans IsCanteenManagerUrlParam je renvoie maintenant un 404 quand la cantine est astente.
Vu que dans DRF les "permissions" est un des premiers checks, ca permet de renvoyer la bonne erreur (et réparer des tests).

### Pourquoi

- généraliser l'usage de `IsCanteenManagerUrlParam` pour tous les endpoints API qui commencent par `"canteens/<int:canteen_pk>/`
- et enlever à terme IsLinkedCanteenManager

### Todo

|Views|PR|
|-|-|
|DiagnosticCreateView & DiagnosticUpdateView|#6815|
|DiagnosticTeledeclarationCreateView & DiagnosticTeledeclarationCancelView & DiagnosticTeledeclarationPdfView|#6812|
|CanteenWasteMeasurementsView & CanteenWasteMeasurementView|#6814|
|CanteenGroupeSatellitesListView & CanteenGroupeSatelliteLinkView & CanteenGroupeSatelliteUnlinkView|cette PR|
|rajouter des tests croisés "cantine x object"|#6816|
