### PR TITLE
docs(API): cacher le champ creation_source (ne pas l'afficher dans le swagger)

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 REQUIRED_FIELDS = ("name", "siret")
+CREATE_ONLY_FIELDS = ("creation_source", *Canteen.MATOMO_FIELDS)
 
 
 class CanteenImageSerializer(serializers.ModelSerializer):
@@ -357,15 +358,13 @@ class FullCanteenSerializer(serializers.ModelSerializer):
         # some fields are required
         for field in REQUIRED_FIELDS:
             fields[field].required = True
-        # some fields are only available on create
-        if self.instance is not None:
-            fields.pop("creation_source", None)
-            for field in Canteen.MATOMO_FIELDS:
+        # some fields are only available on create (and hidden from the docs)
+        for field in CREATE_ONLY_FIELDS:
+            if self.instance is not None:
                 fields.pop(field, None)
-        else:
-            fields["creation_source"].write_only = True
-            for field in Canteen.MATOMO_FIELDS:
+            else:
                 fields[field].write_only = True
+                fields[field].exclude_from_schema = True
         return fields
 
     def update(self, instance, validated_data):

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -16,6 +16,7 @@ FIELDS = (
     + Diagnostic.NON_APPRO_FIELDS
 )
 REQUIRED_FIELDS = ("year",)
+CREATE_ONLY_FIELDS = ("creation_source", *Diagnostic.MATOMO_FIELDS)
 
 
 class DiagnosticSerializer(serializers.ModelSerializer):
@@ -116,15 +117,13 @@ class ManagerDiagnosticSerializer(DiagnosticSerializer):
         # some fields are required
         for field in REQUIRED_FIELDS:
             fields[field].required = True
-        # some fields are only available on create
-        if self.instance is not None:
-            fields.pop("creation_source", None)
-            for field in Diagnostic.MATOMO_FIELDS:
+        # some fields are only available on create (and hidden from the docs)
+        for field in CREATE_ONLY_FIELDS:
+            if self.instance is not None:
                 fields.pop(field, None)
-        else:
-            fields["creation_source"].write_only = True
-            for field in Diagnostic.MATOMO_FIELDS:
+            else:
                 fields[field].write_only = True
+                fields[field].exclude_from_schema = True
         return fields
 
     def validate(self, data):

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -80,7 +80,7 @@ class PurchaseOldSerializer(serializers.ModelSerializer):
 
 
 REQUIRED_FIELDS = ["description", "date", "prix_ht", "famille_produits"]
-READ_ONLY_FIELDS = ["id", "canteen", "creation_source", "import_source", "creation_date", "modification_date"]
+CREATE_ONLY_FIELDS = ["creation_source", "import_source"]
 
 
 class PurchaseSerializer(serializers.ModelSerializer):
@@ -117,6 +117,14 @@ class PurchaseSerializer(serializers.ModelSerializer):
             "creation_date",
             "modification_date",
         )
+        read_only_fields = (
+            "id",
+            "canteen",
+            # "creation_source",
+            # "import_source",
+            "creation_date",
+            "modification_date",
+        )
 
     def get_fields(self):
         fields = super().get_fields()
@@ -125,9 +133,13 @@ class PurchaseSerializer(serializers.ModelSerializer):
             fields[field].required = True
             fields[field].allow_null = False
             fields[field].allow_blank = False
-        # some fields are readonly
-        for field in READ_ONLY_FIELDS:
-            fields[field].read_only = True
+        # some fields are only available on create (and hidden from the docs)
+        for field in CREATE_ONLY_FIELDS:
+            if self.instance is not None:
+                fields.pop(field, None)
+            else:
+                fields[field].write_only = True
+                fields[field].exclude_from_schema = True
         return fields
 
     def to_representation(self, instance):

--- a/api/serializers/wastemeasurement.py
+++ b/api/serializers/wastemeasurement.py
@@ -3,6 +3,9 @@ from rest_framework import serializers
 from data.models import WasteMeasurement
 
 
