### PR TITLE
refactor(API): waste_measurements: utiliser IsCanteenManagerUrlParam au lieu de IsLinkedCanteenManager

### DIFF
--- a/api/tests/test_waste_measurements.py
+++ b/api/tests/test_waste_measurements.py
@@ -8,49 +8,52 @@ from rest_framework.test import APITestCase
 
 from api.tests.utils import authenticate, get_oauth2_token
 from data.factories import CanteenFactory, WasteMeasurementFactory
-from data.models import Canteen, WasteMeasurement
+from data.models import WasteMeasurement
 
 
 class WasteMeasurementsListApiTest(APITestCase):
-    def test_unauthenticated_get_waste_measurements(self):
-        """
-        Get 403 when trying to fetch waste measurements without being authenticated
-        """
-        canteen = CanteenFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory(yearly_meal_count=1000)
 
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}))
+    def test_cannot_get_waste_measurements_if_unauthenticated(self):
+        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_get_waste_measurements_forbidden_canteen(self):
-        """
-        Get 403 when trying to fetch waste measurements without being manager of the canteen
-        """
-        canteen = CanteenFactory()
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}))
+    def test_cannot_get_waste_measurements_if_canteen_unknown(self):
+        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": 9909}))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_get_waste_measurements_if_not_canteen_manager(self):
+        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_get_waste_measurements(self):
-        """
-        Canteen managers can fetch all the waste measurements for a canteen in order of period start date descending
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
         measurement_july = WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 7, 1), period_end_date=datetime.date(2024, 7, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 7, 1),
+            period_end_date=datetime.date(2024, 7, 5),
         )
         measurement_august = WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 8, 1), period_end_date=datetime.date(2024, 8, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 8, 1),
+            period_end_date=datetime.date(2024, 8, 5),
         )
-        WasteMeasurementFactory()  # to be filtered out
+        WasteMeasurementFactory()  # will not be returned
 
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}))
+        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
         body = response.json()
-
         self.assertEqual(len(body), 2)
-        self.assertEqual(body[0]["id"], measurement_august.id)
+        self.assertEqual(body[0]["id"], measurement_august.id)  # ordered by period_start_date desc
         self.assertEqual(body[1]["id"], measurement_july.id)
 
     def test_get_waste_measurements_via_oauth2(self):
@@ -58,40 +61,41 @@ class WasteMeasurementsListApiTest(APITestCase):
         Canteen managers can fetch all the waste measurements for a canteen they manage via oauth2 token
         """
         user, token = get_oauth2_token("waste_measurements:read")
-        canteen = CanteenFactory(managers=[user])
+        self.canteen.managers.add(user)
         measurement_july = WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 7, 1), period_end_date=datetime.date(2024, 7, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 7, 1),
+            period_end_date=datetime.date(2024, 7, 5),
         )
         measurement_august = WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 8, 1), period_end_date=datetime.date(2024, 8, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 8, 1),
+            period_end_date=datetime.date(2024, 8, 5),
         )
-        WasteMeasurementFactory()  # to be filtered out
+        WasteMeasurementFactory()  # will not be returned
 
         self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}))
+        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
         body = response.json()
-
         self.assertEqual(len(body), 2)
-        self.assertEqual(body[0]["id"], measurement_august.id)
+        self.assertEqual(body[0]["id"], measurement_august.id)  # ordered by period_start_date desc
         self.assertEqual(body[1]["id"], measurement_july.id)
 
     @authenticate
     def test_get_period_day_count(self):
-        """
-        Canteen waste measurements should contain a computed field of number of days in period
-        """
-        measurement = WasteMeasurementFactory(
-            period_start_date=datetime.date(2024, 8, 1), period_end_date=datetime.date(2024, 8, 5)
+        self.canteen.managers.add(authenticate.user)
+        WasteMeasurementFactory(
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 8, 1),
+            period_end_date=datetime.date(2024, 8, 5),
         )
-        measurement.canteen.managers.add(authenticate.user)
 
-        response = self.client.get(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": measurement.canteen.id})
-        )
+        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-
         self.assertEqual(body[0]["daysInPeriod"], 5)
 
     @authenticate
