### PR TITLE
improve(Achats): mieux distinguer visuellement les libellés des champs des valeurs

### DIFF
--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -288,5 +288,11 @@ const formatPayload = (form) => {
       width: 33% !important;
     }
   }
+
+  .fr-input-group label.fr-label,
+  .fr-select-group label.fr-label,
+  .fr-fieldset legend.fr-fieldset__legend {
+    font-weight: 700 !important;
+  }
 }
 </style>

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -144,7 +144,7 @@ const formatPayload = (form) => {
       </div>
     </div>
 
-    <div class="fr-grid-row fr-grid-row--gutters">
+    <div class="fr-grid-row fr-grid-row--gutters fr-mb-1w">
       <div class="fr-col-12 fr-col-md-8">
         <DsfrInputGroup
           v-model="form.fournisseur"
@@ -170,7 +170,7 @@ const formatPayload = (form) => {
     </div>
 
     <DsfrRadioButtonSet
-      class="purchase-form__inline-col"
+      class="purchase-form__inline-col fr-mb-4w"
       v-model="form.familleProduits"
       legend="Famille de produit *"
       inline
@@ -179,7 +179,7 @@ const formatPayload = (form) => {
     />
 
     <DsfrCheckboxSet
-      class="purchase-form__inline-col"
+      class="purchase-form__inline-col fr-mb-2w"
       v-model="form.categoriesEgalim"
       legend="Catégories EGalim"
       :options="categoriesEgalimOptions"

--- a/2024-frontend/src/components/PurchaseForm.vue
+++ b/2024-frontend/src/components/PurchaseForm.vue
@@ -287,6 +287,12 @@ const formatPayload = (form) => {
     .fr-fieldset__element--inline {
       width: 33% !important;
     }
+
+    @media (max-width: 768px) {
+      .fr-fieldset__element--inline {
+        width: 100% !important;
+      }
+    }
   }
 
   .fr-input-group label.fr-label,


### PR DESCRIPTION
<img width="2918" height="4298" alt="Nouveau" src="https://github.com/user-attachments/assets/69410bf1-360d-49ae-b8a8-b87975b4737d" />
