### PR TITLE
improve(Etablissement): renomme les composants et personnalise la sidebar pour suivre les maquettes

### DIFF
--- a/2024-frontend/src/layouts/LayoutSidebarCanteen.vue
+++ b/2024-frontend/src/layouts/LayoutSidebarCanteen.vue
@@ -25,15 +25,15 @@ const canteenBadgeGroupe = computed(() => {
 
 /* Sidebar links */
 const menuItems = computed(() =>  {
-  const informationActive = currentRoute.value === "GestionnaireBilanInformations"
-  const gestionnairesActive = currentRoute.value === "GestionnaireBilanGestionnaires"
-  const pagePubliqueActive = currentRoute.value === "GestionnaireBilanPagePublique"
-  const toutesTeledeclarationsActive = currentRoute.value === "GestionnaireBilanToutesTeledeclarations"
-  const cantinesGroupeActive = currentRoute.value === "GestionnaireBilanCantinesGroupe"
+  const informationActive = currentRoute.value === "GestionnaireCantineInformations"
+  const gestionnairesActive = currentRoute.value === "GestionnaireCantineGestionnaires"
+  const pagePubliqueActive = currentRoute.value === "GestionnaireCantinePagePublique"
+  const toutesTeledeclarationsActive = currentRoute.value === "GestionnaireCantineToutesTeledeclarations"
+  const cantinesGroupeActive = currentRoute.value === "GestionnaireCantineGroupe"
 
   const informationPage = {
     text: canteenIsGroupe.value ? "Informations du groupe" : "Mes informations",
-    to: { name: "GestionnaireBilanInformations" },
+    to: { name: "GestionnaireCantineInformations" },
     active: informationActive
   }
   const gestionnairesPage = {
@@ -70,7 +70,7 @@ const menuItems = computed(() =>  {
 </script>
 
 <template>
-  <div class="layout-sidebar-bilan">
+  <div class="layout-sidebar-canteen">
     <h1>{{ canteenName }}</h1>
     <div class="ma-cantine--flex-start ma-cantine--flex-gap-1 fr-mb-4w">
       <DsfrBadge v-if="canteenBadgeGroupe" type="info" :noIcon="true" :label="canteenBadgeGroupe" />
@@ -79,7 +79,7 @@ const menuItems = computed(() =>  {
       <DsfrBadge v-if="canteenBadgeSiren" type="neutral" :label="canteenBadgeSiren" />
     </div>
     <div class="fr-grid-row fr-grid-row--top ma-cantine--sticky__container">
-      <div class="layout-sidebar-bilan__sidebar-container fr-col-12 fr-col-md-3 ma-cantine--sticky__top fr-background-default--grey">
+      <div class="layout-sidebar-canteen__sidebar-container fr-col-12 fr-col-md-3 ma-cantine--sticky__top fr-background-default--grey">
         <DsfrSideMenu :menu-items="menuItems" buttonLabel="Voir le menu"/>
       </div>
       <section class="fr-col-12 fr-col-md-9">
@@ -90,7 +90,7 @@ const menuItems = computed(() =>  {
 </template>
 
 <style lang="scss">
-.layout-sidebar-bilan {
+.layout-sidebar-canteen {
   &__sidebar-container {
     .fr-sidemenu__title {
       display: none !important;

--- a/2024-frontend/src/layouts/LayoutSidebarCanteen.vue
+++ b/2024-frontend/src/layouts/LayoutSidebarCanteen.vue
@@ -4,6 +4,7 @@ import { computedAsync } from "@vueuse/core"
 import { computed } from "vue"
 import urlService from "@/services/urls.js"
 import canteenService from "@/services/canteens.js"
+import AppSeparator from "@/components/AppSeparator.vue"
 
 /* Route */
 const route = useRoute()
@@ -83,7 +84,9 @@ const menuItems = computed(() =>  {
         <DsfrSideMenu :menu-items="menuItems" buttonLabel="Voir le menu"/>
       </div>
       <section class="fr-col-12 fr-col-md-9">
-        <slot :canteenInformation="canteenInformation" :canteenIsGroupe="canteenIsGroupe"></slot>
+        <slot name="title" :canteenIsGroupe="canteenIsGroupe"></slot>
+        <AppSeparator class="fr-mt-3w fr-mb-5w" />
+        <slot name="content" :canteenInformation="canteenInformation" :canteenIsGroupe="canteenIsGroupe"></slot>
       </section>
     </div>
   </div>
@@ -97,6 +100,7 @@ const menuItems = computed(() =>  {
     }
     .fr-sidemenu__inner {
       padding-right: 0 !important;
+      box-shadow: none !important;
     }
   }
 }

--- a/2024-frontend/src/router/authenticated-routes.js
+++ b/2024-frontend/src/router/authenticated-routes.js
@@ -3,7 +3,7 @@ import { sectionId } from "@/constants/site-map.js"
 /* Components */
 import GestionnaireAchatsAjouter from "@/views/GestionnaireAchatsAjouter.vue"
 import GestionnaireAchatsModifier from "@/views/GestionnaireAchatsModifier.vue"
-import GestionnaireBilanInformations from "@/views/GestionnaireBilanInformations.vue"
+import GestionnaireCantineInformations from "@/views/GestionnaireCantineInformations.vue"
 import GestionnaireCantineGerer from "@/views/GestionnaireCantineGerer.vue"
 import GestionnaireCantineGroupeAjouter from "@/views/GestionnaireCantineGroupeAjouter.vue"
 import GestionnaireCantineGroupeModifier from "@/views/GestionnaireCantineGroupeModifier.vue"
@@ -223,8 +223,8 @@ const routes = [
     children: [
       {
         path: "informations",
-        name: "GestionnaireBilanInformations",
-        component: GestionnaireBilanInformations,
+        name: "GestionnaireCantineInformations",
+        component: GestionnaireCantineInformations,
         meta: {
           title: "Informations",
           breadcrumbs: [

--- a/2024-frontend/src/views/GestionnaireCantineInformations.vue
+++ b/2024-frontend/src/views/GestionnaireCantineInformations.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { computedAsync } from "@vueuse/core"
 import { formatSiretOrSiren } from '@/utils'
-import LayoutSidebarBilan from '@/layouts/LayoutSidebarBilan.vue'
+import LayoutSidebarCanteen from '@/layouts/LayoutSidebarCanteen.vue'
 import AppFieldDisplay from '@/components/AppFieldDisplay.vue'
 import AppLinkRouter from '@/components/AppLinkRouter.vue'
 import cantines from '@/data/cantines.json'
@@ -44,7 +44,7 @@ const getPrettyLineMinistry = (canteenLineMinistry) => {
 </script>
 
 <template>
-  <LayoutSidebarBilan v-slot="{ canteenIsGroupe, canteenInformation }">
+  <LayoutSidebarCanteen v-slot="{ canteenIsGroupe, canteenInformation }">
     <div class="ma-cantine--flex-between ma-cantine--flex-gap-1">
       <h2 class="fr-mb-0">{{ canteenIsGroupe ? 'Informations du groupe' : 'Mes informations' }}</h2>
       <DsfrButton @click="goToEdit(canteenIsGroupe)" :label="canteenIsGroupe ? 'Modifier les informations du groupe' : 'Modifier mes informations'" icon="ri-pencil-line" />
@@ -116,5 +116,5 @@ const getPrettyLineMinistry = (canteenLineMinistry) => {
         Vous pouvez l’archiver <AppLinkRouter :to="{ name: 'GestionnaireCantineArchiver', params: { canteenUrlComponent: canteenUrlComponent } }" title="en cliquant ici" />
       </p>
     </div>
-  </LayoutSidebarBilan>
+  </LayoutSidebarCanteen>
 </template>

--- a/2024-frontend/src/views/GestionnaireCantineInformations.vue
+++ b/2024-frontend/src/views/GestionnaireCantineInformations.vue
@@ -44,77 +44,81 @@ const getPrettyLineMinistry = (canteenLineMinistry) => {
 </script>
 
 <template>
-  <LayoutSidebarCanteen v-slot="{ canteenIsGroupe, canteenInformation }">
-    <div class="ma-cantine--flex-between ma-cantine--flex-gap-1">
-      <h2 class="fr-mb-0">{{ canteenIsGroupe ? 'Informations du groupe' : 'Mes informations' }}</h2>
-      <DsfrButton @click="goToEdit(canteenIsGroupe)" :label="canteenIsGroupe ? 'Modifier les informations du groupe' : 'Modifier mes informations'" icon="ri-pencil-line" />
-    </div>
-    <ol class="ma-cantine--ordered-list ma-cantine--unstyled-list">
-      <li class="fr-my-3w">
-        <h3>Caractéristiques</h3>
-        <AppFieldDisplay v-if="!canteenIsGroupe" :label="cantines.economicModelName" :value="getPrettyValue(canteenInformation.economicModel, 'economicModel')" />
-        <AppFieldDisplay :label="cantines.managementTypeName" :value="getPrettyValue(canteenInformation.managementType, 'managementType')" />
-        <AppFieldDisplay :label="cantines.productionTypeName" :value="getPrettyValue(canteenInformation.productionType, 'productionType')" />
-        <AppFieldDisplay v-if="canteenInformation.centralProducerSiret" :label="cantines.centralProducerSiret" :value="canteenInformation.centralProducerSiret" />
-      </li>
-      <li class="fr-my-3w">
-        <h3>Identification de l'établissement</h3>
-        <AppFieldDisplay :label="cantines.id" :value="canteenInformation.id" tooltip="Identifiant unique de l'établissement, ce champ ne peut pas être modifié."/>
-        <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.siret" :label="cantines.siretName" :value="formatSiretOrSiren(canteenInformation.siret)" />
-        <AppFieldDisplay v-if="canteenInformation.sirenUniteLegale" :label="cantines.sirenUniteLegaleName" :value="formatSiretOrSiren(canteenInformation.sirenUniteLegale)" />
-        <AppFieldDisplay :label="canteenIsGroupe ? cantines.nameGroupe : cantines.nameCantine" :value="canteenInformation.name" />
-        <AppFieldDisplay :label="cantines.dailyMealCountName" :value="canteenInformation.dailyMealCount"
-          tooltip="Donnez une moyenne globale sur les jours ouverts de vos établissements (pour évaluer la taille de votre établissement)"
-        />
-        <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.sirenUniteLegale" :label="cantines.city" :value="canteenInformation.city" />
-        <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.sirenUniteLegale" :label="cantines.postalCode" :value="canteenInformation.postalCode" />
-      </li>
-      <li v-if="!canteenIsGroupe" class="fr-my-3w">
-        <h3>Informations générées</h3>
-        <DsfrAlert title="Ces informations ne sont pas modifiables" type="info" class="fr-mb-2w">
-          À partir des informations renseignées, nous avons généré des données avec d'autres référentiels :
-          <a href="https://france-pat.fr" target="_blank">France PAT</a>
-          et
-          <a href="https://annuaire-entreprises.data.gouv.fr" target="_blank">l'annuaire des entreprises</a>.
-          Si vous remarquez une erreur, merci de <AppLinkRouter title="nous contacter" :to="{name: 'Contact'}" />.
-        </DsfrAlert>
-        <AppFieldDisplay v-if="!canteenInformation.sirenUniteLegale" :label="cantines.city" :value="canteenInformation.city" />
-        <AppFieldDisplay v-if="!canteenInformation.sirenUniteLegale" :label="cantines.postalCode" :value="canteenInformation.postalCode" />
-        <AppFieldDisplay :label="cantines.cityInseeCode" :value="canteenInformation.cityInseeCode" />
-        <AppFieldDisplay :label="cantines.departmentLib" :value="canteenInformation.departmentLib" />
-        <AppFieldDisplay :label="cantines.regionLib" :value="canteenInformation.regionLib" />
-        <AppFieldDisplay :label="cantines.patLibList" :value="canteenInformation.patLibList" />
-        <AppFieldDisplay :label="cantines.epciLib" :value="canteenInformation.epciLib" />
-      </li>
-      <li v-if="!canteenIsGroupe" class="fr-my-3w">
-        <h3>Secteurs</h3>
-        <AppFieldDisplay :label="cantines.sectorList" :value="getPrettySectors(canteenInformation.sectorList)" />
-        <AppFieldDisplay v-if="showLineMinistry" :label="cantines.lineMinistry" :value="getPrettyLineMinistry(canteenInformation.lineMinistry)" />
-      </li>
-      <li v-if="canteenInformation.groupe !== null" class="fr-my-3w">
-        <h3>Informations de mon groupe</h3>
-        <DsfrAlert title="Le gestionnaire du groupe de restaurants satellites a ajouté votre établissement" type="info" class="fr-mb-2w">
-          Cela lui permet de réaliser une déclaration unique pour laquelle le montant total des achats du groupe est ensuite réparti automatiquement entre chaque restaurant satellite, au prorata de son nombre de couverts annuels.
-          Si vous remarquez une erreur ou souhaitez ne plus être associer au groupe, merci de <AppLinkRouter title="nous contacter" :to="{name: 'Contact'}" />.
-        </DsfrAlert>
-        <AppFieldDisplay :label="cantines.nameGroupe" :value="canteenInformation.groupe?.name" />
-        <AppFieldDisplay :label="cantines.id" :value="canteenInformation.groupe?.id" />
-        <AppFieldDisplay :label="`${cantines.sirenUniteLegaleName} du groupe`" :value="formatSiretOrSiren(canteenInformation.groupe?.sirenUniteLegale)" />
-      </li>
-      <li v-if="!canteenIsGroupe" class="fr-my-3w">
-        <h3>Description</h3>
-        <p>{{ canteenInformation.publicationComments || 'Aucune description renseignée' }}</p>
-      </li>
-    </ol>
-    <div v-if="canteenUrlComponent" class="fr-container fr-background-alt--red-marianne fr-p-4w fr-mt-3w">
-      <h2 class="fr-h6 fr-text-default--error fr-mb-2w">
-        <span class="mdi mdi-archive"></span>
-        Archiver cet établissement
-      </h2>
-      <p class="fr-mb-0">
-        Vous ne souhaitez plus faire apparaître cet établissement sur la plateforme <em>ma cantine</em> ? <br />
-        Vous pouvez l’archiver <AppLinkRouter :to="{ name: 'GestionnaireCantineArchiver', params: { canteenUrlComponent: canteenUrlComponent } }" title="en cliquant ici" />
-      </p>
-    </div>
+  <LayoutSidebarCanteen >
+    <template #title="{ canteenIsGroupe }">
+      <div class="ma-cantine--flex-between ma-cantine--flex-gap-1">
+        <h2 class="fr-h3 fr-mb-0">{{ canteenIsGroupe ? 'Informations du groupe' : 'Mes informations' }}</h2>
+        <DsfrButton @click="goToEdit(canteenIsGroupe)" :label="canteenIsGroupe ? 'Modifier les informations du groupe' : 'Modifier mes informations'" icon="ri-pencil-line" />
+      </div>
+    </template>
+    <template #content="{ canteenIsGroupe, canteenInformation }">
+      <ol class="ma-cantine--ordered-list ma-cantine--unstyled-list">
+        <li class="fr-my-3w">
+          <h3 class="fr-h5">Caractéristiques</h3>
+          <AppFieldDisplay v-if="!canteenIsGroupe" :label="cantines.economicModelName" :value="getPrettyValue(canteenInformation.economicModel, 'economicModel')" />
+          <AppFieldDisplay :label="cantines.managementTypeName" :value="getPrettyValue(canteenInformation.managementType, 'managementType')" />
+          <AppFieldDisplay :label="cantines.productionTypeName" :value="getPrettyValue(canteenInformation.productionType, 'productionType')" />
+          <AppFieldDisplay v-if="canteenInformation.centralProducerSiret" :label="cantines.centralProducerSiret" :value="canteenInformation.centralProducerSiret" />
+        </li>
+        <li class="fr-my-3w">
+          <h3 class="fr-h5">Identification de l'établissement</h3>
+          <AppFieldDisplay :label="cantines.id" :value="canteenInformation.id" tooltip="Identifiant unique de l'établissement, ce champ ne peut pas être modifié."/>
+          <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.siret" :label="cantines.siretName" :value="formatSiretOrSiren(canteenInformation.siret)" />
+          <AppFieldDisplay v-if="canteenInformation.sirenUniteLegale" :label="cantines.sirenUniteLegaleName" :value="formatSiretOrSiren(canteenInformation.sirenUniteLegale)" />
+          <AppFieldDisplay :label="canteenIsGroupe ? cantines.nameGroupe : cantines.nameCantine" :value="canteenInformation.name" />
+          <AppFieldDisplay :label="cantines.dailyMealCountName" :value="canteenInformation.dailyMealCount"
+            tooltip="Donnez une moyenne globale sur les jours ouverts de vos établissements (pour évaluer la taille de votre établissement)"
+          />
+          <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.sirenUniteLegale" :label="cantines.city" :value="canteenInformation.city" />
+          <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.sirenUniteLegale" :label="cantines.postalCode" :value="canteenInformation.postalCode" />
+        </li>
+        <li v-if="!canteenIsGroupe" class="fr-my-3w">
+          <h3 class="fr-h5">Informations générées</h3>
+          <DsfrAlert title="Ces informations ne sont pas modifiables" type="info" class="fr-mb-2w">
+            À partir des informations renseignées, nous avons généré des données avec d'autres référentiels :
+            <a href="https://france-pat.fr" target="_blank">France PAT</a>
+            et
+            <a href="https://annuaire-entreprises.data.gouv.fr" target="_blank">l'annuaire des entreprises</a>.
+            Si vous remarquez une erreur, merci de <AppLinkRouter title="nous contacter" :to="{name: 'Contact'}" />.
+          </DsfrAlert>
+          <AppFieldDisplay v-if="!canteenInformation.sirenUniteLegale" :label="cantines.city" :value="canteenInformation.city" />
+          <AppFieldDisplay v-if="!canteenInformation.sirenUniteLegale" :label="cantines.postalCode" :value="canteenInformation.postalCode" />
+          <AppFieldDisplay :label="cantines.cityInseeCode" :value="canteenInformation.cityInseeCode" />
+          <AppFieldDisplay :label="cantines.departmentLib" :value="canteenInformation.departmentLib" />
+          <AppFieldDisplay :label="cantines.regionLib" :value="canteenInformation.regionLib" />
+          <AppFieldDisplay :label="cantines.patLibList" :value="canteenInformation.patLibList" />
+          <AppFieldDisplay :label="cantines.epciLib" :value="canteenInformation.epciLib" />
+        </li>
+        <li v-if="!canteenIsGroupe" class="fr-my-3w">
+          <h3 class="fr-h5">Secteurs</h3>
+          <AppFieldDisplay :label="cantines.sectorList" :value="getPrettySectors(canteenInformation.sectorList)" />
+          <AppFieldDisplay v-if="showLineMinistry" :label="cantines.lineMinistry" :value="getPrettyLineMinistry(canteenInformation.lineMinistry)" />
+        </li>
+        <li v-if="canteenInformation.groupe !== null" class="fr-my-3w">
+          <h3 class="fr-h5">Informations de mon groupe</h3>
+          <DsfrAlert title="Le gestionnaire du groupe de restaurants satellites a ajouté votre établissement" type="info" class="fr-mb-2w">
+            Cela lui permet de réaliser une déclaration unique pour laquelle le montant total des achats du groupe est ensuite réparti automatiquement entre chaque restaurant satellite, au prorata de son nombre de couverts annuels.
+            Si vous remarquez une erreur ou souhaitez ne plus être associer au groupe, merci de <AppLinkRouter title="nous contacter" :to="{name: 'Contact'}" />.
+          </DsfrAlert>
+          <AppFieldDisplay :label="cantines.nameGroupe" :value="canteenInformation.groupe?.name" />
+          <AppFieldDisplay :label="cantines.id" :value="canteenInformation.groupe?.id" />
+          <AppFieldDisplay :label="`${cantines.sirenUniteLegaleName} du groupe`" :value="formatSiretOrSiren(canteenInformation.groupe?.sirenUniteLegale)" />
+        </li>
+        <li v-if="!canteenIsGroupe" class="fr-my-3w">
+          <h3 class="fr-h5">Description</h3>
+          <p>{{ canteenInformation.publicationComments || 'Aucune description renseignée' }}</p>
+        </li>
+      </ol>
+      <div v-if="canteenUrlComponent" class="fr-container fr-background-alt--red-marianne fr-p-4w fr-mt-3w">
+        <h3 class="fr-h6 fr-text-default--error fr-mb-2w">
+          <span class="mdi mdi-archive"></span>
+          Archiver cet établissement
+        </h3>
+        <p class="fr-mb-0">
+          Vous ne souhaitez plus faire apparaître cet établissement sur la plateforme <em>ma cantine</em> ? <br />
+          Vous pouvez l’archiver <AppLinkRouter :to="{ name: 'GestionnaireCantineArchiver', params: { canteenUrlComponent: canteenUrlComponent } }" title="en cliquant ici" />
+        </p>
+      </div>
+    </template>
   </LayoutSidebarCanteen>
 </template>


### PR DESCRIPTION
Ticket : https://app.notion.com/p/incubateur-masa/Renommer-structure-de-page-en-Etablissement-et-pas-Bilan-39ede24614be80598e3cd7ed34de64d4

|Avant|Après|
|--|--|
|  <img width="3420" height="5497" alt="avant" src="https://github.com/user-attachments/assets/ee703fb6-f87e-4200-9a74-8966838f84a8" /> | <img width="3420" height="5499" alt="apres" src="https://github.com/user-attachments/assets/c95e83a6-e054-4615-88d8-543711198dc5" /> |
