### PR TITLE
refactor(API): diagnostics: utiliser IsCanteenManagerUrlParam au lieu de IsLinkedCanteenManager

### DIFF
--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -27,9 +27,9 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_create_diagnostic_if_canteen_does_not_exist(self):
+    def test_cannot_create_diagnostic_if_canteen_unknown(self):
         response = self.client.post(
-            reverse("diagnostic_creation", kwargs={"canteen_pk": 999}), self.DIAGNOSTIC_PAYLOAD
+            reverse("diagnostic_creation", kwargs={"canteen_pk": 9999}), self.DIAGNOSTIC_PAYLOAD
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -405,12 +405,42 @@ class DiagnosticUpdateApiTest(APITestCase):
         self.assertEqual(self.diagnostic.year, 2019)
 
     @authenticate
+    def test_cannot_update_diagnostic_if_canteen_unknown(self):
+        response = self.client.patch(
+            reverse(
+                "diagnostic_update",
+                kwargs={"canteen_pk": 9999, "pk": self.diagnostic.id},
+            ),
+            {"year": 2020},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.diagnostic.refresh_from_db()
+        self.assertEqual(self.diagnostic.year, 2019)
+
+    @authenticate
     def test_cannot_update_diagnostic_if_not_canteen_manager(self):
         payload = {"year": 2020}
 
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.diagnostic.refresh_from_db()
+        self.assertEqual(self.diagnostic.year, 2019)
+
+    @authenticate
+    def test_cannot_update_diagnostic_if_diagnostic_unknown(self):
+        self.diagnostic.canteen.managers.add(authenticate.user)
+
+        response = self.client.patch(
+            reverse(
+                "diagnostic_update",
+                kwargs={"canteen_pk": self.diagnostic.canteen.id, "pk": 9999},
+            ),
+            {"year": 2020},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.diagnostic.refresh_from_db()
         self.assertEqual(self.diagnostic.year, 2019)
 

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -1,12 +1,12 @@
 import logging
 
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.db.models import Exists, OuterRef
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseServerError
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import CreateAPIView, ListAPIView, UpdateAPIView
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.views import APIView
@@ -15,8 +15,7 @@ from api.exceptions import DuplicateException
 from api.permissions import (
     IsAuthenticated,
     IsAuthenticatedOrTokenHasResourceScope,
-    IsCanteenManager,
-    IsLinkedCanteenManager,
+    IsCanteenManagerUrlParam,
 )
 from api.serializers import (
     DiagnosticAndCanteenSerializer,
@@ -39,7 +38,7 @@ logger = logging.getLogger(__name__)
     )
 )
 class DiagnosticCreateView(CreateAPIView):
-    permission_classes = [IsAuthenticatedOrTokenHasResourceScope]
+    permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     required_scopes = ["canteen"]
     model = Diagnostic
     serializer_class = ManagerDiagnosticSerializer
@@ -49,22 +48,22 @@ class DiagnosticCreateView(CreateAPIView):
         kwargs.setdefault("action", "create")
         return ManagerDiagnosticSerializer(*args, **kwargs)
 
+    def _get_canteen(self):
+        # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
+        return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
+
     def perform_create(self, serializer):
         try:
-            canteen_id = self.request.parser_context.get("kwargs").get("canteen_pk")
-            canteen = Canteen.objects.get(pk=canteen_id)
-            if not IsCanteenManager().has_object_permission(self.request, self, canteen):
-                raise PermissionDenied()
+            canteen = self._get_canteen()
             serializer.is_valid(raise_exception=True)
             creation_user = self.request.user
             creation_source = serializer.validated_data.get("creation_source") or CreationSource.API
             diagnostic = serializer.save(canteen=canteen, creation_user=creation_user, creation_source=creation_source)
             update_change_reason_with_auth(self, diagnostic)
-        except ObjectDoesNotExist as e:
-            logger.warning(f"Attempt to create a diagnostic from an unexistent canteen ID : {canteen_id}: \n{e}")
-            raise NotFound()
         except IntegrityError as e:
-            logger.warning(f"Attempt to create an existing diagnostic for canteen ID {canteen_id}:\n{e}")
+            logger.warning(
+                f"Attempt to create an existing diagnostic for canteen ID {self.kwargs['canteen_pk']}:\n{e}"
+            )
             raise DuplicateException()
 
 
@@ -75,7 +74,7 @@ class DiagnosticCreateView(CreateAPIView):
     ),
 )
 class DiagnosticUpdateView(UpdateAPIView):
-    permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsLinkedCanteenManager]
+    permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     required_scopes = ["canteen"]
     http_method_names = ["patch"]  # disable "put"
     queryset = Diagnostic.objects.all()


### PR DESCRIPTION
Suite à #6811
- utilise IsCanteenManagerUrlParam au lieu de IsLinkedCanteenManager
- permet de simplifier le code des views
- mise à jour des tests