@@ -101,12 +105,12 @@ class WasteMeasurementsListApiTest(APITestCase):
         This is done by taking dividing the total mass by period meal count and multiplying by canteen's
         yearly meal count
         """
-        canteen = CanteenFactory(yearly_meal_count=1000, managers=[authenticate.user])
-        WasteMeasurementFactory(canteen=canteen, meal_count=10, total_mass=50)
+        self.canteen.managers.add(authenticate.user)
+        WasteMeasurementFactory(canteen=self.canteen, meal_count=10, total_mass=50)
 
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}))
+        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+
         body = response.json()
-
         self.assertEqual(body[0]["totalYearlyWasteEstimation"], 5000)
 
     @authenticate
@@ -114,118 +118,71 @@ class WasteMeasurementsListApiTest(APITestCase):
         """
         Canteen managers can fetch all the waste measurements for a canteen in a particular time period
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
         measurement_july = WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 7, 1), period_end_date=datetime.date(2024, 7, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 7, 1),
+            period_end_date=datetime.date(2024, 7, 5),
         )
         measurement_august = WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 8, 1), period_end_date=datetime.date(2024, 8, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 8, 1),
+            period_end_date=datetime.date(2024, 8, 5),
         )
         # the following should be filtered out
         WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 9, 1), period_end_date=datetime.date(2024, 9, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 9, 1),
+            period_end_date=datetime.date(2024, 9, 5),
         )
 
         query = "?period_start_date_after=2024-07-01&period_end_date_before=2024-09-01"
-        path = reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id})
+        path = reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id})
         response = self.client.get(path + query)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
         body = response.json()
-
         self.assertEqual(len(body), 2)
         self.assertEqual(body[0]["id"], measurement_august.id)
         self.assertEqual(body[1]["id"], measurement_july.id)
 
 
-class WasteMeasurementsDetailApiTest(APITestCase):
-    @authenticate
-    def test_cannot_get_waste_measurement_not_manager(self):
-        """
-        If the user is not the manager of the canteen, they get a 403 when attempting to view the waste measurement
-        """
-        canteen = CanteenFactory()
-        measurement = WasteMeasurementFactory(canteen=canteen)
-
-        response = self.client.get(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id})
-        )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_get_waste_measurement(self):
-        """
-        Canteen managers can fetch the waste measurement of a canteen they manage
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        measurement = WasteMeasurementFactory(canteen=canteen)
-
-        response = self.client.get(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id})
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        body = response.json()
-        self.assertIn("periodStartDate", body)
-
-    def test_get_waste_measurement_via_oauth2(self):
-        """
-        Canteen managers can fetch the waste measurement of a canteen they manage via oauth2 token
-        """
-        user, token = get_oauth2_token("waste_measurements:read")
-        canteen = CanteenFactory(managers=[user])
-        measurement = WasteMeasurementFactory(canteen=canteen)
-
-        self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.get(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id})
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        body = response.json()
-        self.assertIn("periodStartDate", body)
-
-
 class WasteMeasurementsCreateApiTest(APITestCase):
-    def test_unauthenticated_create_waste_measurement_call(self):
-        """
-        When calling this API unathenticated we expect a 403
-        """
-        canteen = CanteenFactory()
-        response = self.client.post(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}), {})
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+
+    def test_cannot_create_waste_measurement_if_unauthenticated(self):
+        response = self.client.post(
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), {}
+        )
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_waste_measurement_missing_canteen(self):
-        """
-        When calling this API on an unexistent canteen we expect a 404
-        """
-        self.assertIsNone(Canteen.objects.filter(id=999).first())
+    def test_cannot_create_waste_measurement_if_canteen_unknown(self):
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": 999}),
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": 9999}),
             {
                 "period_start_date": "2024-08-01",
                 "period_end_date": "2024-08-10",
                 "meal_count": 500,
             },
         )
+
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_waste_measurement_forbidden_canteen(self):
-        """
-        When calling this API on a canteen that the user doesn't manage,
-        we expect a 403
-        """
-        canteen = CanteenFactory()
+    def test_cannot_create_waste_measurement_if_not_canteen_manager(self):
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}),
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}),
             {
                 "period_start_date": "2024-08-01",
                 "period_end_date": "2024-08-10",
                 "meal_count": 500,
             },
         )
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
@@ -234,7 +191,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         When calling this API on a canteen that the user manages
         we expect a waste_measurement to be created
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
 
         payload = {
             "period_start_date": "2024-08-01",
@@ -254,12 +211,11 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         }
 
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}), payload
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
         )
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-        waste_measurement = WasteMeasurement.objects.get(canteen__id=canteen.id)
-
+        waste_measurement = WasteMeasurement.objects.get(canteen__id=self.canteen.id)
         self.assertEqual(waste_measurement.period_start_date, datetime.date(2024, 8, 1))
         self.assertEqual(waste_measurement.period_end_date, datetime.date(2024, 8, 10))
         self.assertEqual(waste_measurement.meal_count, 500)
@@ -280,7 +236,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
 
     def test_create_waste_measurement_via_oauth2(self):
         user, token = get_oauth2_token("waste_measurements:create")
-        canteen = CanteenFactory(managers=[user])
+        self.canteen.managers.add(user)
 
         payload = {
             "period_start_date": "2024-08-01",
@@ -301,9 +257,10 @@ class WasteMeasurementsCreateApiTest(APITestCase):
 
         self.client.credentials(Authorization=f"Bearer {token}")
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}),
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}),
             payload,
         )
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @authenticate
@@ -311,7 +268,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         """
         Same start & end dates (Period of 1 day)
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
 
         payload = {
             "period_start_date": "2024-08-01",
@@ -319,8 +276,9 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         }
 
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}), payload
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
         )
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @authenticate
@@ -328,15 +286,15 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         """
         Period start date and period end date must be given
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
 
         payload = {}
 
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}), payload
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
         self.assertEqual(body["periodStartDate"][0], "Champ requis.")
         self.assertEqual(body["periodEndDate"][0], "Champ requis.")
@@ -347,7 +305,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         """
         The period end date cannot be in the future
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
 
         payload = {
             "period_start_date": "2024-08-01",
@@ -355,10 +313,10 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         }
 
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}), payload
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["periodEndDate"][0], "La date ne peut pas être dans le futur")
 
     @authenticate
