### PR TITLE
refactor(Achats): permettre d'ignorer les validations on delete grâce à skip_validations

### DIFF
--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -299,6 +299,13 @@ class Purchase(SoftDeletionModel):
             self.full_clean()
         super().save(**kwargs)
 
+    def delete(self, skip_validations=False, **kwargs):
+        """
+        Override the SoftDeletionModel delete method
+        - add the skip_validations parameter to skip validations (USE WITH CAUTION)
+        """
+        super().delete(skip_validations=skip_validations, **kwargs)
+
     @property
     def categories_egalim(self) -> list[str]:
         return [c for c in (self.caracteristiques or []) if c in Purchase.CHARACTERISTIC_LABELS_EGALIM]

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -290,11 +290,13 @@ class Purchase(SoftDeletionModel):
         if validation_errors:
             raise ValidationError(validation_errors)
 
-    def save(self, **kwargs):
+    def save(self, skip_validations=False, **kwargs):
         """
         - full_clean(): run validations (with extra validations in clean())
+            - this can be skipped with skip_validations=True (USE WITH CAUTION)
         """
-        self.full_clean()
+        if not skip_validations:
+            self.full_clean()
         super().save(**kwargs)
 
     @property

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -562,7 +562,11 @@ class CanteenModelSaveTest(TransactionTestCase):
     def test_canteen_skip_validations_on_save(self):
         canteen = CanteenFactory(siret="75665621899905", siren_unite_legale=None)
         canteen.siret = None
-        # should not raise
+
+        # without skip_validations
+        self.assertRaises(ValidationError, canteen.save)
+
+        # with skip_validations
         canteen.save(skip_validations=True)
         self.assertEqual(canteen.siret, None)
 

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -237,6 +237,17 @@ class PurchaseModelDeleteTest(TestCase):
         self.assertEqual(Purchase.objects.count(), 0)
         self.assertEqual(Purchase.all_objects.count(), 0)
 
+    def test_can_soft_delete_if_missing_data_using_skip_validations(self):
+        self.purchase.caracteristiques = [Purchase.Characteristic.EUROPE, Purchase.Characteristic.FRANCE]
+        self.purchase.save(skip_validations=True)
+
+        # without skip_validations
+        self.assertRaises(ValidationError, self.purchase.delete)
+
+        # with skip_validations
+        self.purchase.delete(skip_validations=True)
+        self.assertIsNotNone(self.purchase.deletion_date)
+
 
 class PurchaseQuerySetTest(TestCase):
     @classmethod

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -205,7 +205,11 @@ class PurchaseModelSaveTest(TransactionTestCase):
     def test_purchase_skip_validations_on_save(self):
         purchase = PurchaseFactory()
         purchase.caracteristiques = [Purchase.Characteristic.EUROPE, Purchase.Characteristic.FRANCE]
-        # should not raise
+
+        # without skip_validations
+        self.assertRaises(ValidationError, purchase.save)
+
+        # with skip_validations
         purchase.save(skip_validations=True)
         self.assertEqual(len(purchase.caracteristiques), 2)
 

--- a/data/tests/test_purchase.py
+++ b/data/tests/test_purchase.py
@@ -202,6 +202,13 @@ class PurchaseModelSaveTest(TransactionTestCase):
             with self.subTest(prix_ht=VALUE_NOT_OK):
                 self.assertRaises(ValidationError, PurchaseFactory, prix_ht=VALUE_NOT_OK)
 
+    def test_purchase_skip_validations_on_save(self):
+        purchase = PurchaseFactory()
+        purchase.caracteristiques = [Purchase.Characteristic.EUROPE, Purchase.Characteristic.FRANCE]
+        # should not raise
+        purchase.save(skip_validations=True)
+        self.assertEqual(len(purchase.caracteristiques), 2)
+
 
 class PurchaseModelDeleteTest(TestCase):
     @classmethod


### PR DESCRIPTION
### Quoi

Suite de #6936. Et similaire à ce qui existe déjà sur `Canteen`

Rajoute le paramètre `skip_validations` à `Purchase.delete()`