### PR TITLE
refactor(API): meilleur facon de créer les champs metadata (et ne pas les renvoyer ensuite)

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -20,6 +20,9 @@ from .user import CanteenManagerSerializer
 logger = logging.getLogger(__name__)
 
 
+REQUIRED_FIELDS = ("name", "siret")
+
+
 class CanteenImageSerializer(serializers.ModelSerializer):
     image = Base64ImageField()
     id = serializers.IntegerField(required=False)
@@ -188,7 +191,6 @@ class ElectedCanteenSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Canteen
-        read_only_fields = ("publication_status",)
         fields = (
             "id",
             "name",
@@ -218,6 +220,7 @@ class ElectedCanteenSerializer(serializers.ModelSerializer):
             "central_kitchen_diagnostics",
             "publication_status",  # property
         )
+        read_only_fields = ("publication_status",)
 
 
 class SatelliteCanteenSerializer(serializers.ModelSerializer):
@@ -228,10 +231,6 @@ class SatelliteCanteenSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Canteen
-        read_only_fields = (
-            "id",
-            "publication_status",
-        )
         fields = (
             "id",
             "name",
@@ -245,6 +244,10 @@ class SatelliteCanteenSerializer(serializers.ModelSerializer):
             "publication_status",  # property
             "is_managed_by_user",  # annotate
             "action",  # annotate
+        )
+        read_only_fields = (
+            "id",
+            "publication_status",
         )
 
 
@@ -268,30 +271,6 @@ class FullCanteenSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Canteen
-        read_only_fields = (
-            "id",
-            "epci",
-            "epci_lib",
-            "pat_list",
-            "pat_lib_list",
-            "department_lib",
-            "region",
-            "region_lib",
-            "managers",
-            "manager_invitations",
-            "publication_status",
-            "groupe",
-            "central_kitchen",
-            "central_kitchen_diagnostics",
-            "satellites",
-            "satellites_count",
-            "satellites_missing_data_count",
-            "satellites_already_teledeclared_count",
-            "is_satellite",
-            "modification_date",
-            "badges",
-            "resource_actions",
-        )
         fields = (
             "id",
             "name",
@@ -348,16 +327,46 @@ class FullCanteenSerializer(serializers.ModelSerializer):
             "badges",
             "resource_actions",
         )
+        read_only_fields = (
+            "id",
+            "epci",
+            "epci_lib",
+            "pat_list",
+            "pat_lib_list",
+            "department_lib",
+            "region",
+            "region_lib",
+            "managers",
+            "manager_invitations",
+            "publication_status",
+            "groupe",
+            "central_kitchen",
+            "central_kitchen_diagnostics",
+            "satellites",
+            "satellites_count",
+            "satellites_missing_data_count",
+            "satellites_already_teledeclared_count",
+            "is_satellite",
+            "modification_date",
+            "badges",
+            "resource_actions",
+        )
 
-        extra_kwargs = {"name": {"required": True}, "siret": {"required": True}}
-
-    def __init__(self, *args, **kwargs):
-        action = kwargs.pop("action", None)
-        super().__init__(*args, **kwargs)
-        if action != "create":
-            self.fields.pop("creation_mtm_source")
-            self.fields.pop("creation_mtm_campaign")
-            self.fields.pop("creation_mtm_medium")
+    def get_fields(self):
+        fields = super().get_fields()
+        # some fields are required
+        for field in REQUIRED_FIELDS:
+            fields[field].required = True
+        # some fields are only available on create
+        if self.instance is not None:
+            fields.pop("creation_source", None)
+            for field in Canteen.MATOMO_FIELDS:
+                fields.pop(field, None)
+        else:
+            fields["creation_source"].write_only = True
+            for field in Canteen.MATOMO_FIELDS:
+                fields[field].write_only = True
+        return fields
 
     def update(self, instance, validated_data):
         if "images" not in validated_data:

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -106,20 +106,26 @@ class PublicServiceDiagnosticSerializer(DiagnosticSerializer):
 class ManagerDiagnosticSerializer(DiagnosticSerializer):
     class Meta:
         model = Diagnostic
