### PR TITLE
feat(Cantines): API: endpoint dédié à la récupération, l'upload et la suppression de logo

### DIFF
--- a/api/serializers/canteen_images.py
+++ b/api/serializers/canteen_images.py
@@ -1,7 +1,19 @@
 from rest_framework import serializers
 from drf_base64.fields import Base64ImageField
 
-from data.models import CanteenImage
+from data.models import Canteen, CanteenImage
+
+
+class CanteenLogoSerializer(serializers.ModelSerializer):
+    id = serializers.IntegerField(read_only=True)
+    logo = Base64ImageField()
+
+    class Meta:
+        model = Canteen
+        fields = (
+            "id",
+            "logo",
+        )
 
 
 class CanteenImageSerializer(serializers.ModelSerializer):

--- a/api/tests/test_canteen_images.py
+++ b/api/tests/test_canteen_images.py
@@ -38,7 +38,7 @@ class CanteenLogoUploadApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_can_upload_canteen_logo(self):
+    def test_upload_canteen_logo(self):
         self.canteen.managers.add(authenticate.user)
         image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
         image_base_64 = None
@@ -54,7 +54,7 @@ class CanteenLogoUploadApiTest(APITestCase):
         body = response.json()
         self.assertIn("logo", body)
 
-    def test_can_upload_canteen_logo_via_oauth2(self):
+    def test_upload_canteen_logo_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
         self.canteen.managers.add(user)
         self.client.credentials(Authorization=f"Bearer {token}")
@@ -72,14 +72,41 @@ class CanteenLogoUploadApiTest(APITestCase):
         body = response.json()
         self.assertIn("logo", body)
 