+CREATE_ONLY_FIELDS = ["creation_source"]
+
+
 class WasteMeasurementSerializer(serializers.ModelSerializer):
     days_in_period = serializers.IntegerField(read_only=True)  # property
     total_yearly_waste_estimation = serializers.FloatField(read_only=True, allow_null=True)  # property
@@ -37,15 +40,18 @@ class WasteMeasurementSerializer(serializers.ModelSerializer):
         )
         read_only_fields = (
             "id",
+            # "creation_source",
             "creation_date",
             "modification_date",
         )
 
     def get_fields(self):
         fields = super().get_fields()
-        # some fields are only available on create
-        if self.instance is not None:
-            fields.pop("creation_source", None)
-        else:
-            fields["creation_source"].write_only = True
+        # some fields are only available on create (and hidden from the docs)
+        for field in CREATE_ONLY_FIELDS:
+            if self.instance is not None:
+                fields.pop(field, None)
+            else:
+                fields[field].write_only = True
+                fields[field].exclude_from_schema = True
         return fields

--- a/api/serializers/wastemeasurement.py
+++ b/api/serializers/wastemeasurement.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from data.models import WasteMeasurement
 
 
+REQUIRED_FIELDS = ["period_start_date", "period_end_date"]
 CREATE_ONLY_FIELDS = ["creation_source"]
 
 
@@ -47,6 +48,11 @@ class WasteMeasurementSerializer(serializers.ModelSerializer):
 
     def get_fields(self):
         fields = super().get_fields()
+        # some fields are required
+        for field in REQUIRED_FIELDS:
+            fields[field].required = True
+            fields[field].allow_null = False
+            fields[field].allow_blank = False
         # some fields are only available on create (and hidden from the docs)
         for field in CREATE_ONLY_FIELDS:
             if self.instance is not None:

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -223,6 +223,8 @@ class CanteenDetailApiTest(APITestCase):
         body = response.json()
         self.assertEqual(body["id"], user_canteen.id)
         self.assertEqual(body["managers"][0]["email"], authenticate.user.email)
+        self.assertNotIn("creationUser", body)
+        self.assertNotIn("creationSource", body)
 
     @authenticate
     def test_get_single_user_canteen_groupe(self):

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -408,7 +408,7 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
-class DiagnosticRetrieveApiTest(APITestCase):
+class DiagnosticDetailApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
@@ -420,7 +420,7 @@ class DiagnosticRetrieveApiTest(APITestCase):
         )
 
     @authenticate
-    def test_retrieve_diagnostic_not_allowed(self):
+    def test_cannot_get_diagnostic(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.get(self.url)
@@ -782,7 +782,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
 class DiagnosticDeleteApiTest(APITestCase):
     @authenticate
-    def test_delete_diagnostic_not_allowed(self):
+    def test_cannot_delete_diagnostic(self):
         diagnostic = DiagnosticFactory(year=2019)
         diagnostic.canteen.managers.add(authenticate.user)
 

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -560,7 +560,7 @@ class PurchaseCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
-class PurchaseRetrieveApiTest(APITestCase):
+class PurchaseDetailApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
@@ -581,13 +581,13 @@ class PurchaseRetrieveApiTest(APITestCase):
             "canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": cls.canteen.id, "pk": cls.purchase.id}
         )
 
