### PR TITLE
improve(1TD1Site): remplir le champ groupe_snapshot pour les TD générées (2/2)

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -552,6 +552,7 @@ CANTEEN_TELEDECLARATION_SNAPSHOT_FIELDS = (
     "management_type",
     "economic_model",
     "central_producer_siret",
+    # cout_repas,
     "groupe_id",
     "is_filled",
 )

--- a/macantine/management/commands/teledeclaration_generate_1td1site.py
+++ b/macantine/management/commands/teledeclaration_generate_1td1site.py
@@ -164,6 +164,13 @@ def create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, app
     # change the id (to create a new object)
     diagnostic_satellite.pk = None
 
+    # init TD fields
+    # diagnostic_satellite.creation_date = diagnostic.teledeclaration_date  # won't work. see update_generated_diagnostic_teledeclared_creation_date
+    diagnostic_satellite.teledeclaration_mode = Diagnostic.TeledeclarationMode.SITE
+    diagnostic_satellite.groupe_snapshot = diagnostic.canteen_snapshot
+    diagnostic_satellite.satellites_snapshot = None
+    diagnostic_satellite.generated_from_groupe_diagnostic = True
+
     # change the canteen FK & canteen_snapshot
     diagnostic_satellite.canteen = None
     # we fetch the canteen satellite as of the creation date of the diagnostic, for accurate snapshot
@@ -194,12 +201,6 @@ def create_diagnostic_teledeclared_for_satellite(diagnostic, satellite_dict, app
     )
     for field in updated_diagnostic_appro_fields.keys():
         setattr(diagnostic_satellite, field, updated_diagnostic_appro_fields[field])
-
-    # change some last fields
-    # diagnostic_satellite.creation_date = diagnostic.teledeclaration_date  # won't work. see update_generated_diagnostic_teledeclared_creation_date
-    diagnostic_satellite.teledeclaration_mode = Diagnostic.TeledeclarationMode.SITE
-    diagnostic_satellite.satellites_snapshot = None
-    diagnostic_satellite.generated_from_groupe_diagnostic = True
 
     if apply:
         try:

--- a/macantine/tests/test_teledeclaration_generate_1td1site_2024.py
+++ b/macantine/tests/test_teledeclaration_generate_1td1site_2024.py
@@ -459,7 +459,36 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         self.assertEqual(diagnostic_generated.creation_date, central_diagnostic.teledeclaration_date)
 
     @authenticate
-    def test_empty_satellites_snapshot(self):
+    def test_groupe_snapshot_filled(self):
+        """
+        The groupe_snapshot should be filled with the canteen snapshot of the central diagnostic.
+        """
+        central = CanteenFactory(
+            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, daily_meal_count=3
+        )
+        satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
+        )
+
+        with freeze_time("2025-03-30"):  # during the 2024 campaign
+            central_diagnostic = DiagnosticFactory(
+                canteen=central,
+                year=2024,
+                valeur_totale=10000,
+                valeur_bio=2000,
+            )
+            central_diagnostic.teledeclare(applicant=authenticate.user)
+
+        # Run the script
+        call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
+
+        # After the script is run
+        diagnostic_generated = Diagnostic.all_objects.in_year(2024).teledeclared().get(canteen=satellite)
+        self.assertIsNotNone(diagnostic_generated.groupe_snapshot)
+        self.assertEqual(diagnostic_generated.groupe_snapshot["siret"], central.siret)
+
+    @authenticate
+    def test_satellites_snapshot_empty(self):
         """
         The satellites_snapshot should be empty for the generated diagnostics.
         """

--- a/macantine/tests/test_teledeclaration_generate_1td1site_2025.py
+++ b/macantine/tests/test_teledeclaration_generate_1td1site_2025.py
@@ -389,7 +389,63 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
 
 class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
     @authenticate
-    def test_empty_satellites_snapshot(self):
+    def test_set_correct_creation_date(self):
+        """
+        The creation date of the generated diagnostics should be the date of the teledeclaration of the central diagnostic.
+        """
+        central = CanteenFactory(
+            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, daily_meal_count=3
+        )
+        satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
+        )
+
+        with freeze_time("2026-03-30"):  # during the 2025 campaign
+            central_diagnostic = DiagnosticFactory(
+                canteen=central,
+                year=2025,
+                valeur_totale=10000,
+                valeur_bio=2000,
+            )
+            central_diagnostic.teledeclare(applicant=authenticate.user)
+
+        # Run the script
+        call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
+
+        # After the script is run
+        diagnostic_generated = Diagnostic.all_objects.in_year(2025).teledeclared().get(canteen=satellite)
+        self.assertEqual(diagnostic_generated.creation_date, central_diagnostic.teledeclaration_date)
+
+    @authenticate
+    def test_groupe_snapshot_filled(self):
+        """
+        The groupe_snapshot should be filled for the generated diagnostics.
+        """
+        groupe = CanteenFactory(
+            production_type=Canteen.ProductionType.GROUPE, yearly_meal_count=1011, daily_meal_count=3
+        )
+        satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
+
+        with freeze_time("2026-03-30"):  # during the 2025 campaign
+            groupe_diagnostic = DiagnosticFactory(
+                canteen=groupe,
+                year=2025,
+                valeur_totale=10000,
+                valeur_bio=2000,
+            )
+            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+
+        # Run the script
+        call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
+
+        # After the script is run
+        diagnostic_generated = Diagnostic.all_objects.in_year(2025).teledeclared().get(canteen=satellite)
+        self.assertIsNotNone(diagnostic_generated.groupe_snapshot)
+        self.assertEqual(diagnostic_generated.groupe_snapshot["id"], groupe.id)
+        self.assertEqual(diagnostic_generated.groupe_snapshot["name"], groupe.name)
+
+    @authenticate
+    def test_satellites_snapshot_empty(self):
         """
         The satellites_snapshot should be empty for the generated diagnostics.
         """


### PR DESCRIPTION
Suite de #6799 (nouveau champ `Diagnostic.groupe_snapshot`)

- [x] script 1td1site : remplir le champ (avec le snapshot existant du groupe)
- [x] ajout de tests