### PR TITLE
refactor(Evaluation Gaspillage): regrouper les validateurs dans un fichier dédié. cleanup des tests

### DIFF
--- a/api/tests/test_waste_measurements.py
+++ b/api/tests/test_waste_measurements.py
@@ -151,11 +151,10 @@ class WasteMeasurementsCreateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.canteen = CanteenFactory()
+        cls.url = reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": cls.canteen.id})
 
     def test_cannot_create_waste_measurement_if_unauthenticated(self):
-        response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), {}
-        )
+        response = self.client.post(self.url, {})
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -175,7 +174,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
     @authenticate
     def test_cannot_create_waste_measurement_if_not_canteen_manager(self):
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}),
+            self.url,
             {
                 "period_start_date": "2024-08-01",
                 "period_end_date": "2024-08-10",
@@ -210,9 +209,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "leftovers_total_mass": 30.3,
         }
 
-        response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
-        )
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         waste_measurement = WasteMeasurement.objects.get(canteen__id=self.canteen.id)
@@ -256,10 +253,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         }
 
         self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}),
-            payload,
-        )
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -275,9 +269,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_end_date": "2024-08-01",
         }
 
-        response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
-        )
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -290,9 +282,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
 
         payload = {}
 
-        response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
-        )
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
@@ -312,9 +302,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_end_date": "2024-08-20",
         }
 
-        response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
-        )
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["periodEndDate"][0], "La date ne peut pas être dans le futur")
@@ -331,9 +319,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_end_date": "2024-08-01",
         }
 
-        response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
-        )
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -358,9 +344,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_end_date": "2024-08-01",
         }
 
-        response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
-        )
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -374,9 +358,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_end_date": "2024-07-03",
         }
 
-        response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
-        )
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -395,9 +377,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_end_date": "2024-07-16",
         }
 
-        response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}), payload
-        )
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -414,7 +394,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.post(
-            reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}),
+            self.url,
             {
                 "period_start_date": "2024-07-01",
                 "period_end_date": "2024-07-05",
@@ -431,14 +411,13 @@ class WasteMeasurementsDetailApiTest(APITestCase):
         cls.measurement = WasteMeasurementFactory(
             canteen=cls.canteen, period_start_date=datetime.date(2023, 1, 1), period_end_date=datetime.date(2023, 1, 5)
         )
+        cls.url = reverse(
+            "canteen_waste_measurement_detail", kwargs={"pk": cls.measurement.id, "canteen_pk": cls.canteen.id}
+        )
 
     @authenticate
     def test_cannot_get_waste_measurement_if_unauthenticated(self):
-        response = self.client.get(
-            reverse(
-                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
-            )
-        )
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -452,11 +431,7 @@ class WasteMeasurementsDetailApiTest(APITestCase):
 
     @authenticate
     def test_cannot_get_waste_measurement_if_not_canteen_manager(self):
-        response = self.client.get(
-            reverse(
-                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
-            )
-        )
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -493,30 +468,24 @@ class WasteMeasurementsDetailApiTest(APITestCase):
     def test_get_waste_measurement(self):
         self.canteen.managers.add(authenticate.user)
 
-        response = self.client.get(
-            reverse(
-                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
-            )
-        )
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertIn("periodStartDate", body)
+        self.assertIn("periodEndDate", body)
 
     def test_get_waste_measurement_via_oauth2(self):
         user, token = get_oauth2_token("waste_measurements:read")
         self.canteen.managers.add(user)
 
         self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.get(
-            reverse(
-                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
-            )
-        )
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertIn("periodStartDate", body)
+        self.assertIn("periodEndDate", body)
 
 
 class WasteMeasurementsUpdateApiTest(APITestCase):
@@ -529,17 +498,15 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
             period_start_date=datetime.date(2023, 1, 1),
             period_end_date=datetime.date(2023, 1, 5),
         )
