### PR TITLE
refactor(Cantines): Logo: nouvelle property + affichage dans l'admin

### DIFF
--- a/api/serializers/canteen.py
+++ b/api/serializers/canteen.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from drf_base64.fields import Base64ImageField
 from drf_spectacular.utils import extend_schema_serializer
@@ -787,12 +786,7 @@ class CanteenOpenDataSerializer(serializers.ModelSerializer):
         return ",".join(obj.pat_lib_list)
 
     def get_logo(self, obj):
-        bucket_url = os.environ.get("CELLAR_HOST")
-        bucket_name = os.environ.get("CELLAR_BUCKET_NAME")
-
-        if obj.logo:
-            return f"{bucket_url}/{bucket_name}/media/{obj.logo}"
-        return ""
+        return obj.logo_full_url
 
     def get_sector_list(self, obj):
         return ",".join(obj.sector_lib_list)

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -124,7 +124,7 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
             },
         ),
         ("Informations groupe", {"fields": ("groupe", "satellites_display")}),
-        ("Images", {"fields": ("logo", "image_count")}),
+        ("Images", {"fields": ("logo", "logo_display", "image_count")}),
         (
             "Informations supplémentaires",
             {"fields": ("is_filled", "publication_status_display", "has_been_claimed")},
@@ -151,6 +151,7 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
     )
     readonly_fields = (
         "satellites_display",
+        "logo_display",
         "image_count",
         "is_filled",
         "publication_status_display",
@@ -210,6 +211,14 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         return obj.declaration_donnees_2025
 
     télédéclarée.boolean = True
+
+    @admin.display(description="Logo")
+    def logo_display(self, obj):
+        print("logo", obj.logo)
+        print("logo_full_url", obj.logo_full_url)
+        if obj.logo:
+            return format_html(f'<img src="{obj.logo_full_url}" width="100" height="100" />')
+        return "-"
 
     @admin.display(description="Nombre d'images")
     def image_count(self, obj):

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -214,8 +214,6 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
 
     @admin.display(description="Logo")
     def logo_display(self, obj):
-        print("logo", obj.logo)
-        print("logo_full_url", obj.logo_full_url)
         if obj.logo:
             return format_html(f'<img src="{obj.logo_full_url}" width="100" height="100" />')
         return "-"

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -6,7 +6,6 @@ from django.contrib.auth import get_user_model
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import ValidationError
 from django.db import models
-from django.conf import settings
 from django.db.models import BooleanField, Case, Count, Exists, F, Func, OuterRef, Q, Subquery, Value, When
 from django.db.models.functions import Coalesce, Length
 from django.db.models.signals import post_save
@@ -896,7 +895,7 @@ class Canteen(DirtyFieldsMixin, SoftDeletionModel):
     @property
     def logo_full_url(self):
         if self.logo:
-            return f"{settings.AWS_S3_ENDPOINT_URL}/{settings.AWS_STORAGE_BUCKET_NAME}/media/{self.logo}"
+            return self.logo.url
         return None
 
     def _is_filled(self) -> bool:

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import ValidationError
 from django.db import models
+from django.conf import settings
 from django.db.models import BooleanField, Case, Count, Exists, F, Func, OuterRef, Q, Subquery, Value, When
 from django.db.models.functions import Coalesce, Length
 from django.db.models.signals import post_save
@@ -891,6 +892,12 @@ class Canteen(DirtyFieldsMixin, SoftDeletionModel):
             if not getattr(self, field_name):
                 return True
         return False
+
+    @property
+    def logo_full_url(self):
+        if self.logo:
+            return f"{settings.AWS_S3_ENDPOINT_URL}/{settings.AWS_STORAGE_BUCKET_NAME}/media/{self.logo}"
+        return None
 
     def _is_filled(self) -> bool:
         # basic rules


### PR DESCRIPTION
### Quoi

En parallèle de #6931
Petite PR pour améliorer la gestion de `Canteen.logo`
- nouvelle property réutilisable `logo_full_url`
- affichage dans l'admin

### Capture d'écran

<img width="573" height="318" alt="image" src="https://github.com/user-attachments/assets/f0ba64e1-7019-4002-b63f-362551aac3cc" />

### Note

> Django's ImageField.url property automatically generates the correct URL for any storage backend (S3, FileSystemStorage, etc.). You don't need to check which storage is being used.
