### PR TITLE
feat(Cantines): API: nouvel endpoint /check qui renvoi des infos (is_filled, errors)

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -2,6 +2,7 @@
 
 from .user import LoggedUserSerializer, UserInfoSerializer  # noqa: F401
 from .canteen import (  # noqa: F401
+    CanteenCheckSerializer,
     PublicCanteenSerializer,
     PublicCanteenPreviewSerializer,
     FullCanteenSerializer,

--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -27,6 +27,13 @@ CREATE_ONLY_FIELDS = ("creation_source", *Canteen.MATOMO_FIELDS)
 # READ_ONLY_FIELDS: see serializers
 
 
+class CanteenCheckSerializer(serializers.Serializer):
+    is_filled = serializers.BooleanField(read_only=True)
+    # infos = serializers.DictField(read_only=True)
+    # warnings = serializers.DictField(read_only=True)
+    errors = serializers.DictField(read_only=True)
+
+
 class CanteenImageSerializer(serializers.ModelSerializer):
     image = Base64ImageField()
     id = serializers.IntegerField(required=False)

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -462,47 +462,49 @@ class CanteenDetailApiTest(APITestCase):
         self.assertEqual(body["badges"]["year"], 2022)
 
 
-class CanteenDetailValidationCheckApiTest(APITestCase):
-    def test_cannot_get_canteen_validation_check_if_unauthenticated(self):
+class CanteenDetailCheckApiTest(APITestCase):
+    def test_cannot_get_canteen_check_if_unauthenticated(self):
         canteen = CanteenFactory()
 
-        response = self.client.get(reverse("canteen_validation_check", kwargs={"canteen_pk": canteen.id}))
+        response = self.client.get(reverse("canteen_check", kwargs={"canteen_pk": canteen.id}))
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_get_canteen_validation_check_if_canteen_does_not_exist(self):
-        response = self.client.get(reverse("canteen_validation_check", kwargs={"canteen_pk": 9999}))
+    def test_cannot_get_canteen_check_if_canteen_does_not_exist(self):
+        response = self.client.get(reverse("canteen_check", kwargs={"canteen_pk": 9999}))
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_get_canteen_validation_check_if_not_manager(self):
+    def test_cannot_get_canteen_check_if_not_manager(self):
         canteen = CanteenFactory()
 
-        response = self.client.get(reverse("canteen_validation_check", kwargs={"canteen_pk": canteen.id}))
+        response = self.client.get(reverse("canteen_check", kwargs={"canteen_pk": canteen.id}))
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_get_canteen_validation_check_without_errors(self):
+    def test_get_canteen_check_without_errors(self):
         canteen = CanteenFactory(managers=[authenticate.user])
 
-        response = self.client.get(reverse("canteen_validation_check", kwargs={"canteen_pk": canteen.id}))
+        response = self.client.get(reverse("canteen_check", kwargs={"canteen_pk": canteen.id}))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
+        self.assertEqual(body["isFilled"], True)
         self.assertEqual(body["errors"], {})
 
     @authenticate
-    def test_get_canteen_validation_check_with_errors(self):
+    def test_get_canteen_check_with_errors(self):
         canteen = CanteenFactory(managers=[authenticate.user])
         Canteen.objects.filter(pk=canteen.id).update(siret="invalid_siret", sector_list=[])
 
-        response = self.client.get(reverse("canteen_validation_check", kwargs={"canteen_pk": canteen.id}))
+        response = self.client.get(reverse("canteen_check", kwargs={"canteen_pk": canteen.id}))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
+        self.assertEqual(body["isFilled"], True)
         self.assertNotEqual(body["errors"], {})
         self.assertEqual(body["errors"]["siret"], ["14 caractères numériques sont attendus"])
         self.assertEqual(body["errors"]["sectorList"], ["Le champ doit contenir entre 1 et 3 secteurs."])

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -498,13 +498,15 @@ class CanteenDetailCheckApiTest(APITestCase):
     @authenticate
     def test_get_canteen_check_with_errors(self):
         canteen = CanteenFactory(managers=[authenticate.user])
-        Canteen.objects.filter(pk=canteen.id).update(siret="invalid_siret", sector_list=[])
+        canteen.siret = "invalid_siret"
+        canteen.sector_list = []
+        canteen.save(skip_validations=True)
 
         response = self.client.get(reverse("canteen_check", kwargs={"canteen_pk": canteen.id}))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(body["isFilled"], True)
+        self.assertEqual(body["isFilled"], False)
         self.assertNotEqual(body["errors"], {})
         self.assertEqual(body["errors"]["siret"], ["14 caractères numériques sont attendus"])
         self.assertEqual(body["errors"]["sectorList"], ["Le champ doit contenir entre 1 et 3 secteurs."])

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -462,6 +462,52 @@ class CanteenDetailApiTest(APITestCase):
         self.assertEqual(body["badges"]["year"], 2022)
 
 
+class CanteenDetailValidationCheckApiTest(APITestCase):
+    def test_cannot_get_canteen_validation_check_if_unauthenticated(self):
+        canteen = CanteenFactory()
+
+        response = self.client.get(reverse("canteen_validation_check", kwargs={"canteen_pk": canteen.id}))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_get_canteen_validation_check_if_canteen_does_not_exist(self):
+        response = self.client.get(reverse("canteen_validation_check", kwargs={"canteen_pk": 9999}))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_get_canteen_validation_check_if_not_manager(self):
+        canteen = CanteenFactory()
+
+        response = self.client.get(reverse("canteen_validation_check", kwargs={"canteen_pk": canteen.id}))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_get_canteen_validation_check_without_errors(self):
+        canteen = CanteenFactory(managers=[authenticate.user])
+
+        response = self.client.get(reverse("canteen_validation_check", kwargs={"canteen_pk": canteen.id}))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["errors"], {})
+
+    @authenticate
+    def test_get_canteen_validation_check_with_errors(self):
+        canteen = CanteenFactory(managers=[authenticate.user])
+        Canteen.objects.filter(pk=canteen.id).update(siret="invalid_siret", sector_list=[])
+
+        response = self.client.get(reverse("canteen_validation_check", kwargs={"canteen_pk": canteen.id}))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertNotEqual(body["errors"], {})
+        self.assertEqual(body["errors"]["siret"], ["14 caractères numériques sont attendus"])
+        self.assertEqual(body["errors"]["sectorList"], ["Le champ doit contenir entre 1 et 3 secteurs."])
+
+
 class CanteenCreateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/api/urls.py
