### PR TITLE
improve(Établissement): affiche les champs en erreur

### DIFF
--- a/2024-frontend/src/components/AppFieldDisplay.vue
+++ b/2024-frontend/src/components/AppFieldDisplay.vue
@@ -6,7 +6,8 @@ const props = defineProps(['label', 'value', 'tooltip'])
 
 const valueFormatted = computed(() => {
   const isArray = Array.isArray(props.value)
-  return isArray ? props.value?.join(' ; <br/>') : props.value
+  const value = isArray ? props.value?.join(' ; <br/>') : props.value
+  return value !== null ? value : 'Non renseigné'
 })
 </script>
 
@@ -15,9 +16,11 @@ const valueFormatted = computed(() => {
     <div class="fr-col-12 fr-col-md-5">
       <p class="fr-mb-0 fr-text--bold">{{ label }} :</p>
     </div>
-    <div class="fr-col-12 fr-col-md-7 ma-cantine--flex-start ma-cantine--flex-top">
-      <AppRawHtml :html="valueFormatted || 'Non renseigné'" />
-      <DsfrTooltip v-if="tooltip" :content="tooltip" />
+    <div class="fr-col-12 fr-col-md-7">
+      <div class="ma-cantine--flex-start ma-cantine--flex-top fr-mb-1w">
+        <AppRawHtml :html="valueFormatted" />
+        <DsfrTooltip v-if="tooltip" :content="tooltip" />
+      </div>
     </div>
   </div>
 </template>

--- a/2024-frontend/src/components/AppFieldDisplay.vue
+++ b/2024-frontend/src/components/AppFieldDisplay.vue
@@ -2,13 +2,16 @@
 import { computed } from 'vue'
 import AppRawHtml from '@/components/AppRawHtml.vue'
 
-const props = defineProps(['label', 'value', 'tooltip'])
+const props = defineProps(['label', 'value', 'tooltip', 'error'])
 
 const valueFormatted = computed(() => {
   const isArray = Array.isArray(props.value)
   const value = isArray ? props.value?.join(' ; <br/>') : props.value
   return value !== null ? value : 'Non renseigné'
 })
+
+const hasError = computed(() => props.error && props.error.length > 0)
+const errorMessage = computed(() => hasError.value ? props.error?.join(', ') : "")
 </script>
 
 <template>
@@ -21,6 +24,7 @@ const valueFormatted = computed(() => {
         <AppRawHtml :html="valueFormatted" />
         <DsfrTooltip v-if="tooltip" :content="tooltip" />
       </div>
+      <p v-if="hasError" class="fr-message fr-message--error">{{ errorMessage }}</p>
     </div>
   </div>
 </template>

--- a/2024-frontend/src/components/AppFieldDisplay.vue
+++ b/2024-frontend/src/components/AppFieldDisplay.vue
@@ -7,7 +7,8 @@ const props = defineProps(['label', 'value', 'tooltip', 'error'])
 const valueFormatted = computed(() => {
   const isArray = Array.isArray(props.value)
   const value = isArray ? props.value?.join(' ; <br/>') : props.value
-  return value !== null ? value : 'Non renseigné'
+  const valueIsEmpty = value === null || value === undefined || value === ''
+  return valueIsEmpty ? 'Non renseigné' : value
 })
 
 const hasError = computed(() => props.error && props.error.length > 0)

--- a/2024-frontend/src/components/AppFieldDisplay.vue
+++ b/2024-frontend/src/components/AppFieldDisplay.vue
@@ -12,7 +12,7 @@ const valueFormatted = computed(() => {
 })
 
 const hasError = computed(() => props.error && props.error.length > 0)
-const errorMessage = computed(() => hasError.value ? props.error?.join(', ') : "")
+const errorMessage = computed(() => hasError.value ? props.error?.join(' ') : "")
 </script>
 
 <template>

--- a/2024-frontend/src/components/CanteenDisplayInformations.vue
+++ b/2024-frontend/src/components/CanteenDisplayInformations.vue
@@ -86,9 +86,5 @@ const getPrettyLineMinistry = (canteenLineMinistry) => {
       <AppFieldDisplay :label="cantines.id" :value="canteenInformation.groupe?.id" />
       <AppFieldDisplay :label="`${cantines.sirenUniteLegaleName} du groupe`" :value="formatSiretOrSiren(canteenInformation.groupe?.sirenUniteLegale)" />
     </li>
-    <li v-if="!canteenIsGroupe" class="fr-my-3w">
-      <h3 class="fr-h5">Description</h3>
-      <p>{{ canteenInformation.publicationComments || 'Aucune description renseignée' }}</p>
-    </li>
   </ol>
 </template>

--- a/2024-frontend/src/components/CanteenDisplayInformations.vue
+++ b/2024-frontend/src/components/CanteenDisplayInformations.vue
@@ -51,7 +51,9 @@ const getPrettyLineMinistry = (canteenLineMinistry) => {
       <h3 class="fr-h5">Identification de l'établissement</h3>
       <AppFieldDisplay :label="cantines.id" :value="canteenInformation.id" tooltip="Identifiant unique de l'établissement, ce champ ne peut pas être modifié."/>
       <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.siret" :label="cantines.siretName" :value="formatSiretOrSiren(canteenInformation.siret)" :error="canteenErrors?.siret" />
-      <AppFieldDisplay v-if="canteenInformation.sirenUniteLegale" :label="cantines.sirenUniteLegaleName" :value="formatSiretOrSiren(canteenInformation.sirenUniteLegale)" :error="canteenErrors?.sirenUniteLegale" />
+      <AppFieldDisplay v-else-if="canteenInformation.sirenUniteLegale" :label="cantines.sirenUniteLegaleName" :value="formatSiretOrSiren(canteenInformation.sirenUniteLegale)" :error="canteenErrors?.sirenUniteLegale" />
+      <AppFieldDisplay v-else-if="!canteenIsGroupe && !canteenInformation.sirenUniteLegale && !canteenInformation.siret" :label="`${cantines.siretName} ou ${cantines.sirenUniteLegaleName}`" :value="null" :error="canteenErrors?.siret" />
+      <AppFieldDisplay v-else-if="canteenIsGroupe && !canteenInformation.sirenUniteLegale" :label="cantines.sirenUniteLegaleName" :value="null" :error="canteenErrors?.sirenUniteLegale" />
       <AppFieldDisplay :label="canteenIsGroupe ? cantines.nameGroupe : cantines.nameCantine" :value="canteenInformation.name" :error="canteenErrors?.name" />
       <AppFieldDisplay :label="cantines.dailyMealCountName" :value="canteenInformation.dailyMealCount" :error="canteenErrors?.dailyMealCount"
         tooltip="Donnez une moyenne globale sur les jours ouverts de vos établissements (pour évaluer la taille de votre établissement)"

--- a/2024-frontend/src/components/CanteenDisplayInformations.vue
+++ b/2024-frontend/src/components/CanteenDisplayInformations.vue
@@ -10,6 +10,15 @@ import cantineService from '@/services/canteens'
 
 const props = defineProps(["canteenIsGroupe", "canteenInformation"])
 
+/* Dynamic fields */
+const showCentralProducerSiret = computed(() => {
+  const isFilled = props.canteenInformation.centralProducerSiret
+  const isGroupe = props.canteenIsGroupe
+  const isSatellite = props.canteenInformation.productionType === "siteCookedElsewhere"
+  return isFilled || isGroupe || isSatellite
+})
+const showGroupeInformations = computed(() => props.canteenInformation.groupe !== null)
+
 /* Value */
 const getPrettyValue = (name, field) => {
   if (!name) return null
@@ -45,7 +54,7 @@ const getPrettyLineMinistry = (canteenLineMinistry) => {
       <AppFieldDisplay v-if="!canteenIsGroupe" :label="cantines.economicModelName" :value="getPrettyValue(canteenInformation.economicModel, 'economicModel')" :error="canteenErrors?.economicModel" />
       <AppFieldDisplay :label="cantines.managementTypeName" :value="getPrettyValue(canteenInformation.managementType, 'managementType')" :error="canteenErrors?.managementType" />
       <AppFieldDisplay :label="cantines.productionTypeName" :value="getPrettyValue(canteenInformation.productionType, 'productionType')" :error="canteenErrors?.productionType" />
-      <AppFieldDisplay v-if="canteenInformation.centralProducerSiret" :label="cantines.centralProducerSiret" :value="formatSiretOrSiren(canteenInformation.centralProducerSiret)" :error="canteenErrors?.centralProducerSiret" />
+      <AppFieldDisplay v-if="showCentralProducerSiret" :label="cantines.centralProducerSiret" :value="formatSiretOrSiren(canteenInformation.centralProducerSiret)" :error="canteenErrors?.centralProducerSiret" />
     </li>
     <li class="fr-my-3w">
       <h3 class="fr-h5">Identification de l'établissement</h3>
@@ -83,7 +92,7 @@ const getPrettyLineMinistry = (canteenLineMinistry) => {
       <AppFieldDisplay :label="cantines.sectorList" :value="getPrettySectors(canteenInformation.sectorList)" :error="canteenErrors?.sectorList" />
       <AppFieldDisplay v-if="showLineMinistry" :label="cantines.lineMinistry" :value="getPrettyLineMinistry(canteenInformation.lineMinistry)" :error="canteenErrors?.lineMinistry" />
     </li>
-    <li v-if="canteenInformation.groupe !== null" class="fr-my-3w">
+    <li v-if="showGroupeInformations" class="fr-my-3w">
       <h3 class="fr-h5">Informations de mon groupe</h3>
       <DsfrAlert title="Le gestionnaire du groupe de restaurants satellites a ajouté votre établissement" type="info" class="fr-mb-2w">
         Cela lui permet de réaliser une déclaration unique pour laquelle le montant total des achats du groupe est ensuite réparti automatiquement entre chaque restaurant satellite, au prorata de son nombre de couverts annuels.

--- a/2024-frontend/src/components/CanteenDisplayInformations.vue
+++ b/2024-frontend/src/components/CanteenDisplayInformations.vue
@@ -1,19 +1,24 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { computedAsync } from "@vueuse/core"
 import { formatSiretOrSiren } from '@/utils'
 import AppFieldDisplay from '@/components/AppFieldDisplay.vue'
 import AppLinkRouter from '@/components/AppLinkRouter.vue'
 import cantines from '@/data/cantines.json'
 import sectorsService from '@/services/sectors'
+import cantineService from '@/services/canteens'
 
-defineProps(["canteenIsGroupe", "canteenInformation"])
+const props = defineProps(["canteenIsGroupe", "canteenInformation"])
 
 /* Value */
 const getPrettyValue = (name, field) => {
   if (!name) return null
   return cantines[field].find(model => model.value === name).label
 }
+
+/* Errors */
+const canteenCheck = computedAsync(async () => await cantineService.checkCanteen(props.canteenInformation.id), [])
+const canteenErrors = computed(() => canteenCheck.value.isFilled ? [] : canteenCheck.value.errors)
 
 /* Sectors and line ministries */
 const sectorsList = computedAsync(async () => await sectorsService.getSectors(), [])
@@ -37,18 +42,18 @@ const getPrettyLineMinistry = (canteenLineMinistry) => {
   <ol class="ma-cantine--ordered-list ma-cantine--unstyled-list">
     <li class="fr-my-3w">
       <h3 class="fr-h5">Caractéristiques</h3>
-      <AppFieldDisplay v-if="!canteenIsGroupe" :label="cantines.economicModelName" :value="getPrettyValue(canteenInformation.economicModel, 'economicModel')" />
-      <AppFieldDisplay :label="cantines.managementTypeName" :value="getPrettyValue(canteenInformation.managementType, 'managementType')" />
-      <AppFieldDisplay :label="cantines.productionTypeName" :value="getPrettyValue(canteenInformation.productionType, 'productionType')" />
+      <AppFieldDisplay v-if="!canteenIsGroupe" :label="cantines.economicModelName" :value="getPrettyValue(canteenInformation.economicModel, 'economicModel')" :error="canteenErrors?.economicModel" />
+      <AppFieldDisplay :label="cantines.managementTypeName" :value="getPrettyValue(canteenInformation.managementType, 'managementType')" :error="canteenErrors?.managementType" />
+      <AppFieldDisplay :label="cantines.productionTypeName" :value="getPrettyValue(canteenInformation.productionType, 'productionType')" :error="canteenErrors?.productionType" />
       <AppFieldDisplay v-if="canteenInformation.centralProducerSiret" :label="cantines.centralProducerSiret" :value="formatSiretOrSiren(canteenInformation.centralProducerSiret)" />
     </li>
     <li class="fr-my-3w">
       <h3 class="fr-h5">Identification de l'établissement</h3>
       <AppFieldDisplay :label="cantines.id" :value="canteenInformation.id" tooltip="Identifiant unique de l'établissement, ce champ ne peut pas être modifié."/>
-      <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.siret" :label="cantines.siretName" :value="formatSiretOrSiren(canteenInformation.siret)" />
-      <AppFieldDisplay v-if="canteenInformation.sirenUniteLegale" :label="cantines.sirenUniteLegaleName" :value="formatSiretOrSiren(canteenInformation.sirenUniteLegale)" />
-      <AppFieldDisplay :label="canteenIsGroupe ? cantines.nameGroupe : cantines.nameCantine" :value="canteenInformation.name" />
-      <AppFieldDisplay :label="cantines.dailyMealCountName" :value="canteenInformation.dailyMealCount"
+      <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.siret" :label="cantines.siretName" :value="formatSiretOrSiren(canteenInformation.siret)" :error="canteenErrors?.siret" />
+      <AppFieldDisplay v-if="canteenInformation.sirenUniteLegale" :label="cantines.sirenUniteLegaleName" :value="formatSiretOrSiren(canteenInformation.sirenUniteLegale)" :error="canteenErrors?.sirenUniteLegale" />
+      <AppFieldDisplay :label="canteenIsGroupe ? cantines.nameGroupe : cantines.nameCantine" :value="canteenInformation.name" :error="canteenErrors?.name" />
+      <AppFieldDisplay :label="cantines.dailyMealCountName" :value="canteenInformation.dailyMealCount" :error="canteenErrors?.dailyMealCount"
         tooltip="Donnez une moyenne globale sur les jours ouverts de vos établissements (pour évaluer la taille de votre établissement)"
       />
       <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.sirenUniteLegale" :label="cantines.city" :value="canteenInformation.city" />
@@ -73,8 +78,8 @@ const getPrettyLineMinistry = (canteenLineMinistry) => {
     </li>
     <li v-if="!canteenIsGroupe" class="fr-my-3w">
       <h3 class="fr-h5">Secteurs</h3>
-      <AppFieldDisplay :label="cantines.sectorList" :value="getPrettySectors(canteenInformation.sectorList)" />
-      <AppFieldDisplay v-if="showLineMinistry" :label="cantines.lineMinistry" :value="getPrettyLineMinistry(canteenInformation.lineMinistry)" />
+      <AppFieldDisplay :label="cantines.sectorList" :value="getPrettySectors(canteenInformation.sectorList)" :error="canteenErrors?.sectorList" />
+      <AppFieldDisplay v-if="showLineMinistry" :label="cantines.lineMinistry" :value="getPrettyLineMinistry(canteenInformation.lineMinistry)" :error="canteenErrors?.lineMinistry" />
     </li>
     <li v-if="canteenInformation.groupe !== null" class="fr-my-3w">
       <h3 class="fr-h5">Informations de mon groupe</h3>

--- a/2024-frontend/src/components/CanteenDisplayInformations.vue
+++ b/2024-frontend/src/components/CanteenDisplayInformations.vue
@@ -1,0 +1,94 @@
+<script setup>
+import { ref } from 'vue'
+import { computedAsync } from "@vueuse/core"
+import { formatSiretOrSiren } from '@/utils'
+import AppFieldDisplay from '@/components/AppFieldDisplay.vue'
+import AppLinkRouter from '@/components/AppLinkRouter.vue'
+import cantines from '@/data/cantines.json'
+import sectorsService from '@/services/sectors'
+
+defineProps(["canteenIsGroupe", "canteenInformation"])
+
+/* Value */
+const getPrettyValue = (name, field) => {
+  if (!name) return null
+  return cantines[field].find(model => model.value === name).label
+}
+
+/* Sectors and line ministries */
+const sectorsList = computedAsync(async () => await sectorsService.getSectors(), [])
+const lineMinistriesList = computedAsync(async () => await sectorsService.getMinistries(), [])
+const showLineMinistry = ref(false)
+const getPrettySectors = (canteenSectors) => {
+  if (sectorsList.value.length === 0 || !canteenSectors || canteenSectors.length === 0) return []
+  const filteredSectors = sectorsList.value.filter((sector) => canteenSectors.includes(sector.value))
+  showLineMinistry.value = filteredSectors.some((sector) => sector.hasLineMinistry)
+  const filteredSectorsNames = filteredSectors.map((filter) => filter.name)
+  return filteredSectorsNames
+}
+const getPrettyLineMinistry = (canteenLineMinistry) => {
+  if (lineMinistriesList.value.length === 0 || !canteenLineMinistry ) return null
+  const filteredLineMinistries = lineMinistriesList.value.filter((ministry) => ministry.value === canteenLineMinistry)
+  return filteredLineMinistries.length > 0 ? filteredLineMinistries[0].name : null
+}
+</script>
+
+<template>
+  <ol class="ma-cantine--ordered-list ma-cantine--unstyled-list">
+    <li class="fr-my-3w">
+      <h3 class="fr-h5">Caractéristiques</h3>
+      <AppFieldDisplay v-if="!canteenIsGroupe" :label="cantines.economicModelName" :value="getPrettyValue(canteenInformation.economicModel, 'economicModel')" />
+      <AppFieldDisplay :label="cantines.managementTypeName" :value="getPrettyValue(canteenInformation.managementType, 'managementType')" />
+      <AppFieldDisplay :label="cantines.productionTypeName" :value="getPrettyValue(canteenInformation.productionType, 'productionType')" />
+      <AppFieldDisplay v-if="canteenInformation.centralProducerSiret" :label="cantines.centralProducerSiret" :value="formatSiretOrSiren(canteenInformation.centralProducerSiret)" />
+    </li>
+    <li class="fr-my-3w">
+      <h3 class="fr-h5">Identification de l'établissement</h3>
+      <AppFieldDisplay :label="cantines.id" :value="canteenInformation.id" tooltip="Identifiant unique de l'établissement, ce champ ne peut pas être modifié."/>
+      <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.siret" :label="cantines.siretName" :value="formatSiretOrSiren(canteenInformation.siret)" />
+      <AppFieldDisplay v-if="canteenInformation.sirenUniteLegale" :label="cantines.sirenUniteLegaleName" :value="formatSiretOrSiren(canteenInformation.sirenUniteLegale)" />
+      <AppFieldDisplay :label="canteenIsGroupe ? cantines.nameGroupe : cantines.nameCantine" :value="canteenInformation.name" />
+      <AppFieldDisplay :label="cantines.dailyMealCountName" :value="canteenInformation.dailyMealCount"
+        tooltip="Donnez une moyenne globale sur les jours ouverts de vos établissements (pour évaluer la taille de votre établissement)"
+      />
+      <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.sirenUniteLegale" :label="cantines.city" :value="canteenInformation.city" />
+      <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.sirenUniteLegale" :label="cantines.postalCode" :value="canteenInformation.postalCode" />
+    </li>
+    <li v-if="!canteenIsGroupe" class="fr-my-3w">
+      <h3 class="fr-h5">Informations générées</h3>
+      <DsfrAlert title="Ces informations ne sont pas modifiables" type="info" class="fr-mb-2w">
+        À partir des informations renseignées, nous avons généré des données avec d'autres référentiels :
+        <a href="https://france-pat.fr" target="_blank">France PAT</a>
+        et
+        <a href="https://annuaire-entreprises.data.gouv.fr" target="_blank">l'annuaire des entreprises</a>.
+        Si vous remarquez une erreur, merci de <AppLinkRouter title="nous contacter" :to="{name: 'Contact'}" />.
+      </DsfrAlert>
+      <AppFieldDisplay v-if="!canteenInformation.sirenUniteLegale" :label="cantines.city" :value="canteenInformation.city" />
+      <AppFieldDisplay v-if="!canteenInformation.sirenUniteLegale" :label="cantines.postalCode" :value="canteenInformation.postalCode" />
+      <AppFieldDisplay :label="cantines.cityInseeCode" :value="canteenInformation.cityInseeCode" />
+      <AppFieldDisplay :label="cantines.departmentLib" :value="canteenInformation.departmentLib" />
+      <AppFieldDisplay :label="cantines.regionLib" :value="canteenInformation.regionLib" />
+      <AppFieldDisplay :label="cantines.patLibList" :value="canteenInformation.patLibList" />
+      <AppFieldDisplay :label="cantines.epciLib" :value="canteenInformation.epciLib" />
+    </li>
+    <li v-if="!canteenIsGroupe" class="fr-my-3w">
+      <h3 class="fr-h5">Secteurs</h3>
+      <AppFieldDisplay :label="cantines.sectorList" :value="getPrettySectors(canteenInformation.sectorList)" />
+      <AppFieldDisplay v-if="showLineMinistry" :label="cantines.lineMinistry" :value="getPrettyLineMinistry(canteenInformation.lineMinistry)" />
+    </li>
+    <li v-if="canteenInformation.groupe !== null" class="fr-my-3w">
+      <h3 class="fr-h5">Informations de mon groupe</h3>
+      <DsfrAlert title="Le gestionnaire du groupe de restaurants satellites a ajouté votre établissement" type="info" class="fr-mb-2w">
+        Cela lui permet de réaliser une déclaration unique pour laquelle le montant total des achats du groupe est ensuite réparti automatiquement entre chaque restaurant satellite, au prorata de son nombre de couverts annuels.
+        Si vous remarquez une erreur ou souhaitez ne plus être associer au groupe, merci de <AppLinkRouter title="nous contacter" :to="{name: 'Contact'}" />.
+      </DsfrAlert>
+      <AppFieldDisplay :label="cantines.nameGroupe" :value="canteenInformation.groupe?.name" />
+      <AppFieldDisplay :label="cantines.id" :value="canteenInformation.groupe?.id" />
+      <AppFieldDisplay :label="`${cantines.sirenUniteLegaleName} du groupe`" :value="formatSiretOrSiren(canteenInformation.groupe?.sirenUniteLegale)" />
+    </li>
+    <li v-if="!canteenIsGroupe" class="fr-my-3w">
+      <h3 class="fr-h5">Description</h3>
+      <p>{{ canteenInformation.publicationComments || 'Aucune description renseignée' }}</p>
+    </li>
+  </ol>
+</template>

--- a/2024-frontend/src/components/CanteenDisplayInformations.vue
+++ b/2024-frontend/src/components/CanteenDisplayInformations.vue
@@ -45,7 +45,7 @@ const getPrettyLineMinistry = (canteenLineMinistry) => {
       <AppFieldDisplay v-if="!canteenIsGroupe" :label="cantines.economicModelName" :value="getPrettyValue(canteenInformation.economicModel, 'economicModel')" :error="canteenErrors?.economicModel" />
       <AppFieldDisplay :label="cantines.managementTypeName" :value="getPrettyValue(canteenInformation.managementType, 'managementType')" :error="canteenErrors?.managementType" />
       <AppFieldDisplay :label="cantines.productionTypeName" :value="getPrettyValue(canteenInformation.productionType, 'productionType')" :error="canteenErrors?.productionType" />
-      <AppFieldDisplay v-if="canteenInformation.centralProducerSiret" :label="cantines.centralProducerSiret" :value="formatSiretOrSiren(canteenInformation.centralProducerSiret)" />
+      <AppFieldDisplay v-if="canteenInformation.centralProducerSiret" :label="cantines.centralProducerSiret" :value="formatSiretOrSiren(canteenInformation.centralProducerSiret)" :error="canteenErrors?.centralProducerSiret" />
     </li>
     <li class="fr-my-3w">
       <h3 class="fr-h5">Identification de l'établissement</h3>

--- a/2024-frontend/src/services/canteens.js
+++ b/2024-frontend/src/services/canteens.js
@@ -53,6 +53,17 @@ const updateCanteen = (payload, id) => {
     .catch((e) => e)
 }
 
+const checkCanteen = (canteenId) => {
+  return fetch(`/api/v1/canteens/${canteenId}/check`, {
+    method: "GET",
+    headers: {
+      "X-CSRFToken": window.CSRF_TOKEN || "",
+    },
+  })
+    .then(verifyResponse)
+    .then((response) => response)
+    .catch((e) => e)
+}
 
 const fetchSatellites = (canteenId) => {
   return fetch(`/api/v1/canteens/${canteenId}/satellites/`, {
@@ -147,6 +158,7 @@ export default {
   canteenStatus,
   fetchCanteen,
   updateCanteen,
+  checkCanteen,
   claimCanteen,
   deleteCanteen,
   teamJoinRequest,

--- a/2024-frontend/src/services/canteensTable.js
+++ b/2024-frontend/src/services/canteensTable.js
@@ -26,7 +26,7 @@ const getSatellitesCountSentence = (satellitesCount) => {
 }
 
 const getSiretOrSirenInfos = (canteen) => {
-  return canteen.siret || canteen.sirenUniteLegale
+  return canteen.siret || canteen.sirenUniteLegale || ""
 }
 
 const getCityInfos = (canteen) => {

--- a/2024-frontend/src/views/GestionnaireCantineInformations.vue
+++ b/2024-frontend/src/views/GestionnaireCantineInformations.vue
@@ -1,13 +1,8 @@
 <script setup>
-import { ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import { computedAsync } from "@vueuse/core"
-import { formatSiretOrSiren } from '@/utils'
 import LayoutSidebarCanteen from '@/layouts/LayoutSidebarCanteen.vue'
-import AppFieldDisplay from '@/components/AppFieldDisplay.vue'
 import AppLinkRouter from '@/components/AppLinkRouter.vue'
-import cantines from '@/data/cantines.json'
-import sectorsService from '@/services/sectors'
+import CanteenDisplayInformations from '@/components/CanteenDisplayInformations.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -17,29 +12,6 @@ const canteenUrlComponent = route.params.canteenUrlComponent
 const goToEdit = (canteenIsGroupe) => {
   const pageName = canteenIsGroupe ? 'GestionnaireCantineGroupeModifier' : 'GestionnaireCantineRestaurantModifier'
   router.push({ name: pageName })
-}
-
-/* Value */
-const getPrettyValue = (name, field) => {
-  if (!name) return null
-  return cantines[field].find(model => model.value === name).label
-}
-
-/* Sectors and line ministries */
-const sectorsList = computedAsync(async () => await sectorsService.getSectors(), [])
-const lineMinistriesList = computedAsync(async () => await sectorsService.getMinistries(), [])
-const showLineMinistry = ref(false)
-const getPrettySectors = (canteenSectors) => {
-  if (sectorsList.value.length === 0 || !canteenSectors || canteenSectors.length === 0) return []
-  const filteredSectors = sectorsList.value.filter((sector) => canteenSectors.includes(sector.value))
-  showLineMinistry.value = filteredSectors.some((sector) => sector.hasLineMinistry)
-  const filteredSectorsNames = filteredSectors.map((filter) => filter.name)
-  return filteredSectorsNames
-}
-const getPrettyLineMinistry = (canteenLineMinistry) => {
-  if (lineMinistriesList.value.length === 0 || !canteenLineMinistry ) return null
-  const filteredLineMinistries = lineMinistriesList.value.filter((ministry) => ministry.value === canteenLineMinistry)
-  return filteredLineMinistries.length > 0 ? filteredLineMinistries[0].name : null
 }
 </script>
 
@@ -52,63 +24,7 @@ const getPrettyLineMinistry = (canteenLineMinistry) => {
       <DsfrButton @click="goToEdit(canteenIsGroupe)" :label="canteenIsGroupe ? 'Modifier les informations du groupe' : 'Modifier mes informations'" icon="ri-pencil-line" />
     </template>
     <template #content="{ canteenIsGroupe, canteenInformation }">
-      <ol class="ma-cantine--ordered-list ma-cantine--unstyled-list">
-        <li class="fr-my-3w">
-          <h3 class="fr-h5">Caractéristiques</h3>
-          <AppFieldDisplay v-if="!canteenIsGroupe" :label="cantines.economicModelName" :value="getPrettyValue(canteenInformation.economicModel, 'economicModel')" />
-          <AppFieldDisplay :label="cantines.managementTypeName" :value="getPrettyValue(canteenInformation.managementType, 'managementType')" />
-          <AppFieldDisplay :label="cantines.productionTypeName" :value="getPrettyValue(canteenInformation.productionType, 'productionType')" />
-          <AppFieldDisplay v-if="canteenInformation.centralProducerSiret" :label="cantines.centralProducerSiret" :value="formatSiretOrSiren(canteenInformation.centralProducerSiret)" />
-        </li>
-        <li class="fr-my-3w">
-          <h3 class="fr-h5">Identification de l'établissement</h3>
-          <AppFieldDisplay :label="cantines.id" :value="canteenInformation.id" tooltip="Identifiant unique de l'établissement, ce champ ne peut pas être modifié."/>
-          <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.siret" :label="cantines.siretName" :value="formatSiretOrSiren(canteenInformation.siret)" />
-          <AppFieldDisplay v-if="canteenInformation.sirenUniteLegale" :label="cantines.sirenUniteLegaleName" :value="formatSiretOrSiren(canteenInformation.sirenUniteLegale)" />
-          <AppFieldDisplay :label="canteenIsGroupe ? cantines.nameGroupe : cantines.nameCantine" :value="canteenInformation.name" />
-          <AppFieldDisplay :label="cantines.dailyMealCountName" :value="canteenInformation.dailyMealCount"
-            tooltip="Donnez une moyenne globale sur les jours ouverts de vos établissements (pour évaluer la taille de votre établissement)"
-          />
-          <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.sirenUniteLegale" :label="cantines.city" :value="canteenInformation.city" />
-          <AppFieldDisplay v-if="!canteenIsGroupe && canteenInformation.sirenUniteLegale" :label="cantines.postalCode" :value="canteenInformation.postalCode" />
-        </li>
-        <li v-if="!canteenIsGroupe" class="fr-my-3w">
-          <h3 class="fr-h5">Informations générées</h3>
-          <DsfrAlert title="Ces informations ne sont pas modifiables" type="info" class="fr-mb-2w">
-            À partir des informations renseignées, nous avons généré des données avec d'autres référentiels :
-            <a href="https://france-pat.fr" target="_blank">France PAT</a>
-            et
-            <a href="https://annuaire-entreprises.data.gouv.fr" target="_blank">l'annuaire des entreprises</a>.
-            Si vous remarquez une erreur, merci de <AppLinkRouter title="nous contacter" :to="{name: 'Contact'}" />.
-          </DsfrAlert>
-          <AppFieldDisplay v-if="!canteenInformation.sirenUniteLegale" :label="cantines.city" :value="canteenInformation.city" />
-          <AppFieldDisplay v-if="!canteenInformation.sirenUniteLegale" :label="cantines.postalCode" :value="canteenInformation.postalCode" />
-          <AppFieldDisplay :label="cantines.cityInseeCode" :value="canteenInformation.cityInseeCode" />
-          <AppFieldDisplay :label="cantines.departmentLib" :value="canteenInformation.departmentLib" />
-          <AppFieldDisplay :label="cantines.regionLib" :value="canteenInformation.regionLib" />
-          <AppFieldDisplay :label="cantines.patLibList" :value="canteenInformation.patLibList" />
-          <AppFieldDisplay :label="cantines.epciLib" :value="canteenInformation.epciLib" />
-        </li>
-        <li v-if="!canteenIsGroupe" class="fr-my-3w">
-          <h3 class="fr-h5">Secteurs</h3>
-          <AppFieldDisplay :label="cantines.sectorList" :value="getPrettySectors(canteenInformation.sectorList)" />
-          <AppFieldDisplay v-if="showLineMinistry" :label="cantines.lineMinistry" :value="getPrettyLineMinistry(canteenInformation.lineMinistry)" />
-        </li>
-        <li v-if="canteenInformation.groupe !== null" class="fr-my-3w">
-          <h3 class="fr-h5">Informations de mon groupe</h3>
-          <DsfrAlert title="Le gestionnaire du groupe de restaurants satellites a ajouté votre établissement" type="info" class="fr-mb-2w">
-            Cela lui permet de réaliser une déclaration unique pour laquelle le montant total des achats du groupe est ensuite réparti automatiquement entre chaque restaurant satellite, au prorata de son nombre de couverts annuels.
-            Si vous remarquez une erreur ou souhaitez ne plus être associer au groupe, merci de <AppLinkRouter title="nous contacter" :to="{name: 'Contact'}" />.
-          </DsfrAlert>
-          <AppFieldDisplay :label="cantines.nameGroupe" :value="canteenInformation.groupe?.name" />
-          <AppFieldDisplay :label="cantines.id" :value="canteenInformation.groupe?.id" />
-          <AppFieldDisplay :label="`${cantines.sirenUniteLegaleName} du groupe`" :value="formatSiretOrSiren(canteenInformation.groupe?.sirenUniteLegale)" />
-        </li>
-        <li v-if="!canteenIsGroupe" class="fr-my-3w">
-          <h3 class="fr-h5">Description</h3>
-          <p>{{ canteenInformation.publicationComments || 'Aucune description renseignée' }}</p>
-        </li>
-      </ol>
+      <CanteenDisplayInformations :canteen-is-groupe="canteenIsGroupe" :canteen-information="canteenInformation" />
       <div v-if="canteenUrlComponent" class="fr-container fr-background-alt--red-marianne fr-p-4w fr-mt-3w">
         <h3 class="fr-h6 fr-text-default--error fr-mb-2w">
           <span class="mdi mdi-archive"></span>


### PR DESCRIPTION
Ticket : https://app.notion.com/p/incubateur-masa/Frontend-afficher-les-champs-en-erreur-pour-une-cantine-3a4de24614be8056910ae8e478a541e7

|Groupe|Restaurant|
|--|--|
| <img width="2918" height="3414" alt="Groupe" src="https://github.com/user-attachments/assets/abfad8e9-61d2-4c0e-8a10-7ea984754766" /> | <img width="2918" height="5102" alt="Site" src="https://github.com/user-attachments/assets/5424e95d-9b11-4238-8042-a457d20baa7b" /> |

Et légère correction : 
- suppression du champ description comme il est géré dans la page publique