-    def test_cannot_retrieve_purchase_if_unauthenticated(self):
+    def test_cannot_get_purchase_if_unauthenticated(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_retrieve_if_canteen_unknown(self):
+    def test_cannot_get_purchase_if_canteen_unknown(self):
         response = self.client.get(
             reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": 999, "pk": self.purchase.id})
         )
@@ -595,13 +595,13 @@ class PurchaseRetrieveApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_retrieve_if_not_canteen_manager(self):
+    def test_cannot_get_purchase_if_not_canteen_manager(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_retrieve_if_purchase_unknown(self):
+    def test_cannot_get_purchase_if_purchase_unknown(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.get(
@@ -611,7 +611,7 @@ class PurchaseRetrieveApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_retrieve_purchase_if_not_corresponding_canteen(self):
+    def test_cannot_get_purchase_if_not_corresponding_canteen(self):
         canteen_other = CanteenFactory()
         purchase_other = PurchaseFactory(canteen=canteen_other)
         self.canteen.managers.add(authenticate.user)
@@ -638,7 +638,7 @@ class PurchaseRetrieveApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_retrieve_purchase(self):
+    def test_get_purchase(self):
         self.purchase.canteen.managers.add(authenticate.user)
 
         response = self.client.get(self.url)
@@ -664,7 +664,7 @@ class PurchaseRetrieveApiTest(APITestCase):
         self.assertIn("creationDate", body)
         self.assertIn("modificationDate", body)
 
-    def test_can_retrieve_purchase_via_oauth2_only_if_same_creation_source(self):
+    def test_get_purchase_via_oauth2_only_if_same_creation_source(self):
         user, token = get_oauth2_token("canteen:write")
         self.purchase.canteen.managers.add(user)
 

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -386,6 +386,38 @@ class PurchaseCreateApiTest(APITestCase):
         self.assertEqual(purchase.creation_source_api_oauth2_application, token.application)
 
     @authenticate
+    def test_create_purchase_creation_user_and_source(self):
+        self.canteen.managers.add(authenticate.user)
+
+        # from the APP
+        payload = {**self.PURCHASE_PAYLOAD, "creation_source": "APP"}
+        response = self.client.post(self.url, payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertNotIn("creation_user", body)
+        self.assertNotIn("creation_source", body)
+        self.assertNotIn("creation_source_api_oauth2_application", body)
+        purchase = Purchase.objects.first()
+        self.assertEqual(purchase.creation_user, authenticate.user)
+        self.assertEqual(purchase.creation_source, CreationSource.APP)
+        self.assertEqual(purchase.creation_source_api_oauth2_application, None)
+
+        # cleanup
+        Purchase.objects.all().delete()
+
+        # defaults to API
+        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertNotIn("creation_user", body)
+        self.assertNotIn("creation_source", body)
+        self.assertNotIn("creation_source_api_oauth2_application", body)
+        purchase = Purchase.objects.first()
+        self.assertEqual(purchase.creation_user, authenticate.user)
+        self.assertEqual(purchase.creation_source, CreationSource.API)
+        self.assertEqual(purchase.creation_source_api_oauth2_application, None)
+
+    @authenticate
     def test_create_purchase_required_fields(self):
         self.canteen.managers.add(authenticate.user)
 
@@ -627,8 +659,8 @@ class PurchaseRetrieveApiTest(APITestCase):
         self.assertEqual(body["estCircuitCourt"], False)
         self.assertIsNone(body["definitionLocal"])
         self.assertNotIn("creationUser", body)
-        self.assertEqual(body["creationSource"], CreationSource.APP)
-        self.assertIsNone(body["importSource"])
+        self.assertNotIn("creationSource", body)
+        self.assertNotIn("importSource", body)
         self.assertIn("creationDate", body)
         self.assertIn("modificationDate", body)
 

--- a/api/tests/test_waste_measurements.py
+++ b/api/tests/test_waste_measurements.py
@@ -507,6 +507,8 @@ class WasteMeasurementsDetailApiTest(APITestCase):
         body = response.json()
         self.assertIn("periodStartDate", body)
         self.assertIn("periodEndDate", body)
+        self.assertNotIn("creationUser", body)
+        self.assertNotIn("creationSource", body)
 
     def test_get_waste_measurement_via_oauth2(self):
         user, token = get_oauth2_token("waste_measurements:read")


### PR DESCRIPTION
Dans la continuité de #6843

Le champ `creation_source` apparaissait dans le swagger.
C'est un champ interne/caché, donc pas besoin de l'afficher.

Modèles concernés : Canteen, Diagnostic, Purchase, WasteMeasurement