### PR TITLE
refactor(Evaluation Gaspillage): script pour remplir creation_user & creation_source (grâce à l'historisation)

### DIFF
--- a/macantine/management/commands/wastemeasurement_fill_creation_user_and_source.py
+++ b/macantine/management/commands/wastemeasurement_fill_creation_user_and_source.py
@@ -1,0 +1,102 @@
+import logging
+from collections import Counter
+
+from django.core.management.base import BaseCommand
+
+from data.utils import has_charfield_missing_query
+from data.models import WasteMeasurement
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Usage:
+    - python manage.py wastemeasurement_fill_creation_user_and_source --field creation_user
+    - python manage.py wastemeasurement_fill_creation_user_and_source --field creation_source --apply
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--field",
+            type=str,
+            required=True,
+            choices=["creation_user", "creation_source"],
+            help="Field to fill: creation_user or creation_source",
+        )
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="To apply changes, otherwise just show what would be done (dry run).",
+            default=False,
+        )
+
+    def handle(self, *args, **options):
+        field = options["field"]
+        apply = options["apply"]
+        logger.info(f"Start task: wastemeasurement_fill_creation_user_and_source ({field}) (apply={apply})")
+
+        if not apply:
+            logger.info("Dry run mode, no changes will be applied.")
+
+        if field == "creation_user":
+            fill_creation_user(apply=apply)
+        elif field == "creation_source":
+            fill_creation_source(apply=apply)
+
+
+def fill_creation_user(apply):
+    """
+    Rules:
+    - if creation_user is null, empty or None, then look at the first version of the wastemeasurement in the history:
+        - set creation_user to history_user
+    - else creation_user stays empty
+    """
+    wm_qs = WasteMeasurement.objects.filter(creation_user__isnull=True)
+    logger.info(f"Found {wm_qs.count()} waste measurements with missing creation_user")
+
+    if apply:
+        for index, wm in enumerate(wm_qs.all(), start=1):
+            wm_first_version = WasteMeasurement.history.filter(id=wm.id).last()
+            if not wm.creation_user and wm_first_version and wm_first_version.history_type == "+":
+                if wm_first_version.history_user_id:
+                    wm.creation_user = wm_first_version.history_user
+                    WasteMeasurement.objects.filter(id=wm.id).update(creation_user=wm.creation_user)
+            if index % 5000 == 0:
+                logger.info(f"Processed {index} waste measurements")
+
+    wm_qs_after = WasteMeasurement.objects.exclude(creation_user__isnull=True)
+    logger.info(f"Done! {wm_qs_after.count()} waste measurements with filled creation_user")
+
+
+def fill_creation_source(apply):
+    """
+    Rules:
+    - if creation_source is null, empty or None, then look at the first version of the wastemeasurement in the history:
+        - if history_change_reason is null and history_user is staff, then creation_source = "ADMIN"
+        - else if history_change_reason starts with "Mass CSV import", then creation_source = "IMPORT"
+        - else if history_change_reason is "SessionAuthentication", then creation_source = "APP"
+        - else if history_change_reason is "OAuth2Authentication", then creation_source = "API"
+    - else creation_source stays empty
+    """
+    wm_qs = WasteMeasurement.objects.filter(has_charfield_missing_query("creation_source"))
+    logger.info(f"Found {wm_qs.count()} waste measurements with missing creation_source")
+    logger.info(Counter(WasteMeasurement.objects.values_list("creation_source", flat=True)))
+
+    if apply:
+        for index, wm in enumerate(wm_qs.all(), start=1):
+            wm_first_version = WasteMeasurement.history.filter(id=wm.id).last()
+            if not wm.creation_source and wm_first_version and wm_first_version.history_type == "+":
+                if wm_first_version.history_change_reason is None:
+                    if wm_first_version.history_user_id and wm_first_version.history_user.is_staff:
+                        WasteMeasurement.objects.filter(id=wm.id).update(creation_source="ADMIN")
+                elif wm_first_version.history_change_reason == "SessionAuthentication":
+                    WasteMeasurement.objects.filter(id=wm.id).update(creation_source="APP")
+                elif wm_first_version.history_change_reason == "OAuth2Authentication":
+                    WasteMeasurement.objects.filter(id=wm.id).update(creation_source="API")
+                if index % 5000 == 0:
+                    logger.info(f"Processed {index} waste measurements")
+
+    wm_qs_after = WasteMeasurement.objects.exclude(has_charfield_missing_query("creation_source"))
+    logger.info(f"Done! {wm_qs_after.count()} waste measurements with filled creation_source")
+    logger.info(Counter(WasteMeasurement.objects.values_list("creation_source", flat=True)))

