### PR TITLE
fix(API): Swagger: réparer les warnings qui s'affichent dans la console

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1909,48 +1909,56 @@ class Diagnostic(models.Model):
             return round(self.valeur_totale / self.canteen_yearly_meal_count, 2)
 
     @property
-    def percentage_valeur_totale(self):
+    def percentage_valeur_totale(self) -> float:
         return 1
 
     @property
-    def percentage_valeur_bio(self):
+    def percentage_valeur_bio(self) -> float | None:
         if self.valeur_totale and self.valeur_bio is not None:
             return self.valeur_bio / self.valeur_totale
+        return None
 
     @property
-    def percentage_valeur_siqo(self):
+    def percentage_valeur_siqo(self) -> float | None:
         if self.valeur_totale and self.valeur_siqo is not None:
             return self.valeur_siqo / self.valeur_totale
+        return None
 
     @property
-    def percentage_valeur_externalites_performance(self):
+    def percentage_valeur_externalites_performance(self) -> float | None:
         if self.valeur_totale and self.valeur_externalites_performance is not None:
             return self.valeur_externalites_performance / self.valeur_totale
+        return None
 
     @property
-    def percentage_valeur_egalim_autres(self):
+    def percentage_valeur_egalim_autres(self) -> float | None:
         if self.valeur_totale and self.valeur_egalim_autres is not None:
             return self.valeur_egalim_autres / self.valeur_totale
+        return None
 
     @property
-    def percentage_valeur_viandes_volailles_egalim(self):
+    def percentage_valeur_viandes_volailles_egalim(self) -> float | None:
         if self.valeur_viandes_volailles and self.valeur_viandes_volailles_egalim is not None:
             return self.valeur_viandes_volailles_egalim / self.valeur_viandes_volailles
+        return None
 
     @property
-    def percentage_valeur_viandes_volailles_france(self):
+    def percentage_valeur_viandes_volailles_france(self) -> float | None:
         if self.valeur_viandes_volailles and self.valeur_viandes_volailles_france is not None:
             return self.valeur_viandes_volailles_france / self.valeur_viandes_volailles
+        return None
 
     @property
-    def percentage_valeur_produits_de_la_mer_egalim(self):
+    def percentage_valeur_produits_de_la_mer_egalim(self) -> float | None:
         if self.valeur_produits_de_la_mer and self.valeur_produits_de_la_mer_egalim is not None:
             return self.valeur_produits_de_la_mer_egalim / self.valeur_produits_de_la_mer
+        return None
 
     @property
-    def percentage_valeur_produits_de_la_mer_france(self):
+    def percentage_valeur_produits_de_la_mer_france(self) -> float | None:
         if self.valeur_produits_de_la_mer and self.valeur_produits_de_la_mer_france is not None:
             return self.valeur_produits_de_la_mer_france / self.valeur_produits_de_la_mer
+        return None
 
     @property
     def valeur_totale_is_filled(self):


### PR DESCRIPTION
### Quoi

Quand on chargeait la page `/swagger-ui` on avait pas mal de warning

```
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteenSummaries > CanteenSummarySerializer > CentralKitchenDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_totale". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteenSummaries > CanteenSummarySerializer > CentralKitchenDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_bio". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteenSummaries > CanteenSummarySerializer > CentralKitchenDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_siqo". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteenSummaries > CanteenSummarySerializer > CentralKitchenDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_externalites_performance". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteenSummaries > CanteenSummarySerializer > CentralKitchenDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_egalim_autres". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteenSummaries > CanteenSummarySerializer > CentralKitchenDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_viandes_volailles_egalim". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteenSummaries > CanteenSummarySerializer > CentralKitchenDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_viandes_volailles_france". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteenSummaries > CanteenSummarySerializer > CentralKitchenDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_produits_de_la_mer_egalim". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteenSummaries > CanteenSummarySerializer > CentralKitchenDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_produits_de_la_mer_france". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteensView > FullCanteenSerializer > ApproDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_totale". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteensView > FullCanteenSerializer > ApproDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_bio". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteensView > FullCanteenSerializer > ApproDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_siqo". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteensView > FullCanteenSerializer > ApproDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_externalites_performance". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteensView > FullCanteenSerializer > ApproDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_egalim_autres". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteensView > FullCanteenSerializer > ApproDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_viandes_volailles_egalim". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteensView > FullCanteenSerializer > ApproDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_viandes_volailles_france". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteensView > FullCanteenSerializer > ApproDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_produits_de_la_mer_egalim". Consider using a type hint or @extend_schema_field. Defaulting to string.
ma-cantine/api/serializers/diagnostic.py: Warning [UserCanteensView > FullCanteenSerializer > ApproDiagnosticSerializer]: unable to resolve type hint for function "percentage_valeur_produits_de_la_mer_france". Consider using a type hint or @extend_schema_field. Defaulting to string.
```

Cette PR rajoute du typing sur quelques properties et ainsi aider DRF à infer le type. 0 warnings après coup :tada:  