-        read_only_fields = ("id",)
         fields = (
             FIELDS + Diagnostic.MATOMO_FIELDS + Diagnostic.CREATION_META_FIELDS + Diagnostic.TUNNEL_PROGRESS_FIELDS
         )
+        read_only_fields = ("id",)
 
-    def __init__(self, *args, **kwargs):
-        action = kwargs.pop("action", None)
-        super().__init__(*args, **kwargs)
-        if action == "create":
-            for field in REQUIRED_FIELDS:
-                self.fields[field].required = True
-        else:
+    def get_fields(self):
+        fields = super().get_fields()
+        # some fields are required
+        for field in REQUIRED_FIELDS:
+            fields[field].required = True
+        # some fields are only available on create
+        if self.instance is not None:
+            fields.pop("creation_source", None)
             for field in Diagnostic.MATOMO_FIELDS:
-                self.fields.pop(field)
+                fields.pop(field, None)
+        else:
+            fields["creation_source"].write_only = True
+            for field in Diagnostic.MATOMO_FIELDS:
+                fields[field].write_only = True
+        return fields
 
     def validate(self, data):
         # TODO: move these rules to the model

--- a/api/serializers/managerinvitation.py
+++ b/api/serializers/managerinvitation.py
@@ -6,5 +6,5 @@ from data.models import ManagerInvitation
 class ManagerInvitationSerializer(serializers.ModelSerializer):
     class Meta:
         model = ManagerInvitation
-        read_only_fields = ("email",)
         fields = ("email",)
+        read_only_fields = ("email",)

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -44,6 +44,15 @@ class PurchaseSerializer(serializers.ModelSerializer):
             "modification_date",
         )
 
+    def get_fields(self):
+        fields = super().get_fields()
+        # some fields are only available on create
+        if self.instance is not None:
+            fields.pop("creation_source", None)
+        else:
+            fields["creation_source"].write_only = True
+        return fields
+
     # TODO: remove once we finish the translation to French
     @staticmethod
     def _normalize_characteristics(validated_data):

--- a/api/serializers/user.py
+++ b/api/serializers/user.py
@@ -25,12 +25,6 @@ class LoggedUserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = get_user_model()
-        read_only_fields = (
-            "id",
-            "username",
-            "is_staff",
-            "has_mtm_data",
-        )
         fields = (
             "id",
             "email",
@@ -51,17 +45,23 @@ class LoggedUserSerializer(serializers.ModelSerializer):
             "mcp_organizations",
             "departments",
         )
+        read_only_fields = (
+            "id",
+            "username",
+            "is_staff",
+            "has_mtm_data",
+        )
 
 
 class CanteenManagerSerializer(serializers.ModelSerializer):
     class Meta:
         model = get_user_model()