@@ -366,7 +324,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         """
         The period start date must be before end date
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
 
         payload = {
             "period_start_date": "2024-08-10",
@@ -374,10 +332,10 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         }
 
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}), payload
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json()["periodStartDate"][0], "La date de début ne peut pas être après la date de fin"
         )
@@ -387,9 +345,11 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         """
         A new measurement cannot have a period that overlaps with an existing measurement
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
         WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 7, 1), period_end_date=datetime.date(2024, 7, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 7, 1),
+            period_end_date=datetime.date(2024, 7, 5),
         )
 
         # check a start date that falls in existing period
@@ -397,9 +357,11 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_start_date": "2024-07-03",
             "period_end_date": "2024-08-01",
         }
+
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}), payload
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
         )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json()["_All__"][0],
@@ -411,9 +373,11 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_start_date": "2024-06-10",
             "period_end_date": "2024-07-03",
         }
+
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}), payload
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
         )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json()["_All__"][0],
@@ -422,15 +386,19 @@ class WasteMeasurementsCreateApiTest(APITestCase):
 
         # check a start and end date that encapsulate the periods of existing measurements
         WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 7, 10), period_end_date=datetime.date(2024, 7, 15)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 7, 10),
+            period_end_date=datetime.date(2024, 7, 15),
         )
         payload = {
             "period_start_date": "2024-06-30",
             "period_end_date": "2024-07-16",
         }
+
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}), payload
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
         )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json()["_All__"][0],
