### PR TITLE
refactor(API): pointer vers l'app OAuth2 définie dans les settings

### DIFF
--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -1,5 +1,6 @@
 from urllib.parse import quote
 
+from django.conf import settings
 from dirtyfields import DirtyFieldsMixin
 from django.contrib.auth import get_user_model
 from django.contrib.postgres.fields import ArrayField
@@ -11,7 +12,6 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.functional import cached_property
-from oauth2_provider.models import Application as OAuth2Application
 from simple_history.models import HistoricalRecords
 from simple_history.utils import update_change_reason
 
@@ -669,7 +669,7 @@ class Canteen(DirtyFieldsMixin, SoftDeletionModel):
         verbose_name="Source de création de la cantine",
     )
     creation_source_api_oauth2_application = models.ForeignKey(
-        OAuth2Application,
+        settings.OAUTH2_PROVIDER_APPLICATION_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1,6 +1,7 @@
 import operator
 from functools import reduce
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator
@@ -9,7 +10,6 @@ from django.db.models import DecimalField, F, Func, IntegerField, Q, Sum, Value
 from django.db.models.expressions import RawSQL
 from django.db.models.functions import Coalesce
 from django.utils import timezone
-from oauth2_provider.models import Application as OAuth2Application
 from simple_history.models import HistoricalRecords
 
 from common.utils import utils as utils_utils
@@ -1737,7 +1737,7 @@ class Diagnostic(models.Model):
         verbose_name="Source de création du diagnostic",
     )
     creation_source_api_oauth2_application = models.ForeignKey(
-        OAuth2Application,
+        settings.OAUTH2_PROVIDER_APPLICATION_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,

--- a/data/models/historyauthenticationmethod.py
+++ b/data/models/historyauthenticationmethod.py
@@ -1,8 +1,8 @@
 import logging
 
+from django.conf import settings
 from django.db import models
 from django.dispatch import receiver
-from oauth2_provider.models import Application as OAuth2Application
 from simple_history.models import HistoricalRecords
 from simple_history.signals import pre_create_historical_record
 
@@ -28,7 +28,7 @@ class AuthenticationMethodHistoricalRecords(models.Model):
     )
 
     history_source_api_oauth2_application = models.ForeignKey(
-        OAuth2Application,
+        settings.OAUTH2_PROVIDER_APPLICATION_MODEL,
         verbose_name="Application OAuth2 (API) qui a fait la modification",
         null=True,
         blank=True,

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -1,12 +1,12 @@
 from datetime import date
 from decimal import Decimal
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.validators import MinValueValidator, ValidationError
 from django.db import models
 from django.db.models import Q, Sum
 from django.db.models.functions import ExtractYear
-from oauth2_provider.models import Application as OAuth2Application
 
 from common.utils import utils as utils_utils
 from data.fields import ChoiceArrayField
@@ -261,7 +261,7 @@ class Purchase(SoftDeletionModel):
         verbose_name="Source de création de l'achat",
     )
     creation_source_api_oauth2_application = models.ForeignKey(
-        OAuth2Application,
+        settings.OAUTH2_PROVIDER_APPLICATION_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,

--- a/data/models/wastemeasurement.py
+++ b/data/models/wastemeasurement.py
@@ -1,7 +1,7 @@
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import models
-from oauth2_provider.models import Application as OAuth2Application
 from simple_history.models import HistoricalRecords
 
 from common.utils import utils as utils_utils
@@ -88,7 +88,7 @@ class WasteMeasurement(models.Model):
         verbose_name="Source de création de l'évaluation du gaspillage alimentaire",
     )
     creation_source_api_oauth2_application = models.ForeignKey(
-        OAuth2Application,
+        settings.OAUTH2_PROVIDER_APPLICATION_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,


### PR DESCRIPTION
### Quoi

Suite à #6843 on avait créé des champs qui pointaient vers `OAuth2Application` directement au lieu de `settings.OAUTH2_PROVIDER_APPLICATION_MODEL`

### Pourquoi

Permet d'être plus flexible, si on veut un jour enrichir l'underlying model "Application". par exemple rajouter des champs comme le nom du prestataire !