+++ b/api/urls.py
@@ -70,8 +70,8 @@ from api.views import (
     UndoClaimCanteenView,
     UpdateUserView,
     UserCanteenActions,
+    UserCanteenCheckView,
     UserCanteenListExportView,
-    UserCanteenValidationCheckView,
     UserCanteenPreviews,
     UserCanteenSummaries,
     UserCanteensView,
@@ -109,9 +109,9 @@ urlpatterns = {
     ),
     path("canteens/<int:pk>", RetrieveUpdateUserCanteenView.as_view(), name="single_canteen"),
     path(
-        "canteens/<int:canteen_pk>/validation-check/",
-        UserCanteenValidationCheckView.as_view(),
-        name="canteen_validation_check",
+        "canteens/<int:canteen_pk>/check",
+        UserCanteenCheckView.as_view(),
+        name="canteen_check",
     ),
     path(
         "canteens/<int:canteen_pk>/purchases/",

--- a/api/urls.py
+++ b/api/urls.py
@@ -71,6 +71,7 @@ from api.views import (
     UpdateUserView,
     UserCanteenActions,
     UserCanteenListExportView,
+    UserCanteenValidationCheckView,
     UserCanteenPreviews,
     UserCanteenSummaries,
     UserCanteensView,
@@ -107,6 +108,11 @@ urlpatterns = {
         name="user_canteen_list_export",
     ),
     path("canteens/<int:pk>", RetrieveUpdateUserCanteenView.as_view(), name="single_canteen"),
+    path(
+        "canteens/<int:canteen_pk>/validation-check/",
+        UserCanteenValidationCheckView.as_view(),
+        name="canteen_validation_check",
+    ),
     path(
         "canteens/<int:canteen_pk>/purchases/",
         PurchaseCreateView.as_view(),

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -12,17 +12,10 @@ from .canteen import (  # noqa: F401
     SendCanteenNotFoundEmail,
     TerritoryCanteensListView,
     UserCanteenActions,
+    UserCanteenCheckView,
     UserCanteenPreviews,
     UserCanteenSummaries,
     UserCanteensView,
-    UserCanteenValidationCheckView,
-)
-from .canteen_managers import (  # noqa: F401
-    AddManagerView,
-    ClaimCanteenView,
-    RemoveManagerView,
-    TeamJoinRequestView,
-    UndoClaimCanteenView,
 )
 from .canteen_create_import import CanteensCreateImportView  # noqa: F401
 from .canteen_export import UserCanteenListExportView  # noqa: F401
@@ -31,6 +24,13 @@ from .canteen_groupe import (  # noqa: F401
     CanteenGroupeSatellitesListView,
     CanteenGroupeSatelliteUnlinkView,
 )  # noqa: F401
+from .canteen_managers import (  # noqa: F401
+    AddManagerView,
+    ClaimCanteenView,
+    RemoveManagerView,
+    TeamJoinRequestView,
+    UndoClaimCanteenView,
+)
 from .canteen_managers_import import CanteensManagersImportView  # noqa: F401
 from .canteen_update_import import CanteensUpdateImportView  # noqa: F401
 from .communityevent import CommunityEventsView  # noqa: F401

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -15,6 +15,7 @@ from .canteen import (  # noqa: F401
     UserCanteenPreviews,
     UserCanteenSummaries,
     UserCanteensView,
+    UserCanteenValidationCheckView,
 )
 from .canteen_managers import (  # noqa: F401
     AddManagerView,

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -30,6 +30,7 @@ from api.permissions import (
     IsElectedOfficial,
 )
 from api.serializers import (
+    CanteenCheckSerializer,
     CanteenActionsLightSerializer,
     CanteenActionsSerializer,
     CanteenAnalysisSerializer,
@@ -339,9 +340,10 @@ class UserCanteensView(ListCreateAPIView):
         summary="Vérifier les erreurs de validation pour une cantine.",
         description="Retourne toutes les erreurs de validation potentielles pour une cantine (champs manquants, valeurs invalides, etc.).",
         tags=["Cantines"],
+        responses=CanteenCheckSerializer,
     )
 )
-class UserCanteenValidationCheckView(APIView):
+class UserCanteenCheckView(APIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     required_scopes = ["canteen"]
 
@@ -358,7 +360,8 @@ class UserCanteenValidationCheckView(APIView):
         except ValidationError as e:
             errors = e.message_dict
 
-        return Response({"errors": errors}, status=status.HTTP_200_OK)
+        response = {"is_filled": canteen.is_filled, "errors": errors}
+        return Response(CanteenCheckSerializer(response).data)
 
 
 @extend_schema_view(

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -26,6 +26,7 @@ from api.permissions import (
     IsAuthenticated,
     IsAuthenticatedOrTokenHasResourceScope,
     IsCanteenManager,
+    IsCanteenManagerUrlParam,
     IsElectedOfficial,
 )
 from api.serializers import (
@@ -331,6 +332,33 @@ class UserCanteensView(ListCreateAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return super().create(request, *args, **kwargs)
+
+
+@extend_schema_view(
+    get=extend_schema(
+        summary="Vérifier les erreurs de validation pour une cantine.",
+        description="Retourne toutes les erreurs de validation potentielles pour une cantine (champs manquants, valeurs invalides, etc.).",
+        tags=["Cantines"],
+    )
+)
+class UserCanteenValidationCheckView(APIView):
+    permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
+    required_scopes = ["canteen"]
+
+    def _get_canteen(self):
+        # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
+        return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
+
+    def get(self, request, canteen_pk):
+        canteen = self._get_canteen()
+
+        errors = {}
+        try:
+            canteen.full_clean()
+        except ValidationError as e:
+            errors = e.message_dict
+
+        return Response({"errors": errors}, status=status.HTTP_200_OK)
 
 
 @extend_schema_view(


### PR DESCRIPTION
### Quoi

Nouvel endpoint `canteens/<int:canteen_pk>/check`
- pas d'erreurs
  ```
  {
    is_filled: true,
    errors: {}
  }
  ```
- erreurs
  ```
  {
    is_filled: true,
    errors: {"siret": ["14 caractères numériques sont attendus"], "sectorList": ["Le champ doit contenir entre 1 et 3 secteurs."]}
  }
  ```

### Comment

En appellant `full_clean`