@@ -443,34 +411,160 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         It shouldn't matter when other canteens have created their waste measurements
         """
         WasteMeasurementFactory(period_start_date=datetime.date(2024, 7, 1), period_end_date=datetime.date(2024, 7, 5))
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
 
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": canteen.id}),
+            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}),
             {
                 "period_start_date": "2024-07-01",
                 "period_end_date": "2024-07-05",
             },
         )
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
 
+class WasteMeasurementsDetailApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.measurement = WasteMeasurementFactory(
+            canteen=cls.canteen, period_start_date=datetime.date(2023, 1, 1), period_end_date=datetime.date(2023, 1, 5)
+        )
+
+    @authenticate
+    def test_cannot_get_waste_measurement_if_unauthenticated(self):
+        response = self.client.get(
+            reverse(
+                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_get_waste_measurement_if_canteen_unknown(self):
+        response = self.client.get(
+            reverse("canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": 9909})
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_get_waste_measurement_if_not_canteen_manager(self):
+        response = self.client.get(
+            reverse(
+                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_get_waste_measurement(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(
+            reverse(
+                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("periodStartDate", body)
+
+    def test_get_waste_measurement_via_oauth2(self):
+        user, token = get_oauth2_token("waste_measurements:read")
+        self.canteen.managers.add(user)
+
+        self.client.credentials(Authorization=f"Bearer {token}")
+        response = self.client.get(
+            reverse(
+                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("periodStartDate", body)
+
+
 class WasteMeasurementsUpdateApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.measurement = WasteMeasurementFactory(
+            canteen=cls.canteen,
+            meal_count=100,
+            period_start_date=datetime.date(2023, 1, 1),
+            period_end_date=datetime.date(2023, 1, 5),
+        )
+
+    @authenticate
+    def test_cannot_update_waste_measurement_if_unauthenticated(self):
+        payload = {"mealCount": 200}
+
+        response = self.client.patch(
+            reverse(
+                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
+            ),
+            payload,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_update_waste_measurement_if_canteen_unknown(self):
+        payload = {"mealCount": 200}
+
+        response = self.client.get(
+            reverse("canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": 9909}),
+            payload,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_update_waste_measurement_if_measurement_unknown(self):
+        self.canteen.managers.add(authenticate.user)
+        payload = {"mealCount": 200}
+
+        response = self.client.get(
+            reverse("canteen_waste_measurement_detail", kwargs={"pk": 9999, "canteen_pk": self.canteen.id}), payload
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_update_waste_measurement_if_not_canteen_manager(self):
+        payload = {"mealCount": 200}
+
+        response = self.client.patch(
+            reverse(
+                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
+            ),
+            payload,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     @authenticate
     def test_update_waste_measurement(self):
         """
         Canteen managers can edit the waste measurement of a canteen they manage
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        measurement = WasteMeasurementFactory(canteen=canteen, meal_count=100)
-
+        self.canteen.managers.add(authenticate.user)
         payload = {"mealCount": 200}
+
         response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id}),
+            reverse(
+                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
+            ),
             payload,
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["mealCount"], 200)
 
@@ -479,18 +573,18 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         Canteen managers can edit the waste measurement of a canteen they manage via oauth2 token
         """
         user, token = get_oauth2_token("waste_measurements:write")
-        canteen = CanteenFactory(managers=[user])
-        measurement = WasteMeasurementFactory(canteen=canteen, meal_count=100)
-
+        self.canteen.managers.add(user)
         payload = {"mealCount": 200}
 
         self.client.credentials(Authorization=f"Bearer {token}")
         response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id}),
+            reverse(
+                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
+            ),
             payload,
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["mealCount"], 200)
 
@@ -500,18 +594,18 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         """
         The period end date cannot be updated to be in the future
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
         measurement = WasteMeasurementFactory(
-            canteen=canteen, period_start_date="2024-08-01", period_end_date="2024-08-05"
+            canteen=self.canteen, period_start_date="2024-08-01", period_end_date="2024-08-05"
         )
-
         payload = {"period_end_date": "2024-08-20"}
+
         response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id}),
+            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
             payload,
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["periodEndDate"][0], "La date ne peut pas être dans le futur")
 
     @authenticate
@@ -519,17 +613,21 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         """
         The period start date must be before end date in update
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
         measurement = WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 8, 1), period_end_date=datetime.date(2024, 8, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 8, 1),
+            period_end_date=datetime.date(2024, 8, 5),
         )
 
         # change start_date to after end_date
         payload = {"period_start_date": "2024-08-10"}
+
         response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id}),
+            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
             payload,
         )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json()["periodStartDate"][0], "La date de début ne peut pas être après la date de fin"
@@ -537,10 +635,12 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
 
         # change end_date to before start_date
         payload = {"period_end_date": "2024-07-31"}
+
         response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id}),
+            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
             payload,
         )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["periodEndDate"][0], "La date de fin ne peut pas être avant la date de début")
 
@@ -549,20 +649,26 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         """
         A measurement update cannot have a period that overlaps with an existing measurement
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
+        self.canteen.managers.add(authenticate.user)
         WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 7, 1), period_end_date=datetime.date(2024, 7, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 7, 1),