-        read_only_fields = (
+        fields = (
             "email",
             "first_name",
             "last_name",
         )
-        fields = (
+        read_only_fields = (
             "email",
             "first_name",
             "last_name",

--- a/api/serializers/wastemeasurement.py
+++ b/api/serializers/wastemeasurement.py
@@ -9,7 +9,6 @@ class WasteMeasurementSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = WasteMeasurement
-        read_only_fields = ("id",)
         fields = (
             "id",
             "canteen_id",
@@ -32,4 +31,12 @@ class WasteMeasurementSerializer(serializers.ModelSerializer):
             "leftovers_is_sorted",
             "leftovers_edible_mass",
             "leftovers_inedible_mass",
+            "creation_source",
+            "creation_date",
+            "modification_date",
+        )
+        read_only_fields = (
+            "id",
+            "creation_date",
+            "modification_date",
         )

--- a/api/serializers/wastemeasurement.py
+++ b/api/serializers/wastemeasurement.py
@@ -31,7 +31,6 @@ class WasteMeasurementSerializer(serializers.ModelSerializer):
             "leftovers_is_sorted",
             "leftovers_edible_mass",
             "leftovers_inedible_mass",
-            "creation_source",
             "creation_date",
             "modification_date",
         )

--- a/api/serializers/wastemeasurement.py
+++ b/api/serializers/wastemeasurement.py
@@ -31,11 +31,5 @@ class WasteMeasurementSerializer(serializers.ModelSerializer):
             "leftovers_is_sorted",
             "leftovers_edible_mass",
             "leftovers_inedible_mass",
-            "creation_date",
-            "modification_date",
         )
-        read_only_fields = (
-            "id",
-            "creation_date",
-            "modification_date",
-        )
+        read_only_fields = ("id",)

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -536,30 +536,27 @@ class CanteenCreateApiTest(APITestCase):
         mock_get_pat_csv(mock)
 
         # from the APP
-        response = self.client.post(
-            reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "creation_source": "APP"}
-        )
-
+        payload = {**CANTEEN_SITE_DEFAULT_PAYLOAD, "creation_source": "APP"}
+        response = self.client.post(reverse("user_canteens"), payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        body = response.json()
-        created_canteen = Canteen.objects.get(pk=body["id"])
-        self.assertEqual(created_canteen.creation_source, CreationSource.APP)
-        created_canteen.hard_delete()
+        canteen = Canteen.objects.first()
+        self.assertEqual(canteen.creation_source, CreationSource.APP)
+
+        # cleanup
+        Canteen.objects.all().delete()
 
         # defaults to API
         response = self.client.post(reverse("user_canteens"), CANTEEN_SITE_DEFAULT_PAYLOAD)
-
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        body = response.json()
-        created_canteen = Canteen.objects.get(pk=body["id"])
-        self.assertEqual(created_canteen.creation_source, CreationSource.API)
-        created_canteen.hard_delete()
+        canteen = Canteen.objects.first()
+        self.assertEqual(canteen.creation_source, CreationSource.API)
+
+        # cleanup
+        Canteen.objects.all().delete()
 
         # returns a 404 if the creation_source is not valid
-        response = self.client.post(
-            reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "creation_source": "UNKNOWN"}
-        )
-
+        payload = {**CANTEEN_SITE_DEFAULT_PAYLOAD, "creation_source": "UNKNOWN"}
+        response = self.client.post(reverse("user_canteens"), payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @authenticate
@@ -962,7 +959,7 @@ class CanteenDeleteApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
-        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.canteen = CanteenFactory(managers=[cls.user], creation_user=cls.user, creation_source=CreationSource.APP)
         cls.url = reverse("single_canteen", kwargs={"pk": cls.canteen.id})
 
     def test_cannot_delete_canteen_if_unauthenticated(self):

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -528,7 +528,7 @@ class CanteenCreateApiTest(APITestCase):
 
     @requests_mock.Mocker()
     @authenticate
-    def test_create_canteen_creation_source(self, mock):
+    def test_create_canteen_creation_user_and_source(self, mock):
         mock_fetch_geo_data_from_siret(mock, siret="92341284500011", success=True)
         mock_fetch_communes(mock)
         mock_fetch_epcis(mock)
@@ -539,7 +539,10 @@ class CanteenCreateApiTest(APITestCase):
         payload = {**CANTEEN_SITE_DEFAULT_PAYLOAD, "creation_source": "APP"}
         response = self.client.post(reverse("user_canteens"), payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNotIn("creation_user", response.json())
+        self.assertNotIn("creation_source", response.json())
         canteen = Canteen.objects.first()
+        self.assertEqual(canteen.creation_user, authenticate.user)
         self.assertEqual(canteen.creation_source, CreationSource.APP)
 
         # cleanup
@@ -548,7 +551,10 @@ class CanteenCreateApiTest(APITestCase):
         # defaults to API
         response = self.client.post(reverse("user_canteens"), CANTEEN_SITE_DEFAULT_PAYLOAD)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNotIn("creation_user", response.json())
+        self.assertNotIn("creation_source", response.json())
         canteen = Canteen.objects.first()
+        self.assertEqual(canteen.creation_user, authenticate.user)
         self.assertEqual(canteen.creation_source, CreationSource.API)
 
         # cleanup
@@ -558,6 +564,35 @@ class CanteenCreateApiTest(APITestCase):
         payload = {**CANTEEN_SITE_DEFAULT_PAYLOAD, "creation_source": "UNKNOWN"}
         response = self.client.post(reverse("user_canteens"), payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @requests_mock.Mocker()
+    @authenticate
+    def test_create_canteen_with_tracking_info(self, mock):
+        """
+        The app should store the mtm parameters on creation
+        """
+        mock_fetch_geo_data_from_siret(mock, siret="92341284500011", success=True)
+        mock_fetch_communes(mock)
+        mock_fetch_epcis(mock)
+        mock_get_pat_dataset_resource(mock)
+        mock_get_pat_csv(mock)
+
+        payload = CANTEEN_SITE_DEFAULT_PAYLOAD.copy()
+        payload["creation_mtm_source"] = "mtm_source_value"
+        payload["creation_mtm_campaign"] = "mtm_campaign_value"
+        payload["creation_mtm_medium"] = "mtm_medium_value"
+
+        response = self.client.post(reverse("user_canteens"), payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNotIn("creation_mtm_source", response.json())
+        self.assertNotIn("creation_mtm_campaign", response.json())
+        self.assertNotIn("creation_mtm_medium", response.json())
+        body = response.json()
+        created_canteen = Canteen.objects.get(pk=body["id"])
+        self.assertEqual(created_canteen.creation_mtm_source, "mtm_source_value")
+        self.assertEqual(created_canteen.creation_mtm_campaign, "mtm_campaign_value")
+        self.assertEqual(created_canteen.creation_mtm_medium, "mtm_medium_value")
 
     @authenticate
     def test_cannot_create_canteen_without_siret(self):
@@ -667,32 +702,6 @@ class CanteenCreateApiTest(APITestCase):
         created_canteen = Canteen.objects.get(pk=body["id"])
         self.assertEqual(created_canteen.images.count(), 1)
 
-    @requests_mock.Mocker()
-    @authenticate
-    def test_create_canteen_with_tracking_info(self, mock):
-        """
-        The app should store the mtm parameters on creation
-        """
-        mock_fetch_geo_data_from_siret(mock, siret="92341284500011", success=True)
-        mock_fetch_communes(mock)
-        mock_fetch_epcis(mock)
-        mock_get_pat_dataset_resource(mock)
-        mock_get_pat_csv(mock)
-
-        payload = CANTEEN_SITE_DEFAULT_PAYLOAD.copy()
-        payload["creation_mtm_source"] = "mtm_source_value"
-        payload["creation_mtm_campaign"] = "mtm_campaign_value"
-        payload["creation_mtm_medium"] = "mtm_medium_value"
-
-        response = self.client.post(reverse("user_canteens"), payload, format="json")
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        body = response.json()
-        created_canteen = Canteen.objects.get(pk=body["id"])
-        self.assertEqual(created_canteen.creation_mtm_source, "mtm_source_value")
-        self.assertEqual(created_canteen.creation_mtm_campaign, "mtm_campaign_value")
-        self.assertEqual(created_canteen.creation_mtm_medium, "mtm_medium_value")
-
 
 class CanteenUpdateApiTest(APITestCase):
     @classmethod
@@ -704,11 +713,12 @@ class CanteenUpdateApiTest(APITestCase):
             creation_user=cls.user,
             creation_source=CreationSource.APP,
         )
+        cls.url = reverse("single_canteen", kwargs={"pk": cls.canteen.id})
 
     def test_cannot_update_canteen_if_unauthenticated(self):
         payload = {"management_type": Canteen.ManagementType.CONCEDED}
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -716,7 +726,7 @@ class CanteenUpdateApiTest(APITestCase):
     def test_cannot_update_canteen_with_put(self):
         payload = {"management_type": Canteen.ManagementType.CONCEDED}
 
-        response = self.client.put(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)
+        response = self.client.put(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
@@ -724,7 +734,7 @@ class CanteenUpdateApiTest(APITestCase):
     def test_cannot_update_canteen_if_not_canteen_manager(self):
         payload = {"management_type": Canteen.ManagementType.CONCEDED}
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -748,7 +758,7 @@ class CanteenUpdateApiTest(APITestCase):
             "reservationExpeParticipant": True,
         }
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.canteen.refresh_from_db()
@@ -765,7 +775,7 @@ class CanteenUpdateApiTest(APITestCase):
             "productionType": Canteen.ProductionType.ON_SITE_CENTRAL,
         }
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+        response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.canteen.refresh_from_db()
@@ -779,9 +789,7 @@ class CanteenUpdateApiTest(APITestCase):
         for empty in ["", None]:
             payload = {"siret": empty, "siren_unite_legale": empty}
 
-            response = self.client.patch(
-                reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json"
-            )
+            response = self.client.patch(self.url, payload, format="json")
 
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             body = response.json()
@@ -804,7 +812,7 @@ class CanteenUpdateApiTest(APITestCase):
         self.canteen.managers.add(authenticate.user)
         payload = {"siret": siret_2}
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+        response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
@@ -816,7 +824,7 @@ class CanteenUpdateApiTest(APITestCase):
         # same if the user is manager of the other canteen
         canteen_2.managers.add(authenticate.user)
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+        response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
@@ -830,7 +838,7 @@ class CanteenUpdateApiTest(APITestCase):
         self.canteen.managers.add(authenticate.user)
         payload = {"siret": self.canteen.siret}
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+        response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -849,7 +857,7 @@ class CanteenUpdateApiTest(APITestCase):
         self.canteen.managers.add(authenticate.user)
         payload = {"siret": "21340172201787"}
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+        response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.canteen.refresh_from_db()
@@ -871,7 +879,7 @@ class CanteenUpdateApiTest(APITestCase):
             ]
         }
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+        response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.canteen.refresh_from_db()
@@ -896,7 +904,7 @@ class CanteenUpdateApiTest(APITestCase):
             ]
         }
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+        response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.canteen.refresh_from_db()
@@ -905,7 +913,7 @@ class CanteenUpdateApiTest(APITestCase):
         # Delete image
         payload = {"images": []}
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+        response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.canteen.refresh_from_db()
@@ -923,9 +931,12 @@ class CanteenUpdateApiTest(APITestCase):
             "creationSource": CreationSource.API,
         }
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)
+        response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertNotIn("creation_user", body)
+        self.assertNotIn("creation_source", body)
         self.canteen.refresh_from_db()
         self.assertEqual(self.canteen.management_type, Canteen.ManagementType.CONCEDED)
         self.assertEqual(self.canteen.reservation_expe_participant, True)