+        cls.url = reverse(
+            "canteen_waste_measurement_detail", kwargs={"pk": cls.measurement.id, "canteen_pk": cls.canteen.id}
+        )
 
     @authenticate
     def test_cannot_update_waste_measurement_if_unauthenticated(self):
         payload = {"mealCount": 200}
 
-        response = self.client.patch(
-            reverse(
-                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
-            ),
-            payload,
-        )
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -569,12 +536,7 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
     def test_cannot_update_waste_measurement_if_not_canteen_manager(self):
         payload = {"mealCount": 200}
 
-        response = self.client.patch(
-            reverse(
-                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
-            ),
-            payload,
-        )
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -620,12 +582,7 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         self.canteen.managers.add(authenticate.user)
         payload = {"mealCount": 200}
 
-        response = self.client.patch(
-            reverse(
-                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
-            ),
-            payload,
-        )
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -640,12 +597,7 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         payload = {"mealCount": 200}
 
         self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.patch(
-            reverse(
-                "canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": self.canteen.id}
-            ),
-            payload,
-        )
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -705,7 +657,9 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.json()["periodEndDate"][0], "La date de fin ne peut pas être avant la date de début")
+        self.assertEqual(
+            response.json()["periodStartDate"][0], "La date de début ne peut pas être après la date de fin"
+        )
 
     @authenticate
     def test_periods_cannot_overlap_in_update(self):