+    @authenticate
+    def test_upload_canteen_logo_even_if_canteen_not_filled(self):
+        self.canteen.managers.add(authenticate.user)
+        self.canteen.siret = None
+        self.canteen.save(skip_validations=True)
+        self.assertIsNone(self.canteen.siret)
+        self.assertFalse(self.canteen.is_filled)
+
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        image_base_64 = None
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
+        payload = {
+            "logo": "data:image/jpeg;base64," + image_base_64,
+        }
+        response = self.client.post(self.url, data=payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("logo", body)
+
+    @authenticate
     def test_can_replace_existing_logo(self):
         self.canteen.managers.add(authenticate.user)
-        # First set a logo
+
+        # First upload a logo
         image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
         with open(image_path, "rb") as image:
             image_base_64 = base64.b64encode(image.read()).decode("utf-8")
-        self.canteen.logo = "data:image/jpeg;base64," + image_base_64
-        self.canteen.save()
+
+        payload = {
+            "logo": "data:image/jpeg;base64," + image_base_64,
+        }
+        response = self.client.post(self.url, data=payload, format="json")
 
         # Now replace it with a new logo
         new_image_path = os.path.join(CURRENT_DIR, "files/test-image-2.jpg")
@@ -94,6 +121,161 @@ class CanteenLogoUploadApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertIn("logo", body)
+
+
+class CanteenLogoRetrieveApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.url = reverse("canteen_logo", kwargs={"canteen_pk": cls.canteen.pk})
+
+    def test_cannot_retrieve_canteen_logo_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_retrieve_canteen_logo_if_canteen_unknown(self):
+        url = reverse("canteen_logo", kwargs={"canteen_pk": 999})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_retrieve_canteen_logo_if_not_canteen_manager(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_retrieve_canteen_logo(self):
+        self.canteen.managers.add(authenticate.user)
+
+        # First upload a logo
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
+        payload = {
+            "logo": "data:image/jpeg;base64," + image_base_64,
+        }
+        response = self.client.post(self.url, data=payload, format="json")
+
+        # Now retrieve the logo
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("logo", body)
+
+    def test_retrieve_canteen_logo_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:read")
+        self.canteen.managers.add(user)
+        self.client.credentials(Authorization=f"Bearer {token}")
+
+        # First upload a logo
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
+        payload = {
+            "logo": "data:image/jpeg;base64," + image_base_64,
+        }
+        response = self.client.post(self.url, data=payload, format="json")
+
+        # Now retrieve the logo
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("logo", body)
+
+
+class CanteenLogoDeleteApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.url = reverse("canteen_logo", kwargs={"canteen_pk": cls.canteen.pk})
+
+    def test_cannot_delete_canteen_logo_if_unauthenticated(self):
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_delete_canteen_logo_if_canteen_unknown(self):
+        url = reverse("canteen_logo", kwargs={"canteen_pk": 999})
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_delete_canteen_logo_if_not_canteen_manager(self):
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_delete_canteen_logo(self):
+        self.canteen.managers.add(authenticate.user)
+
+        # First upload a logo
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
+        payload = {
+            "logo": "data:image/jpeg;base64," + image_base_64,
+        }
+        response = self.client.post(self.url, data=payload, format="json")
+
+        # Now delete the logo
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_delete_canteen_logo_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:write")
+        self.canteen.managers.add(user)
+        self.client.credentials(Authorization=f"Bearer {token}")
+
+        # First upload a logo
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
+        payload = {
+            "logo": "data:image/jpeg;base64," + image_base_64,
+        }
+        response = self.client.post(self.url, data=payload, format="json")
+
+        # Now delete the logo
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    @authenticate
+    def test_delete_canteen_logo_even_if_canteen_not_filled(self):
+        self.canteen.managers.add(authenticate.user)
+        self.canteen.siret = None
+        self.canteen.save(skip_validations=True)
+        self.assertIsNone(self.canteen.siret)
+        self.assertFalse(self.canteen.is_filled)
+
+        # First upload a logo
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
+        payload = {
+            "logo": "data:image/jpeg;base64," + image_base_64,
+        }
+        response = self.client.post(self.url, data=payload, format="json")
+
+        # Now delete the logo
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
 class CanteenImagesListApiTest(APITestCase):

--- a/api/tests/test_canteen_images.py
+++ b/api/tests/test_canteen_images.py
@@ -191,6 +191,29 @@ class CanteenLogoRetrieveApiTest(APITestCase):
         self.assertIn("logo", body)
 
 
+class CanteenLogoUpdateApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.url = reverse("canteen_logo", kwargs={"canteen_pk": cls.canteen.pk})
+
+    @authenticate
+    def test_cannot_update_canteen_logo_with_patch(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.patch(self.url, data={}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @authenticate
+    def test_cannot_update_canteen_logo_with_put(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.put(self.url, data={}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+
 class CanteenLogoDeleteApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/api/tests/test_canteen_images.py
+++ b/api/tests/test_canteen_images.py
@@ -25,8 +25,8 @@ class CanteenLogoUploadApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_upload_canteen_logo_if_canteen_unknown(self):
-        url = reverse("canteen_logo", kwargs={"canteen_pk": 999})
+    def test_cannot_upload_canteen_logo_if_canteen_does_not_exist(self):
+        url = reverse("canteen_logo", kwargs={"canteen_pk": 9999})
         response = self.client.post(url, data={})
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -135,8 +135,8 @@ class CanteenLogoRetrieveApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_retrieve_canteen_logo_if_canteen_unknown(self):
-        url = reverse("canteen_logo", kwargs={"canteen_pk": 999})
+    def test_cannot_retrieve_canteen_logo_if_canteen_does_not_exist(self):
+        url = reverse("canteen_logo", kwargs={"canteen_pk": 9999})
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -226,8 +226,8 @@ class CanteenLogoDeleteApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_delete_canteen_logo_if_canteen_unknown(self):
-        url = reverse("canteen_logo", kwargs={"canteen_pk": 999})
+    def test_cannot_delete_canteen_logo_if_canteen_does_not_exist(self):
+        url = reverse("canteen_logo", kwargs={"canteen_pk": 9999})
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/api/tests/test_canteen_images.py
+++ b/api/tests/test_canteen_images.py
@@ -13,6 +13,89 @@ from data.models import CanteenImage
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
+class CanteenLogoUploadApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.url = reverse("canteen_logo", kwargs={"canteen_pk": cls.canteen.pk})
+
+    def test_cannot_upload_canteen_logo_if_unauthenticated(self):
+        response = self.client.post(self.url, data={})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_upload_canteen_logo_if_canteen_unknown(self):
+        url = reverse("canteen_logo", kwargs={"canteen_pk": 999})
+        response = self.client.post(url, data={})
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_upload_canteen_logo_if_not_canteen_manager(self):
+        response = self.client.post(self.url, data={})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_can_upload_canteen_logo(self):
+        self.canteen.managers.add(authenticate.user)
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        image_base_64 = None
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
+        payload = {
+            "logo": "data:image/jpeg;base64," + image_base_64,
+        }
+        response = self.client.post(self.url, data=payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("logo", body)
+
+    def test_can_upload_canteen_logo_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:write")
+        self.canteen.managers.add(user)
+        self.client.credentials(Authorization=f"Bearer {token}")
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        image_base_64 = None
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
+        payload = {
+            "logo": "data:image/jpeg;base64," + image_base_64,
+        }
+        response = self.client.post(self.url, data=payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("logo", body)
+
+    def test_can_replace_existing_logo(self):
+        self.canteen.managers.add(authenticate.user)
+        # First set a logo
+        image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
+        with open(image_path, "rb") as image:
+            image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+        self.canteen.logo = "data:image/jpeg;base64," + image_base_64
+        self.canteen.save()
+
+        # Now replace it with a new logo
+        new_image_path = os.path.join(CURRENT_DIR, "files/test-image-2.jpg")
+        with open(new_image_path, "rb") as new_image:
+            new_image_base_64 = base64.b64encode(new_image.read()).decode("utf-8")
+
+        new_payload = {
+            "logo": "data:image/jpeg;base64," + new_image_base_64,
+        }
+        response = self.client.post(self.url, data=new_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("logo", body)
+
+
 class CanteenImagesListApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/api/urls.py
+++ b/api/urls.py
@@ -74,6 +74,7 @@ from api.views import (
     UserCanteenImagesListView,
     UserCanteenImagesRetrieveUpdateDestroyView,
     UserCanteenListExportView,
+    UserCanteenLogoView,
     UserCanteenManagersInvitationsView,
     UserCanteenManagersView,
     UserCanteenPreviews,
@@ -116,6 +117,11 @@ urlpatterns = {
         "canteens/<int:canteen_pk>/check",
         UserCanteenCheckView.as_view(),
         name="canteen_check",
+    ),
+    path(
+        "canteens/<int:canteen_pk>/logo",
+        UserCanteenLogoView.as_view(),
+        name="canteen_logo",
     ),
     path(
         "canteens/<int:canteen_pk>/images/",

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -24,7 +24,7 @@ from .canteen_groupe import (  # noqa: F401
     CanteenGroupeSatellitesListView,
     CanteenGroupeSatelliteUnlinkView,
 )  # noqa: F401
-from .canteen_images import UserCanteenImagesListView, UserCanteenImagesRetrieveUpdateDestroyView  # noqa: F401
+from .canteen_images import UserCanteenLogoView, UserCanteenImagesListView, UserCanteenImagesRetrieveUpdateDestroyView  # noqa: F401
 from .canteen_managers import (  # noqa: F401
     AddManagerView,
     ClaimCanteenView,

--- a/api/views/canteen_images.py
+++ b/api/views/canteen_images.py
@@ -51,7 +51,7 @@ class UserCanteenLogoView(APIView):
         serializer.is_valid(raise_exception=True)
 
         canteen.logo = serializer.validated_data["logo"]
-        canteen.save()
+        canteen.save(skip_validations=True)
 
         response_serializer = CanteenLogoSerializer(canteen, context={"request": request})
         return Response(response_serializer.data, status=status.HTTP_200_OK)
@@ -64,7 +64,7 @@ class UserCanteenLogoView(APIView):
 
         canteen.logo.delete()
         canteen.logo = None
-        canteen.save()
+        canteen.save(skip_validations=True)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/api/views/canteen_images.py
+++ b/api/views/canteen_images.py
@@ -62,7 +62,7 @@ class UserCanteenLogoView(APIView):
         if not canteen.logo:
             raise NotFound()
 
-        canteen.logo.delete()
+        canteen.logo.delete(save=False)
         canteen.logo = None
         canteen.save(skip_validations=True)
 

--- a/api/views/canteen_images.py
+++ b/api/views/canteen_images.py
@@ -2,10 +2,71 @@ from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIV
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from django.http import JsonResponse
 from rest_framework import status
+from rest_framework.exceptions import NotFound
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from api.permissions import IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam
-from data.models import CanteenImage, Canteen
-from api.serializers.canteen_images import CanteenImageSerializer
+from api.serializers.canteen_images import CanteenImageSerializer, CanteenLogoSerializer
+from data.models import Canteen, CanteenImage
+
+
+@extend_schema_view(
+    get=extend_schema(
+        summary="Obtenir le logo d'une cantine.",
+        description="",
+        tags=["Cantines"],
+    ),
+    post=extend_schema(
+        summary="Ajouter le logo d'une cantine.",
+        description="",
+        tags=["Cantines"],
+    ),
+    delete=extend_schema(
+        summary="Supprimer le logo d'une cantine.",
+        description="",
+        tags=["Cantines"],
+    ),
+)
+class UserCanteenLogoView(APIView):
+    permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
+    http_method_names = ["get", "post", "delete"]
+
+    def _get_canteen(self):
+        return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
+
+    def get(self, request, *args, **kwargs):
+        canteen = self._get_canteen()
+
+        if not canteen.logo:
+            raise NotFound()
+
+        serializer = CanteenLogoSerializer(canteen, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def post(self, request, *args, **kwargs):
+        canteen = self._get_canteen()
+
+        serializer = CanteenLogoSerializer(canteen, data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+
+        canteen.logo = serializer.validated_data["logo"]
+        canteen.save()
+
+        response_serializer = CanteenLogoSerializer(canteen, context={"request": request})
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+    def delete(self, request, *args, **kwargs):
+        canteen = self._get_canteen()
+
+        if not canteen.logo:
+            raise NotFound()
+
+        canteen.logo.delete()
+        canteen.logo = None
+        canteen.save()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @extend_schema_view(
@@ -16,7 +77,7 @@ from api.serializers.canteen_images import CanteenImageSerializer
         responses=CanteenImageSerializer(many=True),
     ),
     post=extend_schema(
-        summary="Ajouter une image.",
+        summary="Ajouter une image d'une cantine.",
         description="",
         tags=["Cantines"],
     ),
@@ -42,7 +103,7 @@ class UserCanteenImagesListView(ListCreateAPIView):
 
 @extend_schema_view(
     delete=extend_schema(
-        summary="Supprimer une image.",
+        summary="Supprimer une image d'une cantine.",
         description="",
         tags=["Cantines"],
     ),


### PR DESCRIPTION
### Quoi

Similaire à ce qu'on a fait pour `Purchase.facture` dans #6840

Cette fois ci on créé un endpoint dédié pour `Canteen.logo`
- retrieve
- create
- destroy