@@ -946,9 +957,13 @@ class CanteenUpdateApiTest(APITestCase):
             "creation_mtm_medium": "mtm_medium_value",
         }
 
-        response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload, format="json")
+        response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertNotIn("mtm_source_value", body)
+        self.assertNotIn("mtm_campaign_value", body)
+        self.assertNotIn("mtm_medium_value", body)
         self.canteen.refresh_from_db()
         self.assertIsNone(self.canteen.creation_mtm_source)
         self.assertIsNone(self.canteen.creation_mtm_campaign)

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -923,6 +923,7 @@ class CanteenUpdateApiTest(APITestCase):
         payload = {
             "managementType": Canteen.ManagementType.CONCEDED,
             "reservationExpeParticipant": True,
+            "creationSource": CreationSource.API,
         }
 
         response = self.client.patch(reverse("single_canteen", kwargs={"pk": self.canteen.id}), payload)

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -520,7 +520,7 @@ class DiagnosticUpdateApiTest(APITestCase):
         self.assertEqual(self.diagnostic.creation_user, self.user)
         self.assertEqual(self.diagnostic.creation_source, CreationSource.APP)
 
-        payload = {"year": 2020}
+        payload = {"year": 2020, "creationSource": CreationSource.API}
 
         response = self.client.patch(self.url, payload)
 

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -90,18 +90,23 @@ class DiagnosticCreateApiTest(APITestCase):
         payload = {**self.DIAGNOSTIC_PAYLOAD, "creation_source": "APP"}
         response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        diagnostic = Diagnostic.objects.get(canteen__id=self.canteen.id)
