### PR TITLE
refactor(Achats): permettre d'ignorer les validations on save grâce à skip_validations

### DIFF
--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -290,11 +290,13 @@ class Purchase(SoftDeletionModel):
         if validation_errors:
             raise ValidationError(validation_errors)
 
-    def save(self, **kwargs):
+    def save(self, skip_validations=False, **kwargs):
         """
         - full_clean(): run validations (with extra validations in clean())
+            - this can be skipped with skip_validations=True (USE WITH CAUTION)
         """
-        self.full_clean()
+        if not skip_validations:
+            self.full_clean()
         super().save(**kwargs)
 
     @property

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -562,7 +562,11 @@ class CanteenModelSaveTest(TransactionTestCase):
     def test_canteen_skip_validations_on_save(self):
         canteen = CanteenFactory(siret="75665621899905", siren_unite_legale=None)
         canteen.siret = None
-        # should not raise
+
+        # without skip_validations
+        self.assertRaises(ValidationError, canteen.save)
+
+        # with skip_validations
         canteen.save(skip_validations=True)
         self.assertEqual(canteen.siret, None)
 

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -205,7 +205,11 @@ class PurchaseModelSaveTest(TransactionTestCase):
     def test_purchase_skip_validations_on_save(self):
         purchase = PurchaseFactory()
         purchase.caracteristiques = [Purchase.Characteristic.EUROPE, Purchase.Characteristic.FRANCE]
-        # should not raise
+
+        # without skip_validations
+        self.assertRaises(ValidationError, purchase.save)
+
+        # with skip_validations
         purchase.save(skip_validations=True)
         self.assertEqual(len(purchase.caracteristiques), 2)
 

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -202,6 +202,13 @@ class PurchaseModelSaveTest(TransactionTestCase):
             with self.subTest(prix_ht=VALUE_NOT_OK):
                 self.assertRaises(ValidationError, PurchaseFactory, prix_ht=VALUE_NOT_OK)
 
+    def test_purchase_skip_validations_on_save(self):
+        purchase = PurchaseFactory()
+        purchase.caracteristiques = [Purchase.Characteristic.EUROPE, Purchase.Characteristic.FRANCE]
+        # should not raise
+        purchase.save(skip_validations=True)
+        self.assertEqual(len(purchase.caracteristiques), 2)
+
 
 class PurchaseModelDeleteTest(TestCase):
     @classmethod


### PR DESCRIPTION
### Quoi

Comme c'est déjà le cas sur le modèle `Canteen`

Rajoute le paramètre `skip_validations` à `Purchase.save()`

### Pourquoi

Permettre d'ajouter ou de supprimer une facture d'un achat en erreur (PR à venir)