### PR TITLE
feat(Cantines): API: nouvel endpoint pour ajouter 1 image

### DIFF
--- a/api/serializers/canteen_images.py
+++ b/api/serializers/canteen_images.py
@@ -5,7 +5,7 @@ from data.models import CanteenImage
 
 
 class CanteenImageSerializer(serializers.ModelSerializer):
-    id = serializers.IntegerField(required=False)
+    id = serializers.IntegerField(read_only=True)
     image = Base64ImageField()
 
     class Meta:

--- a/api/tests/test_canteen_images.py
+++ b/api/tests/test_canteen_images.py
@@ -1,9 +1,12 @@
+import base64
+import os
+
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-import os
 from django.core.files import File
 from api.tests.utils import authenticate, get_oauth2_token
+
 from data.factories.canteen import CanteenFactory
 from data.models import CanteenImage
 
@@ -75,3 +78,70 @@ class CanteenImagesListApiTest(APITestCase):
             self.assertIn("id", item)
             self.assertIn("image", item)
             self.assertIn("altText", item)
+
+
+class CanteenImagesCreateApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.url = reverse("canteen_images_list", kwargs={"canteen_pk": cls.canteen.pk})
+
+    def test_cannot_create_canteen_image_unauthenticated(self):
+        response = self.client.post(self.url, data={})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_create_canteen_image_if_canteen_does_not_exist(self):
+        url = reverse("canteen_images_list", kwargs={"canteen_pk": 999})
+        response = self.client.post(url, data={})
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_create_canteen_image_if_not_canteen_manager(self):
+        response = self.client.post(self.url, data={})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_canteen_image_create(self):
+        self.canteen.managers.add(authenticate.user)
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        image_base_64 = None
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
+        payload = {
+            "image": "data:image/jpeg;base64," + image_base_64,
+        }
+        response = self.client.post(self.url, data=payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertIn("id", body)
+        self.assertIn("image", body)
+        self.assertIn("altText", body)
+        self.assertIsNone(body["altText"])
+
+    def test_canteen_image_create_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:write")
+        self.canteen.managers.add(user)
+        self.client.credentials(Authorization=f"Bearer {token}")
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        image_base_64 = None
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
+        payload = {
+            "image": "data:image/jpeg;base64," + image_base_64,
+            "altText": "Test image 1",  # optional field
+        }
+        response = self.client.post(self.url, data=payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertIn("id", body)
+        self.assertIn("image", body)
+        self.assertIn("altText", body)
+        self.assertEqual(body["altText"], "Test image 1")

--- a/api/tests/test_canteen_images.py
+++ b/api/tests/test_canteen_images.py
@@ -105,7 +105,7 @@ class CanteenImagesCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_canteen_image_create(self):
+    def test_create_canteen_image(self):
         self.canteen.managers.add(authenticate.user)
         image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
         image_base_64 = None
@@ -124,7 +124,7 @@ class CanteenImagesCreateApiTest(APITestCase):
         self.assertIn("altText", body)
         self.assertIsNone(body["altText"])
 
-    def test_canteen_image_create_via_oauth2(self):
+    def test_create_canteen_image_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
         self.canteen.managers.add(user)
         self.client.credentials(Authorization=f"Bearer {token}")
@@ -145,3 +145,27 @@ class CanteenImagesCreateApiTest(APITestCase):
         self.assertIn("image", body)
         self.assertIn("altText", body)
         self.assertEqual(body["altText"], "Test image 1")
+
+    @authenticate
+    def test_create_canteen_image_even_if_canteen_not_filled(self):
+        self.canteen.managers.add(authenticate.user)
+        self.canteen.siret = None
+        self.canteen.save(skip_validations=True)
+        self.assertIsNone(self.canteen.siret)
+        self.assertFalse(self.canteen.is_filled)
+
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        image_base_64 = None
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
+        payload = {
+            "image": "data:image/jpeg;base64," + image_base_64,
+        }
+        response = self.client.post(self.url, data=payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertIn("id", body)
+        self.assertIn("image", body)
+        self.assertIn("altText", body)

--- a/api/views/canteen_images.py
+++ b/api/views/canteen_images.py
@@ -1,4 +1,4 @@
-from rest_framework.generics import ListAPIView
+from rest_framework.generics import ListCreateAPIView
 from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from api.permissions import IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam
@@ -13,13 +13,18 @@ from api.serializers.canteen_images import CanteenImageSerializer
         description="",
         tags=["Cantines"],
         responses=CanteenImageSerializer(many=True),
-    )
+    ),
+    post=extend_schema(
+        summary="Ajouter une image.",
+        description="",
+        tags=["Cantines"],
+    ),
 )
-class UserCanteenImagesListView(ListAPIView):
-    model = CanteenImage
-    serializer_class = CanteenImageSerializer
+class UserCanteenImagesListView(ListCreateAPIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     required_scopes = ["canteen"]
+    model = CanteenImage
+    serializer_class = CanteenImageSerializer
 
     def _get_canteen(self):
         # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
@@ -28,3 +33,7 @@ class UserCanteenImagesListView(ListAPIView):
     def get_queryset(self):
         canteen = self._get_canteen()
         return canteen.images.all()
+
+    def perform_create(self, serializer):
+        canteen = self._get_canteen()
+        serializer.save(canteen=canteen)


### PR DESCRIPTION
### Quoi

Suite de #6920

On réutilise l'endpoint, mais on rajoute la possibilité de faire un POST dessus.
Et ainsi ajouter des images.