### PR TITLE
fix(Historisation): enlève groupe_snapshot de l'historisation des Diagnostic

### DIFF
--- a/data/migrations/0267_history_source_and_api_oauth2.py
+++ b/data/migrations/0267_history_source_and_api_oauth2.py
@@ -14,6 +14,10 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RemoveField(
+            model_name='historicaldiagnostic',
+            name='groupe_snapshot',
+        ),
+        migrations.RemoveField(
             model_name='historicalteledeclaration',
             name='authentication_method',
         ),


### PR DESCRIPTION
Suite à #6799
On avait ajouté un nouveau champ `Diagnostic.groupe_snapshot`
Mais on l'avait enlevé de l'historisation seulement dans un deuxième temps, et il manquait un bout de migration