+        diagnostic = Diagnostic.objects.first()
         self.assertEqual(diagnostic.creation_source, CreationSource.APP)
 
+        # cleanup
+        Diagnostic.objects.all().delete()
+
         # defaults to API
-        payload = {"year": 2021}
-        response = self.client.post(self.url, payload)
+        response = self.client.post(self.url, self.DIAGNOSTIC_PAYLOAD)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        diagnostic = Diagnostic.objects.get(canteen__id=self.canteen.id, year=2021)
+        diagnostic = Diagnostic.objects.first()
         self.assertEqual(diagnostic.creation_source, CreationSource.API)
 
+        # cleanup
+        Diagnostic.objects.all().delete()
+
         # returns a 404 if the creation_source is not valid
-        payload = {"year": 2022, "creation_source": "UNKNOWN"}
+        payload = {**self.DIAGNOSTIC_PAYLOAD, "creation_source": "UNKNOWN"}
         response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -67,7 +67,6 @@ class DiagnosticCreateApiTest(APITestCase):
         diagnostic = Diagnostic.objects.first()
         self.assertEqual(diagnostic.canteen, self.canteen)
         self.assertEqual(diagnostic.year, 2020)
-        self.assertEqual(diagnostic.creation_user, authenticate.user)
 
     def test_create_minimal_diagnostic_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
