### PR TITLE
improve(Management Commands): nouvelle class `MaCantineBaseCommand` pour gérer le loggage des résultats de nos commandes

### DIFF
--- a/common/utils/commands.py
+++ b/common/utils/commands.py
@@ -1,0 +1,68 @@
+import logging
+import io
+
+from django.utils import timezone
+from django.core.management.base import BaseCommand
+
+from common.models import CommandLog
+
+
+DJANGO_DEFAULT_OPTIONS = {"no_color", "settings", "traceback", "verbosity", "pythonpath", "force_color", "skip_checks"}
+
+
+class MaCantineBaseCommand(BaseCommand):
+    """
+    Custom base command that automatically logs execution
+    - creates a CommandLog entry
+    - input_data: captures args (positional) & options (named)
+    - output_data: captures INFO-level logs and above
+    """
+
+    def execute(self, *args, **options):
+        # init
+        command_name = self.__class__.__module__.split(".")[-1]
+        input_data = {"args": args, "options": {k: v for k, v in options.items() if k not in DJANGO_DEFAULT_OPTIONS}}
+        start_date = timezone.now()
+
+        # logging
+        log_capture = io.StringIO()
+        handler = logging.StreamHandler(log_capture)
+        handler.setLevel(logging.INFO)
+        formatter = logging.Formatter("%(levelname)s - %(message)s")
+        handler.setFormatter(formatter)
+        root_logger = logging.getLogger()
+        original_level = root_logger.level
+        root_logger.setLevel(logging.INFO)
+        root_logger.addHandler(handler)
+
+        try:
+            result = super().execute(*args, **options)
+            end_date = timezone.now()
+            log_contents = log_capture.getvalue()
+
+            CommandLog.objects.create(
+                command_name=command_name,
+                input_data=input_data,
+                status=CommandLog.Status.SUCCESS,
+                output_data=log_contents,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            return result
+        except Exception as e:
+            end_date = timezone.now()
+            log_contents = log_capture.getvalue() + f"\nERROR: {str(e)}"
+
+            CommandLog.objects.create(
+                command_name=command_name,
+                input_data=input_data,
+                status=CommandLog.Status.FAILURE,
+                output_data=log_contents,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            raise e
+        finally:
+            root_logger.removeHandler(handler)
+            root_logger.setLevel(original_level)
+            log_capture.close()

--- a/common/utils/tests/test_utils.py
+++ b/common/utils/tests/test_utils.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
+from django.core.management import call_command
 
 from common.utils import utils as utils_utils
+from common.models import CommandLog
 
 
 class UtilsTest(TestCase):
@@ -25,3 +27,19 @@ class UtilsTest(TestCase):
         ]:
             with self.subTest(text=TUPLE):
                 self.assertEqual(utils_utils.clean_unicode_string(TUPLE[0]), TUPLE[1])
+
+
+class CommandsTest(TestCase):
+    def test_ma_cantine_base_command_creates_command_log(self):
+        # before
+        self.assertEqual(CommandLog.objects.count(), 0)
+
+        # call a command that inherits from MaCantineBaseCommand
+        call_command("canteen_delete", "--canteen-siret-list", "92341284500011,23456789012345")
+
+        # after
+        self.assertEqual(CommandLog.objects.count(), 1)
+        command_log = CommandLog.objects.first()
+        self.assertEqual(command_log.command_name, "canteen_delete")
+        self.assertEqual(command_log.input_data["options"]["canteen_siret_list"], "92341284500011,23456789012345")
+        self.assertEqual(command_log.status, CommandLog.Status.SUCCESS)

--- a/macantine/management/commands/canteen_delete.py
+++ b/macantine/management/commands/canteen_delete.py
@@ -8,12 +8,11 @@ python manage.py canteen_delete --canteen-siret-list 92341284500011,234567890123
 Ran on 2025-04-24
 """
 
-from django.core.management.base import BaseCommand
-
 from data.models import Canteen, Diagnostic, Teledeclaration
+from common.utils.commands import MaCantineBaseCommand
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     help = "Soft delete a specified list of canteens"
 
     def add_arguments(self, parser):

--- a/macantine/management/commands/canteen_fill_creation_user_and_source.py
+++ b/macantine/management/commands/canteen_fill_creation_user_and_source.py
@@ -1,17 +1,17 @@
 import logging
 from collections import Counter
 
-from django.core.management.base import BaseCommand
 from django.db.models import Q, Case, When, F, Value
 from django.db.models.functions import Length
 
+from common.utils.commands import MaCantineBaseCommand
 from data.utils import has_charfield_missing_query
 from data.models import Canteen
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Usage:
     - python manage.py canteen_fill_creation_user_and_source --field creation_user

--- a/macantine/management/commands/canteen_fill_declaration_donnees_year_field.py
+++ b/macantine/management/commands/canteen_fill_declaration_donnees_year_field.py
@@ -1,14 +1,14 @@
 import logging
 
-from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from data.models import Canteen, Diagnostic
+from common.utils.commands import MaCantineBaseCommand
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Rules:
     - every canteen that has a diagnostic teledeclared for the given year

--- a/macantine/management/commands/canteen_fill_is_filled_field.py
+++ b/macantine/management/commands/canteen_fill_is_filled_field.py
@@ -1,13 +1,12 @@
 import logging
 
-from django.core.management.base import BaseCommand
-
 from data.models import Canteen
+from common.utils.commands import MaCantineBaseCommand
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Usage:
     - python manage.py canteen_fill_is_filled_field

--- a/macantine/management/commands/canteen_migrate_central_to_groupe.py
+++ b/macantine/management/commands/canteen_migrate_central_to_groupe.py
@@ -1,11 +1,11 @@
 import logging
 from collections import Counter
 
-from django.core.management.base import BaseCommand
 from simple_history.utils import update_change_reason
 
 from data.models import Canteen
 from api.serializers import SatelliteTeledeclarationSerializer
+from common.utils.commands import MaCantineBaseCommand
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ def satellite_from_central_dict(canteen_central_dict):
     }
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Rules:
     - CENTRAL => GROUPE

--- a/macantine/management/commands/canteen_update_geolocation_data_using_siret.py
+++ b/macantine/management/commands/canteen_update_geolocation_data_using_siret.py
@@ -2,16 +2,17 @@ import logging
 import time
 from pathlib import Path
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import CommandError
 
 from common.api.recherche_entreprises import fetch_geo_data_from_siret
 from data.models import Canteen
 from data.utils import read_csv
+from common.utils.commands import MaCantineBaseCommand
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Script to cleanup the canteen geolocation data (using the SIRET) (API Recherche Entreprises)
     - empty API response: canteen SIRET is probably unknown, reset geolocation data (siret_inconnu will be updated)

--- a/macantine/management/commands/canteen_update_pat_data_using_city_insee_code.py
+++ b/macantine/management/commands/canteen_update_pat_data_using_city_insee_code.py
@@ -1,15 +1,14 @@
 import logging
 
-from django.core.management.base import BaseCommand
-
 from common.api.datagouv import fetch_commune_pat_list, map_pat_list_to_communes_insee_code, PAT_DATAGOUV_DATE
 from data.models import Canteen
 from data.utils import has_charfield_missing_query
+from common.utils.commands import MaCantineBaseCommand
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Usage:
     - python manage.py canteen_update_pat_data_using_city_insee_code

--- a/macantine/management/commands/diagnostic_fill_computed_fields.py
+++ b/macantine/management/commands/diagnostic_fill_computed_fields.py
@@ -1,8 +1,7 @@
 import logging
 
-from django.core.management.base import BaseCommand
-
 from data.models import Diagnostic
+from common.utils.commands import MaCantineBaseCommand
 
 logger = logging.getLogger(__name__)
 
@@ -10,7 +9,7 @@ logger = logging.getLogger(__name__)
 FIELD_LIST = Diagnostic.AGGREGATED_APPRO_FIELDS + Diagnostic.EGALIM_STATS_FIELDS + Diagnostic.OTHER_COMPUTED_FIELDS
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Goal: command to fill Diagnostic "computed" fields (see FIELD_LIST)
 

--- a/macantine/management/commands/diagnostic_fill_creation_user_and_source.py
+++ b/macantine/management/commands/diagnostic_fill_creation_user_and_source.py
@@ -1,17 +1,17 @@
 import logging
 from collections import Counter
 
-from django.core.management.base import BaseCommand
 from django.db.models import Q, Case, When, F, Value
 from django.db.models.functions import Length
 
 from data.utils import has_charfield_missing_query
 from data.models import Diagnostic
+from common.utils.commands import MaCantineBaseCommand
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Usage:
     - python manage.py diagnostic_fill_creation_user_and_source --field creation_user

--- a/macantine/management/commands/diagnostic_fill_invalid_warning_reason_list.py
+++ b/macantine/management/commands/diagnostic_fill_invalid_warning_reason_list.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.core.management.base import BaseCommand
 from django.db.models import F, Func, Value
 
 from data.models import Diagnostic
@@ -18,6 +17,7 @@ from data.models.diagnostic import (
     valeur_totale_is_filled_query,
 )
 from data.utils import has_arrayfield_missing_query
+from common.utils.commands import MaCantineBaseCommand
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ def _append_reason_item(qs, field_prefix, reason_item):
     )
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Goal: fill the invalid_reason_list & warning_reason_list fields
 

--- a/macantine/management/commands/generate_geo_data_to_json.py
+++ b/macantine/management/commands/generate_geo_data_to_json.py
@@ -1,7 +1,5 @@
 import json
 
-from django.core.management.base import BaseCommand
-
 from common.utils.utils import clean_unicode_string
 from common.api.datagouv import fetch_pats
 from common.api.decoupage_administratif import (
@@ -11,9 +9,10 @@ from common.api.decoupage_administratif import (
     fetch_epcis,
     fetch_regions,
 )
+from common.utils.commands import MaCantineBaseCommand
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Usage: python manage.py generate_geo_data_to_json --scope region
     """

--- a/macantine/management/commands/teledeclaration_fill_egalim_fields.py
+++ b/macantine/management/commands/teledeclaration_fill_egalim_fields.py
@@ -1,13 +1,12 @@
 import logging
 
-from django.core.management.base import BaseCommand
-
 from data.models import Diagnostic
+from common.utils.commands import MaCantineBaseCommand
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Goal: after adding the Diagnostic.EGALIM_STATS_FIELDS, command to fill those fields
 

--- a/macantine/management/commands/teledeclaration_fix_old.py
+++ b/macantine/management/commands/teledeclaration_fix_old.py
@@ -1,6 +1,5 @@
 from collections import Counter
 
-from django.core.management.base import BaseCommand
 from django.db.models import Func, IntegerField
 from simple_history.utils import update_change_reason
 
@@ -9,9 +8,10 @@ from common.api.decoupage_administratif import map_communes_infos
 from data.models import Canteen, Diagnostic
 from data.models.sector import get_sector_list_from_old_sector_dict_list
 from data.utils import has_charfield_missing_query
+from common.utils.commands import MaCantineBaseCommand
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     set_canteen_id_before_v4
     - Description: dans les premières versions de la télédéclaration (avant v4), le canteen_id n'était pas stocké dans le canteen_snapshot du diagnostic. On peut le récupérer via la FK vers Canteen.

--- a/macantine/management/commands/teledeclaration_generate_1td1site.py
+++ b/macantine/management/commands/teledeclaration_generate_1td1site.py
@@ -2,7 +2,6 @@ import logging
 import time
 from copy import deepcopy
 
-from django.core.management.base import BaseCommand
 from django.db.models import F, Func, Value
 from django.db.utils import IntegrityError
 
@@ -12,11 +11,12 @@ from macantine.utils import (
     set_satellite_common_fields_from_groupe_diagnostic,
     set_satellite_diagnostic_appro_values_from_groupe_diagnostic,
 )
+from common.utils.commands import MaCantineBaseCommand
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     """
     Goal: Generate diagnostics for satellite canteens that are linked to a groupe (or groupe), based on the diagnostic of their groupe.
 

--- a/macantine/management/commands/teledeclaration_resubmit.py
+++ b/macantine/management/commands/teledeclaration_resubmit.py
@@ -13,17 +13,17 @@ Ran on 2026-04-15 (last day of 2025 campaign)
 import logging
 
 from django.db import transaction
-from django.core.management.base import BaseCommand
 from django.core.exceptions import ValidationError
 from simple_history.utils import update_change_reason
 
 from data.models import Diagnostic
+from common.utils.commands import MaCantineBaseCommand
 
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     help = "Resubmit teledeclarations for a specified list of diagnostics"
 
     def add_arguments(self, parser):

--- a/macantine/management/commands/teledeclaration_submit_correction.py
+++ b/macantine/management/commands/teledeclaration_submit_correction.py
@@ -9,17 +9,17 @@ python manage.py teledeclaration_submit_correction --year 2025
 
 import logging
 
-from django.core.management.base import BaseCommand
 from django.core.exceptions import ValidationError
 from simple_history.utils import update_change_reason
 
 from data.models import Diagnostic, User
+from common.utils.commands import MaCantineBaseCommand
 
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     help = "Submit CORRECTION teledeclarations (during the correction campaign)"
 
     def add_arguments(self, parser):

--- a/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
+++ b/macantine/management/commands/teledeclaration_submit_outside_of_campaign.py
@@ -12,7 +12,6 @@ python manage.py teledeclaration_submit_outside_of_campaign --year 2025 --diagno
 
 import logging
 
-from django.core.management.base import BaseCommand
 from django.core.exceptions import ValidationError
 from simple_history.utils import update_change_reason
 from django.utils import timezone
@@ -23,12 +22,13 @@ from macantine.utils import (
     get_year_campaign_end_date_or_today_date,
     get_year_correction_end_date_or_campaign_end_date_or_today_date,
 )
+from common.utils.commands import MaCantineBaseCommand
 
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(MaCantineBaseCommand):
     help = "Submit teledeclarations outside of the campaign"
 
     def add_arguments(self, parser):


### PR DESCRIPTION
Suite à #6837

### Quoi

- nouvelle class `MaCantineBaseCommand`
- ajout à nos management command existantes
  - :information_source: seulement celles qui manipulent/modifient des données

### Capture d'écran

<img width="754" height="975" alt="Screenshot from 2026-06-22 13-05-17" src="https://github.com/user-attachments/assets/1bd55813-19f8-40d2-98e2-5baa090e7415" />
