### PR TITLE
fix(Achats): passe le formulaire sur 3 colonnes et enlève le fond bleu

### DIFF
--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -248,7 +248,10 @@ const formatPayload = (form) => {
       <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
         <div class="fr-col-12 fr-col-md-4">
           <p class="fr-legend-text fr-mb-1w">Facture</p>
-          <p class="fr-hint-text fr-mb-2w">Ce champ n'est pas obligatoire, vous pouvez le laisser vide si vous n'avez pas de facture pour cet achat, ou si vous utilisez un autre moyen pour stocker vos justificatifs.</p>
+          <p class="fr-hint-text fr-mb-2w">Ce champ est facultatif.
+Il n'est pas nécessaire d'importer ses factures pdf si vous disposez déjà d'un espace de stockage fiable et sécurisé (sur votre ordinateur ou autre logiciel par exemple).
+
+</p>
         </div>
         <div class="fr-col-12 fr-col-md-4">
           <DsfrFileUpload

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -244,21 +244,27 @@ const formatPayload = (form) => {
       </div>
     </div>
 
-    <p class="fr-legend-text fr-mb-1w">Facture</p>
-    <p class="fr-hint-text fr-mb-2w">Ce champ n'est pas obligatoire, vous pouvez le laisser vide si vous n'avez pas de facture pour cet achat, ou si vous utilisez un autre moyen pour stocker vos justificatifs.</p>
-    <div class="fr-grid-row fr-grid-row--top fr-grid-row--gutters">
-      <div v-if="form.invoiceUrl" class="fr-col-12 fr-col-md-6">
-        <p class="fr-mb-2w">Vous avez déjà importé une facture pour cet achat, accéder au fichier en <a :href="form.invoiceUrl" target="_blank">cliquant ici</a>.</p>
-      </div>
-      <div class="fr-col-12" :class="{ 'fr-col-md-6': form.invoiceUrl }">
-        <DsfrFileUpload
-          v-model="invoiceFileInputValue"
-          :label="form.invoiceUrl ? 'Télécharger un nouveau fichier' : 'Télécharger un fichier'"
-          hint="PDF ou image (JPEG, PNG) — 10 Mo maximum"
-          accept="image/jpeg,image/png,application/pdf"
-          :error="invoiceFileError"
-          @change="onInvoiceFileChange"
-        />
+    <div class="fr-card fr-p-3w">
+      <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
+        <div class="fr-col-12 fr-col-md-4">
+          <p class="fr-legend-text fr-mb-1w">Facture</p>
+          <p class="fr-hint-text fr-mb-2w">Ce champ n'est pas obligatoire, vous pouvez le laisser vide si vous n'avez pas de facture pour cet achat, ou si vous utilisez un autre moyen pour stocker vos justificatifs.</p>
+        </div>
+        <div class="fr-col-12 fr-col-md-4">
+          <DsfrFileUpload
+            v-model="invoiceFileInputValue"
+            :label="form.invoiceUrl ? 'Télécharger un nouveau fichier' : 'Télécharger un fichier'"
+            hint="PDF ou image (JPEG, PNG) — 10 Mo maximum"
+            accept="image/jpeg,image/png,application/pdf"
+            :error="invoiceFileError"
+            @change="onInvoiceFileChange"
+          />
+        </div>
+        <div class="fr-col-12 fr-col-md-4">
+          <div v-if="form.invoiceUrl" class="fr-col-12 fr-col-md-6">
+            <p class="fr-mb-2w">Vous avez déjà importé une facture pour cet achat, accéder au fichier en <a :href="form.invoiceUrl" target="_blank">cliquant ici</a>.</p>
+          </div>
+       </div>
       </div>
     </div>
 

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -261,8 +261,8 @@ const formatPayload = (form) => {
           />
         </div>
         <div class="fr-col-12 fr-col-md-4">
-          <div v-if="form.invoiceUrl" class="fr-col-12 fr-col-md-6">
-            <p class="fr-mb-2w">Vous avez déjà importé une facture pour cet achat, accéder au fichier en <a :href="form.invoiceUrl" target="_blank">cliquant ici</a>.</p>
+          <div v-if="form.invoiceUrl">
+            <p class="fr-mb-2w">Vous avez déjà importé une facture pour cet achat : <a :href="form.invoiceUrl" target="_blank">voir le fichier</a>.</p>
           </div>
        </div>
       </div>
@@ -312,7 +312,6 @@ const formatPayload = (form) => {
   &__inline-col {
     .fr-fieldset {
       align-items: flex-start !important;
-      padding: 0.75rem;
     }
     .fr-fieldset__element--inline {
       width: 33% !important;

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -137,30 +137,22 @@ const formatPayload = (form) => {
 </script>
 
 <template>
-  <form class="purchase-form fr-p-2w fr-p-md-7w fr-col-12 fr-col-lg-7 fr-background-default--grey fr-mt-4w" @submit.prevent="">
-    <DsfrInputGroup
-      v-model="form.description"
-      label="Description du produit *"
-      label-visible
-      list="descriptions"
-      placeholder="Yaourts bio, légumes bio de juin..."
-      :error-message="formatError(v$.description)"
-    />
-    <datalist id="descriptions">
-      <option v-for="description in autocompleteOptions.descriptions" :key="description" :value="description"></option>
-    </datalist>
-    <DsfrInputGroup
-      v-model="form.provider"
-      label="Fournisseur *"
-      label-visible
-      list="providers"
-      :error-message="formatError(v$.provider)"
-    />
-    <datalist id="providers">
-      <option v-for="provider in autocompleteOptions.providers" :key="provider" :value="provider"></option>
-    </datalist>
-    <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
-      <div class="fr-col-12 fr-col-md-6">
+  <form class="purchase-form" @submit.prevent="">
+    <div class="fr-grid-row fr-grid-row--gutters">
+      <div class="fr-col-12 fr-col-md-8">
+        <DsfrInputGroup
+          v-model="form.description"
+          label="Description du produit *"
+          label-visible
+          list="descriptions"
+          placeholder="Yaourts bio, légumes bio de juin..."
+          :error-message="formatError(v$.description)"
+        />
+        <datalist id="descriptions">
+          <option v-for="description in autocompleteOptions.descriptions" :key="description" :value="description"></option>
+        </datalist>
+      </div>
+      <div class="fr-col-12 fr-col-md-4">
         <DsfrInputGroup
           v-model.number="form.priceHt"
           type="number"
@@ -169,7 +161,21 @@ const formatPayload = (form) => {
           :error-message="formatError(v$.priceHt)"
         />
       </div>
-      <div class="fr-col-12 fr-col-md-6">
+    </div>
+    <div class="fr-grid-row fr-grid-row--gutters">
+      <div class="fr-col-12 fr-col-md-8">
+        <DsfrInputGroup
+          v-model="form.provider"
+          label="Fournisseur *"
+          label-visible
+          list="providers"
+          :error-message="formatError(v$.provider)"
+        />
+        <datalist id="providers">
+          <option v-for="provider in autocompleteOptions.providers" :key="provider" :value="provider"></option>
+        </datalist>
+      </div>
+      <div class="fr-col-12 fr-col-md-4">
         <DsfrInputGroup
           v-model="form.date"
           type="date"
@@ -180,70 +186,82 @@ const formatPayload = (form) => {
         />
       </div>
     </div>
-    <div class="fr-mb-3w">
-      <p class="fr-legend-text fr-mb-1w">Facture</p>
-      <div class="fr-grid-row fr-grid-row--top fr-grid-row--gutters">
-        <div v-if="form.invoiceUrl" class="fr-col-12 fr-col-md-6">
-          <p class="fr-mb-2w">Vous avez déjà importé une facture pour cet achat, accéder au fichier en <a :href="form.invoiceUrl" target="_blank">cliquant ici</a>.</p>
-        </div>
-        <div class="fr-col-12" :class="{ 'fr-col-md-6': form.invoiceUrl }">
-          <DsfrFileUpload
-            v-model="invoiceFileInputValue"
-            :label="form.invoiceUrl ? 'Télécharger un nouveau fichier' : 'Télécharger un fichier'"
-            hint="PDF ou image (JPEG, PNG) — 10 Mo maximum"
-            accept="image/jpeg,image/png,application/pdf"
-            :error="invoiceFileError"
-            @change="onInvoiceFileChange"
-          />
-        </div>
-      </div>
-    </div>
+
     <DsfrRadioButtonSet
+      class="purchase-form__inline-col"
       v-model="form.family"
       legend="Famille de produit *"
+      inline
       :options="familleProduitOptions"
       :error-message="formatError(v$.family)"
     />
 
     <DsfrCheckboxSet
+      class="purchase-form__inline-col"
       v-model="form.characteristicsEgalim"
       legend="Catégories EGalim"
       :options="categoriesEgalimOptions"
       small
-    />
-
-    <DsfrSelect
-      v-model="form.characteristicsOrigines"
-      label="Origine"
-      :options="[{ value: '', text: '--' }, ...categoriesOriginesOptions]"
-    />
-
-    <DsfrCheckboxSet
-      v-model="form.characteristicsCircuitCourt"
-      legend="Circuit court"
-      :options="estCircuitCourtOptions"
-      small
       inline
     />
 
-    <DsfrCheckboxSet
-      v-model="form.characteristicsLocal"
-      legend="« Local »"
-      :options="estLocalOptions"
-      small
-      inline
-      class="fr-mb-n2w"
-      @change="onLocalChange"
-    />
-    <DsfrSelect
-      v-if="showLocalDefinition"
-      v-model="form.localDefinition"
-      label="Précisions *"
-      hint="Précisez la provenance du produit"
-      labelVisible
-      :options="definitionLocalOptions"
-      :error-message="formatError(v$.localDefinition)"
-    />
+    <div class="fr-grid-row fr-grid-row--gutters">
+      <div class="fr-col-12 fr-col-md-4">
+        <DsfrSelect
+          v-model="form.characteristicsOrigines"
+          label="Origine"
+          :options="[{ value: '', text: '--' }, ...categoriesOriginesOptions]"
+        />
+      </div>
+      <div class="fr-col-12 fr-col-md-4">
+        <DsfrCheckboxSet
+          v-model="form.characteristicsCircuitCourt"
+          legend="Circuit court"
+          :options="estCircuitCourtOptions"
+          small
+          inline
+        />
+      </div>
+      <div class="fr-col-12 fr-col-md-4">
+        <DsfrCheckboxSet
+          v-model="form.characteristicsLocal"
+          legend="« Local »"
+          :options="estLocalOptions"
+          small
+          inline
+          class="fr-mb-n2w"
+          @change="onLocalChange"
+        />
+        <DsfrSelect
+          v-if="showLocalDefinition"
+          v-model="form.localDefinition"
+          label="Précisions *"
+          hint="Précisez la provenance du produit"
+          labelVisible
+          :options="definitionLocalOptions"
+          :error-message="formatError(v$.localDefinition)"
+        />
+      </div>
+    </div>
+
+    <p class="fr-legend-text fr-mb-1w">Facture</p>
+    <p class="fr-hint-text fr-mb-2w">Ce champ n'est pas obligatoire, vous pouvez le laisser vide si vous n'avez pas de facture pour cet achat, ou si vous utilisez un autre moyen pour stocker vos justificatifs.</p>
+    <div class="fr-grid-row fr-grid-row--top fr-grid-row--gutters">
+      <div v-if="form.invoiceUrl" class="fr-col-12 fr-col-md-6">
+        <p class="fr-mb-2w">Vous avez déjà importé une facture pour cet achat, accéder au fichier en <a :href="form.invoiceUrl" target="_blank">cliquant ici</a>.</p>
+      </div>
+      <div class="fr-col-12" :class="{ 'fr-col-md-6': form.invoiceUrl }">
+        <DsfrFileUpload
+          v-model="invoiceFileInputValue"
+          :label="form.invoiceUrl ? 'Télécharger un nouveau fichier' : 'Télécharger un fichier'"
+          hint="PDF ou image (JPEG, PNG) — 10 Mo maximum"
+          accept="image/jpeg,image/png,application/pdf"
+          :error="invoiceFileError"
+          @change="onInvoiceFileChange"
+        />
+      </div>
+    </div>
+
     <div class="fr-mt-6w ma-cantine--flex-end">
       <DsfrButton
         v-if="showDeleteButton"
@@ -283,6 +301,16 @@ const formatPayload = (form) => {
     display: flex;
     justify-content: center;
     align-items: center;
+  }
+
+  &__inline-col {
+    .fr-fieldset {
+      align-items: flex-start !important;
+      padding: 0.75rem;
+    }
+    .fr-fieldset__element--inline {
+      width: 33% !important;
+    }
   }
 }
 </style>

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -248,10 +248,7 @@ const formatPayload = (form) => {
       <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
         <div class="fr-col-12 fr-col-md-4">
           <p class="fr-legend-text fr-mb-1w">Facture</p>
-          <p class="fr-hint-text fr-mb-2w">Ce champ est facultatif.
-Il n'est pas nécessaire d'importer ses factures pdf si vous disposez déjà d'un espace de stockage fiable et sécurisé (sur votre ordinateur ou autre logiciel par exemple).
-
-</p>
+          <p class="fr-hint-text fr-mb-2w">Ce champ est facultatif. Il n'est pas nécessaire d'importer ses factures pdf si vous disposez déjà d'un espace de stockage fiable et sécurisé (sur votre ordinateur ou autre logiciel par exemple).</p>
         </div>
         <div class="fr-col-12 fr-col-md-4">
           <DsfrFileUpload

--- a/2024-frontend/src/data/documentation.json
+++ b/2024-frontend/src/data/documentation.json
@@ -1,6 +1,5 @@
 {
   "accueil": "https://ma-cantine.crisp.help/fr/",
-  "ajouterAchat": "https://ma-cantine.crisp.help/fr/article/ajouter-manuellement-un-produit-via-loutil-de-suivi-des-achats-egalim-zdbhv7/",
   "bienDemarrer": "https://ma-cantine.crisp.help/fr/category/bien-demarrer-1fn9r2h/",
   "calculerNombreCouverts": "https://ma-cantine.crisp.help/fr/article/bien-calculer-son-nombre-de-couverts-1w58ozp/?bust=1766138160563",
   "correctionCampaign": "https://ma-cantine.crisp.help/fr/article/la-campagne-de-correction-pour-ma-teledeclaration-faq-1sk8ipw/",
@@ -14,6 +13,7 @@
   "lutteGaspillageAlimentaire": "https://ma-cantine.crisp.help/fr/article/comprendre-mes-obligations-lutte-contre-le-gaspillage-alimentaire-5ekzj7/",
   "qualiteDurabiliteProduits": "https://ma-cantine.crisp.help/fr/article/comprendre-mes-obligations-qualite-et-durabilite-des-produits-w3xg0f/",
   "rapportsBilansStatistiquesEgalim": "https://ma-cantine.crisp.help/fr/article/rapports-bilans-statistiques-egalim-de-la-restauration-collective-18z8ru0/",
+  "suiviAchatsEgalim": "https://ma-cantine.crisp.help/fr/category/suivis-des-achats-l57vl7/",
   "teledeclaration": "https://ma-cantine.crisp.help/fr/category/teledeclaration-18r0z84/",
   "trouverIdCantine": "https://ma-cantine.crisp.help/fr/article/ou-trouver-lid-de-ma-cantine-ou-de-mon-groupe-th6t5u/"
 }

--- a/2024-frontend/src/views/GestionnaireAchatsAjouter.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsAjouter.vue
@@ -52,11 +52,11 @@ const resetForm = () => {
 </script>
 
 <template>
-  <section class="fr-grid-row fr-grid-row--bottom fr-mb-4w">
+  <section class="fr-grid-row fr-grid-row--middle fr-mb-4w">
     <div class="fr-col-12 fr-col-md-6 fr-mb-4w fr-mb-md-0">
-      <h1>{{ route.meta.title }} pour la cantine «&nbsp;{{ canteenName }}&nbsp;»</h1>
+      <h1>{{ route.meta.title }}</h1>
       <p>
-        Enregistrez ici les achats alimentaires de votre établissement pour suivre et faciliter la réalisation de votre déclaration.
+        Pour la cantine «&nbsp;{{ canteenName }}&nbsp;»
       </p>
     </div>
     <div class="fr-col-offset-md-1"></div>

--- a/2024-frontend/src/views/GestionnaireAchatsAjouter.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsAjouter.vue
@@ -52,7 +52,7 @@ const resetForm = () => {
 </script>
 
 <template>
-  <section class="fr-grid-row fr-grid-row--bottom">
+  <section class="fr-grid-row fr-grid-row--bottom fr-mb-4w">
     <div class="fr-col-12 fr-col-md-6 fr-mb-4w fr-mb-md-0">
       <h1>{{ route.meta.title }} pour la cantine «&nbsp;{{ canteenName }}&nbsp;»</h1>
       <p>
@@ -73,13 +73,9 @@ const resetForm = () => {
       </li>
     </AppRessources>
   </section>
-  <section
-    class="fr-background-alt--blue-france fr-p-3w fr-mt-4w fr-grid-row fr-grid-row--center"
-  >
-    <PurchaseForm
-      :showCreateButton="true"
-      :key="forceRerender"
-      @sendForm="(payload) => savePurchase(payload)"
-    />
-  </section>
+  <PurchaseForm
+    :showCreateButton="true"
+    :key="forceRerender"
+    @sendForm="(payload) => savePurchase(payload)"
+  />
 </template>

--- a/2024-frontend/src/views/GestionnaireAchatsAjouter.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsAjouter.vue
@@ -62,8 +62,8 @@ const resetForm = () => {
     <div class="fr-col-offset-md-1"></div>
     <AppRessources>
       <li>
-        <a :href="documentation.ajouterAchat" target="_blank">
-          Tutoriel pour ajouter un achat manuellement
+        <a :href="documentation.suiviAchatsEgalim" target="_blank">
+          En savoir plus sur l'outil de suivi des achats EGalim
         </a>
       </li>
       <li>

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -108,8 +108,8 @@ const goToPurchasesList = () => {
     <div class="fr-col-offset-md-1"></div>
     <AppRessources>
       <li>
-        <a :href="documentation.ajouterAchat" target="_blank">
-          Tutoriel pour ajouter un achat manuellement
+        <a :href="documentation.suiviAchatsEgalim" target="_blank">
+          En savoir plus sur l'outil de suivi des achats EGalim
         </a>
       </li>
       <li>

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -118,17 +118,16 @@ const goToPurchasesList = () => {
   </section>
   <section class="fr-mt-4w">
     <AppLoader v-if="isLoading" />
-    <div v-else-if="purchaseData.id" class="fr-background-alt--blue-france fr-p-3w fr-grid-row fr-grid-row--center">
-      <PurchaseForm
-        :key="forceRerender"
-        :purchase-data="purchaseData"
-        :showCancelButton="true"
-        :showDeleteButton="true"
-        @sendForm="(payload) => savePurchase(payload)"
-        @cancel="goToPurchasesList"
-        @delete="deletePurchase"
-      />
-    </div>
+    <PurchaseForm
+      v-else-if="purchaseData.id"
+      :key="forceRerender"
+      :purchase-data="purchaseData"
+      :showCancelButton="true"
+      :showDeleteButton="true"
+      @sendForm="(payload) => savePurchase(payload)"
+      @cancel="goToPurchasesList"
+      @delete="deletePurchase"
+    />
     <div v-else-if="purchaseDeleted" class="fr-col-12 fr-col-lg-7">
       <p>
         L'achat a bien été supprimé pour la cantine « {{ canteenName }} ». <br />

--- a/2024-frontend/src/views/GestionnaireAchatsModifier.vue
+++ b/2024-frontend/src/views/GestionnaireAchatsModifier.vue
@@ -98,9 +98,12 @@ const goToPurchasesList = () => {
 </script>
 
 <template>
-  <section class="fr-grid-row fr-grid-row--bottom">
+  <section class="fr-grid-row fr-grid-row--middle">
     <div class="fr-col-12 fr-col-md-6 fr-mb-4w fr-mb-md-0">
-      <h1>{{ route.meta.title }} pour la cantine «&nbsp;{{ canteenName }}&nbsp;»</h1>
+      <h1>{{ route.meta.title }}</h1>
+      <p>
+        Pour la cantine «&nbsp;{{ canteenName }}&nbsp;»
+      </p>
     </div>
     <div class="fr-col-offset-md-1"></div>
     <AppRessources>


### PR DESCRIPTION
Suite à la migration en vue 3 du formulaire dans #6759

Ticket : https://app.notion.com/p/incubateur-masa/Passer-le-formulaire-d-ajout-achat-en-2-colonnes-387de24614be80bfa794f278695705f6

|Avant|Après|
|--|--|
| <img width="3420" height="6086" alt="Avant-achat" src="https://github.com/user-attachments/assets/a6ffe92a-442b-46fc-9842-0710b6b96108" /> | <img width="3420" height="4162" alt="Apres" src="https://github.com/user-attachments/assets/4b591b1a-b510-42df-ad62-a7e800eab997" /> |