@@ -83,13 +82,16 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(diagnostic.creation_user, user)
 
     @authenticate
-    def test_create_diagnostic_creation_source(self):
+    def test_create_diagnostic_creation_user_and_source(self):
         self.canteen.managers.add(authenticate.user)
 
         # from the APP
         payload = {**self.DIAGNOSTIC_PAYLOAD, "creation_source": "APP"}
         response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertNotIn("creation_user", body)
+        self.assertNotIn("creation_source", body)
         diagnostic = Diagnostic.objects.first()
         self.assertEqual(diagnostic.creation_source, CreationSource.APP)
 
@@ -99,6 +101,9 @@ class DiagnosticCreateApiTest(APITestCase):
         # defaults to API
         response = self.client.post(self.url, self.DIAGNOSTIC_PAYLOAD)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertNotIn("creation_user", body)
+        self.assertNotIn("creation_source", body)
         diagnostic = Diagnostic.objects.first()
         self.assertEqual(diagnostic.creation_source, CreationSource.API)
 
@@ -109,6 +114,29 @@ class DiagnosticCreateApiTest(APITestCase):
         payload = {**self.DIAGNOSTIC_PAYLOAD, "creation_source": "UNKNOWN"}
         response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @authenticate
+    def test_create_diagnostic_with_tracking_info(self):
+        self.canteen.managers.add(authenticate.user)
+
+        payload = {
+            **self.DIAGNOSTIC_PAYLOAD,
+            "creation_mtm_source": "mtm_source_value",
+            "creation_mtm_campaign": "mtm_campaign_value",
+            "creation_mtm_medium": "mtm_medium_value",
+        }
+
+        response = self.client.post(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertNotIn("creation_mtm_source", body)
+        self.assertNotIn("creation_mtm_campaign", body)
+        self.assertNotIn("creation_mtm_medium", body)
+        diagnostic = Diagnostic.objects.first()
+        self.assertEqual(diagnostic.creation_mtm_source, "mtm_source_value")
+        self.assertEqual(diagnostic.creation_mtm_campaign, "mtm_campaign_value")
+        self.assertEqual(diagnostic.creation_mtm_medium, "mtm_medium_value")
 
     @authenticate
     def test_create_full_diagnostic(self):
@@ -155,9 +183,6 @@ class DiagnosticCreateApiTest(APITestCase):
             "communicates_on_food_plan": True,
             "communicates_on_food_quality": True,
             "communication_frequency": "YEARLY",
-            "creation_mtm_source": "mtm_source_value",
-            "creation_mtm_campaign": "mtm_campaign_value",
-            "creation_mtm_medium": "mtm_medium_value",
             # detailed value fields
             "valeur_viandes_volailles_bio": 10,
             "valeur_produits_de_la_mer_bio": 10,
@@ -292,9 +317,6 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(diagnostic.communication_frequency, "YEARLY")
         self.assertTrue(diagnostic.communicates_on_food_quality)
         self.assertEqual(diagnostic.creation_source, CreationSource.API)
-        self.assertEqual(diagnostic.creation_mtm_source, "mtm_source_value")
-        self.assertEqual(diagnostic.creation_mtm_campaign, "mtm_campaign_value")
-        self.assertEqual(diagnostic.creation_mtm_medium, "mtm_medium_value")
         self.assertEqual(diagnostic.label_sum("bio"), 80)
         self.assertEqual(diagnostic.label_sum("label_rouge"), 80)
         self.assertEqual(diagnostic.label_sum("aocaop_igp_stg"), 80)
@@ -551,6 +573,10 @@ class DiagnosticUpdateApiTest(APITestCase):
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertNotIn("creation_mtm_source", body)
+        self.assertNotIn("creation_mtm_campaign", body)
+        self.assertNotIn("creation_mtm_medium", body)
         self.diagnostic.refresh_from_db()
         self.assertEqual(self.diagnostic.year, 2020)
         self.assertIsNone(self.diagnostic.creation_mtm_source)

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -424,23 +424,6 @@ class PurchaseUpdateApiTest(APITestCase):
         self.assertEqual(float(self.purchase.prix_ht), 15.23)
 
     @authenticate
-    def test_update_purchase_does_not_update_creation_user(self):
-        self.purchase.canteen.managers.add(authenticate.user)
-        payload = {
-            "description": "Saumon",
-            "provider": "Test fournisseur",
-            "price_ht": 15.23,
-            "creation_source": CreationSource.API,
-        }
-
-        response = self.client.patch(self.url, payload)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.purchase.refresh_from_db()
-        self.assertEqual(self.purchase.creation_user, self.user)  # unchanged
-        # self.assertEqual(self.purchase.creation_source, CreationSource.APP)  # TODO: should not be possible
-
-    @authenticate
     def test_update_purchase_does_not_update_creation_user_and_source(self):
         self.purchase.canteen.managers.add(authenticate.user)
         self.assertEqual(self.purchase.creation_user, self.user)
@@ -450,6 +433,7 @@ class PurchaseUpdateApiTest(APITestCase):
             "description": "Saumon",
             "provider": "Test fournisseur",
             "price_ht": 15.23,
+            "creationSource": CreationSource.API,
         }
 
         response = self.client.patch(self.url, payload)

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -322,17 +322,20 @@ class PurchaseCreateApiTest(APITestCase):
         purchase = Purchase.objects.first()
         self.assertEqual(purchase.definition_local, Purchase.Local.AUTOUR_SERVICE)
         self.assertEqual(len(purchase.caracteristiques), 2)