--- a/macantine/tests/test_wastemeasurement_fill_creation_user_and_source.py
+++ b/macantine/tests/test_wastemeasurement_fill_creation_user_and_source.py
@@ -1,0 +1,76 @@
+from django.core.management import call_command
+from rest_framework.test import APITestCase
+from django.urls import reverse
+
+from api.tests.utils import authenticate, get_oauth2_token
+from data.factories import WasteMeasurementFactory, CanteenFactory
+from data.models import WasteMeasurement
+from data.models.creation_source import CreationSource
+
+
+class WastemeasurementFillCreationUserAndSourceTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.url = reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": cls.canteen.id})
+        cls.WM_PAYLOAD = {"period_start_date": "2024-08-01", "period_end_date": "2024-08-10"}
+
+    def test_fill_for_waste_measurement_created_from_api(self):
+        user, token = get_oauth2_token("waste_measurements:create")
+        self.canteen.managers.add(user)
+        self.client.credentials(Authorization=f"Bearer {token}")
+        response = self.client.post(self.url, self.WM_PAYLOAD)
+        wm_id = response.json()["id"]
+
+        self.assertEqual(WasteMeasurement.objects.count(), 1)
+        WasteMeasurement.objects.filter(id=wm_id).update(creation_user=None, creation_source=None)
+        wm = WasteMeasurement.objects.get(id=wm_id)
+        self.assertIsNone(wm.creation_user)
+        self.assertIsNone(wm.creation_source)
+
+        # run management command
+        call_command("wastemeasurement_fill_creation_user_and_source", field="creation_user", apply=True)
+        call_command("wastemeasurement_fill_creation_user_and_source", field="creation_source", apply=True)
+
+        wm.refresh_from_db()
+        self.assertEqual(wm.creation_user, user)
+        self.assertEqual(wm.creation_source, CreationSource.API)
+
+    @authenticate
+    def test_fill_for_waste_measurement_created_from_app(self):
+        self.canteen.managers.add(authenticate.user)
+        payload = {**self.WM_PAYLOAD, "creation_source": "APP"}
+        response = self.client.post(self.url, payload)
+        wm_id = response.json()["id"]
+
+        self.assertEqual(WasteMeasurement.objects.count(), 1)
+        WasteMeasurement.objects.filter(id=wm_id).update(creation_user=None, creation_source=None)
+        wm = WasteMeasurement.objects.get(id=wm_id)
+        self.assertIsNone(wm.creation_user)
+        self.assertIsNone(wm.creation_source)
+
+        # run management command
+        call_command("wastemeasurement_fill_creation_user_and_source", field="creation_user", apply=True)
+        call_command("wastemeasurement_fill_creation_user_and_source", field="creation_source", apply=True)
+
+        wm.refresh_from_db()
+        self.assertEqual(wm.creation_user, authenticate.user)
+        self.assertEqual(wm.creation_source, CreationSource.APP)
+
+    def test_fill_for_waste_measurement_created_from_code(self):
+        wm = WasteMeasurementFactory(canteen=self.canteen)
+
+        self.assertEqual(WasteMeasurement.objects.count(), 1)
+        WasteMeasurement.objects.filter(id=wm.id).update(creation_user=None, creation_source=None)
+        wm.refresh_from_db()
+        self.assertIsNone(wm.creation_user)
+        self.assertIsNone(wm.creation_source)
+
+        # run management command
+        call_command("wastemeasurement_fill_creation_user_and_source", field="creation_user", apply=True)
+        call_command("wastemeasurement_fill_creation_user_and_source", field="creation_source", apply=True)
+
+        # check results
+        wm.refresh_from_db()
+        self.assertIsNone(wm.creation_user)
+        self.assertIsNone(wm.creation_source)


### PR DESCRIPTION
### Quoi

Suite à #6831 (nouveaux champs `WasteMeasurement.creation_user` & `creation_source`)

Script pour remplir ces champs (grâce à l'historisation !)

### Résultats

- lancé en local, ca remplit bien :)
- ajout d'un test

### Notes

Similaire à #6761 (Canteen) & #6763 (Diagnostic)