### PR TITLE
refactor(API): renvoyer un 404 si l'objet n'appartient pas à la cantine (diagnostic & wastemeasurement)

### DIFF
--- a/api/tests/test_diagnostic_teledeclaration.py
+++ b/api/tests/test_diagnostic_teledeclaration.py
@@ -226,6 +226,34 @@ class DiagnosticTeledeclarationCreateApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    @authenticate
+    @freeze_time("2025-03-30")  # during the 2024 campaign
+    def test_cannot_teledeclare_diagnostic_if_not_corresponding_canteen(self):
+        canteen_other = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+        diagnostic_other = DiagnosticFactory(canteen=canteen_other, year=2024)
+        self.canteen_site.managers.add(authenticate.user)
+
+        response = self.client.post(
+            reverse(
+                "diagnostic_teledeclaration_create",
+                kwargs={"canteen_pk": self.canteen_site.id, "pk": diagnostic_other.id},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # even if the user manages canteen_other
+        canteen_other.managers.add(authenticate.user)
+
+        response = self.client.post(
+            reverse(
+                "diagnostic_teledeclaration_create",
+                kwargs={"canteen_pk": self.canteen_site.id, "pk": diagnostic_other.id},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     @freeze_time("2025-03-30")  # during the 2024 campaign
     def test_cannot_teledeclare_with_oauth2_token(self):
         user, token = get_oauth2_token("canteen:write")
@@ -415,6 +443,34 @@ class DiagnosticTeledeclarationCancelView(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    @freeze_time("2025-03-30")  # during the 2024 campaign
+    def test_cannot_cancel_teledeclaration_if_not_corresponding_canteen(self):
+        canteen_other = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+        diagnostic_other = DiagnosticFactory(canteen=canteen_other, year=2024)
+        self.canteen_site.managers.add(authenticate.user)
+
+        response = self.client.post(
+            reverse(
+                "diagnostic_teledeclaration_cancel",
+                kwargs={"canteen_pk": self.canteen_site.id, "pk": diagnostic_other.id},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # even if the user manages canteen_other
+        canteen_other.managers.add(authenticate.user)
+
+        response = self.client.post(
+            reverse(
+                "diagnostic_teledeclaration_cancel",
+                kwargs={"canteen_pk": self.canteen_site.id, "pk": diagnostic_other.id},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @freeze_time("2025-03-30")  # during the 2024 campaign
     def test_cannot_cancel_teledeclaration_with_oauth2_token(self):

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -373,6 +373,26 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
+class DiagnosticRetrieveApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.diagnostic = DiagnosticFactory(year=2019, canteen=cls.canteen)
+        cls.url = reverse(
+            "diagnostic_update",
+            kwargs={"canteen_pk": cls.diagnostic.canteen.id, "pk": cls.diagnostic.id},
+        )
+
+    @authenticate
+    def test_retrieve_diagnostic_not_allowed(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+
 class DiagnosticUpdateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
@@ -443,6 +463,35 @@ class DiagnosticUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.diagnostic.refresh_from_db()
         self.assertEqual(self.diagnostic.year, 2019)
+
+    @authenticate
+    def test_cannot_update_diagnostic_if_not_corresponding_canteen(self):
+        canteen_other = CanteenFactory()
+        diagnostic_other = DiagnosticFactory(canteen=canteen_other)
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.patch(
+            reverse(
+                "diagnostic_update",
+                kwargs={"canteen_pk": self.diagnostic.canteen.id, "pk": diagnostic_other.id},
+            ),
+            {"year": 2020},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # even if the user manages canteen_other
+        canteen_other.managers.add(authenticate.user)
+
+        response = self.client.patch(
+            reverse(
+                "diagnostic_update",
+                kwargs={"canteen_pk": self.diagnostic.canteen.id, "pk": diagnostic_other.id},
+            ),
+            {"year": 2020},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_update_diagnostic(self):

--- a/api/tests/test_waste_measurements.py
+++ b/api/tests/test_waste_measurements.py
@@ -461,6 +461,35 @@ class WasteMeasurementsDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
+    def test_cannot_get_waste_measurement_if_not_corresponding_canteen(self):
+        canteen2 = CanteenFactory()
+        measurement2 = WasteMeasurementFactory(
+            canteen=canteen2, period_start_date=datetime.date(2023, 1, 1), period_end_date=datetime.date(2023, 1, 5)
+        )
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(
+            reverse(
+                "canteen_waste_measurement_detail",
+                kwargs={"pk": measurement2.id, "canteen_pk": self.canteen.id},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # even if user manages the canteen of the measurement
+        canteen2.managers.add(authenticate.user)
+
+        response = self.client.get(
+            reverse(
+                "canteen_waste_measurement_detail",
+                kwargs={"pk": measurement2.id, "canteen_pk": self.canteen.id},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
     def test_get_waste_measurement(self):
         self.canteen.managers.add(authenticate.user)
 
@@ -548,6 +577,40 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_update_waste_measurement_if_not_corresponding_canteen(self):
+        canteen_other = CanteenFactory()
+        measurement_other = WasteMeasurementFactory(
+            canteen=canteen_other,
+            period_start_date=datetime.date(2023, 1, 1),
+            period_end_date=datetime.date(2023, 1, 5),
+        )
+        self.canteen.managers.add(authenticate.user)
+        payload = {"mealCount": 200}
+
+        response = self.client.patch(
+            reverse(
+                "canteen_waste_measurement_detail",
+                kwargs={"pk": measurement_other.id, "canteen_pk": self.canteen.id},
+            ),
+            payload,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # even if user manages canteen_other
+        canteen_other.managers.add(authenticate.user)
+
+        response = self.client.patch(
+            reverse(
+                "canteen_waste_measurement_detail",
+                kwargs={"pk": measurement_other.id, "canteen_pk": self.canteen.id},
+            ),
+            payload,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_update_waste_measurement(self):

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -7,7 +7,7 @@ from django.db.models import Exists, OuterRef
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseServerError
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.generics import CreateAPIView, ListAPIView, UpdateAPIView
+from rest_framework.generics import CreateAPIView, ListAPIView, UpdateAPIView, get_object_or_404
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.views import APIView
 
@@ -77,16 +77,16 @@ class DiagnosticUpdateView(UpdateAPIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     required_scopes = ["canteen"]
     http_method_names = ["patch"]  # disable "put"
-    queryset = Diagnostic.objects.all()
+    model = Diagnostic
     serializer_class = ManagerDiagnosticSerializer
 
     def _get_canteen(self):
         # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
         return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
 
-    def get_queryset(self):
+    def get_object(self):
         canteen = self._get_canteen()
-        return self.queryset.filter(canteen=canteen)
+        return get_object_or_404(Diagnostic, pk=self.kwargs["pk"], canteen=canteen)
 
     def perform_update(self, serializer):
         if self.get_object().is_teledeclared:

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -80,6 +80,14 @@ class DiagnosticUpdateView(UpdateAPIView):
     queryset = Diagnostic.objects.all()
     serializer_class = ManagerDiagnosticSerializer
 
+    def _get_canteen(self):
+        # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
+        return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
+
+    def get_queryset(self):
+        canteen = self._get_canteen()
+        return self.queryset.filter(canteen=canteen)
+
     def perform_update(self, serializer):
         if self.get_object().is_teledeclared:
             # if the user wants to cancel, see DiagnosticTeledeclarationCancelView

--- a/api/views/diagnostic_teledeclaration.py
+++ b/api/views/diagnostic_teledeclaration.py
@@ -34,9 +34,12 @@ class DiagnosticTeledeclarationCreateView(APIView):
         # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
         return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
 
-    def post(self, request, *args, **kwargs):
+    def get_object(self):
         canteen = self._get_canteen()
-        diagnostic = get_object_or_404(canteen.diagnostics, pk=kwargs.get("pk"))
+        return get_object_or_404(Diagnostic, pk=self.kwargs["pk"], canteen=canteen)
+
+    def post(self, request, *args, **kwargs):
+        diagnostic = self.get_object()
 
         # if ValidationError, it will be raised (and handled by custom_exception_handler)
         diagnostic.teledeclare(request.user)
@@ -52,9 +55,12 @@ class DiagnosticTeledeclarationCancelView(APIView):
         # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
         return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
 
-    def post(self, request, *args, **kwargs):
+    def get_object(self):
         canteen = self._get_canteen()
-        diagnostic = get_object_or_404(canteen.diagnostics, pk=kwargs.get("pk"))
+        return get_object_or_404(Diagnostic, pk=self.kwargs["pk"], canteen=canteen)
+
+    def post(self, request, *args, **kwargs):
+        diagnostic = self.get_object()
 
         # if ValidationError, it will be raised (and handled by custom_exception_handler)
         diagnostic.cancel()
@@ -81,9 +87,12 @@ class DiagnosticTeledeclarationPdfView(APIView):
         # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
         return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
 
-    def get(self, request, *args, **kwargs):
+    def get_object(self):
         canteen = self._get_canteen()
-        diagnostic = get_object_or_404(canteen.diagnostics, pk=kwargs.get("pk"))
+        return get_object_or_404(Diagnostic, pk=self.kwargs["pk"], canteen=canteen)
+
+    def get(self, request, *args, **kwargs):
+        diagnostic = self.get_object()
 
         if not diagnostic.is_teledeclared:
             raise ValidationError("Le diagnostic n'a pas été télédéclaré.")

--- a/api/views/wastemeasurement.py
+++ b/api/views/wastemeasurement.py
@@ -68,3 +68,11 @@ class CanteenWasteMeasurementView(RetrieveUpdateAPIView):
     http_method_names = ["get", "patch"]  # disable "put"
     queryset = WasteMeasurement.objects.all()
     serializer_class = WasteMeasurementSerializer
+
+    def _get_canteen(self):
+        # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
+        return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
+
+    def get_queryset(self):
+        canteen = self._get_canteen()
+        return self.queryset.filter(canteen=canteen)

--- a/api/views/wastemeasurement.py
+++ b/api/views/wastemeasurement.py
@@ -2,7 +2,7 @@ import logging
 
 from django_filters import rest_framework as django_filters
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView
+from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView, get_object_or_404
 
 from api.permissions import (
     IsAuthenticatedOrTokenHasResourceScope,
@@ -66,13 +66,13 @@ class CanteenWasteMeasurementsView(ListCreateAPIView):
 class CanteenWasteMeasurementView(RetrieveUpdateAPIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     http_method_names = ["get", "patch"]  # disable "put"
-    queryset = WasteMeasurement.objects.all()
+    model = WasteMeasurement
     serializer_class = WasteMeasurementSerializer
 
     def _get_canteen(self):
         # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
         return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
 
-    def get_queryset(self):
+    def get_object(self):
         canteen = self._get_canteen()
-        return self.queryset.filter(canteen=canteen)
+        return get_object_or_404(WasteMeasurement, pk=self.kwargs["pk"], canteen=canteen)


### PR DESCRIPTION
Suite à #6812 & #6814 & #6815

J'ai l'impression que notre code permettait de modifier l'objet d'une autre cantine, tant qu'on était gestionnaire des 2 cantines. bon c'est pas un trou, mais c'était bancal, j'ai rajouté un bout de code et des tests pour éviter cela
- Canteen diagnostic update (check + tests)
- Canteen diagnostic teledeclare & cancel (le check était déjà présent, juste rajouté des test)
- Canteen wastemeasurement update (check + tests)