### PR TITLE
feat(Cantines): API: nouvel endpoint pour récupérer & modifier 1 image

### DIFF
--- a/api/tests/test_canteen_images.py
+++ b/api/tests/test_canteen_images.py
@@ -1,13 +1,12 @@
 import base64
 import os
 
+from django.core.files import File
 from django.urls import reverse
-from django.urls.exceptions import NoReverseMatch
 from rest_framework import status
 from rest_framework.test import APITestCase
-from django.core.files import File
-from api.tests.utils import authenticate, get_oauth2_token
 
+from api.tests.utils import authenticate, get_oauth2_token
 from data.factories.canteen import CanteenFactory
 from data.models import CanteenImage
 
@@ -33,14 +32,14 @@ class CanteenImagesListApiTest(APITestCase):
                 canteen_image.save()
         cls.url = reverse("canteen_images_list", kwargs={"canteen_pk": cls.canteen.pk})
 
-    def test_cannot_get_canteen_images_unauthenticated(self):
+    def test_cannot_get_canteen_images_if_unauthenticated(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_get_canteen_images_if_canteen_does_not_exist(self):
-        url = reverse("canteen_images_list", kwargs={"canteen_pk": 999})
+        url = reverse("canteen_images_list", kwargs={"canteen_pk": 9999})
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -52,7 +51,7 @@ class CanteenImagesListApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_canteen_images_list(self):
+    def test_get_canteen_images(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.get(self.url)
@@ -65,7 +64,7 @@ class CanteenImagesListApiTest(APITestCase):
             self.assertIn("image", item)
             self.assertIn("altText", item)
 
-    def test_canteen_images_list_via_oauth2(self):
+    def test_get_canteen_images_via_oauth2(self):
         user, token = get_oauth2_token("canteen:read")
         self.canteen.managers.add(user)
         self.client.credentials(Authorization=f"Bearer {token}")
@@ -93,18 +92,53 @@ class CanteenImagesDetailApiTest(APITestCase):
             canteen_image = CanteenImage(image=file)
             canteen_image.canteen = cls.canteen
             canteen_image.save()
+        cls.url = reverse(
+            "canteen_images_detail",
+            kwargs={"canteen_pk": cls.canteen.pk, "pk": cls.canteen.images.first().pk},
+        )
+
+    def test_cannot_get_canteen_image_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_get_canteen_image_detail(self):
+    def test_cannot_get_canteen_image_if_canteen_does_not_exist(self):
+        url = reverse("canteen_images_detail", kwargs={"canteen_pk": 9999, "pk": 1})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_get_canteen_image_if_not_canteen_manager(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_get_canteen_image_detail(self):
         self.canteen.managers.add(authenticate.user)
 
-        with self.assertRaises(NoReverseMatch):
-            self.client.get(
-                reverse(
-                    "canteen_images_detail",
-                    kwargs={"canteen_pk": self.canteen.pk, "pk": self.canteen.images.first().pk},
-                )
-            )
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("id", body)
+        self.assertIn("image", body)
+        self.assertIn("altText", body)
+
+    def test_get_canteen_image_detail_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:read")
+        self.canteen.managers.add(user)
+        self.client.credentials(Authorization=f"Bearer {token}")
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("id", body)
+        self.assertIn("image", body)
+        self.assertIn("altText", body)
 
 
 class CanteenImagesCreateApiTest(APITestCase):
@@ -113,14 +147,14 @@ class CanteenImagesCreateApiTest(APITestCase):
         cls.canteen = CanteenFactory()
         cls.url = reverse("canteen_images_list", kwargs={"canteen_pk": cls.canteen.pk})
 
-    def test_cannot_create_canteen_image_unauthenticated(self):
+    def test_cannot_create_canteen_image_if_unauthenticated(self):
         response = self.client.post(self.url, data={})
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_create_canteen_image_if_canteen_does_not_exist(self):
-        url = reverse("canteen_images_list", kwargs={"canteen_pk": 999})
+        url = reverse("canteen_images_list", kwargs={"canteen_pk": 9999})
         response = self.client.post(url, data={})
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -210,19 +244,84 @@ class CanteenImagesUpdateApiTest(APITestCase):
             canteen_image = CanteenImage(image=file)
             canteen_image.canteen = cls.canteen
             canteen_image.save()
+        cls.url = reverse(
+            "canteen_images_detail",
+            kwargs={"canteen_pk": cls.canteen.pk, "pk": cls.canteen.images.first().pk},
+        )
+
+    def test_cannot_update_canteen_image_if_unauthenticated(self):
+        response = self.client.patch(self.url, data={})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_update_canteen_image(self):
-        self.canteen.managers.add(authenticate.user)
+    def test_cannot_update_canteen_image_if_canteen_does_not_exist(self):
+        url = reverse("canteen_images_detail", kwargs={"canteen_pk": 9999, "pk": 1})
+        response = self.client.patch(url, data={})
 
-        with self.assertRaises(NoReverseMatch):
-            self.client.patch(
-                reverse(
-                    "canteen_images_detail",
-                    kwargs={"canteen_pk": self.canteen.pk, "pk": self.canteen.images.first().pk},
-                ),
-                data={},
-            )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_update_canteen_image_if_not_canteen_manager(self):
+        response = self.client.patch(self.url, data={})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_update_canteen_image(self):
+        self.canteen.managers.add(authenticate.user)
+        self.assertEqual(self.canteen.images.first().alt_text, None)
+
+        payload = {
+            "altText": "Updated alt text",
+        }
+        response = self.client.patch(self.url, data=payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("id", body)
+        self.assertIn("image", body)
+        self.assertIn("altText", body)
+        self.assertEqual(body["altText"], "Updated alt text")
+
+    def test_update_canteen_image_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:write")
+        self.canteen.managers.add(user)
+        self.client.credentials(Authorization=f"Bearer {token}")
+        self.assertEqual(self.canteen.images.first().alt_text, None)
+
+        payload = {
+            "altText": "Updated alt text via OAuth2",
+        }
+        response = self.client.patch(self.url, data=payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("id", body)
+        self.assertIn("image", body)
+        self.assertIn("altText", body)
+        self.assertEqual(body["altText"], "Updated alt text via OAuth2")
+
+    @authenticate
+    def test_update_canteen_image_even_if_canteen_not_filled(self):
+        self.canteen.managers.add(authenticate.user)
+        self.canteen.siret = None
+        self.canteen.save(skip_validations=True)
+        self.assertIsNone(self.canteen.siret)
+        self.assertFalse(self.canteen.is_filled)
+        self.assertEqual(self.canteen.images.first().alt_text, None)
+
+        payload = {
+            "altText": "Updated alt text even if canteen not filled",
+        }
+        response = self.client.patch(self.url, data=payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("id", body)
+        self.assertIn("image", body)
+        self.assertIn("altText", body)
+        self.assertEqual(body["altText"], "Updated alt text even if canteen not filled")
 
 
 class CanteenImagesDeleteApiTest(APITestCase):
@@ -238,18 +337,18 @@ class CanteenImagesDeleteApiTest(APITestCase):
             canteen_image.canteen = cls.canteen
             canteen_image.save()
         cls.url = reverse(
-            "canteen_images_destroy",
+            "canteen_images_detail",
             kwargs={"canteen_pk": cls.canteen.pk, "pk": cls.canteen.images.first().pk},
         )
 
-    def test_cannot_delete_canteen_image_unauthenticated(self):
+    def test_cannot_delete_canteen_image_if_unauthenticated(self):
         response = self.client.delete(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_delete_canteen_image_if_canteen_does_not_exist(self):
-        url = reverse("canteen_images_destroy", kwargs={"canteen_pk": 999, "pk": 1})
+        url = reverse("canteen_images_detail", kwargs={"canteen_pk": 9999, "pk": 1})
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -262,7 +361,7 @@ class CanteenImagesDeleteApiTest(APITestCase):
 
     @authenticate
     def test_cannot_delete_canteen_image_if_image_does_not_exist(self):
-        url = reverse("canteen_images_destroy", kwargs={"canteen_pk": self.canteen.pk, "pk": 999})
+        url = reverse("canteen_images_detail", kwargs={"canteen_pk": self.canteen.pk, "pk": 9999})
         self.canteen.managers.add(authenticate.user)
         response = self.client.delete(url)
 

--- a/api/tests/test_canteen_images.py
+++ b/api/tests/test_canteen_images.py
@@ -30,7 +30,7 @@ class CanteenImagesListApiTest(APITestCase):
                 canteen_image = CanteenImage(image=file)
                 canteen_image.canteen = cls.canteen
                 canteen_image.save()
-        cls.url = reverse("canteen_images_list", kwargs={"canteen_pk": cls.canteen.pk})
+        cls.url = reverse("canteen_images_list_create", kwargs={"canteen_pk": cls.canteen.pk})
 
     def test_cannot_get_canteen_images_if_unauthenticated(self):
         response = self.client.get(self.url)
@@ -39,7 +39,7 @@ class CanteenImagesListApiTest(APITestCase):
 
     @authenticate
     def test_cannot_get_canteen_images_if_canteen_does_not_exist(self):
-        url = reverse("canteen_images_list", kwargs={"canteen_pk": 9999})
+        url = reverse("canteen_images_list_create", kwargs={"canteen_pk": 9999})
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -93,7 +93,7 @@ class CanteenImagesDetailApiTest(APITestCase):
             canteen_image.canteen = cls.canteen
             canteen_image.save()
         cls.url = reverse(
-            "canteen_images_detail",
+            "canteen_images_retrieve_update_destroy",
             kwargs={"canteen_pk": cls.canteen.pk, "pk": cls.canteen.images.first().pk},
         )
 
@@ -104,7 +104,7 @@ class CanteenImagesDetailApiTest(APITestCase):
 
     @authenticate
     def test_cannot_get_canteen_image_if_canteen_does_not_exist(self):
-        url = reverse("canteen_images_detail", kwargs={"canteen_pk": 9999, "pk": 1})
+        url = reverse("canteen_images_retrieve_update_destroy", kwargs={"canteen_pk": 9999, "pk": 1})
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -145,7 +145,7 @@ class CanteenImagesCreateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.canteen = CanteenFactory()
-        cls.url = reverse("canteen_images_list", kwargs={"canteen_pk": cls.canteen.pk})
+        cls.url = reverse("canteen_images_list_create", kwargs={"canteen_pk": cls.canteen.pk})
 
     def test_cannot_create_canteen_image_if_unauthenticated(self):
         response = self.client.post(self.url, data={})
@@ -154,7 +154,7 @@ class CanteenImagesCreateApiTest(APITestCase):
 
     @authenticate
     def test_cannot_create_canteen_image_if_canteen_does_not_exist(self):
-        url = reverse("canteen_images_list", kwargs={"canteen_pk": 9999})
+        url = reverse("canteen_images_list_create", kwargs={"canteen_pk": 9999})
         response = self.client.post(url, data={})
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -245,7 +245,7 @@ class CanteenImagesUpdateApiTest(APITestCase):
             canteen_image.canteen = cls.canteen
             canteen_image.save()
         cls.url = reverse(
-            "canteen_images_detail",
+            "canteen_images_retrieve_update_destroy",
             kwargs={"canteen_pk": cls.canteen.pk, "pk": cls.canteen.images.first().pk},
         )
 
@@ -256,7 +256,7 @@ class CanteenImagesUpdateApiTest(APITestCase):
 
     @authenticate
     def test_cannot_update_canteen_image_if_canteen_does_not_exist(self):
-        url = reverse("canteen_images_detail", kwargs={"canteen_pk": 9999, "pk": 1})
+        url = reverse("canteen_images_retrieve_update_destroy", kwargs={"canteen_pk": 9999, "pk": 1})
         response = self.client.patch(url, data={})
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -337,7 +337,7 @@ class CanteenImagesDeleteApiTest(APITestCase):
             canteen_image.canteen = cls.canteen
             canteen_image.save()
         cls.url = reverse(
-            "canteen_images_detail",
+            "canteen_images_retrieve_update_destroy",
             kwargs={"canteen_pk": cls.canteen.pk, "pk": cls.canteen.images.first().pk},
         )
 
@@ -348,7 +348,7 @@ class CanteenImagesDeleteApiTest(APITestCase):
 
     @authenticate
     def test_cannot_delete_canteen_image_if_canteen_does_not_exist(self):
-        url = reverse("canteen_images_detail", kwargs={"canteen_pk": 9999, "pk": 1})
+        url = reverse("canteen_images_retrieve_update_destroy", kwargs={"canteen_pk": 9999, "pk": 1})
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -361,7 +361,7 @@ class CanteenImagesDeleteApiTest(APITestCase):
 
     @authenticate
     def test_cannot_delete_canteen_image_if_image_does_not_exist(self):
-        url = reverse("canteen_images_detail", kwargs={"canteen_pk": self.canteen.pk, "pk": 9999})
+        url = reverse("canteen_images_retrieve_update_destroy", kwargs={"canteen_pk": self.canteen.pk, "pk": 9999})
         self.canteen.managers.add(authenticate.user)
         response = self.client.delete(url)
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -120,12 +120,12 @@ urlpatterns = {
     path(
         "canteens/<int:canteen_pk>/images/",
         UserCanteenImagesListView.as_view(),
-        name="canteen_images_list",
+        name="canteen_images_list_create",
     ),
     path(
         "canteens/<int:canteen_pk>/images/<int:pk>",
         UserCanteenImagesRetrieveUpdateDestroyView.as_view(),
-        name="canteen_images_detail",
+        name="canteen_images_retrieve_update_destroy",
     ),
     path(
         "canteens/<int:canteen_pk>/purchases/",

--- a/api/urls.py
+++ b/api/urls.py
@@ -72,7 +72,7 @@ from api.views import (
     UserCanteenActions,
     UserCanteenCheckView,
     UserCanteenImagesListView,
-    UserCanteenImagesDestroyView,
+    UserCanteenImagesRetrieveUpdateDestroyView,
     UserCanteenListExportView,
     UserCanteenManagersInvitationsView,
     UserCanteenManagersView,
@@ -124,8 +124,8 @@ urlpatterns = {
     ),
     path(
         "canteens/<int:canteen_pk>/images/<int:pk>",
-        UserCanteenImagesDestroyView.as_view(),
-        name="canteen_images_destroy",
+        UserCanteenImagesRetrieveUpdateDestroyView.as_view(),
+        name="canteen_images_detail",
     ),
     path(
         "canteens/<int:canteen_pk>/purchases/",

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -24,16 +24,16 @@ from .canteen_groupe import (  # noqa: F401
     CanteenGroupeSatellitesListView,
     CanteenGroupeSatelliteUnlinkView,
 )  # noqa: F401
+from .canteen_images import UserCanteenImagesListView, UserCanteenImagesRetrieveUpdateDestroyView  # noqa: F401
 from .canteen_managers import (  # noqa: F401
     AddManagerView,
     ClaimCanteenView,
-    UserCanteenManagersView,
-    UserCanteenManagersInvitationsView,
     RemoveManagerView,
     TeamJoinRequestView,
     UndoClaimCanteenView,
+    UserCanteenManagersInvitationsView,
+    UserCanteenManagersView,
 )
-from .canteen_images import UserCanteenImagesListView, UserCanteenImagesDestroyView  # noqa: F401
 from .canteen_managers_import import CanteensManagersImportView  # noqa: F401
 from .canteen_update_import import CanteensUpdateImportView  # noqa: F401
 from .communityevent import CommunityEventsView  # noqa: F401

--- a/api/views/canteen_images.py
+++ b/api/views/canteen_images.py
@@ -1,9 +1,10 @@
-from rest_framework.generics import ListCreateAPIView, DestroyAPIView
+from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
 from drf_spectacular.utils import extend_schema, extend_schema_view
+from django.http import JsonResponse
+from rest_framework import status
 
 from api.permissions import IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam
 from data.models import CanteenImage, Canteen
-
 from api.serializers.canteen_images import CanteenImageSerializer
 
 
@@ -46,7 +47,7 @@ class UserCanteenImagesListView(ListCreateAPIView):
         tags=["Cantines"],
     ),
 )
-class UserCanteenImagesDestroyView(DestroyAPIView):
+class UserCanteenImagesRetrieveUpdateDestroyView(RetrieveUpdateDestroyAPIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     required_scopes = ["canteen"]
     model = CanteenImage
@@ -59,3 +60,8 @@ class UserCanteenImagesDestroyView(DestroyAPIView):
     def get_queryset(self):
         canteen = self._get_canteen()
         return canteen.images.all()
+
+    def put(self, request, *args, **kwargs):
+        return JsonResponse(
+            {"error": "Only PATCH request supported in this resource"}, status=status.HTTP_405_METHOD_NOT_ALLOWED
+        )


### PR DESCRIPTION
### Quoi

Suite à #6920 (list) & #6929 (create) & #6930 (destroy)
- permettre de récupérer 1 image
- permettre de modifier 1 image
- réutilisé la view `UserCanteenImagesDestroyView` et renommé en `UserCanteenImagesRetrieveUpdateDestroyView`
- renommé aussi `canteen_images_list` en `canteen_images_list_create` (pour être plus clair)