### PR TITLE
refactor(Achats): API: améliorer les urls pour les endpoint 'summary' & 'purchaseSummary'

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -123,6 +123,16 @@ urlpatterns = {
         name="purchase_facture",
     ),
     path(
+        "canteens/<int:canteen_pk>/purchases/summary",
+        CanteenPurchasesSummaryView.as_view(),
+        name="canteen_purchases_summary",
+    ),
+    path(
+        "canteens/<int:canteen_pk>/purchases/percentageSummary",
+        CanteenPurchasesPercentageSummaryView.as_view(),
+        name="canteen_purchases_percentage_summary",
+    ),
+    path(
         "canteens/<int:canteen_pk>/diagnostics/",
         DiagnosticCreateView.as_view(),
         name="diagnostic_creation",
@@ -240,16 +250,6 @@ urlpatterns = {
         "purchases/restore/",
         PurchasesRestoreView.as_view(),
         name="restore_purchases",
-    ),
-    path(
-        "canteenPurchasesSummary/<int:canteen_pk>",
-        CanteenPurchasesSummaryView.as_view(),
-        name="canteen_purchases_summary",
-    ),
-    path(
-        "canteenPurchasesPercentageSummary/<int:canteen_pk>",
-        CanteenPurchasesPercentageSummaryView.as_view(),
-        name="canteen_purchases_percentage_summary",
     ),
     path(
         "createDiagnosticsFromPurchases/<int:year>",

--- a/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
+++ b/frontend/src/components/CanteenPublication/ResultsComponents/QualityMeasureResults.vue
@@ -299,7 +299,7 @@ export default {
     },
     getPurchasesSummary() {
       return fetch(
-        `/api/v1/canteenPurchasesPercentageSummary/${this.canteen.id}?year=${this.thisYear}&ignoreRedaction=${this.editable}`
+        `/api/v1/canteens/${this.canteen.id}/purchases/percentageSummary?year=${this.thisYear}&ignoreRedaction=${this.editable}`
       )
         .then((response) => (response.ok ? response.json() : undefined))
         .then((response) => {

--- a/frontend/src/components/DiagnosticSummary/PurchasesSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/PurchasesSummary.vue
@@ -83,7 +83,7 @@ export default {
       this.purchasesSummary = null
       this.purchasesFetchingError = false
       if (this.canteen?.id) {
-        return fetch(`/api/v1/canteenPurchasesSummary/${this.canteen.id}?year=${this.year}`)
+        return fetch(`/api/v1/canteens/${this.canteen.id}/purchases/summary?year=${this.year}`)
           .then((response) => (response.ok ? response.json() : {}))
           .then((response) => (this.purchasesSummary = response))
           .catch(() => {

--- a/frontend/src/views/DashboardManager/EgalimProgression.vue
+++ b/frontend/src/views/DashboardManager/EgalimProgression.vue
@@ -299,7 +299,7 @@ export default {
     fetchPurchasesSummary() {
       this.purchasesSummary = null
       if (this.canteen?.id) {
-        return fetch(`/api/v1/canteenPurchasesSummary/${this.canteen.id}?year=${this.year}`)
+        return fetch(`/api/v1/canteens/${this.canteen.id}/purchases/summary?year=${this.year}`)
           .then((response) => (response.ok ? response.json() : {}))
           .then((response) => (this.purchasesSummary = response))
           .catch((e) => {

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/index.vue
@@ -188,7 +188,7 @@ export default {
       this.$emit("tunnel-autofill", e)
     },
     fetchPurchasesSummary() {
-      fetch(`/api/v1/canteenPurchasesSummary/${this.canteen.id}?year=${this.diagnostic.year}`)
+      fetch(`/api/v1/canteens/${this.canteen.id}/purchases/summary?year=${this.diagnostic.year}`)
         .then((response) => (response.ok ? response.json() : {}))
         .then((response) => {
           if (Object.values(response).some((x) => !!x)) {

--- a/frontend/src/views/PurchasesSummary.vue
+++ b/frontend/src/views/PurchasesSummary.vue
@@ -314,7 +314,7 @@ export default {
       this.summary = null
       if (!this.vizCanteenId || !this.vizYear) return
       this.loading = true
-      fetch(`/api/v1/canteenPurchasesSummary/${this.vizCanteenId}?year=${this.vizYear}`)
+      fetch(`/api/v1/canteens/${this.vizCanteenId}/purchases/summary?year=${this.vizYear}`)
         .then((response) => (response.ok ? response.json() : {}))
         .then((response) => {
           this.summary = response
@@ -325,7 +325,7 @@ export default {
       this.yearlySummary = null
       if (!this.vizCanteenId) return
       this.loading = true
-      fetch(`/api/v1/canteenPurchasesSummary/${this.vizCanteenId}`)
+      fetch(`/api/v1/canteens/${this.vizCanteenId}/purchases/summary`)
         .then((response) => (response.ok ? response.json() : {}))
         .then((response) => {
           const results = response.results


### PR DESCRIPTION
### Quoi

|Avant|Après|
|-|-|
|`canteenPurchasesSummary/<int:canteen_pk>`|`canteens/<int:canteen_pk>/purchases/summary`|
|`canteenPurchasesPercentageSummary/<int:canteen_pk>`|`canteens/<int:canteen_pk>/purchases/percentageSummary`|

### Pourquoi

homogéniser le nommage des endpoints API (prefix canteen)