### PR TITLE
feat(Achats): API: endpoint dédié à la récupération, l'upload et la suppression de facture

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -55,6 +55,8 @@ from .purchase import (  # noqa: F401
     PurchaseSerializer,
     PurchaseOldSerializer,
     PurchaseSummarySerializer,
+    PurchaseFactureUploadSerializer,
+    PurchaseFactureResponseSerializer,
     PurchasePercentageSummarySerializer,
     PurchaseExportSerializer,
 )

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -160,6 +160,23 @@ class PurchaseSerializer(serializers.ModelSerializer):
         return internal_value
 
 
+class PurchaseFactureUploadSerializer(serializers.Serializer):
+    facture = Base64FileField(required=True, allow_null=False)
+
+    class Meta:
+        fields = ("facture",)
+
+
+class PurchaseFactureResponseSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    facture = serializers.SerializerMethodField()
+
+    def get_facture(self, obj):
+        if obj.facture:
+            return self.context["request"].build_absolute_uri(obj.facture.url)
+        return None
+
+
 # NB: these names reflect the names in the diagnostic model
 class PurchaseSummarySerializer(serializers.Serializer):
     year = serializers.IntegerField()

--- a/api/tests/test_purchase_facture.py
+++ b/api/tests/test_purchase_facture.py
@@ -110,11 +110,120 @@ class PurchaseFactureUploadTest(APITestCase):
         self.assertNotEqual(self.purchase.facture.name, old_file_name)
 
 
+class PurchaseFactureRetrieveTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.purchase = PurchaseFactory(canteen=cls.canteen, facture=SimpleUploadedFile("facture.pdf", b"pdf content"))
+        cls.url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": cls.canteen.id, "pk": cls.purchase.id},
+        )
+
+    def test_cannot_retrieve_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_retrieve_if_canteen_unknown(self):
+        url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": 9999, "pk": self.purchase.id},
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_retrieve_if_not_canteen_manager(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_retrieve_if_purchase_unknown(self):
+        self.canteen.managers.add(authenticate.user)
+        url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": self.canteen.id, "pk": 9999},
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_retrieve_if_purchase_not_in_corresponding_canteen(self):
+        canteen_other = CanteenFactory()
+        purchase_other = PurchaseFactory(canteen=canteen_other)
+        url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
+        )
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_can_retrieve_facture(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["id"], self.purchase.id)
+        self.assertIsNotNone(data["facture"])
+
+    @authenticate
+    def test_returns_404_if_purchase_has_no_facture(self):
+        self.canteen.managers.add(authenticate.user)
+        self.purchase.facture = None
+        self.purchase.save()
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class PurchaseFactureUpdateTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.purchase = PurchaseFactory(canteen=cls.canteen, facture=SimpleUploadedFile("facture.pdf", b"pdf content"))
+        cls.url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": cls.canteen.id, "pk": cls.purchase.id},
+        )
+
+    @authenticate
+    def test_cannot_update_facture_with_patch(self):
+        self.canteen.managers.add(authenticate.user)
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+
+        response = self.client.patch(self.url, {"facture": file}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @authenticate
+    def test_cannot_update_facture_with_put(self):
+        self.canteen.managers.add(authenticate.user)
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+
+        response = self.client.put(self.url, {"facture": file}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+
 class PurchaseFactureDeleteTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.canteen = CanteenFactory()
-        cls.purchase = PurchaseFactory(canteen=cls.canteen)
+        cls.purchase = PurchaseFactory(canteen=cls.canteen, facture=SimpleUploadedFile("facture.pdf", b"pdf content"))
         cls.url = reverse(
             "purchase_facture",
             kwargs={"canteen_pk": cls.canteen.id, "pk": cls.purchase.id},
@@ -171,9 +280,6 @@ class PurchaseFactureDeleteTest(APITestCase):
     @authenticate
     def test_can_delete_facture(self):
         self.canteen.managers.add(authenticate.user)
-        file = SimpleUploadedFile("facture.pdf", b"pdf content")
-        self.purchase.facture = file
-        self.purchase.save()
         self.assertTrue(self.purchase.facture)
 
         response = self.client.delete(self.url)
@@ -183,12 +289,12 @@ class PurchaseFactureDeleteTest(APITestCase):
         self.assertFalse(self.purchase.facture)
 
     @authenticate
-    def test_can_delete_even_if_purchase_has_no_facture(self):
+    def test_returns_404_if_purchase_has_no_facture(self):
         self.canteen.managers.add(authenticate.user)
+        self.purchase.facture = None
+        self.purchase.save()
         self.assertFalse(self.purchase.facture)
 
         response = self.client.delete(self.url)
 
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.purchase.refresh_from_db()
-        self.assertFalse(self.purchase.facture)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/api/tests/test_purchase_facture.py
+++ b/api/tests/test_purchase_facture.py
@@ -1,0 +1,194 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from api.tests.utils import authenticate
+from data.factories import CanteenFactory, PurchaseFactory
+
+
+class PurchaseFactureUploadTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.purchase = PurchaseFactory(canteen=cls.canteen)
+        cls.url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": cls.canteen.id, "pk": cls.purchase.id},
+        )
+
+    def test_cannot_upload_if_unauthenticated(self):
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+        response = self.client.post(self.url, {"facture": file}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_upload_if_canteen_unknown(self):
+        url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": 9999, "pk": self.purchase.id},
+        )
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+        response = self.client.post(url, {"facture": file}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_upload_if_not_canteen_manager(self):
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+        response = self.client.post(self.url, {"facture": file}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_upload_if_purchase_unknown(self):
+        self.canteen.managers.add(authenticate.user)
+        url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": self.canteen.id, "pk": 9999},
+        )
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+
+        response = self.client.post(url, {"facture": file}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_upload_if_file_missing(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.post(self.url, {}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @authenticate
+    def test_cannot_upload_if_purchase_not_in_corresponding_canteen(self):
+        canteen_other = CanteenFactory()
+        purchase_other = PurchaseFactory(canteen=canteen_other)
+        url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
+        )
+        self.canteen.managers.add(authenticate.user)
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+
+        response = self.client.post(url, {"facture": file}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_can_upload_facture(self):
+        self.canteen.managers.add(authenticate.user)
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+
+        response = self.client.post(self.url, {"facture": file}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["id"], self.purchase.id)
+        self.assertIsNotNone(data["facture"])
+
+        # Verify file was saved
+        self.purchase.refresh_from_db()
+        self.assertTrue(self.purchase.facture)
+        self.assertIn("facture", self.purchase.facture.name)
+
+    @authenticate
+    def test_can_replace_existing_facture(self):
+        self.canteen.managers.add(authenticate.user)
+        old_file = SimpleUploadedFile("old.pdf", b"old content")
+        self.purchase.facture = old_file
+        self.purchase.save()
+        old_file_name = self.purchase.facture.name
+
+        new_file = SimpleUploadedFile("new.pdf", b"new content")
+        response = self.client.post(self.url, {"facture": new_file}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.purchase.refresh_from_db()
+        self.assertNotEqual(self.purchase.facture.name, old_file_name)
+
+
+class PurchaseFactureDeleteTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.purchase = PurchaseFactory(canteen=cls.canteen)
+        cls.url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": cls.canteen.id, "pk": cls.purchase.id},
+        )
+
+    def test_cannot_delete_if_unauthenticated(self):
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_delete_if_canteen_unknown(self):
+        url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": 9999, "pk": self.purchase.id},
+        )
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_delete_if_not_canteen_manager(self):
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_delete_if_purchase_unknown(self):
+        self.canteen.managers.add(authenticate.user)
+        url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": self.canteen.id, "pk": 9999},
+        )
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_delete_if_purchase_not_in_corresponding_canteen(self):
+        canteen_other = CanteenFactory()
+        purchase_other = PurchaseFactory(canteen=canteen_other)
+        url = reverse(
+            "purchase_facture",
+            kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
+        )
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_can_delete_facture(self):
+        self.canteen.managers.add(authenticate.user)
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+        self.purchase.facture = file
+        self.purchase.save()
+        self.assertTrue(self.purchase.facture)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.purchase.refresh_from_db()
+        self.assertFalse(self.purchase.facture)
+
+    @authenticate
+    def test_can_delete_even_if_purchase_has_no_facture(self):
+        self.canteen.managers.add(authenticate.user)
+        self.assertFalse(self.purchase.facture)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.purchase.refresh_from_db()
+        self.assertFalse(self.purchase.facture)

--- a/api/urls.py
+++ b/api/urls.py
@@ -45,6 +45,7 @@ from api.views import (
     PublishedCanteenSingleView,
     PublishedCanteensView,
     PurchaseCreateView,
+    PurchaseFactureView,
     PurchaseListExportView,
     PurchaseOldListCreateView,
     PurchaseOldRetrieveUpdateDestroyView,
@@ -114,6 +115,11 @@ urlpatterns = {
         "canteens/<int:canteen_pk>/purchases/<int:pk>",
         PurchaseRetrieveUpdateDestroyView.as_view(),
         name="canteen_purchase_retrieve_update_destroy",
+    ),
+    path(
+        "canteens/<int:canteen_pk>/purchases/<int:pk>/facture",
+        PurchaseFactureView.as_view(),
+        name="purchase_facture",
     ),
     path(
         "canteens/<int:canteen_pk>/diagnostics/",

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -53,6 +53,7 @@ from .purchase import (  # noqa: F401
     CanteenPurchasesSummaryView,
     DiagnosticsFromPurchasesView,
     PurchaseCreateView,
+    PurchaseFactureView,
     PurchaseOldListCreateView,
     PurchaseOldRetrieveUpdateDestroyView,
     PurchaseOptionsView,

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -213,10 +213,19 @@ class PurchaseOldRetrieveUpdateDestroyView(RetrieveUpdateDestroyAPIView):
 
 class PurchaseFactureView(APIView):
     permission_classes = [IsAuthenticated, IsCanteenManagerUrlParam]
-    http_method_names = ["post", "delete"]
+    http_method_names = ["get", "post", "delete"]
 
     def get_object(self):
         return get_object_or_404(Purchase, pk=self.kwargs.get("pk"), canteen__pk=self.kwargs.get("canteen_pk"))
+
+    def get(self, request, *args, **kwargs):
+        purchase = self.get_object()
+
+        if not purchase.facture:
+            raise NotFound()
+
+        serializer = PurchaseFactureResponseSerializer(purchase, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     def post(self, request, *args, **kwargs):
         purchase = self.get_object()
@@ -233,11 +242,12 @@ class PurchaseFactureView(APIView):
     def delete(self, request, *args, **kwargs):
         purchase = self.get_object()
 
-        if purchase.facture:
-            purchase.facture.delete()
-            purchase.facture = None
-            purchase.save()
+        if not purchase.facture:
+            raise NotFound()
 
+        purchase.facture.delete()
+        purchase.facture = None
+        purchase.save()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -6,7 +6,7 @@ from django.http import JsonResponse
 from django_filters import rest_framework as django_filters
 from rest_framework import status
 from rest_framework.exceptions import NotFound, PermissionDenied
-from rest_framework.generics import GenericAPIView, ListCreateAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.generics import GenericAPIView, ListCreateAPIView, RetrieveUpdateDestroyAPIView, get_object_or_404
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
@@ -20,6 +20,8 @@ from api.permissions import (
     IsLinkedCanteenManager,
 )
 from api.serializers import (
+    PurchaseFactureResponseSerializer,
+    PurchaseFactureUploadSerializer,
     PurchaseOldSerializer,
     PurchasePercentageSummarySerializer,
     PurchaseSerializer,
@@ -207,6 +209,36 @@ class PurchaseOldRetrieveUpdateDestroyView(RetrieveUpdateDestroyAPIView):
                 f"User {self.request.user.id} attempted to update a purchase to an nonexistent canteen {canteen_id}"
             )
             raise NotFound() from e
+
+
+class PurchaseFactureView(APIView):
+    permission_classes = [IsAuthenticated, IsCanteenManagerUrlParam]
+    http_method_names = ["post", "delete"]
+
+    def get_object(self):
+        return get_object_or_404(Purchase, pk=self.kwargs.get("pk"), canteen__pk=self.kwargs.get("canteen_pk"))
+
+    def post(self, request, *args, **kwargs):
+        purchase = self.get_object()
+
+        serializer = PurchaseFactureUploadSerializer(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+
+        purchase.facture = serializer.validated_data["facture"]
+        purchase.save()
+
+        response_serializer = PurchaseFactureResponseSerializer(purchase, context={"request": request})
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+    def delete(self, request, *args, **kwargs):
+        purchase = self.get_object()
+
+        if purchase.facture:
+            purchase.facture.delete()
+            purchase.facture = None
+            purchase.save()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class CanteenPurchasesSummaryView(APIView):


### PR DESCRIPTION
Suite à #6755 & #6810 (nouvel endpoint pour créer/modifier/... des achats), on a sorti les factures du body.

Mais on souhaite maintenir, au moins temporairement, cette fonctionnalité..

Nouvel endpoint `canteens/<int:canteen_pk>/purchases/<int:pk>/facture`