-        self.assertEqual(purchase.creation_user, authenticate.user)
 
     @authenticate
-    def test_create_purchase_creation_source(self):
+    def test_create_purchase_creation_user_and_source(self):
         self.canteen.managers.add(authenticate.user)
 
         # from the APP
         payload = {**self.PURCHASE_PAYLOAD, "creation_source": CreationSource.APP}
         response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertNotIn("creation_user", body)
+        self.assertNotIn("creation_source", body)
         purchase = Purchase.objects.first()
+        self.assertEqual(purchase.creation_user, authenticate.user)
         self.assertEqual(purchase.creation_source, CreationSource.APP)
 
         # cleanup
@@ -341,7 +344,11 @@ class PurchaseCreateApiTest(APITestCase):
         # defaults to API
         response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertNotIn("creation_user", body)
+        self.assertNotIn("creation_source", body)
         purchase = Purchase.objects.first()
+        self.assertEqual(purchase.creation_user, authenticate.user)
         self.assertEqual(purchase.creation_source, CreationSource.API)
 
         # cleanup
@@ -443,6 +450,9 @@ class PurchaseUpdateApiTest(APITestCase):
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertNotIn("creation_user", body)
+        self.assertNotIn("creation_source", body)
         self.purchase.refresh_from_db()
         self.assertEqual(self.purchase.creation_user, self.user)  # unchanged
         self.assertEqual(self.purchase.creation_source, CreationSource.APP)  # unchanged

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -332,16 +332,20 @@ class PurchaseCreateApiTest(APITestCase):
         payload = {**self.PURCHASE_PAYLOAD, "creation_source": CreationSource.APP}
         response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        body = response.json()