@@ -827,14 +781,26 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
 
 
 class WasteMeasurementsDeleteApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.measurement = WasteMeasurementFactory(
+            canteen=cls.canteen,
+            meal_count=100,
+            period_start_date=datetime.date(2023, 1, 1),
+            period_end_date=datetime.date(2023, 1, 5),
+        )
+        cls.url = reverse(
+            "canteen_waste_measurement_detail", kwargs={"pk": cls.measurement.id, "canteen_pk": cls.canteen.id}
+        )
+
     @authenticate
     def test_cannot_delete_waste_measurement(self):
         """
         Canteen managers cannot delete waste measurements
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        measurement = WasteMeasurementFactory(canteen=canteen)
-        response = self.client.delete(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id})
-        )
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.delete(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/data/models/wastemeasurement.py
+++ b/data/models/wastemeasurement.py
@@ -4,6 +4,8 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from simple_history.models import HistoricalRecords
 
+from common.utils import utils as utils_utils
+from data.validators import wastemeasurement as wastemeasurement_validators
 from data.utils import make_optional_positive_decimal_field
 
 from .canteen import Canteen
@@ -65,18 +67,20 @@ class WasteMeasurement(models.Model):
         verbose_name="restes assiette - masse non-comestible (kg)",
     )
 
-    history = HistoricalRecords()
-
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
+    history = HistoricalRecords()
 
     class Meta:
         verbose_name = "évaluation du gaspillage alimentaire"
         verbose_name_plural = "évaluations du gaspillage alimentaire"
 
     def clean(self):
-        self.validate_dates()
-        return super().clean()
+        validation_errors = utils_utils.merge_validation_errors(
+            wastemeasurement_validators.validate_dates(self),
+        )
+        if validation_errors:
+            raise ValidationError(validation_errors)
 
     def save(self, *args, **kwargs):
         self.full_clean()
@@ -94,44 +98,3 @@ class WasteMeasurement(models.Model):
         if not canteen_yearly_meal_count or not self.meal_count or not has_total_mass:
             return None
         return self.total_mass / self.meal_count * canteen_yearly_meal_count
-
-    def validate_dates(self):
-        start_date = self.period_start_date
-        end_date = self.period_end_date
-        start_date_changed = start_date is not None
-        end_date_changed = end_date is not None
-
-        # if this is an update, check which date(s) have been changed so that we can raise relevant errors
-        if self.id:
-            original_object = WasteMeasurement.objects.get(id=self.id)
-            start_date_changed = original_object.period_start_date != start_date
-            end_date_changed = original_object.period_end_date != end_date
-
-        WasteMeasurement._validate_start_before_end(start_date, end_date, start_date_changed, end_date_changed)
-
-        other_measurements = WasteMeasurement.objects.filter(canteen=self.canteen)
-        if self.id:
-            other_measurements = other_measurements.exclude(id=self.id)
-
-        if start_date_changed or end_date_changed:
-            WasteMeasurement._validate_period_not_in_other_period(other_measurements, start_date, end_date)
-
-    def _validate_start_before_end(start_date, end_date, start_date_changed, end_date_changed):
-        if start_date_changed and start_date > end_date:
-            raise ValidationError({"period_start_date": ["La date de début ne peut pas être après la date de fin"]})
-        elif end_date_changed and end_date < start_date:
-            raise ValidationError({"period_end_date": ["La date de fin ne peut pas être avant la date de début"]})
-
-    def _validate_period_not_in_other_period(other_measurements, start_date, end_date):
-        measurements_within_period = other_measurements.filter(
-            period_end_date__gte=start_date, period_start_date__lte=end_date
-        )
-        if measurements_within_period.exists():
-            wm_count = measurements_within_period.count()
-            if wm_count > 1:
-                raise ValidationError(
-                    f"Il existe déjà {wm_count} autres évaluations dans la période {start_date} à {end_date}. Veuillez modifier les évaluations existantes ou corriger les dates de la période."
-                )
-            raise ValidationError(
-                f"Il existe déjà une autre évaluation dans la période {start_date} à {end_date}. Veuillez modifier l'évaluation existante ou corriger les dates de la période."
-            )

--- a/data/validators/wastemeasurement.py
+++ b/data/validators/wastemeasurement.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+from common.utils import utils as utils_utils
+
+
+def validate_dates(instance):
+    """
+    - clean_fields() (called by full_clean()) already checks that the date fields are the correct format
+    - extra validation:
+        - period_end_date cannot be in the futur
+        - period_start_date must be before period_end_date
+        - period_start_date and period_end_date cannot overlap with other WasteMeasurement for the same canteen
+    """
+    from data.models import WasteMeasurement
+
+    errors = {}
+
+    if instance.period_end_date:
+        if instance.period_end_date > datetime.now().date():
+            utils_utils.add_validation_error(
+                errors, "period_end_date", "La date de fin ne peut pas être dans le futur"
+            )
+
+        if instance.period_start_date:
+            if instance.period_start_date > instance.period_end_date:
+                utils_utils.add_validation_error(
+                    errors, "period_start_date", "La date de début ne peut pas être après la date de fin"
+                )
+
+            canteen_wm_within_period_qs = WasteMeasurement.objects.filter(canteen=instance.canteen)
+            if instance.id:
+                canteen_wm_within_period_qs = canteen_wm_within_period_qs.exclude(id=instance.id)
+            canteen_wm_within_period_qs = canteen_wm_within_period_qs.filter(
+                period_end_date__gte=instance.period_start_date, period_start_date__lte=instance.period_end_date
+            )
+            if canteen_wm_within_period_qs.exists():
+                wm_count = canteen_wm_within_period_qs.count()
+                if wm_count > 1:
+                    utils_utils.add_validation_error(
+                        errors,
+                        "_All__",
+                        f"Il existe déjà {wm_count} autres évaluations dans la période {instance.period_start_date} à {instance.period_end_date}. Veuillez modifier les évaluations existantes ou corriger les dates de la période.",
+                    )
+                utils_utils.add_validation_error(
+                    errors,
+                    "_All__",
+                    f"Il existe déjà une autre évaluation dans la période {instance.period_start_date} à {instance.period_end_date}. Veuillez modifier l'évaluation existante ou corriger les dates de la période.",
+                )
+
+    return errors


### PR DESCRIPTION
Première PR sur le cleanup de l'API `WasteMeasurement`
- nouveau fichier `validators/wastemeasurement.py`
- simplifier un peu les validations
- cleanup des tests