+            period_end_date=datetime.date(2024, 7, 5),
         )
 
         # check a start date that falls in existing period
         measurement = WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 8, 1), period_end_date=datetime.date(2024, 8, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 8, 1),
+            period_end_date=datetime.date(2024, 8, 5),
         )
         payload = {"period_start_date": "2024-07-03"}
+
         response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id}),
+            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
             payload,
         )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json()["_All__"][0],
@@ -571,13 +677,17 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
 
         # check an end date that falls in existing period
         measurement = WasteMeasurementFactory(
-            canteen=canteen, period_start_date=datetime.date(2024, 6, 1), period_end_date=datetime.date(2024, 6, 5)
+            canteen=self.canteen,
+            period_start_date=datetime.date(2024, 6, 1),
+            period_end_date=datetime.date(2024, 6, 5),
         )
         payload = {"period_end_date": "2024-07-03"}
+
         response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id}),
+            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
             payload,
         )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json()["_All__"][0],
@@ -589,10 +699,12 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
             "period_start_date": "2024-01-30",
             "period_end_date": "2024-08-10",
         }
+
         response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id}),
+            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
             payload,
         )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json()["_All__"][0],
@@ -604,20 +716,21 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         """
         The period dates cannot be removed
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        measurement = WasteMeasurementFactory(canteen=canteen)
+        self.canteen.managers.add(authenticate.user)
+        measurement = WasteMeasurementFactory(canteen=self.canteen)
 
         payload = {
             "period_start_date": None,
             "period_end_date": "",
         }
+
         response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id}),
+            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
             payload,
             format="json",
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["periodStartDate"][0], "Ce champ ne peut être nul.")
         self.assertEqual(
             response.json()["periodEndDate"][0],

--- a/api/views/wastemeasurement.py
+++ b/api/views/wastemeasurement.py
@@ -1,15 +1,12 @@
 import logging
 
-from django.core.exceptions import ObjectDoesNotExist
 from django_filters import rest_framework as django_filters
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView
 
 from api.permissions import (
     IsAuthenticatedOrTokenHasResourceScope,
-    IsCanteenManager,
-    IsLinkedCanteenManager,
+    IsCanteenManagerUrlParam,
 )
 from api.serializers import WasteMeasurementSerializer
 from api.views.utils import update_change_reason_with_auth
@@ -37,7 +34,7 @@ class WasteMeasurementFilterSet(django_filters.FilterSet):
     )
 )
 class CanteenWasteMeasurementsView(ListCreateAPIView):
-    permission_classes = [IsAuthenticatedOrTokenHasResourceScope]
+    permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     queryset = WasteMeasurement.objects.none()
     serializer_class = WasteMeasurementSerializer
     filter_backends = [
@@ -46,19 +43,8 @@ class CanteenWasteMeasurementsView(ListCreateAPIView):
     filterset_class = WasteMeasurementFilterSet
 
     def _get_canteen(self):
-        canteen_id = self.request.parser_context.get("kwargs").get("canteen_pk")
-        try:
-            canteen = Canteen.objects.get(pk=canteen_id)
-        except ObjectDoesNotExist as e:
-            logger.warning(
-                f"Attempt to create/view a waste measurement from an unexistent canteen ID : {canteen_id}: \n{e}"
-            )
-            raise NotFound()
-
-        if not IsCanteenManager().has_object_permission(self.request, self, canteen):
-            raise PermissionDenied()
-
-        return canteen
+        # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
+        return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
 
     def get_queryset(self):
         canteen = self._get_canteen()
@@ -78,7 +64,7 @@ class CanteenWasteMeasurementsView(ListCreateAPIView):
     )
 )
 class CanteenWasteMeasurementView(RetrieveUpdateAPIView):
-    permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsLinkedCanteenManager]
+    permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     http_method_names = ["get", "patch"]  # disable "put"
     queryset = WasteMeasurement.objects.all()
     serializer_class = WasteMeasurementSerializer


### PR DESCRIPTION
Suite à #6811
- utilise IsCanteenManagerUrlParam au lieu de IsLinkedCanteenManager
- permet de simplifier le code des views
- mise à jour des tests