-        created_purchase = Purchase.objects.get(pk=body["id"])
-        self.assertEqual(created_purchase.creation_source, CreationSource.APP)
+        purchase = Purchase.objects.first()
+        self.assertEqual(purchase.creation_source, CreationSource.APP)
+
+        # cleanup
+        Purchase.objects.all().delete()
 
         # defaults to API
         response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        body = response.json()
-        created_purchase = Purchase.objects.get(pk=body["id"])
-        self.assertEqual(created_purchase.creation_source, CreationSource.API)
+        purchase = Purchase.objects.first()
+        self.assertEqual(purchase.creation_source, CreationSource.API)
+
+        # cleanup
+        Purchase.objects.all().delete()
 
         # returns a 404 if the creation_source is not valid
         payload = {**self.PURCHASE_PAYLOAD, "creation_source": "UNKNOWN"}
@@ -449,7 +453,7 @@ class PurchaseDeleteApiTest(APITestCase):
     def setUpTestData(cls):
         cls.user = UserFactory()
         cls.canteen = CanteenFactory(managers=[cls.user])
-        cls.purchase = PurchaseFactory(canteen=cls.canteen, creation_user=cls.user)
+        cls.purchase = PurchaseFactory(canteen=cls.canteen, creation_user=cls.user, creation_source=CreationSource.APP)
         cls.url = reverse("purchase_retrieve_update_destroy", kwargs={"pk": cls.purchase.id})
 
     def test_cannot_delete_if_unauthenticated(self):

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -292,12 +292,6 @@ class UserCanteensView(ListCreateAPIView):
     search_fields = ["name", "siret"]
     ordering_fields = ["name", "creation_date", "modification_date", "daily_meal_count"]
 
-    def get_serializer(self, *args, **kwargs):
-        kwargs.setdefault("context", self.get_serializer_context())
-        action = "create" if self.request.method == "POST" else None
-        kwargs.setdefault("action", action)
-        return FullCanteenSerializer(*args, **kwargs)
-
     def get_queryset(self):
         return self.request.user.canteens.all()
 

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -43,11 +43,6 @@ class DiagnosticCreateView(CreateAPIView):
     model = Diagnostic
     serializer_class = ManagerDiagnosticSerializer
 
-    def get_serializer(self, *args, **kwargs):
-        kwargs.setdefault("context", self.get_serializer_context())
-        kwargs.setdefault("action", "create")
-        return ManagerDiagnosticSerializer(*args, **kwargs)
-
     def _get_canteen(self):
         # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
         return Canteen.objects.get(pk=self.kwargs["canteen_pk"])


### PR DESCRIPTION
Quelques améliorations dans les API Canteen/Diagnostic/Purchase
- le champ `creation_source` ne doit pouvoir être set qu'au create
- ne jamais renvoyer les champs `creation_source` (et les champs MATOMO)
- mettre `read_only_fields` après `fields`
- update des tests (s'assurer que les champs ne sont pas modifiables ni renvoyés)