### PR TITLE
refactor(Tests): API: homogénéiser les tests suite à beaucoup de changements

### DIFF
--- a/api/tests/test_blog_posts.py
+++ b/api/tests/test_blog_posts.py
@@ -5,11 +5,12 @@ from rest_framework.test import APITestCase
 from data.factories import BlogPostFactory, BlogTagFactory
 
 
-class TestBlogApi(APITestCase):
-    def test_get_published_blog_posts(self):
-        """
-        The API should only return published blog posts
-        """
+class BlogPostListApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("blog_posts_list")
+
+    def test_can_list_blog_posts_if_published(self):
         published_blog_posts = [
             BlogPostFactory(published=True),
             BlogPostFactory(published=True),
@@ -19,13 +20,12 @@ class TestBlogApi(APITestCase):
             BlogPostFactory(published=False),
             BlogPostFactory(published=False),
         ]
-        response = self.client.get(reverse("blog_posts_list"))
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-
         self.assertEqual(body.get("count"), 2)
-
-        results = body.get("results", [])
+        results = body["results"]
 
         for published_blog_post in published_blog_posts:
             self.assertTrue(any(x["id"] == published_blog_post.id for x in results))
@@ -33,26 +33,7 @@ class TestBlogApi(APITestCase):
         for draft_blog_post in draft_blog_posts:
             self.assertFalse(any(x["id"] == draft_blog_post.id for x in results))
 
-    def test_get_single_blog_post(self):
-        """
-        The API should return single blog posts if they are published
-        """
-        tag = BlogTagFactory(name="Test tag")
-        published_blog_post = BlogPostFactory(published=True)
-        published_blog_post.tags.add(tag)
-        draft_blog_post = BlogPostFactory(published=False)
-
-        response = self.client.get(reverse("single_blog_post", kwargs={"pk": published_blog_post.id}))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("Test tag", response.json()["tags"])
-
-        response = self.client.get(reverse("single_blog_post", kwargs={"pk": draft_blog_post.id}))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_filter_blog_post(self):
-        """
-        The API should return filtered blog posts
-        """
+    def test_can_filter_blog_posts_by_tag(self):
         tag = BlogTagFactory(name="Test")
         other = BlogTagFactory()
         good_post = BlogPostFactory(published=True)
@@ -61,7 +42,8 @@ class TestBlogApi(APITestCase):
         post = BlogPostFactory(published=True)
         post.tags.add(other)
 
-        response = self.client.get(reverse("blog_posts_list"), {"tag": "Test"})
+        response = self.client.get(self.url, {"tag": "Test"})
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
         self.assertEqual(response.json()["results"][0]["id"], good_post.id)
@@ -79,11 +61,35 @@ class TestBlogApi(APITestCase):
         draft_blog_post = BlogPostFactory(published=False)
         draft_blog_post.tags.add(draft_tag)
 
-        response = self.client.get(reverse("blog_posts_list"))
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-
         tags = body.get("tags", [])
         self.assertIn("Used", tags)
         self.assertNotIn("Unused", tags)
         self.assertNotIn("Draft", tags)
+
+
+class BlogPostDetailApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.blog_post = BlogPostFactory(published=False)
+        cls.url = reverse("single_blog_post", kwargs={"pk": cls.blog_post.id})
+
+    def test_cannot_get_blog_post_if_not_published(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_can_get_blog_post_if_published(self):
+        tag = BlogTagFactory(name="Test tag")
+        self.blog_post.published = True
+        self.blog_post.save()
+        self.blog_post.tags.add(tag)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("Test tag", body["tags"])

--- a/api/tests/test_canteen_action.py
+++ b/api/tests/test_canteen_action.py
@@ -7,50 +7,74 @@ from data.factories import CanteenFactory
 
 
 class CanteenActionListApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("list_actionable_canteens", kwargs={"year": 2021})
+
     def test_cannot_list_canteen_actions_if_unauthenticated(self):
-        response = self.client.get(reverse("list_actionable_canteens", kwargs={"year": 2021}))
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_list_canteen_actions(self):
         CanteenFactory()
         CanteenFactory(managers=[authenticate.user])
-        response = self.client.get(reverse("list_actionable_canteens", kwargs={"year": 2021}))
+
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["results"]), 1)
-        self.assertTrue("action" in response.data["results"][0])
+        body = response.json()
+        self.assertEqual(len(body["results"]), 1)
+        self.assertTrue("action" in body["results"][0])
 
 
 class CanteenActionDetailApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.url = reverse("retrieve_actionable_canteen", kwargs={"pk": cls.canteen.id, "year": 2021})
+
     def test_cannot_retrieve_actionable_canteen_if_unauthenticated(self):
-        canteen = CanteenFactory()
-        response = self.client.get(reverse("retrieve_actionable_canteen", kwargs={"pk": canteen.id, "year": 2021}))
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_retrieve_actionable_canteen_if_not_canteen_manager(self):
-        canteen = CanteenFactory()
-        response = self.client.get(reverse("retrieve_actionable_canteen", kwargs={"pk": canteen.id, "year": 2021}))
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_retrieve_actionable_canteen_if_canteen_manager(self):
-        canteen = CanteenFactory(managers=[authenticate.user])
-        response = self.client.get(reverse("retrieve_actionable_canteen", kwargs={"pk": canteen.id, "year": 2021}))
+    def test_can_retrieve_actionable_canteen(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue("action" in response.data)
+        body = response.json()
+        self.assertTrue("action" in body)
 
 
 class UserCanteenActionListApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("user_canteens_actions", kwargs={"year": 2021})
+
     def test_cannot_list_user_canteen_actions_if_unauthenticated(self):
-        response = self.client.get(reverse("user_canteens_actions", kwargs={"year": 2021}))
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_list_user_canteen_actions(self):
+    def test_can_list_user_canteen_actions(self):
         CanteenFactory()
         CanteenFactory(managers=[authenticate.user])
-        response = self.client.get(reverse("user_canteens_actions", kwargs={"year": 2021}))
+
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
         self.assertEqual(len(response.data), 1)
         self.assertTrue("action" in response.data[0])

--- a/api/tests/test_canteen_export.py
+++ b/api/tests/test_canteen_export.py
@@ -12,13 +12,13 @@ class CanteenListExportApiTest(APITestCase):
     def setUpTestData(cls):
         cls.url = reverse("user_canteen_list_export")
 
-    def test_excel_export_unauthenticated(self):
+    def test_cannot_export_if_unauthenticated(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_excel_export(self):
+    def test_can_export(self):
         CanteenFactory(managers=[authenticate.user])
         CanteenFactory(managers=[authenticate.user])
         CanteenFactory()
@@ -29,7 +29,7 @@ class CanteenListExportApiTest(APITestCase):
         self.assertEqual(len(response.data), 2)
 
     @authenticate
-    def test_excel_export_only_canteens_with_siret(self):
+    def test_can_export_only_canteens_with_siret(self):
         CanteenFactory(
             managers=[authenticate.user],
             siret=None,
@@ -44,7 +44,7 @@ class CanteenListExportApiTest(APITestCase):
 
         self.assertEqual(Canteen.objects.count(), 2)
 
-        response = self.client.get(reverse("user_canteen_list_export"))
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)

--- a/api/tests/test_canteen_groupe.py
+++ b/api/tests/test_canteen_groupe.py
@@ -35,18 +35,6 @@ class CanteenGroupeSatellitesListApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_cannot_list_if_wrong_token(self):
-        _, token = get_oauth2_token("user:read")
-        self.client.credentials(Authorization=f"Bearer {token}")
-
-        url = reverse(
-            "canteen_groupe_satellites_list",
-            kwargs={"canteen_pk": self.canteen_groupe_1.id},
-        )
-        response = self.client.get(url)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
     @authenticate
     def test_cannot_list_if_group_does_not_exist(self):
         url = reverse(
@@ -147,28 +135,6 @@ class CanteenGroupeSatelliteLinkUnlinkApiTest(APITestCase):
         cls.canteen_site = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
 
     def test_cannot_link_unlink_satellite_if_unauthenticated(self):
-        # self.canteen_satellite_0 is not linked yet
-        url = reverse(
-            "canteen_groupe_satellite_link",
-            kwargs={"canteen_pk": self.canteen_groupe_1.id, "satellite_pk": self.canteen_satellite_0.id},
-        )
-        response = self.client.post(url)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-        # self.canteen_satellite_11 is linked to groupe_1
-        url = reverse(
-            "canteen_groupe_satellite_unlink",
-            kwargs={"canteen_pk": self.canteen_groupe_1.id, "satellite_pk": self.canteen_satellite_11.id},
-        )
-        response = self.client.post(url)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_cannot_link_unlink_satellite_if_wrong_token(self):
-        _, token = get_oauth2_token("user:read")
-        self.client.credentials(Authorization=f"Bearer {token}")
-
         # self.canteen_satellite_0 is not linked yet
         url = reverse(
             "canteen_groupe_satellite_link",

--- a/api/tests/test_canteen_groupe.py
+++ b/api/tests/test_canteen_groupe.py
@@ -48,7 +48,7 @@ class CanteenGroupeSatellitesListApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_list_if_group_unknown(self):
+    def test_cannot_list_if_group_does_not_exist(self):
         url = reverse(
             "canteen_groupe_satellites_list",
             kwargs={"canteen_pk": 9999},
@@ -59,7 +59,7 @@ class CanteenGroupeSatellitesListApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_list_if_user_not_group_manager(self):
+    def test_cannot_list_if_not_group_manager(self):
         url = reverse(
             "canteen_groupe_satellites_list",
             kwargs={"canteen_pk": self.canteen_groupe_1.id},
@@ -188,7 +188,7 @@ class CanteenGroupeSatelliteLinkUnlinkApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_link_unlink_satellite_if_group_unknown(self):
+    def test_cannot_link_unlink_satellite_if_group_does_not_exist(self):
         # self.canteen_satellite_0 is not linked yet
         url = reverse(
             "canteen_groupe_satellite_link",

--- a/api/tests/test_canteen_images.py
+++ b/api/tests/test_canteen_images.py
@@ -649,8 +649,9 @@ class CanteenImagesDeleteApiTest(APITestCase):
 
     @authenticate
     def test_cannot_delete_canteen_image_if_image_does_not_exist(self):
-        url = reverse("canteen_images_retrieve_update_destroy", kwargs={"canteen_pk": self.canteen.pk, "pk": 9999})
         self.canteen.managers.add(authenticate.user)
+
+        url = reverse("canteen_images_retrieve_update_destroy", kwargs={"canteen_pk": self.canteen.pk, "pk": 9999})
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/api/tests/test_canteen_images.py
+++ b/api/tests/test_canteen_images.py
@@ -19,26 +19,26 @@ class CanteenLogoUploadApiTest(APITestCase):
         cls.canteen = CanteenFactory()
         cls.url = reverse("canteen_logo", kwargs={"canteen_pk": cls.canteen.pk})
 
-    def test_cannot_upload_canteen_logo_if_unauthenticated(self):
+    def test_cannot_upload_logo_if_unauthenticated(self):
         response = self.client.post(self.url, data={})
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_upload_canteen_logo_if_canteen_does_not_exist(self):
+    def test_cannot_upload_logo_if_canteen_does_not_exist(self):
         url = reverse("canteen_logo", kwargs={"canteen_pk": 9999})
         response = self.client.post(url, data={})
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_upload_canteen_logo_if_not_canteen_manager(self):
+    def test_cannot_upload_logo_if_not_canteen_manager(self):
         response = self.client.post(self.url, data={})
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_upload_canteen_logo(self):
+    def test_can_upload_logo(self):
         self.canteen.managers.add(authenticate.user)
         image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
         image_base_64 = None
@@ -54,7 +54,7 @@ class CanteenLogoUploadApiTest(APITestCase):
         body = response.json()
         self.assertIn("logo", body)
 
-    def test_upload_canteen_logo_via_oauth2(self):
+    def test_can_upload_logo_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
         self.canteen.managers.add(user)
         self.client.credentials(Authorization=f"Bearer {token}")
@@ -73,7 +73,7 @@ class CanteenLogoUploadApiTest(APITestCase):
         self.assertIn("logo", body)
 
     @authenticate
-    def test_upload_canteen_logo_even_if_canteen_not_filled(self):
+    def test_can_upload_logo_even_if_canteen_not_valid(self):
         self.canteen.managers.add(authenticate.user)
         self.canteen.siret = None
         self.canteen.save(skip_validations=True)
@@ -129,26 +129,26 @@ class CanteenLogoRetrieveApiTest(APITestCase):
         cls.canteen = CanteenFactory()
         cls.url = reverse("canteen_logo", kwargs={"canteen_pk": cls.canteen.pk})
 
-    def test_cannot_retrieve_canteen_logo_if_unauthenticated(self):
+    def test_cannot_retrieve_logo_if_unauthenticated(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_retrieve_canteen_logo_if_canteen_does_not_exist(self):
+    def test_cannot_retrieve_logo_if_canteen_does_not_exist(self):
         url = reverse("canteen_logo", kwargs={"canteen_pk": 9999})
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_retrieve_canteen_logo_if_not_canteen_manager(self):
+    def test_cannot_retrieve_logo_if_not_canteen_manager(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_retrieve_canteen_logo(self):
+    def test_can_retrieve_logo(self):
         self.canteen.managers.add(authenticate.user)
 
         # First upload a logo
@@ -168,7 +168,7 @@ class CanteenLogoRetrieveApiTest(APITestCase):
         body = response.json()
         self.assertIn("logo", body)
 
-    def test_retrieve_canteen_logo_via_oauth2(self):
+    def test_can_retrieve_logo_via_oauth2(self):
         user, token = get_oauth2_token("canteen:read")
         self.canteen.managers.add(user)
         self.client.credentials(Authorization=f"Bearer {token}")
@@ -198,7 +198,7 @@ class CanteenLogoUpdateApiTest(APITestCase):
         cls.url = reverse("canteen_logo", kwargs={"canteen_pk": cls.canteen.pk})
 
     @authenticate
-    def test_cannot_update_canteen_logo_with_patch(self):
+    def test_cannot_update_logo_with_patch(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.patch(self.url, data={}, format="json")
@@ -206,7 +206,7 @@ class CanteenLogoUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     @authenticate
-    def test_cannot_update_canteen_logo_with_put(self):
+    def test_cannot_update_logo_with_put(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.put(self.url, data={}, format="json")
@@ -220,26 +220,26 @@ class CanteenLogoDeleteApiTest(APITestCase):
         cls.canteen = CanteenFactory()
         cls.url = reverse("canteen_logo", kwargs={"canteen_pk": cls.canteen.pk})
 
-    def test_cannot_delete_canteen_logo_if_unauthenticated(self):
+    def test_cannot_delete_logo_if_unauthenticated(self):
         response = self.client.delete(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_delete_canteen_logo_if_canteen_does_not_exist(self):
+    def test_cannot_delete_logo_if_canteen_does_not_exist(self):
         url = reverse("canteen_logo", kwargs={"canteen_pk": 9999})
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_delete_canteen_logo_if_not_canteen_manager(self):
+    def test_cannot_delete_logo_if_not_canteen_manager(self):
         response = self.client.delete(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_delete_canteen_logo(self):
+    def test_can_delete_logo(self):
         self.canteen.managers.add(authenticate.user)
 
         # First upload a logo
@@ -257,7 +257,7 @@ class CanteenLogoDeleteApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-    def test_delete_canteen_logo_via_oauth2(self):
+    def test_can_delete_logo_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
         self.canteen.managers.add(user)
         self.client.credentials(Authorization=f"Bearer {token}")
@@ -278,7 +278,7 @@ class CanteenLogoDeleteApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     @authenticate
-    def test_delete_canteen_logo_even_if_canteen_not_filled(self):
+    def test_can_delete_logo_even_if_canteen_not_valid(self):
         self.canteen.managers.add(authenticate.user)
         self.canteen.siret = None
         self.canteen.save(skip_validations=True)
@@ -339,7 +339,7 @@ class CanteenImagesListApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_get_canteen_images(self):
+    def test_can_get_canteen_images(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.get(self.url)
@@ -352,7 +352,7 @@ class CanteenImagesListApiTest(APITestCase):
             self.assertIn("image", item)
             self.assertIn("altText", item)
 
-    def test_get_canteen_images_via_oauth2(self):
+    def test_can_get_canteen_images_via_oauth2(self):
         user, token = get_oauth2_token("canteen:read")
         self.canteen.managers.add(user)
         self.client.credentials(Authorization=f"Bearer {token}")
@@ -404,7 +404,7 @@ class CanteenImagesDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_get_canteen_image_detail(self):
+    def test_can_get_canteen_image(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.get(self.url)
@@ -415,7 +415,7 @@ class CanteenImagesDetailApiTest(APITestCase):
         self.assertIn("image", body)
         self.assertIn("altText", body)
 
-    def test_get_canteen_image_detail_via_oauth2(self):
+    def test_can_get_canteen_image_via_oauth2(self):
         user, token = get_oauth2_token("canteen:read")
         self.canteen.managers.add(user)
         self.client.credentials(Authorization=f"Bearer {token}")
@@ -454,7 +454,7 @@ class CanteenImagesCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_create_canteen_image(self):
+    def test_can_create_canteen_image(self):
         self.canteen.managers.add(authenticate.user)
         image_path = os.path.join(CURRENT_DIR, "files/test-image-1.jpg")
         image_base_64 = None
@@ -473,7 +473,7 @@ class CanteenImagesCreateApiTest(APITestCase):
         self.assertIn("altText", body)
         self.assertIsNone(body["altText"])
 
-    def test_create_canteen_image_via_oauth2(self):
+    def test_can_create_canteen_image_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
         self.canteen.managers.add(user)
         self.client.credentials(Authorization=f"Bearer {token}")
@@ -496,7 +496,7 @@ class CanteenImagesCreateApiTest(APITestCase):
         self.assertEqual(body["altText"], "Test image 1")
 
     @authenticate
-    def test_create_canteen_image_even_if_canteen_not_filled(self):
+    def test_can_create_canteen_image_even_if_canteen_not_valid(self):
         self.canteen.managers.add(authenticate.user)
         self.canteen.siret = None
         self.canteen.save(skip_validations=True)
@@ -556,7 +556,7 @@ class CanteenImagesUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_update_canteen_image(self):
+    def test_can_update_canteen_image(self):
         self.canteen.managers.add(authenticate.user)
         self.assertEqual(self.canteen.images.first().alt_text, None)
 
@@ -572,7 +572,7 @@ class CanteenImagesUpdateApiTest(APITestCase):
         self.assertIn("altText", body)
         self.assertEqual(body["altText"], "Updated alt text")
 
-    def test_update_canteen_image_via_oauth2(self):
+    def test_can_update_canteen_image_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
         self.canteen.managers.add(user)
         self.client.credentials(Authorization=f"Bearer {token}")
@@ -591,7 +591,7 @@ class CanteenImagesUpdateApiTest(APITestCase):
         self.assertEqual(body["altText"], "Updated alt text via OAuth2")
 
     @authenticate
-    def test_update_canteen_image_even_if_canteen_not_filled(self):
+    def test_can_update_canteen_image_even_if_canteen_not_valid(self):
         self.canteen.managers.add(authenticate.user)
         self.canteen.siret = None
         self.canteen.save(skip_validations=True)
@@ -656,13 +656,13 @@ class CanteenImagesDeleteApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_delete_canteen_image(self):
+    def test_can_delete_canteen_image(self):
         self.canteen.managers.add(authenticate.user)
         response = self.client.delete(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-    def test_delete_canteen_image_via_oauth2(self):
+    def test_can_delete_canteen_image_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
         self.canteen.managers.add(user)
         self.client.credentials(Authorization=f"Bearer {token}")
@@ -671,7 +671,7 @@ class CanteenImagesDeleteApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     @authenticate
-    def test_delete_canteen_image_even_if_canteen_not_filled(self):
+    def test_can_delete_canteen_image_even_if_canteen_not_valid(self):
         self.canteen.managers.add(authenticate.user)
         self.canteen.siret = None
         self.canteen.save(skip_validations=True)

--- a/api/tests/test_canteen_managers.py
+++ b/api/tests/test_canteen_managers.py
@@ -124,11 +124,12 @@ class CanteenManagersInvitationsListApiTest(APITestCase):
 
 class CanteenClaimApiTest(APITestCase):
     @authenticate
-    def test_canteen_claim_request(self):
+    def test_can_claim_canteen(self):
         canteen = CanteenFactory()
         canteen.managers.clear()
 
         response = self.client.post(reverse("claim_canteen", kwargs={"canteen_pk": canteen.id}), None)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["id"], canteen.id)
@@ -141,16 +142,16 @@ class CanteenClaimApiTest(APITestCase):
         self.assertTrue(canteen.has_been_claimed)
 
     @authenticate
-    def test_canteen_not_filled_can_be_claimed(self):
+    def test_can_claim_canteen_not_valid(self):
         canteen = CanteenFactory()
         canteen.managers.clear()
         canteen.siret = None
         canteen.save(skip_validations=True)
-
         self.assertIsNone(canteen.siret)
         self.assertFalse(canteen.is_filled)
 
         response = self.client.post(reverse("claim_canteen", kwargs={"canteen_pk": canteen.id}), None)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["id"], canteen.id)
@@ -163,7 +164,7 @@ class CanteenClaimApiTest(APITestCase):
         self.assertTrue(canteen.has_been_claimed)
 
     @authenticate
-    def test_canteen_claim_request_fails_when_already_claimed(self):
+    def test_cannot_claim_canteen_already_claimed(self):
         canteen = CanteenFactory()
         self.assertGreater(canteen.managers.count(), 0)
         user = authenticate.user
@@ -176,7 +177,7 @@ class CanteenClaimApiTest(APITestCase):
         self.assertFalse(canteen.has_been_claimed)
 
     @authenticate
-    def test_undo_claim_canteen(self):
+    def test_can_undo_claim_canteen(self):
         canteen = CanteenFactory(claimed_by=authenticate.user, has_been_claimed=True, managers=[authenticate.user])
 
         response = self.client.post(reverse("undo_claim_canteen", kwargs={"canteen_pk": canteen.id}), None)
@@ -187,7 +188,7 @@ class CanteenClaimApiTest(APITestCase):
         self.assertFalse(canteen.has_been_claimed)
 
     @authenticate
-    def test_undo_claim_for_canteen_not_filled(self):
+    def test_can_undo_claim_for_canteen_not_valid(self):
         canteen = CanteenFactory(claimed_by=authenticate.user, has_been_claimed=True, managers=[authenticate.user])
         canteen.siret = None
         canteen.save(skip_validations=True)
@@ -203,7 +204,7 @@ class CanteenClaimApiTest(APITestCase):
         self.assertFalse(canteen.has_been_claimed)
 
     @authenticate
-    def test_undo_claim_canteen_fails_if_not_original_claimer(self):
+    def test_cannot_undo_claim_canteen_if_not_original_claimer(self):
         other_user = UserFactory()
         canteen = CanteenFactory(claimed_by=other_user, has_been_claimed=True, managers=[authenticate.user])
 
@@ -216,46 +217,30 @@ class CanteenClaimApiTest(APITestCase):
 
 
 class CanteenManagerInvitationApiTest(APITestCase):
-    def test_unauthenticated_add_manager_call(self):
-        """
-        When calling this API unauthenticated we expect a 403
-        """
+    def test_cannot_add_manager_if_unauthenticated(self):
         response = self.client.post(reverse("add_manager"), {"canteenId": 999})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_unauthenticated_remove_manager_call(self):
-        """
-        When calling this API unauthenticated we expect a 403
-        """
+    def test_cannot_remove_manager_if_unauthenticated(self):
         response = self.client.post(reverse("remove_manager"), {"canteenId": 999})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_add_manager_missing_canteen(self):
-        """
-        When calling this API on a nonexistent canteen we expect a 404
-        """
-        payload = {"canteenId": 999, "email": "test@example.com"}
+    def test_cannot_add_manager_if_canteen_does_not_exist(self):
+        payload = {"canteenId": 9999, "email": "test@example.com"}
         response = self.client.post(reverse("add_manager"), payload)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         with self.assertRaises(ManagerInvitation.DoesNotExist):
-            ManagerInvitation.objects.get(canteen__id=999)
+            ManagerInvitation.objects.get(canteen__id=9999)
 
     @authenticate
-    def test_remove_manager_missing_canteen(self):
-        """
-        When calling this API on a nonexistent canteen we expect a 404
-        """
-        payload = {"canteenId": 999, "email": "test@example.com"}
+    def test_cannot_remove_manager_if_canteen_does_not_exist(self):
+        payload = {"canteenId": 9999, "email": "test@example.com"}
         response = self.client.post(reverse("remove_manager"), payload)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_add_manager_forbidden_canteen(self):
-        """
-        When calling this API on a canteen that the user doesn't manage,
-        we expect a 404
-        """
+    def test_cannot_add_manager_if_not_canteen_manager(self):
         canteen = CanteenFactory()
         payload = {"canteenId": canteen.id, "email": "test@example.com"}
         response = self.client.post(reverse("add_manager"), payload)
@@ -264,11 +249,7 @@ class CanteenManagerInvitationApiTest(APITestCase):
             ManagerInvitation.objects.get(canteen__id=canteen.id)
 
     @authenticate
-    def test_remove_manager_forbidden_canteen(self):
-        """
-        When calling this API on a canteen that the user doesn't manage,
-        we expect a 404
-        """
+    def test_cannot_remove_manager_if_not_canteen_manager(self):
         canteen = CanteenFactory()
         payload = {"canteenId": canteen.id, "email": "test@example.com"}
         response = self.client.post(reverse("remove_manager"), payload)

--- a/api/tests/test_canteen_managers.py
+++ b/api/tests/test_canteen_managers.py
@@ -22,7 +22,7 @@ class CanteenManagersListApiTest(APITestCase):
 
     @authenticate
     def test_cannot_get_canteen_managers_if_canteen_does_not_exist(self):
-        url = reverse("canteen_managers_list", kwargs={"canteen_pk": 999})
+        url = reverse("canteen_managers_list", kwargs={"canteen_pk": 9999})
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -76,7 +76,7 @@ class CanteenManagersInvitationsListApiTest(APITestCase):
 
     @authenticate
     def test_cannot_get_canteen_managers_invitations_if_canteen_does_not_exist(self):
-        url = reverse("canteen_managers_invitations_list", kwargs={"canteen_pk": 999})
+        url = reverse("canteen_managers_invitations_list", kwargs={"canteen_pk": 9999})
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/api/tests/test_canteen_managers.py
+++ b/api/tests/test_canteen_managers.py
@@ -15,7 +15,7 @@ class CanteenManagersListApiTest(APITestCase):
         cls.canteen = CanteenFactory(managers=[])
         cls.url = reverse("canteen_managers_list", kwargs={"canteen_pk": cls.canteen.id})
 
-    def test_cannot_get_canteen_managers_unauthenticated(self):
+    def test_cannot_get_canteen_managers_if_unauthenticated(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -69,7 +69,7 @@ class CanteenManagersInvitationsListApiTest(APITestCase):
         cls.canteen = CanteenFactory(managers=[])
         cls.url = reverse("canteen_managers_invitations_list", kwargs={"canteen_pk": cls.canteen.id})
 
-    def test_cannot_get_canteen_managers_invitations_unauthenticated(self):
+    def test_cannot_get_canteen_managers_invitations_if_unauthenticated(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -88,7 +88,7 @@ class CanteenManagersInvitationsListApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_canteen_managers_invitations_list(self):
+    def test_can_get_canteen_managers_invitations(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.get(self.url)
@@ -108,7 +108,7 @@ class CanteenManagersInvitationsListApiTest(APITestCase):
         self.assertEqual(len(body), 1)
         self.assertEqual(body[0]["email"], "new.USER@example.com")
 
-    def test_canteen_managers_invitations_list_via_oauth2(self):
+    def test_can_get_canteen_managers_invitations_via_oauth2(self):
         user, token = get_oauth2_token("canteen:read")
         self.canteen.managers.add(user)
         ManagerInvitationFactory(canteen=self.canteen, email="new.USER@example.com")
@@ -257,7 +257,7 @@ class CanteenManagerInvitationApiTest(APITestCase):
 
     @authenticate
     @override_settings(DEFAULT_FROM_EMAIL="test-from@example.com")
-    def test_authenticated_create_manager_invitation(self):
+    def test_can_create_manager_invitation(self):
         """
         When calling this API authenticated we expect to save the
         an unassociated email in the invitations table with the canteen id
@@ -281,7 +281,7 @@ class CanteenManagerInvitationApiTest(APITestCase):
         self.assertEqual(body["managerInvitations"][0]["email"], "test@example.com")
 
     @authenticate
-    def test_authenticated_create_duplicate_manager_invitation(self):
+    def test_can_create_duplicate_manager_invitation(self):
         """
         If API called twice with the same data, only save once,
         and only send one email
@@ -299,7 +299,7 @@ class CanteenManagerInvitationApiTest(APITestCase):
         self.assertEqual(len(mail.outbox), 1)
 
     @authenticate
-    def test_authenticated_create_multiple_manager_invitation(self):
+    def test_can_create_multiple_manager_invitation(self):
         """
         One email can be associated to more than one canteen,
         one canteen can be associated to more than one email
@@ -329,18 +329,18 @@ class CanteenManagerInvitationApiTest(APITestCase):
 
     @authenticate
     @override_settings(DEFAULT_FROM_EMAIL="test-from@example.com")
-    def test_authenticated_add_manager_existing_user(self):
+    def test_can_add_manager_existing_user(self):
         """
         If the email matches an existing user, add the user to the canteen managers
         without going through invitations table. No email sent for now
         """
         canteen = CanteenFactory(managers=[authenticate.user])
         other_user = UserFactory(email="test@example.com")
+
         payload = {"canteenId": canteen.id, "email": other_user.email}
-
         response = self.client.post(reverse("add_manager"), payload)
-        body = response.json()
 
+        body = response.json()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(canteen.managers.all().get(id=other_user.id).id, other_user.id)
         with self.assertRaises(ManagerInvitation.DoesNotExist):
@@ -354,7 +354,7 @@ class CanteenManagerInvitationApiTest(APITestCase):
         self.assertEqual(len(body["managerInvitations"]), canteen.managerinvitation_set.all().count())
 
     @authenticate
-    def test_authenticated_remove_manager(self):
+    def test_can_remove_manager(self):
         """
         It should be possible to remove a given manager from a canteen
         """
@@ -371,7 +371,7 @@ class CanteenManagerInvitationApiTest(APITestCase):
         self.assertEqual(len(body["managers"]), canteen.managers.all().count())
 
     @authenticate
-    def test_authenticated_remove_nonexistent_manager(self):
+    def test_can_remove_nonexistent_manager(self):
         """
         When trying to remove a manager that does not manage a canteen, we will
         respond 200 OK.
@@ -389,7 +389,7 @@ class CanteenManagerInvitationApiTest(APITestCase):
 
     @authenticate
     @override_settings(DEFAULT_FROM_EMAIL="test-from@example.com")
-    def test_authenticated_delete_invitation(self):
+    def test_can_delete_invitation(self):
         """
         We should be able to remove a pending invitation
         """
@@ -408,7 +408,7 @@ class CanteenManagerInvitationApiTest(APITestCase):
 
     @authenticate
     @override_settings(DEFAULT_FROM_EMAIL="test-from@example.com")
-    def test_authenticated_add_manager_email_insensitive(self):
+    def test_can_add_manager_email_insensitive(self):
         """
         If the email does not match an existing user, we try with a case insensitive query
         """
@@ -451,7 +451,7 @@ class CanteenTeamRequestEmailTest(APITestCase):
     @override_settings(CONTACT_EMAIL="contact@example.com")
     @override_settings(HOSTNAME="mysite.com")
     @override_settings(SECURE="True")
-    def test_send_message(self):
+    def test_can_send_message(self):
         canteen = CanteenFactory(
             siret="76494221950672",
             name="Hugo",

--- a/api/tests/test_canteen_ministries.py
+++ b/api/tests/test_canteen_ministries.py
@@ -4,12 +4,13 @@ from rest_framework.test import APITestCase
 
 
 class CanteenMinistriesApiTest(APITestCase):
-    def test_canteen_ministries_list(self):
-        """
-        The API should return all canteen ministries
-        """
-        response = self.client.get(reverse("ministries_list"))
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("ministries_list")
+
+    def test_can_list_canteen_ministries(self):
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-
         self.assertEqual(len(body), 19)

--- a/api/tests/test_canteen_published.py
+++ b/api/tests/test_canteen_published.py
@@ -52,8 +52,7 @@ class CanteenPublishedListApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body.get("count"), 3)
-
-        results = body.get("results", [])
+        results = body["results"]
 
         for published_canteen in published_canteens:
             self.assertTrue(any(x["id"] == published_canteen.id for x in results))
@@ -77,7 +76,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
         response = self.client.get(f"{reverse('published_canteens')}?search={search_term}")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
 
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].get("name"), "Mochi")
@@ -90,7 +90,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
         response = self.client.get(f"{reverse('published_canteens')}?search={search_term}")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
 
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].get("name"), "Wakamé")
@@ -105,7 +106,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
         response = self.client.get(f"{reverse('published_canteens')}?search={search_term}")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
 
         self.assertEqual(len(results), 2)
 
@@ -127,7 +129,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].get("name"), "Shiso")
 
@@ -139,7 +142,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 2)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
@@ -152,7 +156,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 0)
 
         # Filters are inclusive, so a value of 25 brings "Umami"
@@ -162,7 +167,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].get("name"), "Umami")
 
@@ -174,7 +180,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?department=69"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].get("name"), "Shiso")
 
@@ -186,7 +193,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?sector={Sector.EDUCATION_PRIMAIRE}"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 2)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
@@ -194,13 +202,15 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?sector={Sector.ENTERPRISE_ENTREPRISE}"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].get("name"), "Wasabi")
 
         url = f"{reverse('published_canteens')}?sector={Sector.ENTERPRISE_ENTREPRISE}&sector={Sector.SOCIAL_AUTRE}"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 3)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Wasabi", result_names)
@@ -235,7 +245,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 4)
         self.assertEqual(results[0]["name"], "Umami")
         self.assertEqual(results[1]["name"], "Mochi")
@@ -244,7 +255,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?ordering=name"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 4)
         self.assertEqual(results[0]["name"], "Mochi")
         self.assertEqual(results[1]["name"], "Shiso")
@@ -256,7 +268,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?ordering=-modification_date"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 4)
         self.assertEqual(results[0]["name"], "Mochi")
         self.assertEqual(results[1]["name"], "Umami")
@@ -265,7 +278,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?ordering=daily_meal_count"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 4)
         self.assertEqual(results[0]["name"], "Wasabi")
         self.assertEqual(results[1]["name"], "Umami")
@@ -303,7 +317,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?ordering=daily_meal_count"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 4)
         self.assertEqual(results[0]["name"], "Shiso")
         self.assertEqual(results[1]["name"], "Wasabi")
@@ -312,7 +327,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?ordering=-daily_meal_count"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 4)
         self.assertEqual(results[0]["name"], "Umami")
         self.assertEqual(results[1]["name"], "Mochi")
@@ -480,7 +496,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?min_portion_bio={0.2}"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 5)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
@@ -489,7 +506,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?min_portion_combined={0.5}"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 7)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
@@ -500,7 +518,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?min_portion_bio={0.1}&min_portion_combined={0.5}"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 6)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
@@ -510,7 +529,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?badge=appro"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 6)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
@@ -521,7 +541,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
         # if both badge and thresholds specified, return the results that match the most strict threshold
         url = f"{reverse('published_canteens')}?badge=appro&min_portion_combined={0.01}"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 6)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
@@ -531,7 +552,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?badge=appro&min_portion_combined={0.5}"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 5)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Shiso", result_names)
@@ -540,7 +562,8 @@ class CanteenPublishedListFilterApiTest(APITestCase):
 
         url = f"{reverse('published_canteens')}?min_portion_bio={0.001}"
         response = self.client.get(url)
-        results = response.json().get("results", [])
+        body = response.json()
+        results = body["results"]
         self.assertEqual(len(results), 9)
         result_names = list(map(lambda x: x.get("name"), results))
         self.assertIn("Cantine avec bilan mais siret vide", result_names)

--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -154,6 +154,7 @@ class CanteenStatsApiTest(APITestCase):
                 diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
                 year=1990,
             )
+        cls.url = reverse("canteen_statistics")
 
     def setUp(self):
         cache.clear()  # clear cache before each test
@@ -163,7 +164,7 @@ class CanteenStatsApiTest(APITestCase):
         self.assertEqual(Diagnostic.objects.count(), 4)
         self.assertEqual(Diagnostic.objects.teledeclared().count(), 3)
         with self.assertNumQueries(STATS_ENDPOINT_QUERY_COUNT + CACHE_GET_QUERY_COUNT + CACHE_SET_QUERY_COUNT):
-            response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
+            response = self.client.get(self.url, {"year": year_data})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_canteen_count_include_deletion_and_creation_dates(self):
@@ -181,18 +182,18 @@ class CanteenStatsApiTest(APITestCase):
         # - 1 canteen deleted during the campaign
         # - 1 canteen deleted after the campaign
         # - 1 canteen created after the campaign
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
+        response = self.client.get(self.url, {"year": year_data})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 4)  # 5 - 1
 
-        response = self.client.get(reverse("canteen_statistics"), {"year": 2025})
+        response = self.client.get(self.url, {"year": 2025})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 4)  # 5 - 1 - 1 + 1
 
     def test_canteen_statistics(self):
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
+        response = self.client.get(self.url, {"year": year_data})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -251,7 +252,7 @@ class CanteenStatsApiTest(APITestCase):
             )
             canteen_diagnostic.teledeclare(applicant=UserFactory())
 
-        response = self.client.get(reverse("canteen_statistics"), {"year": past_year})
+        response = self.client.get(self.url, {"year": past_year})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -294,7 +295,7 @@ class CanteenStatsApiTest(APITestCase):
             )
             canteen_diagnostic.teledeclare(applicant=UserFactory())
 
-        response = self.client.get(reverse("canteen_statistics"), {"year": past_year})
+        response = self.client.get(self.url, {"year": past_year})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -313,38 +314,38 @@ class CanteenStatsApiTest(APITestCase):
         # Database
         self.assertEqual(Canteen.objects.count(), 6)
         # API endpoint
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
+        response = self.client.get(self.url, {"year": year_data})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 5)  # canteen_old_armee filtered out
 
     def test_filter_by_year(self):
         # without year: 400
-        response = self.client.get(reverse("canteen_statistics"))
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         # year with campaign and report published
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
+        response = self.client.get(self.url, {"year": year_data})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 5)
         self.assertEqual(body["teledeclarationsCount"], 3)
         self.assertFalse("campaignInfo" in body["notes"])
         # year without campaign (past)
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data - 100})
+        response = self.client.get(self.url, {"year": year_data - 100})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 0)
         self.assertEqual(body["teledeclarationsCount"], None)
         self.assertTrue("campaignInfo" in body["notes"])
         # year without campaign (future)
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data + 100})
+        response = self.client.get(self.url, {"year": year_data + 100})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 5)
         self.assertEqual(body["teledeclarationsCount"], None)
         self.assertTrue("campaignInfo" in body["notes"])
         # year with campaign but report not published yet
-        response = self.client.get(reverse("canteen_statistics"), {"year": "2025"})
+        response = self.client.get(self.url, {"year": "2025"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 5)
@@ -352,67 +353,65 @@ class CanteenStatsApiTest(APITestCase):
         self.assertTrue("campaignInfo" in body["notes"])
 
     def test_filter_by_region(self):
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data, "region": ["84"]})
+        response = self.client.get(self.url, {"year": year_data, "region": ["84"]})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 3)
         self.assertEqual(body["teledeclarationsCount"], 3)
 
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data, "region": ["84", "32"]})
+        response = self.client.get(self.url, {"year": year_data, "region": ["84", "32"]})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 3 + 1)
         self.assertEqual(body["teledeclarationsCount"], 3 + 0)
 
     def test_filter_by_department(self):
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data, "department": ["01"]})
+        response = self.client.get(self.url, {"year": year_data, "department": ["01"]})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 1)
         self.assertEqual(body["teledeclarationsCount"], 1)
 
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data, "department": ["01", "38"]})
+        response = self.client.get(self.url, {"year": year_data, "department": ["01", "38"]})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 1 + 1)
         self.assertEqual(body["teledeclarationsCount"], 1 + 1)
 
     def test_filter_by_epci(self):
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data, "epci": ["243400017"]})
+        response = self.client.get(self.url, {"year": year_data, "epci": ["243400017"]})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 2)
         self.assertEqual(body["teledeclarationsCount"], 2)
 
-        response = self.client.get(
-            reverse("canteen_statistics"), {"year": year_data, "epci": ["243400017", "200040715"]}
-        )
+        response = self.client.get(self.url, {"year": year_data, "epci": ["243400017", "200040715"]})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 2 + 1)
         self.assertEqual(body["teledeclarationsCount"], 2 + 1)
 
     def test_filter_by_pat(self):
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data, "pat": ["1"]})
+        response = self.client.get(self.url, {"year": year_data, "pat": ["1"]})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 2)
         self.assertEqual(body["teledeclarationsCount"], 2)
 
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data, "pat": ["1", "2"]})
+        response = self.client.get(self.url, {"year": year_data, "pat": ["1", "2"]})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 2 + 1)
         self.assertEqual(body["teledeclarationsCount"], 2 + 1)
 
     def test_filter_by_city(self):
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data, "city": ["01034"]})
+        response = self.client.get(self.url, {"year": year_data, "city": ["01034"]})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 1)
         self.assertEqual(body["teledeclarationsCount"], 1)
 
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data, "city": ["01034", "38185"]})
+        response = self.client.get(self.url, {"year": year_data, "city": ["01034", "38185"]})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 1 + 1)
@@ -420,7 +419,7 @@ class CanteenStatsApiTest(APITestCase):
 
     def test_filter_by_sectors(self):
         response = self.client.get(
-            reverse("canteen_statistics"),
+            self.url,
             {"year": year_data, "sector": [Sector.EDUCATION_PRIMAIRE, Sector.ENTERPRISE_ENTREPRISE]},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -434,7 +433,7 @@ class CanteenStatsApiTest(APITestCase):
 
     def test_filter_by_management_type(self):
         response = self.client.get(
-            reverse("canteen_statistics"),
+            self.url,
             {
                 "year": year_data,
                 "management_type": [Canteen.ManagementType.DIRECT],
@@ -451,7 +450,7 @@ class CanteenStatsApiTest(APITestCase):
 
     def test_filter_by_production_type(self):
         response = self.client.get(
-            reverse("canteen_statistics"),
+            self.url,
             {
                 "year": year_data,
                 "production_type": [Canteen.ProductionType.CENTRAL, Canteen.ProductionType.CENTRAL_SERVING],
@@ -470,7 +469,7 @@ class CanteenStatsApiTest(APITestCase):
 
     def test_filter_by_economic_model(self):
         response = self.client.get(
-            reverse("canteen_statistics"),
+            self.url,
             {
                 "year": year_data,
                 "economic_model": [Canteen.EconomicModel.PUBLIC],
@@ -486,7 +485,7 @@ class CanteenStatsApiTest(APITestCase):
         self.assertEqual(economic_models["inconnu"], 0)
 
     def test_notes(self):
-        response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
+        response = self.client.get(self.url, {"year": year_data})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["canteenCount"], 5)
@@ -496,34 +495,34 @@ class CanteenStatsApiTest(APITestCase):
 
     def test_notes_canteen_count_description_during_campaign(self):
         with freeze_time(date_in_2023_teledeclaration_campaign):
-            response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
+            response = self.client.get(self.url, {"year": year_data})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             body = response.json()
             self.assertEqual(body["notes"]["canteenCountDescription"], "Au 11 juin 2024")  # end of campaign
 
     def test_notes_canteen_count_description_after_campaign(self):
         with freeze_time("2024-11-01"):
-            response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
+            response = self.client.get(self.url, {"year": year_data})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             body = response.json()
             self.assertEqual(body["notes"]["canteenCountDescription"], "Au 11 juin 2024")
 
     def test_notes_canteen_count_description_campaign_not_found(self):
         with freeze_time(date_in_2023_teledeclaration_campaign):
-            response = self.client.get(reverse("canteen_statistics"), {"year": 9999})
+            response = self.client.get(self.url, {"year": 9999})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             body = response.json()
             self.assertEqual(body["notes"]["canteenCountDescription"], "Au 1 avril 2024")
 
     def test_notes_alert(self):
-        response_2023 = self.client.get(reverse("canteen_statistics"), {"year": year_data})
+        response_2023 = self.client.get(self.url, {"year": year_data})
         self.assertEqual(response_2023.status_code, status.HTTP_200_OK)
         body_2023 = response_2023.json()
         self.assertEqual(
             body_2023["notes"]["alert"]["title"],
             "Les chiffres indiqués sont légèrement inexacts en raison de l’évolution récente de la plateforme ma cantine.",
         )  # en 2023
-        response_2024 = self.client.get(reverse("canteen_statistics"), {"year": 2024})
+        response_2024 = self.client.get(self.url, {"year": 2024})
         self.assertEqual(response_2024.status_code, status.HTTP_200_OK)
         body_2024 = response_2024.json()
         self.assertNotIn("alert", body_2024["notes"])
@@ -532,27 +531,27 @@ class CanteenStatsApiTest(APITestCase):
         # first time: no cache
         self.assertEqual(Canteen.objects.count(), 6)
         with self.assertNumQueries(STATS_ENDPOINT_QUERY_COUNT + CACHE_GET_QUERY_COUNT + CACHE_SET_QUERY_COUNT):
-            response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
+            response = self.client.get(self.url, {"year": year_data})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         # second time: cache hit
         with self.assertNumQueries(0 + CACHE_GET_QUERY_COUNT):
-            response = self.client.get(reverse("canteen_statistics"), {"year": year_data})
+            response = self.client.get(self.url, {"year": year_data})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         # another year: no cache
         with self.assertNumQueries(STATS_ENDPOINT_QUERY_COUNT + CACHE_GET_QUERY_COUNT + CACHE_SET_QUERY_COUNT):
-            response = self.client.get(reverse("canteen_statistics"), {"year": year_data - 1})
+            response = self.client.get(self.url, {"year": year_data - 1})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         # another year again: cache hit
         with self.assertNumQueries(0 + CACHE_GET_QUERY_COUNT):
-            response = self.client.get(reverse("canteen_statistics"), {"year": year_data - 1})
+            response = self.client.get(self.url, {"year": year_data - 1})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         # same year, but with extra filters: no cache
         with self.assertNumQueries(STATS_ENDPOINT_QUERY_COUNT):
-            response = self.client.get(reverse("canteen_statistics"), {"year": year_data, "region": "84"})
+            response = self.client.get(self.url, {"year": year_data, "region": "84"})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         # same year, but with extra filters: still no cache
         with self.assertNumQueries(STATS_ENDPOINT_QUERY_COUNT):
-            response = self.client.get(reverse("canteen_statistics"), {"year": year_data, "region": "84"})
+            response = self.client.get(self.url, {"year": year_data, "region": "84"})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
@@ -560,10 +559,10 @@ class CanteenStats1Td1SiteApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         ETLCommonSetUpTestData(cls, with_diagnostics=True)
-
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
         call_command("teledeclaration_generate_1td1site", year=2023, apply=True)
+        cls.url = reverse("canteen_statistics")
 
     def test_user_1td1site_diagnostics_for_2025(self):
         """
@@ -572,7 +571,8 @@ class CanteenStats1Td1SiteApiTest(APITestCase):
         self.assertEqual(Diagnostic.objects.teledeclared_for_year(2025).count(), 1)
         self.assertEqual(Diagnostic.all_objects.teledeclared_for_year(2025).count(), 1 + 1)
 
-        response = self.client.get(reverse("canteen_statistics"), {"year": 2025})
+        payload = {"year": 2025}
+        response = self.client.get(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -586,7 +586,8 @@ class CanteenStats1Td1SiteApiTest(APITestCase):
         self.assertEqual(Diagnostic.objects.teledeclared_for_year(2024).count(), 3)
         self.assertEqual(Diagnostic.all_objects.teledeclared_for_year(2024).count(), 3 + 1)
 
-        response = self.client.get(reverse("canteen_statistics"), {"year": 2024})
+        payload = {"year": 2024}
+        response = self.client.get(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -600,7 +601,8 @@ class CanteenStats1Td1SiteApiTest(APITestCase):
         self.assertEqual(Diagnostic.objects.teledeclared_for_year(2023).count(), 2)
         self.assertEqual(Diagnostic.all_objects.teledeclared_for_year(2023).count(), 2 + 1)
 
-        response = self.client.get(reverse("canteen_statistics"), {"year": 2023})
+        payload = {"year": 2023}
+        response = self.client.get(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()

--- a/api/tests/test_canteen_territory.py
+++ b/api/tests/test_canteen_territory.py
@@ -7,56 +7,47 @@ from data.factories import CanteenFactory
 
 
 class CanteenTerritoryApiTest(APITestCase):
-    @authenticate
-    def test_territory_canteens_list(self):
-        """
-        Elected profiles should get information on canteens in their
-        geographical area even if they are not the managers
-        """
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("territory_canteens")
 
+    @authenticate
+    def test_can_get_territory_canteens_if_elected_official(self):
         # Set an elected profile
         user = authenticate.user
         user.is_elected_official = True
         user.departments = ["01", "02"]
         user.save()
 
-        # Create canteens
+        # Create canteens (not manager)
         canteen_01 = CanteenFactory(department="01")
         canteen_02 = CanteenFactory(department="02")
         out_of_place_canteen = CanteenFactory(department="03")
 
-        # Make request
-        response = self.client.get(reverse("territory_canteens"))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()["results"]
+        response = self.client.get(self.url)
 
-        self.assertEqual(len(body), 2)
-        ids = list(map(lambda x: x["id"], body))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 2)
+        ids = list(map(lambda x: x["id"], results))
 
         self.assertIn(canteen_01.id, ids)
         self.assertIn(canteen_02.id, ids)
         self.assertNotIn(out_of_place_canteen.id, ids)
 
     @authenticate
-    def test_not_elected_official_territory_canteens_list(self):
-        """
-        Profiles not enabled as "elected" should not get information on
-        canteens via the territory_canteens API endpoint
-        """
-
-        # Set an elected profile
+    def test_cannot_get_territory_canteens_if_not_elected_official(self):
+        # Set a non-elected profile
         user = authenticate.user
         user.is_elected_official = False
         user.save()
 
-        # Make request
-        response = self.client.get(reverse("territory_canteens"))
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_unauthenticated_territory_canteens_list(self):
-        """
-        Profiles not authenticated should not be able to use the endpoint
-        territory_canteens
-        """
-        response = self.client.get(reverse("territory_canteens"))
+    def test_cannot_get_territory_canteens_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -33,20 +33,12 @@ CANTEEN_SITE_DEFAULT_PAYLOAD = {
 
 
 class CanteenListApiTest(APITestCase):
-    def test_cannot_get_user_canteens_unauthenticated(self):
+    def test_cannot_get_user_canteens_if_unauthenticated(self):
         response = self.client.get(reverse("user_canteens"))
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_cannot_get_canteens_with_wrong_oauth2_token(self):
-        _, token = get_oauth2_token("user:read")
-        self.client.credentials(Authorization=f"Bearer {token}")
-
-        response = self.client.get(reverse("user_canteens"))
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_get_canteens_via_oauth2(self):
+    def test_can_get_canteens_via_oauth2(self):
         user, token = get_oauth2_token("canteen:read")
         canteen = CanteenFactory(managers=[user])
 
@@ -59,7 +51,7 @@ class CanteenListApiTest(APITestCase):
         self.assertEqual(body["results"][0]["id"], canteen.id)
 
     @authenticate
-    def test_get_user_canteens(self):
+    def test_can_get_user_canteens(self):
         """
         Users can have access to the full representation of their
         canteens (even if they are not published). This endpoint
@@ -92,7 +84,7 @@ class CanteenListApiTest(APITestCase):
             self.assertFalse(any(x["id"] == other_canteen.id for x in body))
 
     @authenticate
-    def test_get_canteens_without_tracking_info(self):
+    def test_can_get_canteens_without_tracking_info(self):
         """
         Full representation should not contain the tracking info
         """
@@ -114,7 +106,7 @@ class CanteenListApiTest(APITestCase):
 
 class CanteenListFilterApiTest(APITestCase):
     @authenticate
-    def test_get_canteens_filter_production_type(self):
+    def test_can_get_canteens_filter_production_type(self):
         CanteenFactory(production_type="site", managers=[authenticate.user])
         user_central_cuisine = CanteenFactory(production_type="central", managers=[authenticate.user])
         user_central_serving_cuisine = CanteenFactory(production_type="central_serving", managers=[authenticate.user])
@@ -131,7 +123,7 @@ class CanteenListFilterApiTest(APITestCase):
 
 class CanteenListPreviewApiTest(APITestCase):
     @authenticate
-    def test_get_canteens_preview(self):
+    def test_can_get_canteens_preview(self):
         """
         Users can have access to the preview of their
         canteens (even if they are not published).
@@ -153,16 +145,7 @@ class CanteenListPreviewApiTest(APITestCase):
         self.assertEqual(body[0].get("id"), user_canteens[1].id)
         self.assertEqual(body[1].get("id"), user_canteens[0].id)
 
-    def test_cannot_get_canteen_preview_with_wrong_oauth2_token(self):
-        user, token = get_oauth2_token("user:read")
-        CanteenFactory(managers=[user])
-
-        self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.get(reverse("user_canteen_previews"))
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_canteen_preview_via_oauth2(self):
+    def test_can_get_canteen_preview_via_oauth2(self):
         user, token = get_oauth2_token("canteen:read")
         canteen = CanteenFactory(managers=[user])
 
@@ -176,49 +159,43 @@ class CanteenListPreviewApiTest(APITestCase):
 
 
 class CanteenDetailApiTest(APITestCase):
-    def test_cannot_get_single_user_canteen_unauthorized(self):
-        canteen = CanteenFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.url = reverse("single_canteen", kwargs={"pk": cls.canteen.id})
 
-        response = self.client.get(reverse("single_canteen", kwargs={"pk": canteen.id}))
+    def test_cannot_get_single_user_canteen_if_unauthorized(self):
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_get_single_user_canteen_does_not_exist(self):
+    def test_cannot_get_single_user_canteen_if_canteen_does_not_exist(self):
         response = self.client.get(reverse("single_canteen", kwargs={"pk": 9999}))
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_cannot_get_single_user_canteen_if_not_canteen_manager(self):
-        canteen = CanteenFactory()
-
-        response = self.client.get(reverse("single_canteen", kwargs={"pk": canteen.id}))
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_get_single_user_canteen(self):
-        """
-        Users can access the full representation of a single
-        canteen as long as they manage it.
-        """
-        user_canteen = CanteenFactory(managers=[authenticate.user])
+    def test_can_get_single_user_canteen(self):
+        self.canteen.managers.add(authenticate.user)
 
-        response = self.client.get(reverse("single_canteen", kwargs={"pk": user_canteen.id}))
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(body["id"], user_canteen.id)
+        self.assertEqual(body["id"], self.canteen.id)
         self.assertEqual(body["managers"][0]["email"], authenticate.user.email)
         self.assertNotIn("creationUser", body)
         self.assertNotIn("creationSource", body)
 
     @authenticate
-    def test_get_single_user_canteen_groupe(self):
-        """
-        The full representation of a canteen contains the groupe info
-        """
+    def test_can_get_single_user_canteen_groupe(self):
         canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
         user_canteen = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe, managers=[authenticate.user]
@@ -245,7 +222,7 @@ class CanteenDetailApiTest(APITestCase):
         self.assertEqual(body["satellitesCount"], 1)
 
     @authenticate
-    def test_get_numeric_appro_values(self):
+    def test_can_get_numeric_appro_values(self):
         """
         The endpoint for canteen managers should return the economic data of the appro
         values - as opposed to the published endpoint which returns percentage values
@@ -273,7 +250,7 @@ class CanteenDetailApiTest(APITestCase):
         self.assertEqual(serialized_diag["totalLeftovers"], 1234.56)
 
     @authenticate
-    def test_get_canteen_without_tracking(self):
+    def test_can_get_canteen_without_tracking(self):
         """
         Full representation should not contain the tracking info
         """
@@ -293,7 +270,7 @@ class CanteenDetailApiTest(APITestCase):
         self.assertNotIn("mtm_medium_value", body)
 
     @authenticate
-    def test_user_canteen_teledeclaration(self):
+    def test_can_get_user_canteen_teledeclaration(self):
         """
         Only submitted TDs are returned to the managers
         """
@@ -321,7 +298,7 @@ class CanteenDetailApiTest(APITestCase):
         self.assertIsNone(json_diagnostic["teledeclaration"])
 
     @authenticate
-    def test_get_central_kitchen(self):
+    def test_can_get_central_kitchen(self):
         canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
         canteen_satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
@@ -338,7 +315,7 @@ class CanteenDetailApiTest(APITestCase):
 
     @authenticate
     @freeze_time("2024-01-20")
-    def test_canteen_badges(self):
+    def test_can_get_canteen_badges(self):
         """
         The full representation of a canteen contains the badges earned for last year
         A badge can be True, False, or None. None = !True and the tunnel wasn't started,
@@ -373,7 +350,7 @@ class CanteenDetailApiTest(APITestCase):
 
     @authenticate
     @freeze_time("2024-01-20")
-    def test_canteen_badges_vegetarian_diversification_plan_rule(self):
+    def test_can_get_canteen_badges_vegetarian_diversification_plan_rule(self):
         canteen_199_daily_meals = CanteenFactory(managers=[authenticate.user], daily_meal_count=199)
         DiagnosticFactory(
             canteen=canteen_199_daily_meals,
@@ -474,7 +451,7 @@ class CanteenDetailCheckApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_get_canteen_check(self):
+    def test_can_get_canteen_check(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.get(self.url)
@@ -497,7 +474,7 @@ class CanteenDetailCheckApiTest(APITestCase):
         self.assertEqual(body["errors"], {})
 
     @authenticate
-    def test_get_canteen_check_with_errors(self):
+    def test_can_get_canteen_check_with_errors(self):
         self.canteen.managers.add(authenticate.user)
         self.canteen.siret = "invalid_siret"
         self.canteen.sector_list = []
@@ -537,7 +514,7 @@ class CanteenCreateApiTest(APITestCase):
 
     @requests_mock.Mocker()
     @authenticate
-    def test_create_canteen(self, mock):
+    def test_can_create_canteen(self, mock):
         mock_fetch_geo_data_from_siret(mock, siret="92341284500011", success=True)
         mock_fetch_communes(mock)
         mock_fetch_epcis(mock)
@@ -561,7 +538,7 @@ class CanteenCreateApiTest(APITestCase):
         self.assertEqual(canteen_history.history_source_api_oauth2_application, None)
 
     @requests_mock.Mocker()
-    def test_create_canteen_via_oauth2(self, mock):
+    def test_can_create_canteen_via_oauth2(self, mock):
         mock_fetch_geo_data_from_siret(mock, siret="92341284500011", success=True)
         mock_fetch_communes(mock)
         mock_fetch_epcis(mock)
@@ -589,7 +566,7 @@ class CanteenCreateApiTest(APITestCase):
 
     @requests_mock.Mocker()
     @authenticate
-    def test_create_canteen_creation_user_and_source(self, mock):
+    def test_can_create_canteen_creation_user_and_source(self, mock):
         mock_fetch_geo_data_from_siret(mock, siret="92341284500011", success=True)
         mock_fetch_communes(mock)
         mock_fetch_epcis(mock)
@@ -636,7 +613,7 @@ class CanteenCreateApiTest(APITestCase):
 
     @requests_mock.Mocker()
     @authenticate
-    def test_create_canteen_with_tracking_info(self, mock):
+    def test_can_create_canteen_with_tracking_info(self, mock):
         """
         The app should store the mtm parameters on creation
         """
@@ -740,7 +717,7 @@ class CanteenCreateApiTest(APITestCase):
 
     @requests_mock.Mocker()
     @authenticate
-    def test_create_canteen_with_images(self, mock):
+    def test_can_create_canteen_with_images(self, mock):
         """
         The app should create the necessary image models upon the creation of a canteen
         """
@@ -783,7 +760,6 @@ class CanteenUpdateApiTest(APITestCase):
 
     def test_cannot_update_canteen_if_unauthenticated(self):
         payload = {"management_type": Canteen.ManagementType.CONCEDED}
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -791,7 +767,6 @@ class CanteenUpdateApiTest(APITestCase):
     @authenticate
     def test_cannot_update_canteen_with_put(self):
         payload = {"management_type": Canteen.ManagementType.CONCEDED}
-
         response = self.client.put(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
@@ -799,14 +774,13 @@ class CanteenUpdateApiTest(APITestCase):
     @authenticate
     def test_cannot_update_canteen_if_not_canteen_manager(self):
         payload = {"management_type": Canteen.ManagementType.CONCEDED}
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @requests_mock.Mocker()
     @authenticate
-    def test_update_canteen(self, mock):
+    def test_can_update_canteen(self, mock):
         mock_fetch_geo_data_from_siret(mock, siret="21340172201787", success=True)
         mock_fetch_communes(mock)
         mock_fetch_epcis(mock)
@@ -817,13 +791,13 @@ class CanteenUpdateApiTest(APITestCase):
         self.assertEqual(self.canteen.siret, "92341284500011")
         self.assertEqual(self.canteen.city, "Roubaix")
         self.canteen.managers.add(authenticate.user)
+
         payload = {
             "siret": "21340172201787",
             "city": "Montpellier",  # siret changed, geo fields are reset and re-fetched
             "managementType": Canteen.ManagementType.CONCEDED,
             "reservationExpeParticipant": True,
         }
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -834,13 +808,13 @@ class CanteenUpdateApiTest(APITestCase):
         self.assertEqual(self.canteen.reservation_expe_participant, True)
 
     @authenticate
-    def test_update_canteen_production_type(self):
+    def test_can_update_canteen_production_type(self):
         self.assertEqual(self.canteen.production_type, Canteen.ProductionType.ON_SITE)
         self.canteen.managers.add(authenticate.user)
+
         payload = {
             "productionType": Canteen.ProductionType.ON_SITE_CENTRAL,
         }
-
         response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -876,8 +850,8 @@ class CanteenUpdateApiTest(APITestCase):
         canteen_2 = CanteenFactory(siret=siret_2)
         self.assertEqual(self.canteen.siret, "92341284500011")
         self.canteen.managers.add(authenticate.user)
-        payload = {"siret": siret_2}
 
+        payload = {"siret": siret_2}
         response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -899,18 +873,18 @@ class CanteenUpdateApiTest(APITestCase):
         self.assertTrue(body["isManagedByUser"])  # changed
 
     @authenticate
-    def test_update_canteen_with_own_siret(self):
+    def test_can_update_canteen_with_own_siret(self):
         self.assertEqual(self.canteen.siret, "92341284500011")
         self.canteen.managers.add(authenticate.user)
-        payload = {"siret": self.canteen.siret}
 
+        payload = {"siret": self.canteen.siret}
         response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @requests_mock.Mocker()
     @authenticate
-    def test_update_canteen_with_new_siret(self, mock):
+    def test_can_update_canteen_with_new_siret(self, mock):
         mock_fetch_geo_data_from_siret(mock, siret="21340172201787", success=True)
         mock_fetch_communes(mock)
         mock_fetch_epcis(mock)
@@ -921,8 +895,8 @@ class CanteenUpdateApiTest(APITestCase):
         self.assertEqual(self.canteen.city, "Roubaix")
         # self.assertEqual(self.canteen.city_insee_code, "59512")  # ROUBAIX
         self.canteen.managers.add(authenticate.user)
-        payload = {"siret": "21340172201787"}
 
+        payload = {"siret": "21340172201787"}
         response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -937,6 +911,7 @@ class CanteenUpdateApiTest(APITestCase):
         image_base_64 = None
         with open(image_path, "rb") as image:
             image_base_64 = base64.b64encode(image.read()).decode("utf-8")
+
         payload = {
             "images": [
                 {
@@ -944,7 +919,6 @@ class CanteenUpdateApiTest(APITestCase):
                 }
             ]
         }
-
         response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -952,7 +926,7 @@ class CanteenUpdateApiTest(APITestCase):
         self.assertEqual(self.canteen.images.count(), 0)
 
     @authenticate
-    def test_update_canteen_image_if_canteen_manager(self):
+    def test_can_update_canteen_image_if_canteen_manager(self):
         self.canteen.managers.add(authenticate.user)
         self.assertEqual(self.canteen.images.count(), 0)
 
@@ -969,7 +943,6 @@ class CanteenUpdateApiTest(APITestCase):
                 }
             ]
         }
-
         response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -978,7 +951,6 @@ class CanteenUpdateApiTest(APITestCase):
 
         # Delete image
         payload = {"images": []}
-
         response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -986,7 +958,7 @@ class CanteenUpdateApiTest(APITestCase):
         self.assertEqual(self.canteen.images.count(), 0)
 
     @authenticate
-    def test_update_canteen_does_not_update_creation_user_and_source(self):
+    def test_can_update_canteen_does_not_update_creation_user_and_source(self):
         self.canteen.managers.add(authenticate.user)
         self.assertEqual(self.canteen.creation_user, self.user)
         self.assertEqual(self.canteen.creation_source, CreationSource.APP)
@@ -1000,7 +972,6 @@ class CanteenUpdateApiTest(APITestCase):
             "reservationExpeParticipant": True,
             "creationSource": CreationSource.API,
         }
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1031,7 +1002,6 @@ class CanteenUpdateApiTest(APITestCase):
             "creation_mtm_campaign": "mtm_campaign_value",
             "creation_mtm_medium": "mtm_medium_value",
         }
-
         response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1065,7 +1035,7 @@ class CanteenDeleteApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_delete_canteen(self):
+    def test_can_delete_canteen(self):
         self.canteen.managers.add(authenticate.user)
         self.assertEqual(Canteen.objects.count(), 1)
 

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -33,7 +33,7 @@ CANTEEN_SITE_DEFAULT_PAYLOAD = {
 
 
 class CanteenListApiTest(APITestCase):
-    def test_cannot_get_user_canteens_if_unauthenticated(self):
+    def test_cannot_get_canteens_if_unauthenticated(self):
         response = self.client.get(reverse("user_canteens"))
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -51,7 +51,7 @@ class CanteenListApiTest(APITestCase):
         self.assertEqual(body["results"][0]["id"], canteen.id)
 
     @authenticate
-    def test_can_get_user_canteens(self):
+    def test_can_get_canteens(self):
         """
         Users can have access to the full representation of their
         canteens (even if they are not published). This endpoint
@@ -161,7 +161,7 @@ class CanteenListPreviewApiTest(APITestCase):
 class CanteenDetailApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.canteen = CanteenFactory()
+        cls.canteen = CanteenFactory(managers=[])
         cls.url = reverse("single_canteen", kwargs={"pk": cls.canteen.id})
 
     def test_cannot_get_canteen_if_unauthorized(self):
@@ -270,7 +270,7 @@ class CanteenDetailApiTest(APITestCase):
         self.assertNotIn("mtm_medium_value", body)
 
     @authenticate
-    def test_can_get_user_canteen_teledeclaration(self):
+    def test_can_get_canteen_teledeclaration(self):
         """
         Only submitted TDs are returned to the managers
         """

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -177,10 +177,6 @@ class CanteenListPreviewApiTest(APITestCase):
 
 class CanteenDetailApiTest(APITestCase):
     def test_cannot_get_single_user_canteen_unauthorized(self):
-        """
-        Users cannot access to the full representation of a single
-        canteen if they are not authenticated
-        """
         canteen = CanteenFactory()
 
         response = self.client.get(reverse("single_canteen", kwargs={"pk": canteen.id}))
@@ -188,21 +184,13 @@ class CanteenDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_get_single_user_canteen_unknown(self):
-        """
-        Users cannot access the full representation of a single
-        canteen that does not exist.
-        """
+    def test_cannot_get_single_user_canteen_does_not_exist(self):
         response = self.client.get(reverse("single_canteen", kwargs={"pk": 9999}))
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_cannot_get_single_user_canteen_if_not_canteen_manager(self):
-        """
-        Users cannot access the full representation of a single
-        canteen if they do not manage it.
-        """
         canteen = CanteenFactory()
 
         response = self.client.get(reverse("single_canteen", kwargs={"pk": canteen.id}))

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -516,19 +516,17 @@ class CanteenDetailCheckApiTest(APITestCase):
 class CanteenCreateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        pass
+        cls.url = reverse("user_canteens")
 
     def test_cannot_create_canteen_if_unauthenticated(self):
-        response = self.client.post(reverse("user_canteens"), CANTEEN_SITE_DEFAULT_PAYLOAD)
+        response = self.client.post(self.url, CANTEEN_SITE_DEFAULT_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_create_canteen_central(self):
-        response = self.client.post(
-            reverse("user_canteens"),
-            {**CANTEEN_SITE_DEFAULT_PAYLOAD, "productionType": Canteen.ProductionType.CENTRAL},
-        )
+        payload = {**CANTEEN_SITE_DEFAULT_PAYLOAD, "productionType": Canteen.ProductionType.CENTRAL}
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
@@ -546,7 +544,7 @@ class CanteenCreateApiTest(APITestCase):
         mock_get_pat_dataset_resource(mock)
         mock_get_pat_csv(mock)
 
-        response = self.client.post(reverse("user_canteens"), CANTEEN_SITE_DEFAULT_PAYLOAD)
+        response = self.client.post(self.url, CANTEEN_SITE_DEFAULT_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
@@ -573,7 +571,7 @@ class CanteenCreateApiTest(APITestCase):
         user, token = get_oauth2_token("canteen:write")
 
         self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.post(reverse("user_canteens"), CANTEEN_SITE_DEFAULT_PAYLOAD)
+        response = self.client.post(self.url, CANTEEN_SITE_DEFAULT_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
@@ -600,7 +598,7 @@ class CanteenCreateApiTest(APITestCase):
 
         # from the APP
         payload = {**CANTEEN_SITE_DEFAULT_PAYLOAD, "creation_source": "APP"}
-        response = self.client.post(reverse("user_canteens"), payload)
+        response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertNotIn("creation_user", response.json())
         self.assertNotIn("creation_source", response.json())
@@ -616,7 +614,7 @@ class CanteenCreateApiTest(APITestCase):
         Canteen.objects.all().delete()
 
         # defaults to API
-        response = self.client.post(reverse("user_canteens"), CANTEEN_SITE_DEFAULT_PAYLOAD)
+        response = self.client.post(self.url, CANTEEN_SITE_DEFAULT_PAYLOAD)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertNotIn("creation_user", response.json())
         self.assertNotIn("creation_source", response.json())
@@ -633,7 +631,7 @@ class CanteenCreateApiTest(APITestCase):
 
         # returns a 404 if the creation_source is not valid
         payload = {**CANTEEN_SITE_DEFAULT_PAYLOAD, "creation_source": "UNKNOWN"}
-        response = self.client.post(reverse("user_canteens"), payload)
+        response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @requests_mock.Mocker()
@@ -653,7 +651,7 @@ class CanteenCreateApiTest(APITestCase):
         payload["creation_mtm_campaign"] = "mtm_campaign_value"
         payload["creation_mtm_medium"] = "mtm_medium_value"
 
-        response = self.client.post(reverse("user_canteens"), payload, format="json")
+        response = self.client.post(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertNotIn("creation_mtm_source", response.json())
@@ -670,7 +668,7 @@ class CanteenCreateApiTest(APITestCase):
         payload = CANTEEN_SITE_DEFAULT_PAYLOAD.copy()
         del payload["siret"]
 
-        response = self.client.post(reverse("user_canteens"), payload)
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
@@ -678,15 +676,14 @@ class CanteenCreateApiTest(APITestCase):
 
     @authenticate
     def test_cannot_create_canteen_with_bad_siret(self):
-        response = self.client.post(reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "siret": "0123"})
+        response = self.client.post(self.url, {**CANTEEN_SITE_DEFAULT_PAYLOAD, "siret": "0123"})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
         self.assertEqual(body["siret"], ["14 caractères numériques sont attendus"])
 
-        response = self.client.post(
-            reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "siret": "01234567891011"}
-        )
+        payload = {**CANTEEN_SITE_DEFAULT_PAYLOAD, "siret": "01234567891011"}
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
@@ -695,15 +692,13 @@ class CanteenCreateApiTest(APITestCase):
             "Le numéro SIRET est invalide et semble ne pas exister dans les registres officiels, vous pouvez vérifier sa validité depuis le site : https://annuaire-entreprises.data.gouv.fr",
         )
 
-        response = self.client.post(
-            reverse("user_canteens"),
-            {
-                **CANTEEN_SITE_DEFAULT_PAYLOAD,
-                "siret": "01234567891011",
-                "productionType": Canteen.ProductionType.ON_SITE_CENTRAL,
-                "centralProducerSiret": "01234567891011",
-            },
-        )
+        payload = {
+            **CANTEEN_SITE_DEFAULT_PAYLOAD,
+            "siret": "01234567891011",
+            "productionType": Canteen.ProductionType.ON_SITE_CENTRAL,
+            "centralProducerSiret": "01234567891011",
+        }
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
@@ -721,7 +716,8 @@ class CanteenCreateApiTest(APITestCase):
         siret = "26566234910966"
         canteen = CanteenFactory(siret=siret)
 
-        response = self.client.post(reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "siret": siret})
+        payload = {**CANTEEN_SITE_DEFAULT_PAYLOAD, "siret": siret}
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
@@ -733,7 +729,7 @@ class CanteenCreateApiTest(APITestCase):
         # make the user the manager of the canteen
         canteen.managers.add(authenticate.user)
 
-        response = self.client.post(reverse("user_canteens"), {**CANTEEN_SITE_DEFAULT_PAYLOAD, "siret": siret})
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         body = response.json()
@@ -765,8 +761,7 @@ class CanteenCreateApiTest(APITestCase):
                 "image": "data:image/jpeg;base64," + image_base_64,
             }
         ]
-
-        response = self.client.post(reverse("user_canteens"), payload, format="json")
+        response = self.client.post(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -164,25 +164,25 @@ class CanteenDetailApiTest(APITestCase):
         cls.canteen = CanteenFactory()
         cls.url = reverse("single_canteen", kwargs={"pk": cls.canteen.id})
 
-    def test_cannot_get_single_user_canteen_if_unauthorized(self):
+    def test_cannot_get_canteen_if_unauthorized(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_get_single_user_canteen_if_canteen_does_not_exist(self):
+    def test_cannot_get_canteen_if_canteen_does_not_exist(self):
         response = self.client.get(reverse("single_canteen", kwargs={"pk": 9999}))
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_get_single_user_canteen_if_not_canteen_manager(self):
+    def test_cannot_get_canteen_if_not_canteen_manager(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_can_get_single_user_canteen(self):
+    def test_can_get_canteen(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.get(self.url)
@@ -195,7 +195,7 @@ class CanteenDetailApiTest(APITestCase):
         self.assertNotIn("creationSource", body)
 
     @authenticate
-    def test_can_get_single_user_canteen_groupe(self):
+    def test_can_get_canteen_groupe(self):
         canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
         user_canteen = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe, managers=[authenticate.user]

--- a/api/tests/test_canteens_create_import.py
+++ b/api/tests/test_canteens_create_import.py
@@ -36,7 +36,7 @@ class CanteensImportApiErrorTest(APITestCase):
 
         # header missing
         file_path = "./api/tests/files/canteens/canteens_bad_no_header.csv"
-        with open(file_path, "rb") as canteen_file:
+        with open(file_path) as canteen_file:
             response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -61,7 +61,7 @@ class CanteensImportApiErrorTest(APITestCase):
 
         # wrong header
         file_path = "./api/tests/files/canteens/canteens_bad_wrong_header.csv"
-        with open(file_path, "rb") as canteen_file:
+        with open(file_path) as canteen_file:
             response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -82,7 +82,7 @@ class CanteensImportApiErrorTest(APITestCase):
         self.assertEqual(Canteen.objects.count(), 0)
 
         file_path = "./api/tests/files/canteens/canteens_bad_extra_header.csv"
-        with open(file_path, "rb") as canteen_file:
+        with open(file_path) as canteen_file:
             response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/tests/test_canteens_create_import.py
+++ b/api/tests/test_canteens_create_import.py
@@ -15,10 +15,14 @@ from data.models.creation_source import CreationSource
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class CanteensImportApiErrorTest(APITestCase):
-    def test_unauthenticated(self):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("canteens_create_import")
+
+    def test_cannot_import_if_unauthenticated(self):
         self.assertEqual(Canteen.objects.count(), 0)
 
-        response = self.client.post(reverse("canteens_create_import"))
+        response = self.client.post(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(Canteen.objects.count(), 0)
@@ -33,7 +37,7 @@ class CanteensImportApiErrorTest(APITestCase):
         # header missing
         file_path = "./api/tests/files/canteens/canteens_bad_no_header.csv"
         with open(file_path, "rb") as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 0)
@@ -58,7 +62,7 @@ class CanteensImportApiErrorTest(APITestCase):
         # wrong header
         file_path = "./api/tests/files/canteens/canteens_bad_wrong_header.csv"
         with open(file_path, "rb") as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 0)
@@ -79,7 +83,7 @@ class CanteensImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_bad_extra_header.csv"
         with open(file_path, "rb") as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 0)
@@ -103,7 +107,7 @@ class CanteensImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_bad_empty_rows.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 0)
@@ -127,7 +131,7 @@ class CanteensImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_bad_nearly_good.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 0)
@@ -157,7 +161,7 @@ class CanteensImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_bad.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 0)
@@ -200,7 +204,7 @@ class CanteensImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteen_bad_sectors.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 0)
@@ -222,7 +226,7 @@ class CanteensImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_bad_line_ministry.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -249,7 +253,7 @@ class CanteensImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_bad_canteen_already_exists.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 1)
@@ -268,7 +272,7 @@ class CanteensImportApiErrorTest(APITestCase):
     def test_when_errors_count_is_0(self):
         file_path = "./api/tests/files/canteens/canteens_bad_one_error.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -282,7 +286,7 @@ class CanteensImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_good.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 0)
@@ -302,6 +306,7 @@ class CanteensCreateImportApiGroupeTeledeclarationTest(APITestCase):
         cls.groupe_canteen = CanteenFactory(id=9999999992, production_type=Canteen.ProductionType.GROUPE)
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=cls.groupe_canteen)
         cls.teledeclaration = DiagnosticFactory(canteen=cls.groupe_canteen, year=2024)
+        cls.url = reverse("canteens_create_import")
 
     @freeze_time("2025-02-20")  # during the 2024 campaign
     @authenticate
@@ -316,7 +321,7 @@ class CanteensCreateImportApiGroupeTeledeclarationTest(APITestCase):
         # Import
         file_path = "./api/tests/files/canteens/canteens_create_bad_groupe_teledeclared.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -344,7 +349,7 @@ class CanteensCreateImportApiGroupeTeledeclarationTest(APITestCase):
         with freeze_time("2025-07-20"):
             file_path = "./api/tests/files/canteens/canteens_create_bad_groupe_teledeclared.csv"
             with open(file_path) as canteen_file:
-                response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+                response = self.client.post(self.url, {"file": canteen_file})
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             body = response.json()
@@ -369,7 +374,7 @@ class CanteensCreateImportApiGroupeTeledeclarationTest(APITestCase):
         # Import
         file_path = "./api/tests/files/canteens/canteens_create_bad_groupe_teledeclared.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -381,6 +386,10 @@ class CanteensCreateImportApiGroupeTeledeclarationTest(APITestCase):
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class CanteensImportApiSuccessTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("canteens_create_import")
+
     @authenticate
     def test_import_only_canteens(self):
         """
@@ -390,7 +399,7 @@ class CanteensImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_good.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 3)
@@ -411,7 +420,7 @@ class CanteensImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_good_add_manager.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 1)
@@ -432,7 +441,7 @@ class CanteensImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_sectors.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -455,7 +464,7 @@ class CanteensImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_good_max_sectors.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -474,7 +483,7 @@ class CanteensImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_good.xlsx"
         with open(file_path, "rb") as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -498,7 +507,7 @@ class CanteensImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_good_choices_slug_values.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 3)
@@ -521,7 +530,7 @@ class CanteensImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_good_groupe.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Canteen.objects.count(), 2)
@@ -543,7 +552,7 @@ class CanteensImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_good_line_ministry.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_create_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()

--- a/api/tests/test_canteens_managers_import.py
+++ b/api/tests/test_canteens_managers_import.py
@@ -228,7 +228,7 @@ class CanteensManagersImportApiSuccessTest(APITestCase):
         cls.url = reverse("canteens_managers_import")
 
     @authenticate
-    def test_admin_import_managers_success(self):
+    def test_can_import_managers(self):
         """
         Staff user should successfully add managers to existing canteens without sending invitation emails
         """
@@ -264,7 +264,7 @@ class CanteensManagersImportApiSuccessTest(APITestCase):
         self.assertEqual(canteen.import_source, "test_import")
 
     @authenticate
-    def test_admin_import_managers_existing_manager(self):
+    def test_can_import_managers_existing_manager(self):
         """
         If manager is already on the canteen, should not fail (IntegrityError caught)
         """
@@ -291,7 +291,7 @@ class CanteensManagersImportApiSuccessTest(APITestCase):
         self.assertIn(existing_manager, canteen.managers.all())
 
     @authenticate
-    def test_admin_import_multiple_canteens(self):
+    def test_can_import_multiple_canteens(self):
         """
         Staff user can import managers for multiple canteens at once
         """
@@ -320,10 +320,7 @@ class CanteensManagersImportApiSuccessTest(APITestCase):
         self.assertEqual(ManagerInvitation.objects.filter(canteen=canteen2).count(), 1)
 
     @authenticate
-    def test_import_excel_file(self):
-        """
-        Staff user can import Excel (.xlsx) files
-        """
+    def test_can_import_excel_file(self):
         user = authenticate.user
         user.is_staff = True
         user.save()
@@ -346,10 +343,7 @@ class CanteensManagersImportApiSuccessTest(APITestCase):
         self.assertEqual(ManagerInvitation.objects.filter(canteen=canteen).count(), 2)
 
     @authenticate
-    def test_import_for_canteen_not_valid(self):
-        """
-        Staff user can add managers to a canteen not valid
-        """
+    def test_can_import_even_if_canteen_not_valid(self):
         user = authenticate.user
         user.is_staff = True
         user.save()

--- a/api/tests/test_canteens_managers_import.py
+++ b/api/tests/test_canteens_managers_import.py
@@ -65,7 +65,7 @@ class CanteensManagersImportApiErrorTest(APITestCase):
         # Hack : this test works because file has no header and has less columns than the expected header
         # TODO: remove this hack add fix it in other imports
         file_path = "./api/tests/files/canteen_managers/canteen_managers_bad_no_header.csv"
-        with open(file_path, "rb") as managers_file:
+        with open(file_path) as managers_file:
             response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -86,7 +86,7 @@ class CanteensManagersImportApiErrorTest(APITestCase):
         user.save()
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_bad_wrong_header.csv"
-        with open(file_path, "rb") as managers_file:
+        with open(file_path) as managers_file:
             response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -108,7 +108,7 @@ class CanteensManagersImportApiErrorTest(APITestCase):
         user.save()
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_bad_extra_header.csv"
-        with open(file_path, "rb") as managers_file:
+        with open(file_path) as managers_file:
             response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/tests/test_canteens_managers_import.py
+++ b/api/tests/test_canteens_managers_import.py
@@ -13,11 +13,15 @@ from data.models import ImportFailure, ImportType, ManagerInvitation
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class CanteensManagersImportApiNonAdminErrorTest(APITestCase):
-    def test_unauthenticated(self):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("canteens_managers_import")
+
+    def test_cannot_import_if_unauthenticated(self):
         """
         Anonymous users should receive 403 Forbidden
         """
-        response = self.client.post(reverse("canteens_managers_import"))
+        response = self.client.post(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -30,7 +34,7 @@ class CanteensManagersImportApiNonAdminErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_good.csv"
         with open(file_path) as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -45,6 +49,10 @@ class CanteensManagersImportApiNonAdminErrorTest(APITestCase):
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class CanteensManagersImportApiErrorTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("canteens_managers_import")
+
     @authenticate
     def test_validata_missing_header_error(self):
         """
@@ -58,7 +66,7 @@ class CanteensManagersImportApiErrorTest(APITestCase):
         # TODO: remove this hack add fix it in other imports
         file_path = "./api/tests/files/canteen_managers/canteen_managers_bad_no_header.csv"
         with open(file_path, "rb") as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_MANAGERS, file_path)
@@ -79,7 +87,7 @@ class CanteensManagersImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_bad_wrong_header.csv"
         with open(file_path, "rb") as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_MANAGERS, file_path)
@@ -101,7 +109,7 @@ class CanteensManagersImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_bad_extra_header.csv"
         with open(file_path, "rb") as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_MANAGERS, file_path)
@@ -122,7 +130,7 @@ class CanteensManagersImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_bad_empty_rows.csv"
         with open(file_path) as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_MANAGERS, file_path)
@@ -142,7 +150,7 @@ class CanteensManagersImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_bad_siret_not_found.csv"
         with open(file_path) as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_MANAGERS, file_path)
@@ -164,7 +172,7 @@ class CanteensManagersImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_bad_invalid_email.csv"
         with open(file_path) as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_MANAGERS, file_path)
@@ -184,7 +192,7 @@ class CanteensManagersImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_bad_one_error.csv"
         with open(file_path) as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -203,7 +211,7 @@ class CanteensManagersImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_good.csv"
         with open(file_path) as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_MANAGERS, file_path)
@@ -215,6 +223,10 @@ class CanteensManagersImportApiErrorTest(APITestCase):
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class CanteensManagersImportApiSuccessTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("canteens_managers_import")
+
     @authenticate
     def test_admin_import_managers_success(self):
         """
@@ -231,7 +243,7 @@ class CanteensManagersImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_good.csv"
         with open(file_path) as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(ImportFailure.objects.exists())
@@ -265,7 +277,7 @@ class CanteensManagersImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_good.csv"
         with open(file_path) as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(ImportFailure.objects.exists())
@@ -293,7 +305,7 @@ class CanteensManagersImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_good_multiple.csv"
         with open(file_path) as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(ImportFailure.objects.exists())
@@ -320,7 +332,7 @@ class CanteensManagersImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_good.xlsx"
         with open(file_path, "rb") as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(ImportFailure.objects.exists())
@@ -352,7 +364,7 @@ class CanteensManagersImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteen_managers/canteen_managers_good.csv"
         with open(file_path) as managers_file:
-            response = self.client.post(reverse("canteens_managers_import"), {"file": managers_file})
+            response = self.client.post(self.url, {"file": managers_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(ImportFailure.objects.exists())

--- a/api/tests/test_canteens_managers_import.py
+++ b/api/tests/test_canteens_managers_import.py
@@ -334,9 +334,9 @@ class CanteensManagersImportApiSuccessTest(APITestCase):
         self.assertEqual(ManagerInvitation.objects.filter(canteen=canteen).count(), 2)
 
     @authenticate
-    def test_import_for_canteen_not_filled(self):
+    def test_import_for_canteen_not_valid(self):
         """
-        Staff user can add managers to a canteen not filled
+        Staff user can add managers to a canteen not valid
         """
         user = authenticate.user
         user.is_staff = True

--- a/api/tests/test_canteens_schema_import.py
+++ b/api/tests/test_canteens_schema_import.py
@@ -5,7 +5,7 @@ from api.views.canteen_create_import import CANTEEN_SCHEMA_FILE_PATH
 from api.views.canteen_update_import import CANTEEN_UPDATE_SCHEMA_FILE_PATH
 
 
-class CanteensSchemaTest(TestCase):
+class CanteensImportSchemaTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.schema_create = json.load(open(CANTEEN_SCHEMA_FILE_PATH))

--- a/api/tests/test_canteens_update_import.py
+++ b/api/tests/test_canteens_update_import.py
@@ -31,7 +31,7 @@ class CanteensUpdateImportApiErrorTest(APITestCase):
         canteen.managers.add(authenticate.user)
 
         file_path = "./api/tests/files/canteens/canteens_update_bad_no_header.csv"
-        with open(file_path, "rb") as canteen_file:
+        with open(file_path) as canteen_file:
             response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/tests/test_canteens_update_import.py
+++ b/api/tests/test_canteens_update_import.py
@@ -13,8 +13,12 @@ from data.models import Canteen, ImportFailure, ImportType, Sector
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class CanteensUpdateImportApiErrorTest(APITestCase):
-    def test_unauthenticated(self):
-        response = self.client.post(reverse("canteens_update_import"))
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("canteens_update_import")
+
+    def test_cannot_import_if_unauthenticated(self):
+        response = self.client.post(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -28,7 +32,7 @@ class CanteensUpdateImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_update_bad_no_header.csv"
         with open(file_path, "rb") as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_UPDATE, file_path)
@@ -49,7 +53,7 @@ class CanteensUpdateImportApiErrorTest(APITestCase):
         """
         file_path = "./api/tests/files/canteens/canteens_update_bad_canteen_not_found.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_UPDATE, file_path)
@@ -70,7 +74,7 @@ class CanteensUpdateImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_update_bad_permission_denied.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_UPDATE, file_path)
@@ -91,7 +95,7 @@ class CanteensUpdateImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_update_bad_invalid_insee_code.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_UPDATE, file_path)
@@ -115,7 +119,7 @@ class CanteensUpdateImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_update_bad_invalid_email.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_UPDATE, file_path)
@@ -139,7 +143,7 @@ class CanteensUpdateImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_update_bad_invalid_siret.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_UPDATE, file_path)
@@ -160,7 +164,7 @@ class CanteensUpdateImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_update_bad_missing_insee_code.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert_import_failure_created(self, authenticate.user, ImportType.CANTEEN_UPDATE, file_path)
@@ -180,7 +184,7 @@ class CanteensUpdateImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_update_bad_one_error.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": canteen_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -201,6 +205,7 @@ class CanteensUpdateImportApiGroupeTeledeclarationTest(APITestCase):
             groupe=cls.groupe_canteen,
         )
         cls.teledeclaration = DiagnosticFactory(canteen=cls.groupe_canteen, year=2024)
+        cls.url = reverse("canteens_update_import")
 
     @freeze_time("2025-02-20")  # during the 2024 campaign
     @authenticate
@@ -216,7 +221,7 @@ class CanteensUpdateImportApiGroupeTeledeclarationTest(APITestCase):
         # Import
         file_path = "./api/tests/files/canteens/canteens_update_bad_groupe_teledeclared.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -244,7 +249,7 @@ class CanteensUpdateImportApiGroupeTeledeclarationTest(APITestCase):
 
             file_path = "./api/tests/files/canteens/canteens_update_bad_groupe_teledeclared.csv"
             with open(file_path) as canteen_file:
-                response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+                response = self.client.post(self.url, {"file": canteen_file})
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             body = response.json()
@@ -270,7 +275,7 @@ class CanteensUpdateImportApiGroupeTeledeclarationTest(APITestCase):
         with freeze_time("2025-07-20"):
             file_path = "./api/tests/files/canteens/canteens_update_bad_groupe_teledeclared.csv"
             with open(file_path) as canteen_file:
-                response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+                response = self.client.post(self.url, {"file": canteen_file})
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             body = response.json()
@@ -296,7 +301,7 @@ class CanteensUpdateImportApiGroupeTeledeclarationTest(APITestCase):
         # Import
         file_path = "./api/tests/files/canteens/canteens_update_bad_groupe_teledeclared.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -308,6 +313,10 @@ class CanteensUpdateImportApiGroupeTeledeclarationTest(APITestCase):
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class CanteensUpdateImportApiSuccessTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("canteens_update_import")
+
     @authenticate
     def test_update_multiple_canteens(self):
         """
@@ -346,7 +355,7 @@ class CanteensUpdateImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_update_good_multiple.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -404,7 +413,7 @@ class CanteensUpdateImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_update_good_insee.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -434,7 +443,7 @@ class CanteensUpdateImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_update_good_one.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -461,7 +470,7 @@ class CanteensUpdateImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/canteens/canteens_update_good_one.xlsx"
         with open(file_path, "rb") as canteen_file:
-            response = self.client.post(reverse("canteens_update_import"), {"file": canteen_file})
+            response = self.client.post(self.url, {"file": canteen_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()

--- a/api/tests/test_community_events.py
+++ b/api/tests/test_community_events.py
@@ -8,7 +8,7 @@ from rest_framework.test import APITestCase
 from data.factories import CommunityEventFactory
 
 
-class TestCommunityEventApiTest(APITestCase):
+class CommunityEventListApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.community_event_past = CommunityEventFactory(
@@ -25,7 +25,7 @@ class TestCommunityEventApiTest(APITestCase):
         )
         cls.url = reverse("community_event_list")
 
-    def test_get_community_events(self):
+    def test_can_get_community_events_if_upcoming(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/tests/test_diagnostic_teledeclaration.py
+++ b/api/tests/test_diagnostic_teledeclaration.py
@@ -12,13 +12,14 @@ from data.models import Canteen, Diagnostic, Sector, Teledeclaration
 
 
 class DiagnosticToTeledeclareApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.year = 2021
+        cls.url = reverse("diagnostics_to_teledeclare", kwargs={"year": 2021})
+
     @freeze_time("2022-08-30")  # during the 2021 campaign  # but this endpoint doesn't seem to check
     @authenticate
-    def test_get_diagnostics_to_td(self):
-        """
-        Check that the endpoint includes a list of diagnostics that could be teledeclared
-        """
-        last_year = 2021
+    def test_can_get_diagnostics_to_td(self):
         CanteenFactory(  # without diag
             siret="21590350100017",
             production_type=Canteen.ProductionType.ON_SITE,
@@ -35,7 +36,7 @@ class DiagnosticToTeledeclareApiTest(APITestCase):
             economic_model=Canteen.EconomicModel.PUBLIC,
             managers=[authenticate.user],
         )
-        DiagnosticFactory(canteen=canteen_with_incomplete_diag, year=last_year, valeur_totale=None)
+        DiagnosticFactory(canteen=canteen_with_incomplete_diag, year=self.year, valeur_totale=None)
         canteen_with_complete_diag = CanteenFactory(
             siret="21010034300016",
             production_type=Canteen.ProductionType.ON_SITE,
@@ -44,7 +45,7 @@ class DiagnosticToTeledeclareApiTest(APITestCase):
             economic_model=Canteen.EconomicModel.PUBLIC,
             managers=[authenticate.user],
         )
-        complete_diag = DiagnosticFactory(canteen=canteen_with_complete_diag, year=last_year, valeur_totale=10000)
+        complete_diag = DiagnosticFactory(canteen=canteen_with_complete_diag, year=self.year, valeur_totale=10000)
 
         # siret needs to be filled for the diag to be teledeclarable
         canteen_with_missing_data = CanteenFactory(
@@ -58,7 +59,7 @@ class DiagnosticToTeledeclareApiTest(APITestCase):
         canteen_with_missing_data.siret = None
         canteen_with_missing_data.save(skip_validations=True)
         canteen_with_missing_data.refresh_from_db()
-        DiagnosticFactory(canteen=canteen_with_missing_data, year=last_year, valeur_totale=10000)
+        DiagnosticFactory(canteen=canteen_with_missing_data, year=self.year, valeur_totale=10000)
 
         canteen_without_line_ministry = CanteenFactory(
             siret="31285246765507",
@@ -73,10 +74,10 @@ class DiagnosticToTeledeclareApiTest(APITestCase):
         canteen_without_line_ministry.line_ministry = None
         canteen_without_line_ministry.save(skip_validations=True)
         canteen_without_line_ministry.refresh_from_db()
-        DiagnosticFactory(canteen=canteen_without_line_ministry, year=last_year, valeur_totale=10000)
+        DiagnosticFactory(canteen=canteen_without_line_ministry, year=self.year, valeur_totale=10000)
 
         # to verify we are returning the correct diag for the canteen, create another diag for a different year
-        DiagnosticFactory(canteen=canteen_with_complete_diag, year=last_year - 1, valeur_totale=10000)
+        DiagnosticFactory(canteen=canteen_with_complete_diag, year=self.year - 1, valeur_totale=10000)
         canteen_with_td = CanteenFactory(
             siret="55476895458384",
             production_type=Canteen.ProductionType.ON_SITE,
@@ -85,14 +86,15 @@ class DiagnosticToTeledeclareApiTest(APITestCase):
             economic_model=Canteen.EconomicModel.PUBLIC,
             managers=[authenticate.user],
         )
-        td_diag = DiagnosticFactory(canteen=canteen_with_td, year=last_year, valeur_totale=2000)
+        td_diag = DiagnosticFactory(canteen=canteen_with_td, year=self.year, valeur_totale=2000)
         Teledeclaration.create_from_diagnostic(td_diag, authenticate.user)
 
-        response = self.client.get(reverse("diagnostics_to_teledeclare", kwargs={"year": last_year}))
-        diagnostics = response.json().get("results")
+        response = self.client.get(self.url)
 
-        self.assertEqual(len(diagnostics), 1)
-        self.assertEqual(diagnostics[0]["id"], complete_diag.id)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], complete_diag.id)
 
     @authenticate
     def test_get_diagnostics_to_td_none(self):
@@ -100,12 +102,11 @@ class DiagnosticToTeledeclareApiTest(APITestCase):
         Check that the actions endpoint includes an empty list of diagnostics that could be teledeclared
         if there are no diags to TD
         """
-        last_year = 2021
+        response = self.client.get(self.url)
 
-        response = self.client.get(reverse("diagnostics_to_teledeclare", kwargs={"year": last_year}))
-        body = response.json().get("results")
-
-        self.assertEqual(body, [])
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(results, [])
 
     @authenticate
     def test_get_diagnostics_to_td_in_correction_campaign(self):

--- a/api/tests/test_diagnostic_teledeclaration.py
+++ b/api/tests/test_diagnostic_teledeclaration.py
@@ -573,20 +573,25 @@ class DiagnosticTeledeclarationPdfApiTest(APITestCase):
 
     @freeze_time("2025-03-30")  # during the 2024 campaign
     @authenticate
-    def test_cannot_generate_pdf_if_unknown_canteen_or_diagnostic(self):
+    def test_cannot_generate_pdf_if_canteen_does_not_exist(self):
         diagnostic = DiagnosticFactory(year=2024)
         diagnostic.canteen.managers.add(authenticate.user)
         diagnostic.teledeclare(authenticate.user)
 
-        response = self.client.get(
-            reverse("diagnostic_teledeclaration_pdf", kwargs={"canteen_pk": 9999, "pk": diagnostic.id})
-        )
+        url = reverse("diagnostic_teledeclaration_pdf", kwargs={"canteen_pk": 9999, "pk": diagnostic.id})
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        response = self.client.get(
-            reverse("diagnostic_teledeclaration_pdf", kwargs={"canteen_pk": diagnostic.canteen.id, "pk": 9999})
-        )
+    @freeze_time("2025-03-30")  # during the 2024 campaign
+    @authenticate
+    def test_cannot_generate_pdf_if_diagnostic_does_not_exist(self):
+        diagnostic = DiagnosticFactory(year=2024)
+        diagnostic.canteen.managers.add(authenticate.user)
+        diagnostic.teledeclare(authenticate.user)
+
+        url = reverse("diagnostic_teledeclaration_pdf", kwargs={"canteen_pk": diagnostic.canteen.id, "pk": 9999})
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/api/tests/test_diagnostic_teledeclaration.py
+++ b/api/tests/test_diagnostic_teledeclaration.py
@@ -182,7 +182,7 @@ class DiagnosticTeledeclarationCreateApiTest(APITestCase):
 
     @authenticate
     @freeze_time("2025-03-30")  # during the 2024 campaign
-    def test_cannot_teledeclare_if_canteen_unknown(self):
+    def test_cannot_teledeclare_if_canteen_does_not_exist(self):
         diagnostic = DiagnosticFactory(canteen=self.canteen_site, year=2024)
         self.canteen_site.managers.add(authenticate.user)
 
@@ -197,7 +197,7 @@ class DiagnosticTeledeclarationCreateApiTest(APITestCase):
 
     @authenticate
     @freeze_time("2025-03-30")  # during the 2024 campaign
-    def test_cannot_teledeclare_if_diagnostic_unknown(self):
+    def test_cannot_teledeclare_if_diagnostic_does_not_exist(self):
         DiagnosticFactory(canteen=self.canteen_site, year=2024)
         self.canteen_site.managers.add(authenticate.user)
 
@@ -397,7 +397,7 @@ class DiagnosticTeledeclarationCancelView(APITestCase):
 
     @authenticate
     @freeze_time("2025-03-30")  # during the 2024 campaign
-    def test_cannot_cancel_teledeclaration_if_canteen_unknown(self):
+    def test_cannot_cancel_teledeclaration_if_canteen_does_not_exist(self):
         self.canteen_site.managers.add(authenticate.user)
         diagnostic = DiagnosticFactory(canteen=self.canteen_site, year=2024)
         diagnostic.teledeclare(authenticate.user)
@@ -413,7 +413,7 @@ class DiagnosticTeledeclarationCancelView(APITestCase):
 
     @authenticate
     @freeze_time("2025-03-30")  # during the 2024 campaign
-    def test_cannot_cancel_teledeclaration_if_diagnostic_unknown(self):
+    def test_cannot_cancel_teledeclaration_if_diagnostic_does_not_exist(self):
         self.canteen_site.managers.add(authenticate.user)
         diagnostic = DiagnosticFactory(canteen=self.canteen_site, year=2024)
         diagnostic.teledeclare(authenticate.user)

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -89,7 +89,7 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_create_diagnostic_if_canteen_unknown(self):
+    def test_cannot_create_diagnostic_if_canteen_does_not_exist(self):
         response = self.client.post(
             reverse("diagnostic_list_create", kwargs={"canteen_pk": 9999}), self.DIAGNOSTIC_PAYLOAD
         )
@@ -583,7 +583,7 @@ class DiagnosticUpdateApiTest(APITestCase):
         self.assertEqual(self.diagnostic.year, 2025)
 
     @authenticate
-    def test_cannot_update_diagnostic_if_canteen_unknown(self):
+    def test_cannot_update_diagnostic_if_canteen_does_not_exist(self):
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
@@ -607,7 +607,7 @@ class DiagnosticUpdateApiTest(APITestCase):
         self.assertEqual(self.diagnostic.year, 2025)
 
     @authenticate
-    def test_cannot_update_diagnostic_if_diagnostic_unknown(self):
+    def test_cannot_update_diagnostic_if_diagnostic_does_not_exist(self):
         self.diagnostic.canteen.managers.add(authenticate.user)
 
         response = self.client.patch(

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -90,9 +90,8 @@ class DiagnosticCreateApiTest(APITestCase):
 
     @authenticate
     def test_cannot_create_diagnostic_if_canteen_does_not_exist(self):
-        response = self.client.post(
-            reverse("diagnostic_list_create", kwargs={"canteen_pk": 9999}), self.DIAGNOSTIC_PAYLOAD
-        )
+        url = reverse("diagnostic_list_create", kwargs={"canteen_pk": 9999})
+        response = self.client.post(url, self.DIAGNOSTIC_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -102,11 +102,7 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_create_empty_diagnostic_error(self):
-        """
-        When calling this API on a canteen that the user manages
-        we need to provide the required field(s)
-        """
+    def test_cannot_create_empty_diagnostic(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.post(self.url, {})
@@ -114,12 +110,7 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @authenticate
-    def test_create_minimal_diagnostic(self):
-        """
-        When calling this API on a canteen that the user manages
-        we expect a diagnostic to be created
-        (minimal required fields)
-        """
+    def test_can_create_minimal_diagnostic(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.post(self.url, self.DIAGNOSTIC_PAYLOAD)
@@ -129,7 +120,7 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(diagnostic.canteen, self.canteen)
         self.assertEqual(diagnostic.year, 2020)
 
-    def test_create_minimal_diagnostic_via_oauth2(self):
+    def test_can_create_minimal_diagnostic_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
         self.canteen.managers.add(user)
 
@@ -148,7 +139,7 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(diagnostic_history.history_source_api_oauth2_application, token.application)
 
     @authenticate
-    def test_create_diagnostic_creation_user_and_source(self):
+    def test_can_create_diagnostic_creation_user_and_source(self):
         self.canteen.managers.add(authenticate.user)
 
         # from the APP
@@ -194,7 +185,7 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @authenticate
-    def test_create_diagnostic_with_tracking_info(self):
+    def test_can_create_diagnostic_with_tracking_info(self):
         self.canteen.managers.add(authenticate.user)
 
         payload = {
@@ -216,7 +207,7 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(diagnostic.creation_mtm_medium, "mtm_medium_value")
 
     @authenticate
-    def test_create_full_diagnostic(self):
+    def test_can_create_full_diagnostic(self):
         """
         When calling this API on a canteen that the user manages
         we expect a diagnostic to be created
@@ -436,7 +427,7 @@ class DiagnosticCreateApiTest(APITestCase):
         self.assertEqual(diagnostic.total_leftovers, Decimal("1.23456"))
 
     @authenticate
-    def test_cannot_create_duplicate_diagnostic(self):
+    def test_cannot_create_diagnostic_if_already_exists(self):
         """
         Shouldn't be able to add a diagnostic with the same canteen, year and value for generated_from_groupe_diagnostic"
         as an existing diagnostic

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -203,7 +203,6 @@ class DiagnosticCreateApiTest(APITestCase):
             "creation_mtm_campaign": "mtm_campaign_value",
             "creation_mtm_medium": "mtm_medium_value",
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -376,7 +375,6 @@ class DiagnosticCreateApiTest(APITestCase):
             "valeur_autres_local": 10,
             # end of detailed value fields
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -426,11 +424,11 @@ class DiagnosticCreateApiTest(APITestCase):
         On CREATE, total_leftovers should be converted from kg to ton
         """
         self.canteen.managers.add(authenticate.user)
+
         payload = {
             **self.DIAGNOSTIC_PAYLOAD,
             "total_leftovers": 1234.56,
         }
-
         response = self.client.post(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -444,8 +442,8 @@ class DiagnosticCreateApiTest(APITestCase):
         as an existing diagnostic
         """
         self.canteen.managers.add(authenticate.user)
-        payload = {**self.DIAGNOSTIC_PAYLOAD, "generated_from_groupe_diagnostic": False, "valeur_bio": 10}
 
+        payload = {**self.DIAGNOSTIC_PAYLOAD, "generated_from_groupe_diagnostic": False, "valeur_bio": 10}
         self.client.post(self.url, payload)
 
         try:
@@ -465,6 +463,7 @@ class DiagnosticCreateApiTest(APITestCase):
         Do not create a diagnostic where the sum of the values is > total
         """
         self.canteen.managers.add(authenticate.user)
+
         payload = {
             **self.DIAGNOSTIC_PAYLOAD,
             "valeur_bio": 1000,
@@ -472,7 +471,6 @@ class DiagnosticCreateApiTest(APITestCase):
             "valeur_egalim_autres": 1000,
             "valeur_totale": 2000,
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -566,15 +564,14 @@ class DiagnosticUpdateApiTest(APITestCase):
     @authenticate
     def test_cannot_update_diagnostic_with_put(self):
         self.diagnostic.canteen.managers.add(authenticate.user)
-        payload = {"year": 2020}
 
+        payload = {"year": 2020}
         response = self.client.put(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_cannot_update_diagnostic_if_unauthenticated(self):
         payload = {"year": 2020}
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -583,12 +580,13 @@ class DiagnosticUpdateApiTest(APITestCase):
 
     @authenticate
     def test_cannot_update_diagnostic_if_canteen_does_not_exist(self):
+        payload = {"year": 2020}
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": 9999, "pk": self.diagnostic.id},
             ),
-            {"year": 2020},
+            payload,
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -598,7 +596,6 @@ class DiagnosticUpdateApiTest(APITestCase):
     @authenticate
     def test_cannot_update_diagnostic_if_not_canteen_manager(self):
         payload = {"year": 2020}
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -609,12 +606,13 @@ class DiagnosticUpdateApiTest(APITestCase):
     def test_cannot_update_diagnostic_if_diagnostic_does_not_exist(self):
         self.diagnostic.canteen.managers.add(authenticate.user)
 
+        payload = {"year": 2020}
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": self.diagnostic.canteen.id, "pk": 9999},
             ),
-            {"year": 2020},
+            payload,
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -627,12 +625,13 @@ class DiagnosticUpdateApiTest(APITestCase):
         diagnostic_other = DiagnosticFactory(canteen=canteen_other)
         self.canteen.managers.add(authenticate.user)
 
+        payload = {"year": 2020}
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": self.diagnostic.canteen.id, "pk": diagnostic_other.id},
             ),
-            {"year": 2020},
+            payload,
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -640,39 +639,40 @@ class DiagnosticUpdateApiTest(APITestCase):
         # even if the user manages canteen_other
         canteen_other.managers.add(authenticate.user)
 
+        payload = {"year": 2020}
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": self.diagnostic.canteen.id, "pk": diagnostic_other.id},
             ),
-            {"year": 2020},
+            payload,
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_update_diagnostic(self):
+    def test_can_update_diagnostic(self):
         self.diagnostic.canteen.managers.add(authenticate.user)
-        payload = {"year": 2020}
 
+        payload = {"year": 2020}
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.diagnostic.refresh_from_db()
         self.assertEqual(self.diagnostic.year, 2020)
 
-    def test_update_diagnostic_via_oauth2(self):
+    def test_can_update_diagnostic_via_oauth2(self):
         user, token = get_oauth2_token("canteen:write")
         self.diagnostic.canteen.managers.add(user)
-        payload = {"year": 2020}
 
+        payload = {"year": 2020}
         self.client.credentials(Authorization=f"Bearer {token}")
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @authenticate
-    def test_update_diagnostic_does_not_update_creation_user_and_source(self):
+    def test_can_update_diagnostic_does_not_update_creation_user_and_source(self):
         self.diagnostic.canteen.managers.add(authenticate.user)
         self.assertEqual(self.diagnostic.creation_user, self.user)
         self.assertEqual(self.diagnostic.creation_source, CreationSource.APP)
@@ -682,7 +682,6 @@ class DiagnosticUpdateApiTest(APITestCase):
         self.assertEqual(diagnostic_history.history_source_api_oauth2_application, None)
 
         payload = {"year": 2020, "creationSource": CreationSource.API}
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -707,7 +706,6 @@ class DiagnosticUpdateApiTest(APITestCase):
             "creation_mtm_campaign": "mtm_campaign_value",
             "creation_mtm_medium": "mtm_medium_value",
         }
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -728,8 +726,8 @@ class DiagnosticUpdateApiTest(APITestCase):
         """
         diagnostic = DiagnosticFactory(year=2025, valeur_totale=10, valeur_bio=5, valeur_siqo=2)
         diagnostic.canteen.managers.add(authenticate.user)
-        payload = {"valeur_siqo": 999}
 
+        payload = {"valeur_siqo": 999}
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
@@ -749,10 +747,8 @@ class DiagnosticUpdateApiTest(APITestCase):
         """
         canteen = CanteenFactory(managers=[authenticate.user])
         diagnostic = DiagnosticFactory(canteen=canteen, total_leftovers=Decimal("1.23456"))
-        payload = {
-            "total_leftovers": 6666.66,
-        }
 
+        payload = {"total_leftovers": 6666.66}
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
@@ -773,10 +769,8 @@ class DiagnosticUpdateApiTest(APITestCase):
         """
         canteen = CanteenFactory(managers=[authenticate.user])
         diagnostic = DiagnosticFactory(canteen=canteen, total_leftovers=Decimal("1.23456"))
-        payload = {
-            "bread_leftovers": 100,
-        }
 
+        payload = {"bread_leftovers": 100}
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
@@ -797,10 +791,8 @@ class DiagnosticUpdateApiTest(APITestCase):
         """
         canteen = CanteenFactory(managers=[authenticate.user])
         diagnostic = DiagnosticFactory(canteen=canteen, total_leftovers=Decimal("1.23456"))
-        payload = {
-            "total_leftovers": 6666.666,
-        }
 
+        payload = {"total_leftovers": 6666.666}
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
@@ -818,10 +810,7 @@ class DiagnosticUpdateApiTest(APITestCase):
         diagnostic.refresh_from_db()
         self.assertEqual(diagnostic.total_leftovers, Decimal("1.23456"))
 
-        payload = {
-            "total_leftovers": "this shouldn't be a string",
-        }
-
+        payload = {"total_leftovers": "this shouldn't be a string"}
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
@@ -842,8 +831,8 @@ class DiagnosticUpdateApiTest(APITestCase):
         diagnostic.canteen.managers.add(authenticate.user)
         with freeze_time("2022-08-30"):  # during the 2021 campaign
             diagnostic.teledeclare(applicant=authenticate.user)
-        payload = {"year": 2020}
 
+        payload = {"year": 2020}
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
@@ -857,14 +846,14 @@ class DiagnosticUpdateApiTest(APITestCase):
         self.assertEqual(diagnostic.year, 2021)
 
     @authenticate
-    def test_update_diagnostic_cancelled(self):
+    def test_can_update_diagnostic_cancelled(self):
         diagnostic = DiagnosticFactory(year=2021)
         diagnostic.canteen.managers.add(authenticate.user)
         with freeze_time("2022-08-30"):  # during the 2021 campaign
             diagnostic.teledeclare(applicant=authenticate.user)
             diagnostic.cancel()
-        payload = {"year": 2020}
 
+        payload = {"year": 2020}
         response = self.client.patch(
             reverse(
                 "diagnostic_retrieve_update",
@@ -878,7 +867,7 @@ class DiagnosticUpdateApiTest(APITestCase):
         self.assertEqual(diagnostic.year, 2020)
 
     @authenticate
-    def test_update_cancelled_diagnostic_during_correction_campaign(self):
+    def test_can_update_cancelled_diagnostic_during_correction_campaign(self):
         """
         A diagnostic can be edited during the correction campaign if its teledeclaration has been cancelled
         """
@@ -892,7 +881,6 @@ class DiagnosticUpdateApiTest(APITestCase):
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
             payload = {"service_type": Diagnostic.ServiceType.MULTIPLE_SELF}
-
             response = self.client.patch(
                 reverse(
                     "diagnostic_retrieve_update",

--- a/api/tests/test_diagnostics_complete_import.py
+++ b/api/tests/test_diagnostics_complete_import.py
@@ -1,7 +1,5 @@
-import json
 from unittest import skipIf
 
-from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.conf import settings
@@ -10,28 +8,14 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from api.tests.utils import assert_import_failure_created, authenticate
-from api.views.diagnostic_import import DIAGNOSTICS_COMPLETE_SCHEMA_FILE_PATH
 from data.factories import CanteenFactory, DiagnosticFactory
 from data.models import Canteen, Diagnostic, ImportFailure, ImportType
 from data.models.creation_source import CreationSource
 
 
-class DiagnosticsCompleteSchemaTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.schema = json.load(open(DIAGNOSTICS_COMPLETE_SCHEMA_FILE_PATH))
-
-    def get_pattern(self, schema, field_name):
-        field_index = next((i for i, f in enumerate(schema["fields"]) if f["name"] == field_name), None)
-        pattern = schema["fields"][field_index]["constraints"]["pattern"]
-        return pattern
-
-    # no regex patterns to test
-
-
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class DiagnosticsCompleteImportApiErrorTest(APITestCase):
-    def test_unauthenticated(self):
+    def test_cannot_import_if_unauthenticated(self):
         self.assertEqual(Diagnostic.objects.count(), 0)
 
         response = self.client.post(reverse("diagnostics_complete_import"))

--- a/api/tests/test_diagnostics_complete_schema_import.py
+++ b/api/tests/test_diagnostics_complete_schema_import.py
@@ -1,0 +1,17 @@
+import json
+
+from django.test import TestCase
+from api.views.diagnostic_import import DIAGNOSTICS_COMPLETE_SCHEMA_FILE_PATH
+
+
+class DiagnosticsCompleteSchemaTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.schema = json.load(open(DIAGNOSTICS_COMPLETE_SCHEMA_FILE_PATH))
+
+    def get_pattern(self, schema, field_name):
+        field_index = next((i for i, f in enumerate(schema["fields"]) if f["name"] == field_name), None)
+        pattern = schema["fields"][field_index]["constraints"]["pattern"]
+        return pattern
+
+    # no regex patterns to test

--- a/api/tests/test_diagnostics_simple_import.py
+++ b/api/tests/test_diagnostics_simple_import.py
@@ -1,8 +1,6 @@
-import json
 from decimal import Decimal
 from unittest import skipIf
 
-from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from freezegun import freeze_time
@@ -11,28 +9,14 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from api.tests.utils import assert_import_failure_created, authenticate
-from api.views.diagnostic_import import DIAGNOSTICS_SIMPLE_ID_SCHEMA_FILE_PATH
 from data.factories import CanteenFactory, DiagnosticFactory
 from data.models import Canteen, Diagnostic, ImportFailure, ImportType
 from data.models.creation_source import CreationSource
 
 
-class DiagnosticsSimpleSchemaTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.schema = json.load(open(DIAGNOSTICS_SIMPLE_ID_SCHEMA_FILE_PATH))
-
-    def get_pattern(self, schema, field_name):
-        field_index = next((i for i, f in enumerate(schema["fields"]) if f["name"] == field_name), None)
-        pattern = schema["fields"][field_index]["constraints"]["pattern"]
-        return pattern
-
-    # no regex patterns to test
-
-
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class DiagnosticsSimpleImportApiErrorTest(APITestCase):
-    def test_unauthenticated(self):
+    def test_cannot_import_if_unauthenticated(self):
         self.assertEqual(Diagnostic.objects.count(), 0)
 
         response = self.client.post(reverse("diagnostics_simple_import"))

--- a/api/tests/test_diagnostics_simple_schema_import.py
+++ b/api/tests/test_diagnostics_simple_schema_import.py
@@ -1,0 +1,17 @@
+import json
+
+from django.test import TestCase
+from api.views.diagnostic_import import DIAGNOSTICS_SIMPLE_ID_SCHEMA_FILE_PATH
+
+
+class DiagnosticsSimpleSchemaTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.schema = json.load(open(DIAGNOSTICS_SIMPLE_ID_SCHEMA_FILE_PATH))
+
+    def get_pattern(self, schema, field_name):
+        field_index = next((i for i, f in enumerate(schema["fields"]) if f["name"] == field_name), None)
+        pattern = schema["fields"][field_index]["constraints"]["pattern"]
+        return pattern
+
+    # no regex patterns to test

--- a/api/tests/test_initial_data.py
+++ b/api/tests/test_initial_data.py
@@ -34,7 +34,7 @@ class InitialDataApiTest(APITestCase):
         cls.video_tutorial = VideoTutorialFactory(published=True)
         cls.url = reverse("initial_data")
 
-    def test_get_unauthenticated(self):
+    def test_can_get_unauthenticated(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -63,7 +63,7 @@ class InitialDataApiTest(APITestCase):
         self.assertEqual(len(body["lineMinistries"]), len(Canteen.Ministries))
 
     @freeze_time(timezone.now() + datetime.timedelta(days=2))
-    def test_get_unauthenticated_no_upcoming_community_events(self):
+    def test_can_get_unauthenticated_no_upcoming_community_events(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -73,7 +73,7 @@ class InitialDataApiTest(APITestCase):
         self.assertEqual(len(body["communityEvents"]), 0)
 
     @authenticate
-    def test_get_authenticated(self):
+    def test_can_get_authenticated(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -94,7 +94,7 @@ class InitialDataApiTest(APITestCase):
         self.assertEqual(len(body["canteenPreviews"]), 0)
 
     @authenticate
-    def test_get_authenticated_and_manager(self):
+    def test_can_get_authenticated_and_manager(self):
         self.canteen.managers.set([authenticate.user])
 
         response = self.client.get(self.url)

--- a/api/tests/test_partners.py
+++ b/api/tests/test_partners.py
@@ -6,8 +6,12 @@ from data.factories import PartnerFactory, PartnerTypeFactory, UserFactory
 from data.models import Partner, SectorCategory, SectorM2M
 
 
-class TestPartnersApi(APITestCase):
-    def test_get_partners(self):
+class PartnersListApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("partners_list")
+
+    def test_can_list_partners(self):
         """
         Returns partners and the types that are in use therefore available for filtering
         """
@@ -31,13 +35,12 @@ class TestPartnersApi(APITestCase):
         partners[1].sector_categories = [sector_category_2]
         partners[1].save()
         # don't add type to third partner to check null value filtering
-        response = self.client.get(reverse("partners_list"))
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-
         self.assertEqual(body.get("count"), 3)
-
-        results = body.get("results", [])
+        results = body["results"]
         for partner in partners:
             self.assertTrue(any(x["id"] == partner.id for x in results))
 
@@ -57,142 +60,16 @@ class TestPartnersApi(APITestCase):
         self.assertIn(sector_category_2.value, sector_categories)
         self.assertNotIn(sector_category_3.value, sector_categories)
 
-    def test_type_filter(self):
-        """
-        Return the union of all partners based on the types requested
-        """
-        good = PartnerTypeFactory(name="Good")
-        also = PartnerTypeFactory(name="Also good")
-        ignored = PartnerTypeFactory(name="Ignored")
-
-        find_me_1 = PartnerFactory(name="Find me", published=True)
-        find_me_1.types.add(good)
-        find_me_2 = PartnerFactory(name="Find me too", published=True)
-        find_me_2.types.add(ignored)
-        find_me_2.types.add(good)
-        find_me_3 = PartnerFactory(name="Me three", published=True)
-        find_me_3.types.add(also)
-        ignore_me = PartnerFactory(name="Ignore me", published=True)
-        ignore_me.types.add(ignored)
-        PartnerFactory(name="Typeless", published=True)
-
-        url = f"{reverse('partners_list')}?type=Good&type=Also good"
-        response = self.client.get(url)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 3)
-        results = list(map(lambda r: r.get("name"), results))
-        self.assertIn("Find me", results)
-        self.assertIn("Find me too", results)
-        self.assertIn("Me three", results)
-
-    def test_department_filter(self):
-        """
-        Return the union of all partners based on departments requested
-        """
-        PartnerFactory(name="Find me", departments=["09"], published=True)
-        PartnerFactory(name="Find me too", departments=["10"], published=True)
-        PartnerFactory(name="Me three", departments=["10", "11"], published=True)
-        PartnerFactory(name="But not me", departments=["11"], published=True)
-
-        url = f"{reverse('partners_list')}?department=09&department=10"
-        response = self.client.get(url)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 3)
-        results = list(map(lambda r: r.get("name"), results))
-        self.assertIn("Find me", results)
-        self.assertIn("Find me too", results)
-        self.assertIn("Me three", results)
-
-    def test_cost_filter(self):
-        """
-        Return all the free partners
-        """
-        PartnerFactory(name="Find me", gratuity_option=Partner.GratuityOption.FREE, published=True)
-        PartnerFactory(name="But not me", gratuity_option=Partner.GratuityOption.PAID, published=True)
-
-        url = f"{reverse('partners_list')}?gratuityOption=free"
-        response = self.client.get(url)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]["name"], "Find me")
-
-    def test_categories_filter(self):
-        """
-        Returns the union of all partners based on categories (aka needs) requested
-        """
-        PartnerFactory(name="Find me", categories=["appro"], published=True)
-        PartnerFactory(name="Find me too", categories=["plastic"], published=True)
-        PartnerFactory(name="Me three", categories=["plastic", "asso"], published=True)
-        PartnerFactory(name="But not me", categories=["asso"], published=True)
-
-        url = f"{reverse('partners_list')}?category=appro&category=plastic"
-        response = self.client.get(url)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 3)
-        results = list(map(lambda r: r.get("name"), results))
-        self.assertIn("Find me", results)
-        self.assertIn("Find me too", results)
-        self.assertIn("Me three", results)
-
-    def test_get_single_partner(self):
-        type = PartnerTypeFactory(name="Test type")
-        partner = PartnerFactory(published=True)
-        partner.types.add(type)
-
-        response = self.client.get(reverse("single_partner", kwargs={"pk": partner.id}))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("Test type", response.json()["types"])
-
-    def test_get_published_partners_only(self):
+    def test_can_get_published_partners_only(self):
         PartnerFactory(name="I am published", published=True)
         PartnerFactory(name="I am secret", published=False)
 
-        response = self.client.get(reverse("partners_list"))
-        partners = response.json().get("results")
+        response = self.client.get(self.url)
+
+        body = response.json()
+        partners = body["results"]
         self.assertEqual(len(partners), 1)
         self.assertEqual(partners[0]["name"], "I am published")
-
-    def test_get_published_partner_only(self):
-        partner = PartnerFactory(name="I am secret", published=False)
-
-        response = self.client.get(reverse("single_partner", kwargs={"pk": partner.id}))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_create_partner(self):
-        """
-        Test that unauthenticated users can create draft partners
-        """
-        sector_cateory = SectorM2M.Categories.ADMINISTRATION
-        partner_type = PartnerTypeFactory()
-        self.assertEqual(Partner.objects.count(), 0)
-        payload = {
-            "name": "New partner please",
-            "shortDescription": "This is a required field",
-            "published": True,
-            "contactEmail": "test@example.com",
-            "sector_categories": [sector_cateory.value],
-            "types": [partner_type.id],
-        }
-        response = self.client.post(reverse("partners_list"), payload, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(Partner.objects.count(), 1, "Exactly one partner added to DB")
-        partner = Partner.objects.first()
-        self.assertEqual(partner.name, "New partner please")
-        self.assertEqual(partner.short_description, "This is a required field")
-        self.assertEqual(partner.contact_email, "test@example.com")
-        self.assertIn(sector_cateory, partner.sector_categories)
-        self.assertEqual(partner.types.count(), 1)
-        self.assertEqual(partner.types.first().id, partner_type.id)
-        self.assertFalse(partner.published, "A user can't create a published partner")
-
-    def test_cannot_fetch_contact_info(self):
-        partner = PartnerFactory(published=True, contact_email="secret@mi5.com")
-
-        response = self.client.get(reverse("partners_list"))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-        partner = body["results"][0]
-        self.assertNotIn("contactEmail", partner)
 
     def test_randomized_results(self):
         """
@@ -233,3 +110,151 @@ class TestPartnersApi(APITestCase):
         self.assertEqual(user_1_results_1, user_1_results_2)
         self.assertEqual(user_2_results_1, user_2_results_2)
         self.assertNotEqual(user_1_results_1, user_2_results_1)
+
+    def test_cannot_fetch_contact_info(self):
+        partner = PartnerFactory(published=True, contact_email="secret@mi5.com")
+
+        response = self.client.get(reverse("partners_list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        partner = body["results"][0]
+        self.assertNotIn("contactEmail", partner)
+
+
+class PartnersListApiFilterTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("partners_list")
+
+    def test_can_filter_by_type(self):
+        """
+        Return the union of all partners based on the types requested
+        """
+        good = PartnerTypeFactory(name="Good")
+        also = PartnerTypeFactory(name="Also good")
+        ignored = PartnerTypeFactory(name="Ignored")
+
+        find_me_1 = PartnerFactory(name="Find me", published=True)
+        find_me_1.types.add(good)
+        find_me_2 = PartnerFactory(name="Find me too", published=True)
+        find_me_2.types.add(ignored)
+        find_me_2.types.add(good)
+        find_me_3 = PartnerFactory(name="Me three", published=True)
+        find_me_3.types.add(also)
+        ignore_me = PartnerFactory(name="Ignore me", published=True)
+        ignore_me.types.add(ignored)
+        PartnerFactory(name="Typeless", published=True)
+
+        url = f"{self.url}?type=Good&type=Also good"
+        response = self.client.get(url)
+
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 3)
+        results = list(map(lambda r: r.get("name"), results))
+        self.assertIn("Find me", results)
+        self.assertIn("Find me too", results)
+        self.assertIn("Me three", results)
+
+    def test_can_filter_by_department(self):
+        """
+        Return the union of all partners based on departments requested
+        """
+        PartnerFactory(name="Find me", departments=["09"], published=True)
+        PartnerFactory(name="Find me too", departments=["10"], published=True)
+        PartnerFactory(name="Me three", departments=["10", "11"], published=True)
+        PartnerFactory(name="But not me", departments=["11"], published=True)
+
+        url = f"{self.url}?department=09&department=10"
+        response = self.client.get(url)
+
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 3)
+        results = list(map(lambda r: r.get("name"), results))
+        self.assertIn("Find me", results)
+        self.assertIn("Find me too", results)
+        self.assertIn("Me three", results)
+
+    def test_can_filter_by_gratuity_option(self):
+        """
+        Return all the free partners
+        """
+        PartnerFactory(name="Find me", gratuity_option=Partner.GratuityOption.FREE, published=True)
+        PartnerFactory(name="But not me", gratuity_option=Partner.GratuityOption.PAID, published=True)
+
+        url = f"{self.url}?gratuityOption=free"
+        response = self.client.get(url)
+
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["name"], "Find me")
+
+    def test_can_filter_by_category(self):
+        """
+        Returns the union of all partners based on categories (aka needs) requested
+        """
+        PartnerFactory(name="Find me", categories=["appro"], published=True)
+        PartnerFactory(name="Find me too", categories=["plastic"], published=True)
+        PartnerFactory(name="Me three", categories=["plastic", "asso"], published=True)
+        PartnerFactory(name="But not me", categories=["asso"], published=True)
+
+        url = f"{self.url}?category=appro&category=plastic"
+        response = self.client.get(url)
+
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 3)
+        results = list(map(lambda r: r.get("name"), results))
+        self.assertIn("Find me", results)
+        self.assertIn("Find me too", results)
+        self.assertIn("Me three", results)
+
+
+class PartnerCreateApiTest(APITestCase):
+    def test_can_create_partner_if_unauthenticated(self):
+        """
+        Test that unauthenticated users can create draft partners
+        """
+        sector_cateory = SectorM2M.Categories.ADMINISTRATION
+        partner_type = PartnerTypeFactory()
+        self.assertEqual(Partner.objects.count(), 0)
+
+        payload = {
+            "name": "New partner please",
+            "shortDescription": "This is a required field",
+            "published": True,
+            "contactEmail": "test@example.com",
+            "sector_categories": [sector_cateory.value],
+            "types": [partner_type.id],
+        }
+        response = self.client.post(reverse("partners_list"), payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Partner.objects.count(), 1, "Exactly one partner added to DB")
+        partner = Partner.objects.first()
+        self.assertEqual(partner.name, "New partner please")
+        self.assertEqual(partner.short_description, "This is a required field")
+        self.assertEqual(partner.contact_email, "test@example.com")
+        self.assertIn(sector_cateory, partner.sector_categories)
+        self.assertEqual(partner.types.count(), 1)
+        self.assertEqual(partner.types.first().id, partner_type.id)
+        self.assertFalse(partner.published, "A user can't create a published partner")  # draft
+
+
+class PartnerDetailApiTest(APITestCase):
+    def test_can_get_single_partner(self):
+        type = PartnerTypeFactory(name="Test type")
+        partner = PartnerFactory(published=True)
+        partner.types.add(type)
+
+        response = self.client.get(reverse("single_partner", kwargs={"pk": partner.id}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("Test type", response.json()["types"])
+
+    def test_can_get_published_partner_only(self):
+        partner = PartnerFactory(name="I am secret", published=False)
+
+        response = self.client.get(reverse("single_partner", kwargs={"pk": partner.id}))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/api/tests/test_partners.py
+++ b/api/tests/test_partners.py
@@ -213,10 +213,7 @@ class PartnersListApiFilterTest(APITestCase):
 
 
 class PartnerCreateApiTest(APITestCase):
-    def test_can_create_partner_if_unauthenticated(self):
-        """
-        Test that unauthenticated users can create draft partners
-        """
+    def test_can_create_partner_unauthenticated(self):
         sector_cateory = SectorM2M.Categories.ADMINISTRATION
         partner_type = PartnerTypeFactory()
         self.assertEqual(Partner.objects.count(), 0)

--- a/api/tests/test_purchase_export.py
+++ b/api/tests/test_purchase_export.py
@@ -12,13 +12,13 @@ class PurchaseListExportApiTest(APITestCase):
     def setUpTestData(cls):
         cls.url = reverse("purchase_list_export")
 
-    def test_excel_export_unauthenticated(self):
+    def test_cannot_export_if_unauthenticated(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_excel_export(self):
+    def test_can_export(self):
         canteen = CanteenFactory(managers=[authenticate.user])
         PurchaseFactory(description="avoine", canteen=canteen)
         PurchaseFactory(description="tomates", canteen=canteen)
@@ -30,7 +30,7 @@ class PurchaseListExportApiTest(APITestCase):
         self.assertEqual(len(response.data), 3)
 
     @authenticate
-    def test_excel_export_search(self):
+    def test_can_export_search(self):
         canteen = CanteenFactory(managers=[authenticate.user])
         PurchaseFactory(description="avoine", canteen=canteen)
         PurchaseFactory(description="tomates", canteen=canteen)
@@ -43,7 +43,7 @@ class PurchaseListExportApiTest(APITestCase):
         self.assertEqual(len(response.data), 1)
 
     @authenticate
-    def test_excel_export_filter(self):
+    def test_can_export_filter(self):
         canteen = CanteenFactory(managers=[authenticate.user])
         PurchaseFactory(famille_produits=Purchase.Family.PRODUITS_DE_LA_MER, description="avoine", canteen=canteen)
         PurchaseFactory(famille_produits=Purchase.Family.PRODUITS_DE_LA_MER, description="tomates", canteen=canteen)

--- a/api/tests/test_purchase_facture.py
+++ b/api/tests/test_purchase_facture.py
@@ -8,7 +8,7 @@ from data.models import Purchase
 from data.factories import CanteenFactory, PurchaseFactory
 
 
-class PurchaseFactureUploadTest(APITestCase):
+class PurchaseFactureUploadApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.canteen = CanteenFactory()
@@ -18,14 +18,14 @@ class PurchaseFactureUploadTest(APITestCase):
             kwargs={"canteen_pk": cls.canteen.id, "pk": cls.purchase.id},
         )
 
-    def test_cannot_upload_if_unauthenticated(self):
+    def test_cannot_upload_facture_if_unauthenticated(self):
         file = SimpleUploadedFile("facture.pdf", b"pdf content")
         response = self.client.post(self.url, {"facture": file}, format="multipart")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_upload_if_canteen_unknown(self):
+    def test_cannot_upload_facture_if_canteen_does_not_exist(self):
         url = reverse(
             "purchase_facture",
             kwargs={"canteen_pk": 9999, "pk": self.purchase.id},
@@ -36,14 +36,14 @@ class PurchaseFactureUploadTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_upload_if_not_canteen_manager(self):
+    def test_cannot_upload_facture_if_not_canteen_manager(self):
         file = SimpleUploadedFile("facture.pdf", b"pdf content")
         response = self.client.post(self.url, {"facture": file}, format="multipart")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_upload_if_purchase_unknown(self):
+    def test_cannot_upload_facture_if_purchase_does_not_exist(self):
         self.canteen.managers.add(authenticate.user)
         url = reverse(
             "purchase_facture",
@@ -56,7 +56,7 @@ class PurchaseFactureUploadTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_upload_if_file_missing(self):
+    def test_cannot_upload_facture_if_file_missing(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.post(self.url, {}, format="multipart")
@@ -64,7 +64,7 @@ class PurchaseFactureUploadTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @authenticate
-    def test_cannot_upload_if_purchase_not_in_corresponding_canteen(self):
+    def test_cannot_upload_facture_if_purchase_not_in_corresponding_canteen(self):
         canteen_other = CanteenFactory()
         purchase_other = PurchaseFactory(canteen=canteen_other)
         url = reverse(
@@ -96,7 +96,7 @@ class PurchaseFactureUploadTest(APITestCase):
         self.assertIn("facture", self.purchase.facture.name)
 
     @authenticate
-    def test_can_upload_facture_even_if_canteen_not_filled(self):
+    def test_can_upload_facture_even_if_canteen_not_valid(self):
         self.canteen.managers.add(authenticate.user)
         self.canteen.siret = None
         self.canteen.save(skip_validations=True)
@@ -117,7 +117,7 @@ class PurchaseFactureUploadTest(APITestCase):
         self.assertIn("facture", self.purchase.facture.name)
 
     @authenticate
-    def test_can_upload_even_if_purchase_not_filled(self):
+    def test_can_upload_facture_even_if_purchase_not_valid(self):
         self.canteen.managers.add(authenticate.user)
         self.purchase.caracteristiques = [Purchase.Characteristic.EUROPE, Purchase.Characteristic.FRANCE]
         self.purchase.save(skip_validations=True)
@@ -151,7 +151,7 @@ class PurchaseFactureUploadTest(APITestCase):
         self.assertNotEqual(self.purchase.facture.name, old_file_name)
 
 
-class PurchaseFactureRetrieveTest(APITestCase):
+class PurchaseFactureRetrieveApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.canteen = CanteenFactory()
@@ -161,13 +161,13 @@ class PurchaseFactureRetrieveTest(APITestCase):
             kwargs={"canteen_pk": cls.canteen.id, "pk": cls.purchase.id},
         )
 
-    def test_cannot_retrieve_if_unauthenticated(self):
+    def test_cannot_retrieve_facture_if_unauthenticated(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_retrieve_if_canteen_unknown(self):
+    def test_cannot_retrieve_facture_if_canteen_does_not_exist(self):
         url = reverse(
             "purchase_facture",
             kwargs={"canteen_pk": 9999, "pk": self.purchase.id},
@@ -178,13 +178,13 @@ class PurchaseFactureRetrieveTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_retrieve_if_not_canteen_manager(self):
+    def test_cannot_retrieve_facture_if_not_canteen_manager(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_retrieve_if_purchase_unknown(self):
+    def test_cannot_retrieve_facture_if_purchase_does_not_exist(self):
         self.canteen.managers.add(authenticate.user)
         url = reverse(
             "purchase_facture",
@@ -196,7 +196,7 @@ class PurchaseFactureRetrieveTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_retrieve_if_purchase_not_in_corresponding_canteen(self):
+    def test_cannot_retrieve_facture_if_purchase_not_in_corresponding_canteen(self):
         canteen_other = CanteenFactory()
         purchase_other = PurchaseFactory(canteen=canteen_other)
         url = reverse(
@@ -221,7 +221,7 @@ class PurchaseFactureRetrieveTest(APITestCase):
         self.assertIsNotNone(data["facture"])
 
     @authenticate
-    def test_returns_404_if_purchase_has_no_facture(self):
+    def test_return_404_if_purchase_has_no_facture(self):
         self.canteen.managers.add(authenticate.user)
         self.purchase.facture = None
         self.purchase.save()
@@ -231,7 +231,7 @@ class PurchaseFactureRetrieveTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
-class PurchaseFactureUpdateTest(APITestCase):
+class PurchaseFactureUpdateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.canteen = CanteenFactory()
@@ -260,7 +260,7 @@ class PurchaseFactureUpdateTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
-class PurchaseFactureDeleteTest(APITestCase):
+class PurchaseFactureDeleteApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.canteen = CanteenFactory()
@@ -270,13 +270,13 @@ class PurchaseFactureDeleteTest(APITestCase):
             kwargs={"canteen_pk": cls.canteen.id, "pk": cls.purchase.id},
         )
 
-    def test_cannot_delete_if_unauthenticated(self):
+    def test_cannot_delete_facture_if_unauthenticated(self):
         response = self.client.delete(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_delete_if_canteen_unknown(self):
+    def test_cannot_delete_facture_if_canteen_does_not_exist(self):
         url = reverse(
             "purchase_facture",
             kwargs={"canteen_pk": 9999, "pk": self.purchase.id},
@@ -287,13 +287,13 @@ class PurchaseFactureDeleteTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_delete_if_not_canteen_manager(self):
+    def test_cannot_delete_facture_if_not_canteen_manager(self):
         response = self.client.delete(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_delete_if_purchase_unknown(self):
+    def test_cannot_delete_facture_if_purchase_does_not_exist(self):
         self.canteen.managers.add(authenticate.user)
         url = reverse(
             "purchase_facture",
@@ -305,7 +305,7 @@ class PurchaseFactureDeleteTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_delete_if_purchase_not_in_corresponding_canteen(self):
+    def test_cannot_delete_facture_if_purchase_not_in_corresponding_canteen(self):
         canteen_other = CanteenFactory()
         purchase_other = PurchaseFactory(canteen=canteen_other)
         url = reverse(
@@ -330,7 +330,7 @@ class PurchaseFactureDeleteTest(APITestCase):
         self.assertFalse(self.purchase.facture)
 
     @authenticate
-    def test_can_delete_facture_even_if_canteen_not_filled(self):
+    def test_can_delete_facture_even_if_canteen_not_valid(self):
         self.canteen.managers.add(authenticate.user)
         self.canteen.siret = None
         self.canteen.save(skip_validations=True)
@@ -345,7 +345,7 @@ class PurchaseFactureDeleteTest(APITestCase):
         self.assertFalse(self.purchase.facture)
 
     @authenticate
-    def test_can_delete_facture_even_if_purchase_not_filled(self):
+    def test_can_delete_facture_even_if_purchase_not_valid(self):
         self.canteen.managers.add(authenticate.user)
         self.purchase.caracteristiques = [Purchase.Characteristic.EUROPE, Purchase.Characteristic.FRANCE]
         self.purchase.save(skip_validations=True)
@@ -358,7 +358,7 @@ class PurchaseFactureDeleteTest(APITestCase):
         self.assertFalse(self.purchase.facture)
 
     @authenticate
-    def test_returns_404_if_purchase_has_no_facture(self):
+    def test_return_404_if_purchase_has_no_facture(self):
         self.canteen.managers.add(authenticate.user)
         self.purchase.facture = None
         self.purchase.save()

--- a/api/tests/test_purchase_facture.py
+++ b/api/tests/test_purchase_facture.py
@@ -67,13 +67,13 @@ class PurchaseFactureUploadApiTest(APITestCase):
     def test_cannot_upload_facture_if_purchase_not_in_corresponding_canteen(self):
         canteen_other = CanteenFactory()
         purchase_other = PurchaseFactory(canteen=canteen_other)
+        self.canteen.managers.add(authenticate.user)
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+
         url = reverse(
             "purchase_facture",
             kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
         )
-        self.canteen.managers.add(authenticate.user)
-        file = SimpleUploadedFile("facture.pdf", b"pdf content")
-
         response = self.client.post(url, {"facture": file}, format="multipart")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -199,12 +199,12 @@ class PurchaseFactureRetrieveApiTest(APITestCase):
     def test_cannot_retrieve_facture_if_purchase_not_in_corresponding_canteen(self):
         canteen_other = CanteenFactory()
         purchase_other = PurchaseFactory(canteen=canteen_other)
+        self.canteen.managers.add(authenticate.user)
+
         url = reverse(
             "purchase_facture",
             kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
         )
-        self.canteen.managers.add(authenticate.user)
-
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -281,7 +281,6 @@ class PurchaseFactureDeleteApiTest(APITestCase):
             "purchase_facture",
             kwargs={"canteen_pk": 9999, "pk": self.purchase.id},
         )
-
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -295,11 +294,11 @@ class PurchaseFactureDeleteApiTest(APITestCase):
     @authenticate
     def test_cannot_delete_facture_if_purchase_does_not_exist(self):
         self.canteen.managers.add(authenticate.user)
+
         url = reverse(
             "purchase_facture",
             kwargs={"canteen_pk": self.canteen.id, "pk": 9999},
         )
-
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -308,12 +307,12 @@ class PurchaseFactureDeleteApiTest(APITestCase):
     def test_cannot_delete_facture_if_purchase_not_in_corresponding_canteen(self):
         canteen_other = CanteenFactory()
         purchase_other = PurchaseFactory(canteen=canteen_other)
+        self.canteen.managers.add(authenticate.user)
+
         url = reverse(
             "purchase_facture",
             kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
         )
-        self.canteen.managers.add(authenticate.user)
-
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -587,9 +587,9 @@ class PurchaseDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_get_purchase_if_canteen_unknown(self):
+    def test_cannot_get_purchase_if_canteen_does_not_exist(self):
         response = self.client.get(
-            reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": 999, "pk": self.purchase.id})
+            reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": 9999, "pk": self.purchase.id})
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -601,7 +601,7 @@ class PurchaseDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_get_purchase_if_purchase_unknown(self):
+    def test_cannot_get_purchase_if_purchase_does_not_exist(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.get(
@@ -711,13 +711,13 @@ class PurchaseUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_update_if_canteen_unknown(self):
+    def test_cannot_update_if_canteen_does_not_exist(self):
         payload = {
             "prix_ht": 15.23,
         }
 
         response = self.client.patch(
-            reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": 999, "pk": self.purchase.id}),
+            reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": 9999, "pk": self.purchase.id}),
             payload,
         )
 
@@ -735,7 +735,7 @@ class PurchaseUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_update_if_purchase_unknown(self):
+    def test_cannot_update_if_purchase_does_not_exist(self):
         self.canteen.managers.add(authenticate.user)
         payload = {
             "prix_ht": 15.23,
@@ -1152,7 +1152,7 @@ class PurchaseDeleteMultipleApiTest(APITestCase):
         purchase_already_deleted = PurchaseFactory(deletion_date=date)
         purchase_should_delete.canteen.managers.add(authenticate.user)
         purchase_already_deleted.canteen.managers.add(authenticate.user)
-        invalid_id = "999"
+        invalid_id = "9999"
         not_mine = PurchaseFactory(deletion_date=None)
         ids = [purchase_should_delete.id, purchase_already_deleted.id, invalid_id, not_mine.id]
 
@@ -1201,7 +1201,7 @@ class PurchaseRestoreApiTest(APITestCase):
 
 class PurchaseCanteenSummaryApiTest(APITestCase):
     @authenticate
-    def test_cannot_purchase_canteen_summary_if_unauthenticated(self):
+    def test_cannot_get_purchase_canteen_summary_if_unauthenticated(self):
         canteen = CanteenFactory()
 
         response = self.client.get(
@@ -1211,13 +1211,13 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_purchase_canteen_summary_if_canteen_unknown(self):
-        response = self.client.get(reverse("canteen_purchases_summary", kwargs={"canteen_pk": 999999}), {"year": 2020})
+    def test_cannot_get_purchase_canteen_summary_if_canteen_does_not_exist(self):
+        response = self.client.get(reverse("canteen_purchases_summary", kwargs={"canteen_pk": 9999}), {"year": 2020})
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_purchase_total_summary(self):
+    def test_get_purchase_total_summary(self):
         """
         Given a year, return spending by category
         Bio category is the sum of all products with either bio or bio en conversion labels

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -12,304 +12,6 @@ from data.models import Canteen, Diagnostic, Purchase
 from data.models.creation_source import CreationSource
 
 
-class PurchaseOldListApiTest(APITestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = UserFactory()
-        cls.canteen = CanteenFactory(managers=[cls.user])
-        cls.purchase = PurchaseFactory(
-            canteen=cls.canteen,
-            description="tomates",
-            fournisseur="fournisseur",
-            date="2022-01-13",
-            prix_ht=Decimal(4.5),
-            famille_produits=Purchase.Family.FRUITS_ET_LEGUMES,
-            caracteristiques=[Purchase.Characteristic.BIO, Purchase.Characteristic.EUROPE],
-            creation_user=cls.user,
-            creation_source=CreationSource.APP,
-        )
-        cls.url = reverse("purchase_list_create")
-
-    def test_cannot_list_if_unauthenticated(self):
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_can_list_purchases_of_managed_canteens(self):
-        # canteen managed by authenticated user
-        self.canteen.managers.add(authenticate.user)
-        # other user, other canteen, other purchases
-        other_user = UserFactory()
-        other_user_canteen = CanteenFactory(managers=[other_user])
-        PurchaseFactory(canteen=other_user_canteen)
-        canteen_not_managed = CanteenFactory()
-        PurchaseFactory(canteen=canteen_not_managed)
-
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(Purchase.objects.count(), 1 + 1 + 1)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 1)
-
-    def test_cannot_list_purchases_via_oauth2(self):
-        user, token = get_oauth2_token("canteen:write")
-        self.canteen.managers.add(user)
-
-        self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-
-class PurchaseOldListFilterApiTest(APITestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.canteen = CanteenFactory()
-        PurchaseFactory(
-            canteen=cls.canteen,
-            description="avoine",
-            famille_produits=Purchase.Family.PRODUITS_DE_LA_MER,
-            caracteristiques=[Purchase.Characteristic.BIO],
-            date="2020-01-01",
-        )
-        PurchaseFactory(
-            canteen=cls.canteen,
-            description="tomates",
-            famille_produits=Purchase.Family.PRODUITS_DE_LA_MER,
-            caracteristiques=[Purchase.Characteristic.BIO, Purchase.Characteristic.PECHE_DURABLE],
-            date="2020-01-02",
-        )
-        PurchaseFactory(
-            canteen=cls.canteen,
-            description="pommes",
-            famille_produits=Purchase.Family.AUTRES,
-            caracteristiques=[Purchase.Characteristic.PECHE_DURABLE],
-            date="2020-02-01",
-        )
-        cls.other_canteen = CanteenFactory()
-        PurchaseFactory(
-            canteen=cls.other_canteen,
-            description="secret",
-            famille_produits=None,
-            caracteristiques=[],
-            date="2020-01-01",
-        )
-        cls.url = reverse("purchase_list_create")
-
-    @authenticate
-    def test_filter_by_search_text(self):
-        # user is not (yet) the manager of the canteen
-        search_term = "avoine"
-
-        response = self.client.get(f"{self.url}?search={search_term}")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 0)
-
-        # set the user as manager of the canteen
-        self.canteen.managers.add(authenticate.user)
-
-        response = self.client.get(f"{self.url}?search={search_term}")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].get("description"), "avoine")
-
-    @authenticate
-    def test_filter_by_canteen(self):
-        # user is not (yet) the manager of any canteen
-        response = self.client.get(f"{self.url}?canteen__id={self.canteen.id}")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 0)
-
-        # set the user as manager of the canteen
-        self.canteen.managers.add(authenticate.user)
-
-        response = self.client.get(f"{self.url}?canteen__id={self.canteen.id}")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 3)
-
-        # try to filter by a canteen the user doesn't manage
-        response = self.client.get(f"{self.url}?canteen__id={self.other_canteen.id}")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 0)
-
-    @authenticate
-    def test_filter_by_characteristics(self):
-        self.canteen.managers.add(authenticate.user)
-
-        response = self.client.get(f"{self.url}?characteristics={Purchase.Characteristic.BIO}")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 2)
-
-        response = self.client.get(
-            f"{self.url}?characteristics={Purchase.Characteristic.BIO}&characteristics={Purchase.Characteristic.PECHE_DURABLE}"
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 3)
-
-    @authenticate
-    def test_filter_by_family(self):
-        self.canteen.managers.add(authenticate.user)
-
-        response = self.client.get(f"{self.url}?family={Purchase.Family.PRODUITS_DE_LA_MER}")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 2)
-
-    @authenticate
-    def test_filter_by_date(self):
-        self.canteen.managers.add(authenticate.user)
-
-        response = self.client.get(f"{self.url}?date_after=2020-01-02")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 2)
-
-        response = self.client.get(f"{self.url}?date_before=2020-01-01")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 1)
-
-        response = self.client.get(f"{self.url}?date_after=2020-01-02&date_before=2020-02-01")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json().get("results", [])
-        self.assertEqual(len(results), 2)
-
-    @authenticate
-    def test_pagination(self):
-        self.canteen.managers.add(authenticate.user)
-
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-        self.assertEqual(body["count"], 3)
-        self.assertIn("next", body)
-        self.assertIn("previous", body)
-        self.assertEqual(len(body["results"]), 3)
-        self.assertEqual(len(body["families"]), 2)
-        self.assertEqual(len(body["characteristics"]), 2)
-        self.assertEqual(len(body["canteens"]), 1)
-
-        response = self.client.get(f"{self.url}?limit=1&offset=1")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-        self.assertEqual(body["count"], 3)
-        self.assertIn("next", body)
-        self.assertIn("previous", body)
-        self.assertEqual(len(body["results"]), 1)
-        # the pagination should not change the available filter options
-        self.assertEqual(len(body["families"]), 2)
-        self.assertEqual(len(body["characteristics"]), 2)
-        self.assertEqual(len(body["canteens"]), 1)
-
-    @authenticate
-    def test_available_filter_options(self):
-        # set the user as manager + add an extra canteen with purchase
-        self.canteen.managers.add(authenticate.user)
-        canteen_2 = CanteenFactory(managers=[authenticate.user])
-        PurchaseFactory(
-            canteen=canteen_2, famille_produits=Purchase.Family.AUTRES, caracteristiques=[Purchase.Characteristic.BIO]
-        )
-
-        with self.assertNumQueries(7):
-            response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-        self.assertEqual(len(body["results"]), 3 + 1)
-        self.assertEqual(len(body["families"]), 2)
-        self.assertEqual(len(body["characteristics"]), 2)
-        self.assertEqual(len(body["canteens"]), 1 + 1)
-
-        response = self.client.get(f"{self.url}?characteristics={Purchase.Characteristic.BIO}")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-        self.assertEqual(len(body["results"]), 2 + 1)
-        self.assertEqual(len(body["characteristics"]), 2)
-        self.assertEqual(len(body["families"]), 1 + 1)
-        self.assertEqual(len(body["canteens"]), 1 + 1)
-
-        response = self.client.get(f"{self.url}?family={Purchase.Family.PRODUITS_LAITIERS}")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-        self.assertEqual(len(body["results"]), 0)
-        self.assertEqual(len(body["characteristics"]), 0)
-        self.assertEqual(len(body["families"]), 0)
-        self.assertEqual(len(body["canteens"]), 0)
-
-
-class PurchaseOldDetailApiTest(APITestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = UserFactory()
-        cls.canteen = CanteenFactory(managers=[cls.user])
-        cls.purchase = PurchaseFactory(
-            canteen=cls.canteen,
-            description="tomates",
-            fournisseur="fournisseur",
-            date="2022-01-13",
-            prix_ht=Decimal(4.5),
-            famille_produits=Purchase.Family.FRUITS_ET_LEGUMES,
-            caracteristiques=[Purchase.Characteristic.BIO, Purchase.Characteristic.EUROPE],
-            creation_user=cls.user,
-            creation_source=CreationSource.APP,
-        )
-        cls.url = reverse("purchase_retrieve_update_destroy", kwargs={"pk": cls.purchase.id})
-
-    def test_cannot_get_purchase_unauthenticated(self):
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_cannot_get_if_not_canteen_manager(self):
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    @authenticate
-    def test_get_purchase(self):
-        self.canteen.managers.add(authenticate.user)
-
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-        self.assertEqual(body["id"], self.purchase.id)
-
-    def test_cannot_get_purchase_via_oauth2(self):
-        user, token = get_oauth2_token("canteen:write")
-        self.canteen.managers.add(user)
-
-        self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-
 class PurchaseCreateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
@@ -632,7 +334,7 @@ class PurchaseDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_get_purchase(self):
+    def test_can_get_purchase(self):
         self.purchase.canteen.managers.add(authenticate.user)
 
         response = self.client.get(self.url)
@@ -658,7 +360,7 @@ class PurchaseDetailApiTest(APITestCase):
         self.assertIn("creationDate", body)
         self.assertIn("modificationDate", body)
 
-    def test_get_purchase_via_oauth2_only_if_same_creation_source(self):
+    def test_can_get_purchase_via_oauth2_only_if_same_creation_source(self):
         user, token = get_oauth2_token("canteen:write")
         self.purchase.canteen.managers.add(user)
 
@@ -699,7 +401,6 @@ class PurchaseUpdateApiTest(APITestCase):
         payload = {
             "prix_ht": 15.23,
         }
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -709,10 +410,9 @@ class PurchaseUpdateApiTest(APITestCase):
         payload = {
             "prix_ht": 15.23,
         }
-
         url = reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": 9999, "pk": self.purchase.id})
-        response = self.client.patch(url, payload)
 
+        response = self.client.patch(url, payload)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
@@ -721,7 +421,6 @@ class PurchaseUpdateApiTest(APITestCase):
             "description": "Saumon",
             "prix_ht": 15.23,
         }
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -729,13 +428,13 @@ class PurchaseUpdateApiTest(APITestCase):
     @authenticate
     def test_cannot_update_if_purchase_does_not_exist(self):
         self.canteen.managers.add(authenticate.user)
+
         payload = {
             "prix_ht": 15.23,
         }
-
         url = reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": self.canteen.id, "pk": 9999})
-        response = self.client.patch(url, payload)
 
+        response = self.client.patch(url, payload)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
@@ -743,10 +442,10 @@ class PurchaseUpdateApiTest(APITestCase):
         canteen_other = CanteenFactory()
         purchase_other = PurchaseFactory(canteen=canteen_other)
         self.canteen.managers.add(authenticate.user)
+
         payload = {
             "prix_ht": 15.23,
         }
-
         url = reverse(
             "canteen_purchase_retrieve_update_destroy",
             kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
@@ -767,8 +466,9 @@ class PurchaseUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_update_purchase(self):
+    def test_can_update_purchase(self):
         self.purchase.canteen.managers.add(authenticate.user)
+
         payload = {
             "description": "Saumon",
             "prix_ht": 15.23,
@@ -778,7 +478,6 @@ class PurchaseUpdateApiTest(APITestCase):
             "est_local": True,
             "definition_local": Purchase.Local.PAT,
         }
-
         response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -871,228 +570,6 @@ class PurchaseDeleteApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
-class PurchaseOldCreateApiTest(APITestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = UserFactory()
-        cls.canteen = CanteenFactory(managers=[cls.user])
-        cls.url = reverse("purchase_list_create")
-        cls.PURCHASE_PAYLOAD = {
-            "canteen": cls.canteen.id,
-            "description": "Saumon",
-            "provider": "Test fournisseur",
-            "date": "2022-01-13",
-            "price_ht": 15.23,
-            "family": "PRODUITS_DE_LA_MER",
-            "characteristics": ["BIO", "LOCAL"],
-            "local_definition": "COMMUNE",
-        }
-
-    def test_cannot_create_purchase_if_unauthenticated(self):
-        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_cannot_create_purchase_if_canteen_does_not_exist(self):
-        payload = {**self.PURCHASE_PAYLOAD, "canteen": 9999}
-
-        response = self.client.post(self.url, payload)
-
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    @authenticate
-    def test_cannot_create_purchase_if_not_canteen_manager(self):
-        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_create_purchase(self):
-        self.canteen.managers.add(authenticate.user)
-
-        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        purchase = Purchase.objects.first()
-        self.assertEqual(len(purchase.caracteristiques), 2)
-        self.assertEqual(purchase.definition_local, Purchase.Local.COMMUNE)
-        self.assertEqual(purchase.definition_local_km, None)
-
-    @authenticate
-    def test_create_purchase_creation_user_and_source(self):
-        self.canteen.managers.add(authenticate.user)
-
-        # from the APP
-        payload = {**self.PURCHASE_PAYLOAD, "creation_source": CreationSource.APP}
-        response = self.client.post(self.url, payload)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        body = response.json()
-        self.assertNotIn("creationUser", body)
-        self.assertNotIn("creationSource", body)
-        self.assertNotIn("creationSourceApiOauth2Application", body)
-        purchase = Purchase.objects.first()
-        self.assertEqual(purchase.creation_user, authenticate.user)
-        self.assertEqual(purchase.creation_source, CreationSource.APP)
-        self.assertEqual(purchase.creation_source_api_oauth2_application, None)
-
-        # cleanup
-        Purchase.objects.all().delete()
-
-        # defaults to API
-        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        body = response.json()
-        self.assertNotIn("creationUser", body)
-        self.assertNotIn("creationSource", body)
-        self.assertNotIn("creationSourceApiOauth2Application", body)
-        purchase = Purchase.objects.first()
-        self.assertEqual(purchase.creation_user, authenticate.user)
-        self.assertEqual(purchase.creation_source, CreationSource.API)
-        self.assertEqual(purchase.creation_source_api_oauth2_application, None)
-
-        # cleanup
-        Purchase.objects.all().delete()
-
-        # returns a 404 if the creation_source is not valid
-        payload = {**self.PURCHASE_PAYLOAD, "creation_source": "UNKNOWN"}
-        response = self.client.post(self.url, payload)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-
-class PurchaseOldUpdateApiTest(APITestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = UserFactory()
-        cls.canteen = CanteenFactory(managers=[cls.user])
-        cls.purchase = PurchaseFactory(canteen=cls.canteen, creation_user=cls.user, creation_source=CreationSource.APP)
-        cls.url = reverse("purchase_retrieve_update_destroy", kwargs={"pk": cls.purchase.id})
-
-    def test_cannot_update_purchase_if_unauthenticated(self):
-        payload = {
-            "price_ht": 15.23,
-        }
-
-        response = self.client.patch(self.url, payload)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_cannot_update_purchase_with_put(self):
-        self.purchase.canteen.managers.add(authenticate.user)
-        payload = {
-            "description": "Saumon",
-            "provider": "Test fournisseur",
-            "price_ht": 15.23,
-        }
-
-        response = self.client.put(self.url, payload)
-
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-
-    @authenticate
-    def test_cannot_update_if_not_canteen_manager(self):
-        payload = {
-            "description": "Saumon",
-            "provider": "Test fournisseur",
-            "price_ht": 15.23,
-        }
-
-        response = self.client.patch(self.url, payload)
-
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    @authenticate
-    def test_cannot_update_to_another_canteen_if_not_canteen_manager(self):
-        self.purchase.canteen.managers.add(authenticate.user)
-        canteen_not_manager = CanteenFactory()
-
-        payload = {
-            "canteen": canteen_not_manager.id,
-        }
-        response = self.client.patch(self.url, payload)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_update_purchase(self):
-        self.purchase.canteen.managers.add(authenticate.user)
-        new_canteen = CanteenFactory(managers=[authenticate.user])
-        payload = {
-            "canteen": new_canteen.id,
-            "description": "Saumon",
-            "provider": "Test fournisseur",
-            "price_ht": 15.23,
-        }
-
-        response = self.client.patch(self.url, payload)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.purchase.refresh_from_db()
-        self.assertEqual(self.purchase.canteen, new_canteen)
-        self.assertEqual(self.purchase.description, "Saumon")
-        self.assertEqual(self.purchase.fournisseur, "Test fournisseur")
-        self.assertEqual(float(self.purchase.prix_ht), 15.23)
-
-    @authenticate
-    def test_update_purchase_does_not_update_creation_user_and_source(self):
-        self.purchase.canteen.managers.add(authenticate.user)
-        self.assertEqual(self.purchase.creation_user, self.user)
-        self.assertEqual(self.purchase.creation_source, CreationSource.APP)
-        self.assertEqual(self.purchase.creation_source_api_oauth2_application, None)
-
-        payload = {
-            "description": "Saumon",
-            "provider": "Test fournisseur",
-            "price_ht": 15.23,
-            "creationSource": CreationSource.API,
-        }
-
-        response = self.client.patch(self.url, payload)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-        self.assertNotIn("creationUser", body)
-        self.assertNotIn("creationSource", body)
-        self.assertNotIn("creationSourceApiOauth2Application", body)
-        self.purchase.refresh_from_db()
-        self.assertEqual(self.purchase.creation_user, self.user)  # unchanged
-        self.assertEqual(self.purchase.creation_source, CreationSource.APP)  # unchanged
-        self.assertEqual(self.purchase.creation_source_api_oauth2_application, None)  # unchanged
-
-
-class PurchaseOldDeleteApiTest(APITestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = UserFactory()
-        cls.canteen = CanteenFactory(managers=[cls.user])
-        cls.purchase = PurchaseFactory(canteen=cls.canteen, creation_user=cls.user, creation_source=CreationSource.APP)
-        cls.url = reverse("purchase_retrieve_update_destroy", kwargs={"pk": cls.purchase.id})
-
-    def test_cannot_delete_if_unauthenticated(self):
-        response = self.client.delete(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(Purchase.objects.count(), 1)
-
-    @authenticate
-    def test_cannot_delete_if_not_canteen_manager(self):
-        response = self.client.delete(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(Purchase.objects.count(), 1)
-
-    @authenticate
-    def test_delete_purchase(self):
-        self.canteen.managers.add(authenticate.user)
-
-        response = self.client.delete(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(Purchase.objects.count(), 0)
-        self.assertEqual(Purchase.all_objects.count(), 1)
-
-
 class PurchaseDeleteMultipleApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
@@ -1110,7 +587,7 @@ class PurchaseDeleteMultipleApiTest(APITestCase):
         self.assertEqual(Purchase.objects.count(), 2)
 
     @authenticate
-    def test_delete_multiple_purchases(self):
+    def test_can_delete_multiple_purchases(self):
         self.assertIsNone(self.purchase_1.deletion_date)
         self.assertIsNone(self.purchase_2.deletion_date)
         self.canteen.managers.add(authenticate.user)
@@ -1128,7 +605,7 @@ class PurchaseDeleteMultipleApiTest(APITestCase):
         self.assertIsNotNone(self.purchase_2.deletion_date)
 
     @authenticate
-    def test_delete_invalid_purchases(self):
+    def test_can_delete_invalid_purchases(self):
         """
         Ignore ids that are: non-existant; already deleted; not managed by the user
         And delete what can be deleted
@@ -1205,7 +682,7 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_get_purchase_total_summary(self):
+    def test_can_get_purchase_total_summary(self):
         """
         Given a year, return spending by category
         Bio category is the sum of all products with either bio or bio en conversion labels
@@ -1569,7 +1046,7 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         self.assertEqual(body["valeurProduitsDeLaMerLocal"], 0)
 
     @authenticate
-    def test_get_multi_year_purchase_statistics(self):
+    def test_can_get_multi_year_purchase_statistics(self):
         """
         It is possible for a manager to retrieve year-on-year purchase totals for a canteen
         """
@@ -1608,7 +1085,7 @@ class PurchaseCanteenOptionsApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_get_purchase_options(self):
+    def test_can_get_purchase_options(self):
         """
         A manager should be able to retrieve a list of products and fournisseurs that
         they've already entered on their own purchases
@@ -1848,7 +1325,7 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         cls.year = 2024
         cls.url = reverse("canteen_purchases_percentage_summary", kwargs={"canteen_pk": cls.canteen.id})
 
-    def test_get_public_purchases_summary(self):
+    def test_can_get_public_purchases_summary(self):
         """
         Return percentages from purchase data for the given year and canteen
         """
@@ -1967,7 +1444,7 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_get_last_purchase_date_in_public_summary_if_canteen_manager(self):
+    def test_can_get_last_purchase_date_in_public_summary_if_canteen_manager(self):
         """
         The purchases summary should return the last purchase date if the user
         is the manager of the canteen

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -51,7 +51,7 @@ class PurchaseCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_create_empty_purchase_error(self):
+    def test_cannot_create_empty_purchase(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.post(self.url, {})
@@ -59,7 +59,7 @@ class PurchaseCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @authenticate
-    def test_create_minimal_purchase(self):
+    def test_can_create_minimal_purchase(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
@@ -87,7 +87,7 @@ class PurchaseCreateApiTest(APITestCase):
         self.assertEqual(purchase.creation_source_api_oauth2_application, token.application)
 
     @authenticate
-    def test_create_purchase_creation_user_and_source(self):
+    def test_can_create_purchase_creation_user_and_source(self):
         self.canteen.managers.add(authenticate.user)
 
         # from the APP
@@ -119,7 +119,7 @@ class PurchaseCreateApiTest(APITestCase):
         self.assertEqual(purchase.creation_source_api_oauth2_application, None)
 
     @authenticate
-    def test_create_purchase_required_fields(self):
+    def test_cannot_create_purchase_without_required_fields(self):
         self.canteen.managers.add(authenticate.user)
 
         for field in ["description", "date", "prix_ht", "famille_produits"]:
@@ -130,7 +130,7 @@ class PurchaseCreateApiTest(APITestCase):
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @authenticate
-    def test_create_purchase_optional_fields(self):
+    def test_can_create_purchase_with_optional_fields(self):
         self.canteen.managers.add(authenticate.user)
 
         # fournisseur is optional
@@ -406,7 +406,7 @@ class PurchaseUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_update_if_canteen_does_not_exist(self):
+    def test_cannot_update_purchase_if_canteen_does_not_exist(self):
         payload = {
             "prix_ht": 15.23,
         }
@@ -416,7 +416,7 @@ class PurchaseUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_update_if_not_canteen_manager(self):
+    def test_cannot_update_purchase_if_not_canteen_manager(self):
         payload = {
             "description": "Saumon",
             "prix_ht": 15.23,
@@ -426,7 +426,7 @@ class PurchaseUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_update_if_purchase_does_not_exist(self):
+    def test_cannot_update_purchase_if_purchase_does_not_exist(self):
         self.canteen.managers.add(authenticate.user)
 
         payload = {
@@ -525,21 +525,21 @@ class PurchaseDeleteApiTest(APITestCase):
             "canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": cls.canteen.id, "pk": cls.purchase.id}
         )
 
-    def test_cannot_delete_if_unauthenticated(self):
+    def test_cannot_delete_purchase_if_unauthenticated(self):
         response = self.client.delete(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(Purchase.objects.count(), 1)
 
     @authenticate
-    def test_cannot_delete_if_not_canteen_manager(self):
+    def test_cannot_delete_purchase_if_not_canteen_manager(self):
         response = self.client.delete(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(Purchase.objects.count(), 1)
 
     @authenticate
-    def test_delete_purchase(self):
+    def test_can_delete_purchase(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.delete(self.url)
@@ -578,7 +578,7 @@ class PurchaseDeleteMultipleApiTest(APITestCase):
         cls.purchase_1 = PurchaseFactory(canteen=cls.canteen)
         cls.purchase_2 = PurchaseFactory(canteen=cls.canteen)
 
-    def test_cannot_delete_multiple_if_unauthenticated(self):
+    def test_cannot_delete_multiple_purchases_if_unauthenticated(self):
         url = reverse("delete_purchases")
         payload = {"ids": [self.purchase_1.id, self.purchase_2.id]}
         response = self.client.post(url, payload, format="json")
@@ -635,7 +635,7 @@ class PurchaseDeleteMultipleApiTest(APITestCase):
 
 class PurchaseRestoreApiTest(APITestCase):
     @authenticate
-    def test_restore_purchases(self):
+    def test_can_restore_purchases(self):
         """
         This endpoint restores the given IDs of deleted purchases
         """

--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -337,9 +337,8 @@ class PurchaseCreateApiTest(APITestCase):
 
     @authenticate
     def test_cannot_create_purchase_if_canteen_does_not_exist(self):
-        response = self.client.post(
-            reverse("canteen_purchase_create", kwargs={"canteen_pk": 999}), self.PURCHASE_PAYLOAD
-        )
+        url = reverse("canteen_purchase_create", kwargs={"canteen_pk": 9999})
+        response = self.client.post(url, self.PURCHASE_PAYLOAD)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -588,9 +587,8 @@ class PurchaseDetailApiTest(APITestCase):
 
     @authenticate
     def test_cannot_get_purchase_if_canteen_does_not_exist(self):
-        response = self.client.get(
-            reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": 9999, "pk": self.purchase.id})
-        )
+        url = reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": 9999, "pk": self.purchase.id})
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -604,9 +602,8 @@ class PurchaseDetailApiTest(APITestCase):
     def test_cannot_get_purchase_if_purchase_does_not_exist(self):
         self.canteen.managers.add(authenticate.user)
 
-        response = self.client.get(
-            reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": self.canteen.id, "pk": 9999})
-        )
+        url = reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": self.canteen.id, "pk": 9999})
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -616,24 +613,21 @@ class PurchaseDetailApiTest(APITestCase):
         purchase_other = PurchaseFactory(canteen=canteen_other)
         self.canteen.managers.add(authenticate.user)
 
-        response = self.client.get(
-            reverse(
-                "canteen_purchase_retrieve_update_destroy",
-                kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
-            )
+        url = reverse(
+            "canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id}
         )
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         # even if the user manages canteen_other
         canteen_other.managers.add(authenticate.user)
 
-        response = self.client.get(
-            reverse(
-                "canteen_purchase_retrieve_update_destroy",
-                kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
-            )
+        url = reverse(
+            "canteen_purchase_retrieve_update_destroy",
+            kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
         )
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -716,10 +710,8 @@ class PurchaseUpdateApiTest(APITestCase):
             "prix_ht": 15.23,
         }
 
-        response = self.client.patch(
-            reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": 9999, "pk": self.purchase.id}),
-            payload,
-        )
+        url = reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": 9999, "pk": self.purchase.id})
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -741,10 +733,8 @@ class PurchaseUpdateApiTest(APITestCase):
             "prix_ht": 15.23,
         }
 
-        response = self.client.patch(
-            reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": self.canteen.id, "pk": 9999}),
-            payload,
-        )
+        url = reverse("canteen_purchase_retrieve_update_destroy", kwargs={"canteen_pk": self.canteen.id, "pk": 9999})
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -757,26 +747,22 @@ class PurchaseUpdateApiTest(APITestCase):
             "prix_ht": 15.23,
         }
 
-        response = self.client.patch(
-            reverse(
-                "canteen_purchase_retrieve_update_destroy",
-                kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
-            ),
-            payload,
+        url = reverse(
+            "canteen_purchase_retrieve_update_destroy",
+            kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
         )
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         # even if the user manages canteen_other
         canteen_other.managers.add(authenticate.user)
 
-        response = self.client.patch(
-            reverse(
-                "canteen_purchase_retrieve_update_destroy",
-                kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
-            ),
-            payload,
+        url = reverse(
+            "canteen_purchase_retrieve_update_destroy",
+            kwargs={"canteen_pk": self.canteen.id, "pk": purchase_other.id},
         )
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -1116,9 +1102,9 @@ class PurchaseDeleteMultipleApiTest(APITestCase):
         cls.purchase_2 = PurchaseFactory(canteen=cls.canteen)
 
     def test_cannot_delete_multiple_if_unauthenticated(self):
-        response = self.client.post(
-            reverse("delete_purchases"), {"ids": [self.purchase_1.id, self.purchase_2.id]}, format="json"
-        )
+        url = reverse("delete_purchases")
+        payload = {"ids": [self.purchase_1.id, self.purchase_2.id]}
+        response = self.client.post(url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(Purchase.objects.count(), 2)
@@ -1129,9 +1115,9 @@ class PurchaseDeleteMultipleApiTest(APITestCase):
         self.assertIsNone(self.purchase_2.deletion_date)
         self.canteen.managers.add(authenticate.user)
 
-        response = self.client.post(
-            reverse("delete_purchases"), {"ids": [self.purchase_1.id, self.purchase_2.id]}, format="json"
-        )
+        url = reverse("delete_purchases")
+        payload = {"ids": [self.purchase_1.id, self.purchase_2.id]}
+        response = self.client.post(url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -1156,7 +1142,9 @@ class PurchaseDeleteMultipleApiTest(APITestCase):
         not_mine = PurchaseFactory(deletion_date=None)
         ids = [purchase_should_delete.id, purchase_already_deleted.id, invalid_id, not_mine.id]
 
-        response = self.client.post(reverse("delete_purchases"), {"ids": ids}, format="json")
+        url = reverse("delete_purchases")
+        payload = {"ids": ids}
+        response = self.client.post(url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
@@ -1182,9 +1170,9 @@ class PurchaseRestoreApiTest(APITestCase):
             purchase.canteen.managers.add(authenticate.user)
         not_my_purchase = PurchaseFactory(deletion_date=date)
 
-        response = self.client.post(
-            reverse("restore_purchases"), {"ids": [purchase_1.id, purchase_2.id, not_my_purchase.id]}, format="json"
-        )
+        url = reverse("restore_purchases")
+        payload = {"ids": [purchase_1.id, purchase_2.id, not_my_purchase.id]}
+        response = self.client.post(url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -1204,9 +1192,9 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
     def test_cannot_get_purchase_canteen_summary_if_unauthenticated(self):
         canteen = CanteenFactory()
 
-        response = self.client.get(
-            reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
-        )
+        url = reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id})
+        payload = {"year": 2020}
+        response = self.client.get(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -1298,9 +1286,9 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
             canteen=canteen, date="2019-01-01", caracteristiques=[Purchase.Characteristic.BIO], prix_ht=666
         )
 
-        response = self.client.get(
-            reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
-        )
+        url = reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id})
+        payload = {"year": 2020}
+        response = self.client.get(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -1408,9 +1396,9 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
             canteen=canteen, date="2019-01-01", caracteristiques=[Purchase.Characteristic.BIO], prix_ht=666
         )
 
-        response = self.client.get(
-            reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
-        )
+        url = reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id})
+        payload = {"year": 2020}
+        response = self.client.get(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -1493,9 +1481,9 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
             prix_ht=10,
         )
 
-        response = self.client.get(
-            reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
-        )
+        url = reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id})
+        payload = {"year": 2020}
+        response = self.client.get(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -1569,9 +1557,9 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
             prix_ht=10,
         )
 
-        response = self.client.get(
-            reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}), {"year": 2020}
-        )
+        url = reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id})
+        payload = {"year": 2020}
+        response = self.client.get(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -1595,7 +1583,8 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
         other_canteen = CanteenFactory(managers=[authenticate.user])
         PurchaseFactory(canteen=other_canteen, prix_ht=999, date="2021-01-01")
 
-        response = self.client.get(reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id}))
+        url = reverse("canteen_purchases_summary", kwargs={"canteen_pk": canteen.id})
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -1609,8 +1598,12 @@ class PurchaseCanteenSummaryApiTest(APITestCase):
 
 
 class PurchaseCanteenOptionsApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("purchase_options")
+
     def test_cannot_get_purchase_options_if_unauthenticated(self):
-        response = self.client.get(reverse("purchase_options"))
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -1628,7 +1621,7 @@ class PurchaseCanteenOptionsApiTest(APITestCase):
 
         PurchaseFactory(description="secret product", fournisseur="secret fournisseur")
 
-        response = self.client.get(f"{reverse('purchase_options')}")
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -1642,7 +1635,8 @@ class PurchaseCanteenOptionsApiTest(APITestCase):
 
 class DiagnosticsFromPurchasesApiTest(APITestCase):
     def test_cannot_create_diagnostics_from_purchases_if_unauthenticated(self):
-        response = self.client.post(reverse("diagnostics_from_purchases", kwargs={"year": 2020}), {})
+        url = reverse("diagnostics_from_purchases", kwargs={"year": 2020})
+        response = self.client.post(url, {})
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -1651,7 +1645,8 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
         """
         If canteen ids are missing, throw a 400
         """
-        response = self.client.post(reverse("diagnostics_from_purchases", kwargs={"year": 2021}), {})
+        url = reverse("diagnostics_from_purchases", kwargs={"year": 2021})
+        response = self.client.post(url, {})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -1672,19 +1667,17 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
         PurchaseFactory(canteen=canteen_with_diagnostic, date=f"{year}-01-01", prix_ht=666)
         PurchaseFactory(canteen=not_my_canteen, date=f"{year}-01-01", prix_ht=666)
 
-        response = self.client.post(
-            reverse("diagnostics_from_purchases", kwargs={"year": year}),
-            {
-                "canteenIds": [
-                    "666",
-                    not_my_canteen.id,
-                    canteen_with_diagnostic.id,
-                    canteen_without_purchases.id,
-                    canteen_ok.id,
-                ]
-            },
-            format="json",
-        )
+        url = reverse("diagnostics_from_purchases", kwargs={"year": year})
+        payload = {
+            "canteenIds": [
+                "666",
+                not_my_canteen.id,
+                canteen_with_diagnostic.id,
+                canteen_without_purchases.id,
+                canteen_ok.id,
+            ]
+        }
+        response = self.client.post(url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
@@ -1733,11 +1726,9 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
 
         self.assertEqual(Diagnostic.objects.filter(year=year, canteen__in=[canteen_site, central_groupe]).count(), 0)
 
-        response = self.client.post(
-            reverse("diagnostics_from_purchases", kwargs={"year": year}),
-            {"canteenIds": [canteen_site.id, central_groupe.id]},
-            format="json",
-        )
+        url = reverse("diagnostics_from_purchases", kwargs={"year": year})
+        payload = {"canteenIds": [canteen_site.id, central_groupe.id]}
+        response = self.client.post(url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
@@ -1789,11 +1780,9 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
         year = 2025
         self.assertEqual(Diagnostic.objects.filter(year=year, canteen__in=[canteen_site.id]).count(), 0)
 
-        response = self.client.post(
-            reverse("diagnostics_from_purchases", kwargs={"year": year}),
-            {"canteenIds": [canteen_site.id]},
-            format="json",
-        )
+        url = reverse("diagnostics_from_purchases", kwargs={"year": year})
+        payload = {"canteenIds": [canteen_site.id]}
+        response = self.client.post(url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
@@ -1837,11 +1826,9 @@ class DiagnosticsFromPurchasesApiTest(APITestCase):
         year = 2024
         self.assertEqual(Diagnostic.objects.filter(year=year, canteen__in=[canteen_site.id]).count(), 0)
 
-        response = self.client.post(
-            reverse("diagnostics_from_purchases", kwargs={"year": year}),
-            {"canteenIds": [canteen_site.id]},
-            format="json",
-        )
+        url = reverse("diagnostics_from_purchases", kwargs={"year": year})
+        payload = {"canteenIds": [canteen_site.id]}
+        response = self.client.post(url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
@@ -1931,7 +1918,8 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
             prix_ht=999999,
         )
 
-        response = self.client.get(self.url, {"year": self.year})
+        payload = {"year": self.year}
+        response = self.client.get(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -1962,7 +1950,8 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         self.canteen.save()
         PurchaseFactory(canteen=self.canteen, date="2024-01-01")
 
-        response = self.client.get(self.url, {"year": 2024})
+        payload = {"year": 2024}
+        response = self.client.get(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -1972,7 +1961,8 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         """
         PurchaseFactory(canteen=self.canteen, date="2023-12-31")
 
-        response = self.client.get(self.url, {"year": 2024})
+        payload = {"year": 2024}
+        response = self.client.get(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -1988,7 +1978,8 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         PurchaseFactory(canteen=self.canteen, date="2024-05-31")
         PurchaseFactory(canteen=self.canteen, date="2025-01-01")
 
-        response = self.client.get(self.url, {"year": 2024})
+        payload = {"year": 2024}
+        response = self.client.get(self.url, payload)
 
         body = response.json()
         self.assertEqual(body["lastPurchaseDate"], "2024-12-01")
@@ -2001,7 +1992,8 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         """
         PurchaseFactory(canteen=self.canteen, date="2024-05-31")
 
-        response = self.client.get(self.url, {"year": 2024})
+        payload = {"year": 2024}
+        response = self.client.get(self.url, payload)
 
         body = response.json()
         self.assertNotIn("lastPurchaseDate", body)
@@ -2016,7 +2008,8 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         self.canteen.save()
         PurchaseFactory(canteen=self.canteen, date="2024-01-01")
 
-        response = self.client.get(self.url, {"year": 2024, "ignoreRedaction": "true"})
+        payload = {"year": 2024, "ignoreRedaction": "true"}
+        response = self.client.get(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -2030,7 +2023,8 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         self.canteen.save()
         PurchaseFactory(canteen=self.canteen, date="2024-01-01")
 
-        response = self.client.get(self.url, {"year": 2024, "ignoreRedaction": "false"})
+        payload = {"year": 2024, "ignoreRedaction": "false"}
+        response = self.client.get(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -2043,7 +2037,8 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         self.canteen.save()
         PurchaseFactory(canteen=self.canteen, date="2024-01-01")
 
-        response = self.client.get(self.url, {"year": 2024, "ignoreRedaction": "true"})
+        payload = {"year": 2024, "ignoreRedaction": "true"}
+        response = self.client.get(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -2055,6 +2050,7 @@ class PublicPurchasePercentageSummaryApiTest(APITestCase):
         self.canteen.save()
         PurchaseFactory(canteen=self.canteen, date="2024-01-01")
 
-        response = self.client.get(self.url, {"year": 2024, "ignoreRedaction": "true"})
+        payload = {"year": 2024, "ignoreRedaction": "true"}
+        response = self.client.get(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/api/tests/test_purchases_import.py
+++ b/api/tests/test_purchases_import.py
@@ -1,6 +1,4 @@
 import hashlib
-import json
-import re
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
@@ -8,103 +6,28 @@ from unittest import skipIf
 from unittest.mock import patch
 
 from django.conf import settings
-from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from api.tests.utils import assert_import_failure_created, authenticate
-from api.views.purchase_import import PURCHASE_ID_SCHEMA_FILE_PATH, PURCHASE_SIRET_SCHEMA_FILE_PATH
 from data.factories import CanteenFactory
 from data.models import ImportFailure, ImportType
 from data.models.creation_source import CreationSource
 from data.models.purchase import Purchase
 
 
-class PurchasesSchemaTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.schemas = {
-            "siret": json.load(open(PURCHASE_SIRET_SCHEMA_FILE_PATH)),
-            "id": json.load(open(PURCHASE_ID_SCHEMA_FILE_PATH)),
-        }
-
-    @staticmethod
-    def _pattern_for(schema, field_name):
-        field = next(f for f in schema["fields"] if f["name"] == field_name)
-        return field["constraints"]["pattern"]
-
-    def test_famille_produits_regex(self):
-        for schema_name, schema in self.schemas.items():
-            pattern = self._pattern_for(schema, "famille_produits")
-            for VALUE_OK in ["PRODUITS_LAITIERS", "PRODUITS_LAITIERS ", " PRODUITS_LAITIERS "]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
-                    self.assertTrue(re.match(pattern, VALUE_OK))
-            for VALUE_NOT_OK in ["", "TEST", "PRODUITS_LAITIERS,", "PRODUITS_LAITIERS,VIANDES_VOLAILLES"]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
-                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
-
-    def test_categories_egalim_regex(self):
-        for schema_name, schema in self.schemas.items():
-            pattern = self._pattern_for(schema, "categories_egalim")
-            for VALUE_OK in [
-                "BIO",
-                "BIO ",
-                "BIO,COMMERCE_EQUITABLE",
-                "BIO,COMMERCE_EQUITABLE ",
-                " BIO,COMMERCE_EQUITABLE ",
-                " BIO, COMMERCE_EQUITABLE ",
-                " BIO,      COMMERCE_EQUITABLE ",
-                "BIO,BIO",
-            ]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
-                    self.assertTrue(re.match(pattern, VALUE_OK))
-            for VALUE_NOT_OK in ["", "TEST"]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
-                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
-
-    def test_origine_regex(self):
-        for schema_name, schema in self.schemas.items():
-            pattern = self._pattern_for(schema, "origine")
-            for VALUE_OK in [
-                "EUROPE",
-                "FRANCE",
-                "FRANCE ",
-                " FRANCE ",
-            ]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
-                    self.assertTrue(re.match(pattern, VALUE_OK))
-            for VALUE_NOT_OK in ["", "TEST", "FRANCE,", "FRANCE,EUROPE"]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
-                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
-
-    def test_definition_local_regex(self):
-        for schema_name, schema in self.schemas.items():
-            pattern = self._pattern_for(schema, "definition_local")
-            for VALUE_OK in [
-                "PAT",
-                " PAT ",
-                "COMMUNE",
-                "DEPARTEMENT",
-                "DEPARTEMENT ",
-                " DEPARTEMENT ",
-                "REGION",
-                "KM",
-            ]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
-                    self.assertTrue(re.match(pattern, VALUE_OK))
-            for VALUE_NOT_OK in ["", "TEST", "DEPARTEMENT,", "DEPARTEMENT,REGION"]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
-                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
-
-
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class PurchasesImportApiErrorTest(APITestCase):
-    def test_unauthenticated(self):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("purchases_import")
+
+    def test_cannot_import_if_unauthenticated(self):
         self.assertEqual(Purchase.objects.count(), 0)
 
-        response = self.client.post(reverse("purchases_import"), {"type": "siret"})
+        response = self.client.post(self.url, {"type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -120,7 +43,7 @@ class PurchasesImportApiErrorTest(APITestCase):
         # header missing
         file_path = "./api/tests/files/achats/purchases_bad_no_header.csv"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -135,7 +58,7 @@ class PurchasesImportApiErrorTest(APITestCase):
         # wrong header
         file_path = "./api/tests/files/achats/purchases_bad_wrong_header.csv"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -150,7 +73,7 @@ class PurchasesImportApiErrorTest(APITestCase):
         # partial header
         file_path = "./api/tests/files/achats/purchases_bad_partial_header.csv"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -178,7 +101,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_wrong_header_typo.csv"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -254,7 +177,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_extra_columns.csv"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -281,7 +204,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_empty_rows.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("purchases_import"), {"file": canteen_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": canteen_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -306,7 +229,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -351,7 +274,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_one_error.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -368,7 +291,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -387,7 +310,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -409,7 +332,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -430,7 +353,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_one_error.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -448,7 +371,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_corrupt.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -468,6 +391,10 @@ class PurchasesImportApiErrorTest(APITestCase):
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class PurchasesImportApiSuccessTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("purchases_import")
+
     @authenticate
     def test_import_good_purchases(self):
         """
@@ -478,7 +405,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 8)
@@ -540,7 +467,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_with_empty_columns.xlsx"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 2)
@@ -553,7 +480,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_separator_comma.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -573,7 +500,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_decimal_comma.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -596,7 +523,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good.xlsx"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -616,7 +543,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_decimal_comma.xlsx"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -640,7 +567,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
         # comma
         file_path = "./api/tests/files/achats/purchases_good_separator_comma.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -649,7 +576,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
         # tab
         file_path = "./api/tests/files/achats/purchases_good_separator_tab.tsv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1 + 1)
@@ -658,7 +585,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
         # semicolon
         file_path = "./api/tests/files/achats/purchases_good_separator_semicolon.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 2 + 1)
@@ -675,7 +602,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good.csv"
         with open(file_path) as purchase_file:
-            _ = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            _ = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(_process_chunk_mock.call_count, 8)
 
@@ -690,7 +617,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
         # first upload: success
         file_path = "./api/tests/files/achats/purchases_good.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 8)
@@ -698,7 +625,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
         # second upload: duplicate warning
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 8)  # no additional purchases created
@@ -721,7 +648,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_floating_number.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -738,7 +665,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_local_vs_circuit_court.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 2)
@@ -768,7 +695,7 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_siret_caracteristics.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 2)
@@ -801,13 +728,17 @@ class PurchasesImportApiSuccessTest(APITestCase):
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class PurchasesImportIdApiErrorTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("purchases_import")
+
     @authenticate
     def test_canteen_not_found_with_id(self):
         self.assertEqual(Purchase.objects.count(), 0)
 
         file_path = "./api/tests/files/achats/purchases_good_id.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file})
+            response = self.client.post(self.url, {"file": purchase_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -820,6 +751,10 @@ class PurchasesImportIdApiErrorTest(APITestCase):
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class PurchasesImportIdApiSuccessTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("purchases_import")
+
     @authenticate
     def test_import_default_type_is_id(self):
         """
@@ -830,7 +765,7 @@ class PurchasesImportIdApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_id.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file})
+            response = self.client.post(self.url, {"file": purchase_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -850,7 +785,7 @@ class PurchasesImportIdApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_id.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file})
+            response = self.client.post(self.url, {"file": purchase_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -878,7 +813,7 @@ class PurchasesImportIdApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_id_caracteristics.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file})
+            response = self.client.post(self.url, {"file": purchase_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 2)

--- a/api/tests/test_purchases_import.py
+++ b/api/tests/test_purchases_import.py
@@ -42,7 +42,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         # header missing
         file_path = "./api/tests/files/achats/purchases_bad_no_header.csv"
-        with open(file_path, "rb") as purchase_file:
+        with open(file_path) as purchase_file:
             response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -57,7 +57,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         # wrong header
         file_path = "./api/tests/files/achats/purchases_bad_wrong_header.csv"
-        with open(file_path, "rb") as purchase_file:
+        with open(file_path) as purchase_file:
             response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -72,7 +72,7 @@ class PurchasesImportApiErrorTest(APITestCase):
 
         # partial header
         file_path = "./api/tests/files/achats/purchases_bad_partial_header.csv"
-        with open(file_path, "rb") as purchase_file:
+        with open(file_path) as purchase_file:
             response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -100,7 +100,7 @@ class PurchasesImportApiErrorTest(APITestCase):
         self.assertEqual(Purchase.objects.count(), 0)
 
         file_path = "./api/tests/files/achats/purchases_bad_wrong_header_typo.csv"
-        with open(file_path, "rb") as purchase_file:
+        with open(file_path) as purchase_file:
             response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -176,7 +176,7 @@ class PurchasesImportApiErrorTest(APITestCase):
         self.assertEqual(Purchase.objects.count(), 0)
 
         file_path = "./api/tests/files/achats/purchases_bad_extra_columns.csv"
-        with open(file_path, "rb") as purchase_file:
+        with open(file_path) as purchase_file:
             response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -203,8 +203,8 @@ class PurchasesImportApiErrorTest(APITestCase):
         self.assertEqual(Purchase.objects.count(), 0)
 
         file_path = "./api/tests/files/achats/purchases_bad_empty_rows.csv"
-        with open(file_path) as canteen_file:
-            response = self.client.post(self.url, {"file": canteen_file, "type": "siret"})
+        with open(file_path) as purchase_file:
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)

--- a/api/tests/test_purchases_import_old.py
+++ b/api/tests/test_purchases_import_old.py
@@ -1,6 +1,4 @@
 import hashlib
-import json
-import re
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
@@ -8,89 +6,28 @@ from unittest import skipIf
 from unittest.mock import patch
 
 from django.conf import settings
-from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from api.tests.utils import assert_import_failure_created, authenticate
-from api.views.purchase_import_old import PURCHASE_ID_SCHEMA_FILE_PATH, PURCHASE_SIRET_SCHEMA_FILE_PATH
 from data.factories import CanteenFactory
 from data.models import ImportFailure, ImportType
 from data.models.creation_source import CreationSource
 from data.models.purchase import Purchase
 
 
-class PurchasesOldSchemaTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.schemas = {
-            "siret": json.load(open(PURCHASE_SIRET_SCHEMA_FILE_PATH)),
-            "id": json.load(open(PURCHASE_ID_SCHEMA_FILE_PATH)),
-        }
-
-    @staticmethod
-    def _pattern_for(schema, field_name):
-        field = next(f for f in schema["fields"] if f["name"] == field_name)
-        return field["constraints"]["pattern"]
-
-    def test_famille_produits_regex(self):
-        for schema_name, schema in self.schemas.items():
-            pattern = self._pattern_for(schema, "famille_produits")
-            for VALUE_OK in ["PRODUITS_LAITIERS", "PRODUITS_LAITIERS ", " PRODUITS_LAITIERS "]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
-                    self.assertTrue(re.match(pattern, VALUE_OK))
-            for VALUE_NOT_OK in ["", "TEST", "PRODUITS_LAITIERS,", "PRODUITS_LAITIERS,VIANDES_VOLAILLES"]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
-                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
-
-    def test_caracteristiques_regex(self):
-        for schema_name, schema in self.schemas.items():
-            pattern = self._pattern_for(schema, "caracteristiques")
-            for VALUE_OK in [
-                "BIO",
-                "BIO ",
-                "BIO,LOCAL",
-                "BIO,LOCAL ",
-                " BIO,LOCAL ",
-                " BIO, LOCAL ",
-                " BIO,      LOCAL ",
-                "BIO,BIO",
-            ]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
-                    self.assertTrue(re.match(pattern, VALUE_OK))
-            for VALUE_NOT_OK in ["", "TEST"]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
-                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
-
-    def test_definition_local_regex(self):
-        for schema_name, schema in self.schemas.items():
-            pattern = self._pattern_for(schema, "definition_local")
-            for VALUE_OK in [
-                "PAT",
-                " PAT ",
-                "COMMUNE",
-                "DEPARTEMENT",
-                "DEPARTEMENT ",
-                " DEPARTEMENT ",
-                "REGION",
-                "AUTOUR_SERVICE",
-                "AUTRE",
-            ]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
-                    self.assertTrue(re.match(pattern, VALUE_OK))
-            for VALUE_NOT_OK in ["", "TEST", "DEPARTEMENT,", "DEPARTEMENT,REGION", "KM"]:
-                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
-                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
-
-
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class PurchasesImportOldApiErrorTest(APITestCase):
-    def test_unauthenticated(self):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("purchases_import")
+
+    def test_cannot_import_if_unauthenticated(self):
         self.assertEqual(Purchase.objects.count(), 0)
 
-        response = self.client.post(reverse("purchases_import_old"), {"type": "siret"})
+        response = self.client.post(self.url, {"type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -106,7 +43,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
         # header missing
         file_path = "./api/tests/files/achats/purchases_bad_no_header_old.csv"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -121,7 +58,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
         # wrong header
         file_path = "./api/tests/files/achats/purchases_bad_wrong_header_old.csv"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -136,7 +73,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
         # partial header
         file_path = "./api/tests/files/achats/purchases_bad_partial_header_old.csv"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -164,7 +101,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_wrong_header_typo_old.csv"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -222,7 +159,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_extra_columns_old.csv"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -249,7 +186,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_empty_rows_old.csv"
         with open(file_path) as canteen_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": canteen_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": canteen_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -274,7 +211,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -341,7 +278,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -360,7 +297,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -382,7 +319,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -403,7 +340,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_one_error_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -421,7 +358,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_bad_corrupt_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -441,6 +378,10 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class PurchasesImportOldApiSuccessTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("purchases_import")
+
     @authenticate
     def test_import_good_purchases(self):
         """
@@ -451,7 +392,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 8)
@@ -513,7 +454,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_with_empty_columns_old.xlsx"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 2)
@@ -526,7 +467,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_separator_comma_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -549,7 +490,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_old.xlsx"
         with open(file_path, "rb") as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -573,7 +514,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
         # comma
         file_path = "./api/tests/files/achats/purchases_good_separator_comma_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -582,7 +523,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
         # tab
         file_path = "./api/tests/files/achats/purchases_good_separator_tab_old.tsv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1 + 1)
@@ -591,7 +532,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
         # semicolon
         file_path = "./api/tests/files/achats/purchases_good_separator_semicolon_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 2 + 1)
@@ -608,7 +549,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_old.csv"
         with open(file_path) as purchase_file:
-            _ = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            _ = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(_process_chunk_mock.call_count, 8)
 
@@ -623,7 +564,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
         # first upload: success
         file_path = "./api/tests/files/achats/purchases_good_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 8)
@@ -631,7 +572,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
 
         # second upload: duplicate warning
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 8)  # no additional purchases created
@@ -654,7 +595,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_floating_number_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -664,13 +605,17 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class PurchasesImportOldIdApiErrorTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("purchases_import")
+
     @authenticate
     def test_canteen_not_found_with_id(self):
         self.assertEqual(Purchase.objects.count(), 0)
 
         file_path = "./api/tests/files/achats/purchases_good_id_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file})
+            response = self.client.post(self.url, {"file": purchase_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -683,6 +628,10 @@ class PurchasesImportOldIdApiErrorTest(APITestCase):
 
 @skipIf(settings.SKIP_TESTS_THAT_REQUIRE_INTERNET, "Skipping tests that require internet access")
 class PurchasesImportOldIdApiSuccessTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("purchases_import")
+
     @authenticate
     def test_import_default_type_is_id(self):
         """
@@ -693,7 +642,7 @@ class PurchasesImportOldIdApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_id_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file})
+            response = self.client.post(self.url, {"file": purchase_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)
@@ -713,7 +662,7 @@ class PurchasesImportOldIdApiSuccessTest(APITestCase):
 
         file_path = "./api/tests/files/achats/purchases_good_id_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import_old"), {"file": purchase_file})
+            response = self.client.post(self.url, {"file": purchase_file})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 1)

--- a/api/tests/test_purchases_import_old.py
+++ b/api/tests/test_purchases_import_old.py
@@ -22,7 +22,7 @@ from data.models.purchase import Purchase
 class PurchasesImportOldApiErrorTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.url = reverse("purchases_import")
+        cls.url = reverse("purchases_import_old")
 
     def test_cannot_import_if_unauthenticated(self):
         self.assertEqual(Purchase.objects.count(), 0)
@@ -42,7 +42,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         # header missing
         file_path = "./api/tests/files/achats/purchases_bad_no_header_old.csv"
-        with open(file_path, "rb") as purchase_file:
+        with open(file_path) as purchase_file:
             response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -57,7 +57,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         # wrong header
         file_path = "./api/tests/files/achats/purchases_bad_wrong_header_old.csv"
-        with open(file_path, "rb") as purchase_file:
+        with open(file_path) as purchase_file:
             response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -72,7 +72,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 
         # partial header
         file_path = "./api/tests/files/achats/purchases_bad_partial_header_old.csv"
-        with open(file_path, "rb") as purchase_file:
+        with open(file_path) as purchase_file:
             response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -100,7 +100,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
         self.assertEqual(Purchase.objects.count(), 0)
 
         file_path = "./api/tests/files/achats/purchases_bad_wrong_header_typo_old.csv"
-        with open(file_path, "rb") as purchase_file:
+        with open(file_path) as purchase_file:
             response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -158,7 +158,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
         self.assertEqual(Purchase.objects.count(), 0)
 
         file_path = "./api/tests/files/achats/purchases_bad_extra_columns_old.csv"
-        with open(file_path, "rb") as purchase_file:
+        with open(file_path) as purchase_file:
             response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -185,8 +185,8 @@ class PurchasesImportOldApiErrorTest(APITestCase):
         self.assertEqual(Purchase.objects.count(), 0)
 
         file_path = "./api/tests/files/achats/purchases_bad_empty_rows_old.csv"
-        with open(file_path) as canteen_file:
-            response = self.client.post(self.url, {"file": canteen_file, "type": "siret"})
+        with open(file_path) as purchase_file:
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -259,9 +259,9 @@ class PurchasesImportOldApiErrorTest(APITestCase):
         CanteenFactory(siret="21010034300016", managers=[authenticate.user])
         self.assertEqual(Purchase.objects.count(), 0)
 
-        file_path = "./api/tests/files/achats/purchases_bad_one_error.csv"
+        file_path = "./api/tests/files/achats/purchases_bad_one_error_old.csv"
         with open(file_path) as purchase_file:
-            response = self.client.post(reverse("purchases_import"), {"file": purchase_file, "type": "siret"})
+            response = self.client.post(self.url, {"file": purchase_file, "type": "siret"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Purchase.objects.count(), 0)
@@ -270,7 +270,12 @@ class PurchasesImportOldApiErrorTest(APITestCase):
         errors = body["errors"]
         self.assertEqual(body["count"], 0)
         self.assertEqual(len(errors), 1)
-        self.assertTrue(errors.pop(0)["message"].endswith("doit être un nombre décimal."))
+        # self.assertTrue(errors.pop(0)["message"].endswith("doit être un nombre décimal."))
+        self.assertTrue(
+            errors.pop(0)["message"].endswith(
+                "La valeur ne doit comporter que des chiffres et le point comme séparateur décimal"
+            )
+        )
 
     @authenticate
     def test_canteen_not_found_with_siret(self):
@@ -380,7 +385,7 @@ class PurchasesImportOldApiErrorTest(APITestCase):
 class PurchasesImportOldApiSuccessTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.url = reverse("purchases_import")
+        cls.url = reverse("purchases_import_old")
 
     @authenticate
     def test_import_good_purchases(self):
@@ -607,7 +612,7 @@ class PurchasesImportOldApiSuccessTest(APITestCase):
 class PurchasesImportOldIdApiErrorTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.url = reverse("purchases_import")
+        cls.url = reverse("purchases_import_old")
 
     @authenticate
     def test_canteen_not_found_with_id(self):
@@ -630,7 +635,7 @@ class PurchasesImportOldIdApiErrorTest(APITestCase):
 class PurchasesImportOldIdApiSuccessTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.url = reverse("purchases_import")
+        cls.url = reverse("purchases_import_old")
 
     @authenticate
     def test_import_default_type_is_id(self):

--- a/api/tests/test_purchases_old.py
+++ b/api/tests/test_purchases_old.py
@@ -1,0 +1,538 @@
+from decimal import Decimal
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from api.tests.utils import authenticate, get_oauth2_token
+from data.factories import CanteenFactory, PurchaseFactory, UserFactory
+from data.models import Purchase
+from data.models.creation_source import CreationSource
+
+
+class PurchaseOldListApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.purchase = PurchaseFactory(
+            canteen=cls.canteen,
+            description="tomates",
+            fournisseur="fournisseur",
+            date="2022-01-13",
+            prix_ht=Decimal(4.5),
+            famille_produits=Purchase.Family.FRUITS_ET_LEGUMES,
+            caracteristiques=[Purchase.Characteristic.BIO, Purchase.Characteristic.EUROPE],
+            creation_user=cls.user,
+            creation_source=CreationSource.APP,
+        )
+        cls.url = reverse("purchase_list_create")
+
+    def test_cannot_list_purchases_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_can_list_purchases_of_managed_canteens(self):
+        # canteen managed by authenticated user
+        self.canteen.managers.add(authenticate.user)
+        # other user, other canteen, other purchases
+        other_user = UserFactory()
+        other_user_canteen = CanteenFactory(managers=[other_user])
+        PurchaseFactory(canteen=other_user_canteen)
+        canteen_not_managed = CanteenFactory()
+        PurchaseFactory(canteen=canteen_not_managed)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Purchase.objects.count(), 1 + 1 + 1)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 1)
+
+    def test_cannot_list_purchases_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:write")
+        self.canteen.managers.add(user)
+
+        self.client.credentials(Authorization=f"Bearer {token}")
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class PurchaseOldListFilterApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        PurchaseFactory(
+            canteen=cls.canteen,
+            description="avoine",
+            famille_produits=Purchase.Family.PRODUITS_DE_LA_MER,
+            caracteristiques=[Purchase.Characteristic.BIO],
+            date="2020-01-01",
+        )
+        PurchaseFactory(
+            canteen=cls.canteen,
+            description="tomates",
+            famille_produits=Purchase.Family.PRODUITS_DE_LA_MER,
+            caracteristiques=[Purchase.Characteristic.BIO, Purchase.Characteristic.PECHE_DURABLE],
+            date="2020-01-02",
+        )
+        PurchaseFactory(
+            canteen=cls.canteen,
+            description="pommes",
+            famille_produits=Purchase.Family.AUTRES,
+            caracteristiques=[Purchase.Characteristic.PECHE_DURABLE],
+            date="2020-02-01",
+        )
+        cls.other_canteen = CanteenFactory()
+        PurchaseFactory(
+            canteen=cls.other_canteen,
+            description="secret",
+            famille_produits=None,
+            caracteristiques=[],
+            date="2020-01-01",
+        )
+        cls.url = reverse("purchase_list_create")
+
+    @authenticate
+    def test_filter_by_search_text(self):
+        # user is not (yet) the manager of the canteen
+        search_term = "avoine"
+
+        response = self.client.get(f"{self.url}?search={search_term}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 0)
+
+        # set the user as manager of the canteen
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(f"{self.url}?search={search_term}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].get("description"), "avoine")
+
+    @authenticate
+    def test_filter_by_canteen(self):
+        # user is not (yet) the manager of any canteen
+        response = self.client.get(f"{self.url}?canteen__id={self.canteen.id}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 0)
+
+        # set the user as manager of the canteen
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(f"{self.url}?canteen__id={self.canteen.id}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 3)
+
+        # try to filter by a canteen the user doesn't manage
+        response = self.client.get(f"{self.url}?canteen__id={self.other_canteen.id}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 0)
+
+    @authenticate
+    def test_filter_by_characteristics(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(f"{self.url}?characteristics={Purchase.Characteristic.BIO}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 2)
+
+        response = self.client.get(
+            f"{self.url}?characteristics={Purchase.Characteristic.BIO}&characteristics={Purchase.Characteristic.PECHE_DURABLE}"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 3)
+
+    @authenticate
+    def test_filter_by_family(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(f"{self.url}?family={Purchase.Family.PRODUITS_DE_LA_MER}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 2)
+
+    @authenticate
+    def test_filter_by_date(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(f"{self.url}?date_after=2020-01-02")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 2)
+
+        response = self.client.get(f"{self.url}?date_before=2020-01-01")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 1)
+
+        response = self.client.get(f"{self.url}?date_after=2020-01-02&date_before=2020-02-01")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body["results"]
+        self.assertEqual(len(results), 2)
+
+    @authenticate
+    def test_pagination(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["count"], 3)
+        self.assertIn("next", body)
+        self.assertIn("previous", body)
+        self.assertEqual(len(body["results"]), 3)
+        self.assertEqual(len(body["families"]), 2)
+        self.assertEqual(len(body["characteristics"]), 2)
+        self.assertEqual(len(body["canteens"]), 1)
+
+        response = self.client.get(f"{self.url}?limit=1&offset=1")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["count"], 3)
+        self.assertIn("next", body)
+        self.assertIn("previous", body)
+        self.assertEqual(len(body["results"]), 1)
+        # the pagination should not change the available filter options
+        self.assertEqual(len(body["families"]), 2)
+        self.assertEqual(len(body["characteristics"]), 2)
+        self.assertEqual(len(body["canteens"]), 1)
+
+    @authenticate
+    def test_available_filter_options(self):
+        # set the user as manager + add an extra canteen with purchase
+        self.canteen.managers.add(authenticate.user)
+        canteen_2 = CanteenFactory(managers=[authenticate.user])
+        PurchaseFactory(
+            canteen=canteen_2, famille_produits=Purchase.Family.AUTRES, caracteristiques=[Purchase.Characteristic.BIO]
+        )
+
+        with self.assertNumQueries(7):
+            response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body["results"]), 3 + 1)
+        self.assertEqual(len(body["families"]), 2)
+        self.assertEqual(len(body["characteristics"]), 2)
+        self.assertEqual(len(body["canteens"]), 1 + 1)
+
+        response = self.client.get(f"{self.url}?characteristics={Purchase.Characteristic.BIO}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body["results"]), 2 + 1)
+        self.assertEqual(len(body["characteristics"]), 2)
+        self.assertEqual(len(body["families"]), 1 + 1)
+        self.assertEqual(len(body["canteens"]), 1 + 1)
+
+        response = self.client.get(f"{self.url}?family={Purchase.Family.PRODUITS_LAITIERS}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body["results"]), 0)
+        self.assertEqual(len(body["characteristics"]), 0)
+        self.assertEqual(len(body["families"]), 0)
+        self.assertEqual(len(body["canteens"]), 0)
+
+
+class PurchaseOldDetailApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.purchase = PurchaseFactory(
+            canteen=cls.canteen,
+            description="tomates",
+            fournisseur="fournisseur",
+            date="2022-01-13",
+            prix_ht=Decimal(4.5),
+            famille_produits=Purchase.Family.FRUITS_ET_LEGUMES,
+            caracteristiques=[Purchase.Characteristic.BIO, Purchase.Characteristic.EUROPE],
+            creation_user=cls.user,
+            creation_source=CreationSource.APP,
+        )
+        cls.url = reverse("purchase_retrieve_update_destroy", kwargs={"pk": cls.purchase.id})
+
+    def test_cannot_get_purchase_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_get_if_not_canteen_manager(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_can_get_purchase(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["id"], self.purchase.id)
+
+    def test_cannot_get_purchase_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:write")
+        self.canteen.managers.add(user)
+
+        self.client.credentials(Authorization=f"Bearer {token}")
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class PurchaseOldCreateApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.url = reverse("purchase_list_create")
+        cls.PURCHASE_PAYLOAD = {
+            "canteen": cls.canteen.id,
+            "description": "Saumon",
+            "provider": "Test fournisseur",
+            "date": "2022-01-13",
+            "price_ht": 15.23,
+            "family": "PRODUITS_DE_LA_MER",
+            "characteristics": ["BIO", "LOCAL"],
+            "local_definition": "COMMUNE",
+        }
+
+    def test_cannot_create_purchase_if_unauthenticated(self):
+        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_create_purchase_if_canteen_does_not_exist(self):
+        payload = {**self.PURCHASE_PAYLOAD, "canteen": 9999}
+        response = self.client.post(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_create_purchase_if_not_canteen_manager(self):
+        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_create_purchase(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        purchase = Purchase.objects.first()
+        self.assertEqual(len(purchase.caracteristiques), 2)
+        self.assertEqual(purchase.definition_local, Purchase.Local.COMMUNE)
+        self.assertEqual(purchase.definition_local_km, None)
+
+    @authenticate
+    def test_create_purchase_creation_user_and_source(self):
+        self.canteen.managers.add(authenticate.user)
+
+        # from the APP
+        payload = {**self.PURCHASE_PAYLOAD, "creation_source": CreationSource.APP}
+        response = self.client.post(self.url, payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertNotIn("creationUser", body)
+        self.assertNotIn("creationSource", body)
+        self.assertNotIn("creationSourceApiOauth2Application", body)
+        purchase = Purchase.objects.first()
+        self.assertEqual(purchase.creation_user, authenticate.user)
+        self.assertEqual(purchase.creation_source, CreationSource.APP)
+        self.assertEqual(purchase.creation_source_api_oauth2_application, None)
+
+        # cleanup
+        Purchase.objects.all().delete()
+
+        # defaults to API
+        response = self.client.post(self.url, self.PURCHASE_PAYLOAD)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertNotIn("creationUser", body)
+        self.assertNotIn("creationSource", body)
+        self.assertNotIn("creationSourceApiOauth2Application", body)
+        purchase = Purchase.objects.first()
+        self.assertEqual(purchase.creation_user, authenticate.user)
+        self.assertEqual(purchase.creation_source, CreationSource.API)
+        self.assertEqual(purchase.creation_source_api_oauth2_application, None)
+
+        # cleanup
+        Purchase.objects.all().delete()
+
+        # returns a 404 if the creation_source is not valid
+        payload = {**self.PURCHASE_PAYLOAD, "creation_source": "UNKNOWN"}
+        response = self.client.post(self.url, payload)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class PurchaseOldUpdateApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.purchase = PurchaseFactory(canteen=cls.canteen, creation_user=cls.user, creation_source=CreationSource.APP)
+        cls.url = reverse("purchase_retrieve_update_destroy", kwargs={"pk": cls.purchase.id})
+
+    def test_cannot_update_purchase_if_unauthenticated(self):
+        payload = {
+            "price_ht": 15.23,
+        }
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_update_purchase_with_put(self):
+        self.purchase.canteen.managers.add(authenticate.user)
+
+        payload = {
+            "description": "Saumon",
+            "provider": "Test fournisseur",
+            "price_ht": 15.23,
+        }
+        response = self.client.put(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @authenticate
+    def test_cannot_update_if_not_canteen_manager(self):
+        payload = {
+            "description": "Saumon",
+            "provider": "Test fournisseur",
+            "price_ht": 15.23,
+        }
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_update_to_another_canteen_if_not_canteen_manager(self):
+        self.purchase.canteen.managers.add(authenticate.user)
+        canteen_not_manager = CanteenFactory()
+
+        payload = {
+            "canteen": canteen_not_manager.id,
+        }
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_can_update_purchase(self):
+        self.purchase.canteen.managers.add(authenticate.user)
+        new_canteen = CanteenFactory(managers=[authenticate.user])
+
+        payload = {
+            "canteen": new_canteen.id,
+            "description": "Saumon",
+            "provider": "Test fournisseur",
+            "price_ht": 15.23,
+        }
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.purchase.refresh_from_db()
+        self.assertEqual(self.purchase.canteen, new_canteen)
+        self.assertEqual(self.purchase.description, "Saumon")
+        self.assertEqual(self.purchase.fournisseur, "Test fournisseur")
+        self.assertEqual(float(self.purchase.prix_ht), 15.23)
+
+    @authenticate
+    def test_can_update_purchase_does_not_update_creation_user_and_source(self):
+        self.purchase.canteen.managers.add(authenticate.user)
+        self.assertEqual(self.purchase.creation_user, self.user)
+        self.assertEqual(self.purchase.creation_source, CreationSource.APP)
+        self.assertEqual(self.purchase.creation_source_api_oauth2_application, None)
+
+        payload = {
+            "description": "Saumon",
+            "provider": "Test fournisseur",
+            "price_ht": 15.23,
+            "creationSource": CreationSource.API,
+        }
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertNotIn("creationUser", body)
+        self.assertNotIn("creationSource", body)
+        self.assertNotIn("creationSourceApiOauth2Application", body)
+        self.purchase.refresh_from_db()
+        self.assertEqual(self.purchase.creation_user, self.user)  # unchanged
+        self.assertEqual(self.purchase.creation_source, CreationSource.APP)  # unchanged
+        self.assertEqual(self.purchase.creation_source_api_oauth2_application, None)  # unchanged
+
+
+class PurchaseOldDeleteApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.purchase = PurchaseFactory(canteen=cls.canteen, creation_user=cls.user, creation_source=CreationSource.APP)
+        cls.url = reverse("purchase_retrieve_update_destroy", kwargs={"pk": cls.purchase.id})
+
+    def test_cannot_delete_if_unauthenticated(self):
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(Purchase.objects.count(), 1)
+
+    @authenticate
+    def test_cannot_delete_if_not_canteen_manager(self):
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(Purchase.objects.count(), 1)
+
+    @authenticate
+    def test_can_delete_purchase(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Purchase.objects.count(), 0)
+        self.assertEqual(Purchase.all_objects.count(), 1)

--- a/api/tests/test_purchases_schema_import.py
+++ b/api/tests/test_purchases_schema_import.py
@@ -1,0 +1,83 @@
+import json
+import re
+
+from django.test import TestCase
+
+from api.views.purchase_import import PURCHASE_ID_SCHEMA_FILE_PATH, PURCHASE_SIRET_SCHEMA_FILE_PATH
+
+
+class PurchasesImportSchemaTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.schemas = {
+            "siret": json.load(open(PURCHASE_SIRET_SCHEMA_FILE_PATH)),
+            "id": json.load(open(PURCHASE_ID_SCHEMA_FILE_PATH)),
+        }
+
+    @staticmethod
+    def _pattern_for(schema, field_name):
+        field = next(f for f in schema["fields"] if f["name"] == field_name)
+        return field["constraints"]["pattern"]
+
+    def test_famille_produits_regex(self):
+        for schema_name, schema in self.schemas.items():
+            pattern = self._pattern_for(schema, "famille_produits")
+            for VALUE_OK in ["PRODUITS_LAITIERS", "PRODUITS_LAITIERS ", " PRODUITS_LAITIERS "]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
+                    self.assertTrue(re.match(pattern, VALUE_OK))
+            for VALUE_NOT_OK in ["", "TEST", "PRODUITS_LAITIERS,", "PRODUITS_LAITIERS,VIANDES_VOLAILLES"]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
+                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
+
+    def test_categories_egalim_regex(self):
+        for schema_name, schema in self.schemas.items():
+            pattern = self._pattern_for(schema, "categories_egalim")
+            for VALUE_OK in [
+                "BIO",
+                "BIO ",
+                "BIO,COMMERCE_EQUITABLE",
+                "BIO,COMMERCE_EQUITABLE ",
+                " BIO,COMMERCE_EQUITABLE ",
+                " BIO, COMMERCE_EQUITABLE ",
+                " BIO,      COMMERCE_EQUITABLE ",
+                "BIO,BIO",
+            ]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
+                    self.assertTrue(re.match(pattern, VALUE_OK))
+            for VALUE_NOT_OK in ["", "TEST"]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
+                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
+
+    def test_origine_regex(self):
+        for schema_name, schema in self.schemas.items():
+            pattern = self._pattern_for(schema, "origine")
+            for VALUE_OK in [
+                "EUROPE",
+                "FRANCE",
+                "FRANCE ",
+                " FRANCE ",
+            ]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
+                    self.assertTrue(re.match(pattern, VALUE_OK))
+            for VALUE_NOT_OK in ["", "TEST", "FRANCE,", "FRANCE,EUROPE"]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
+                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
+
+    def test_definition_local_regex(self):
+        for schema_name, schema in self.schemas.items():
+            pattern = self._pattern_for(schema, "definition_local")
+            for VALUE_OK in [
+                "PAT",
+                " PAT ",
+                "COMMUNE",
+                "DEPARTEMENT",
+                "DEPARTEMENT ",
+                " DEPARTEMENT ",
+                "REGION",
+                "KM",
+            ]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
+                    self.assertTrue(re.match(pattern, VALUE_OK))
+            for VALUE_NOT_OK in ["", "TEST", "DEPARTEMENT,", "DEPARTEMENT,REGION"]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
+                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))

--- a/api/tests/test_purchases_schema_import_old.py
+++ b/api/tests/test_purchases_schema_import_old.py
@@ -1,0 +1,69 @@
+import json
+import re
+
+from django.test import TestCase
+
+from api.views.purchase_import_old import PURCHASE_ID_SCHEMA_FILE_PATH, PURCHASE_SIRET_SCHEMA_FILE_PATH
+
+
+class PurchasesOldSchemaTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.schemas = {
+            "siret": json.load(open(PURCHASE_SIRET_SCHEMA_FILE_PATH)),
+            "id": json.load(open(PURCHASE_ID_SCHEMA_FILE_PATH)),
+        }
+
+    @staticmethod
+    def _pattern_for(schema, field_name):
+        field = next(f for f in schema["fields"] if f["name"] == field_name)
+        return field["constraints"]["pattern"]
+
+    def test_famille_produits_regex(self):
+        for schema_name, schema in self.schemas.items():
+            pattern = self._pattern_for(schema, "famille_produits")
+            for VALUE_OK in ["PRODUITS_LAITIERS", "PRODUITS_LAITIERS ", " PRODUITS_LAITIERS "]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
+                    self.assertTrue(re.match(pattern, VALUE_OK))
+            for VALUE_NOT_OK in ["", "TEST", "PRODUITS_LAITIERS,", "PRODUITS_LAITIERS,VIANDES_VOLAILLES"]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
+                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
+
+    def test_caracteristiques_regex(self):
+        for schema_name, schema in self.schemas.items():
+            pattern = self._pattern_for(schema, "caracteristiques")
+            for VALUE_OK in [
+                "BIO",
+                "BIO ",
+                "BIO,LOCAL",
+                "BIO,LOCAL ",
+                " BIO,LOCAL ",
+                " BIO, LOCAL ",
+                " BIO,      LOCAL ",
+                "BIO,BIO",
+            ]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
+                    self.assertTrue(re.match(pattern, VALUE_OK))
+            for VALUE_NOT_OK in ["", "TEST"]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
+                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))
+
+    def test_definition_local_regex(self):
+        for schema_name, schema in self.schemas.items():
+            pattern = self._pattern_for(schema, "definition_local")
+            for VALUE_OK in [
+                "PAT",
+                " PAT ",
+                "COMMUNE",
+                "DEPARTEMENT",
+                "DEPARTEMENT ",
+                " DEPARTEMENT ",
+                "REGION",
+                "AUTOUR_SERVICE",
+                "AUTRE",
+            ]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_OK):
+                    self.assertTrue(re.match(pattern, VALUE_OK))
+            for VALUE_NOT_OK in ["", "TEST", "DEPARTEMENT,", "DEPARTEMENT,REGION", "KM"]:
+                with self.subTest(schema=schema_name, VALUE=VALUE_NOT_OK):
+                    self.assertFalse(re.match(pattern, VALUE_NOT_OK))

--- a/api/tests/test_reservation_expe.py
+++ b/api/tests/test_reservation_expe.py
@@ -8,124 +8,113 @@ from data.models import ReservationExpe
 
 
 class ReservationExpeListApiTest(APITestCase):
-    @authenticate
-    def test_get_reservation_expe(self):
-        """
-        Test that we can get a reservation experiment for a canteen
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        ReservationExpeFactory(canteen=canteen, leader_email="test@example.com")
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.reservation_expe = ReservationExpeFactory(canteen=cls.canteen, leader_email="test@example.com")
+        cls.url = reverse("canteen_reservation_expe", kwargs={"canteen_pk": cls.canteen.id})
 
-        response = self.client.get(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}))
+    def test_cannot_get_reservation_expe_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_get_reservation_expe_if_canteen_does_not_exist(self):
+        url = reverse("canteen_reservation_expe", kwargs={"canteen_pk": 9999})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)  # TODO: should be 404
+
+    @authenticate
+    def test_cannot_get_reservation_expe_if_not_canteen_manager(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_get_reservation_expe_if_reservation_expe_does_not_exist(self):
+        canteen = CanteenFactory(managers=[authenticate.user])
+
+        url = reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)  # TODO: should be 404
+
+    @authenticate
+    def test_can_get_reservation_expe(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["leaderEmail"], "test@example.com")
 
-    def test_cannot_get_reservation_expe_unauthenticated(self):
-        """
-        Shouldn't be able to get a reservation expe if not authenticated
-        """
-        canteen = CanteenFactory()
-        ReservationExpeFactory(canteen=canteen)
-
-        response = self.client.get(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}))
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_cannot_get_reservation_expe_not_manager(self):
-        """
-        Shouldn't be able to get a reservation expe if not manager of canteen
-        """
-        canteen = CanteenFactory()
-        ReservationExpeFactory(canteen=canteen)
-
-        response = self.client.get(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}))
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_get_nonexistant_reservation_expe(self):
-        """
-        Test attempting to get a reservation expe that doesn't exist
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
-
-        response = self.client.get(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}))
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-
 
 class ReservationExpeCreateApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.url = reverse("canteen_reservation_expe", kwargs={"canteen_pk": cls.canteen.id})
+
+    def test_cannot_create_reservation_expe_if_unauthenticated(self):
+        payload = {
+            "satisfaction": 5,
+        }
+        response = self.client.post(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     @authenticate
-    def test_create_reservation_expe(self):
-        """
-        Test that we can create a new reservation experiment for a canteen
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
+    def test_cannot_create_reservation_expe_if_canteen_does_not_exist(self):
+        payload = {
+            "satisfaction": 5,
+        }
+        url = reverse("canteen_reservation_expe", kwargs={"canteen_pk": 9999})
+        response = self.client.post(url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_create_reservation_expe_if_not_canteen_manager(self):
+        payload = {
+            "satisfaction": 5,
+        }
+        response = self.client.post(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_can_create_reservation_expe(self):
+        self.canteen.managers.add(authenticate.user)
 
         payload = {
             "leader_email": "test@example.com",
             "satisfaction": 5,
         }
+        response = self.client.post(self.url, payload)
 
-        response = self.client.post(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}), payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
         body = response.json()
         self.assertEqual(body["leaderEmail"], "test@example.com")
         self.assertEqual(body["satisfaction"], 5)
-
-        self.assertEqual(ReservationExpe.objects.get(canteen=canteen).leader_email, "test@example.com")
-        self.assertEqual(ReservationExpe.objects.get(canteen=canteen).satisfaction, 5)
-
-    def test_cannot_create_reservation_expe_not_authenticated(self):
-        """
-        Shouldn't be able to create a reservation expe if not authenticated
-        """
-        canteen = CanteenFactory()
-
-        payload = {
-            "satisfaction": 5,
-        }
-
-        response = self.client.post(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}), payload)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_cannot_create_reservation_expe_not_manager(self):
-        """
-        Shouldn't be able to create a reservation expe if not the manager of the canteen
-        """
-        canteen = CanteenFactory()
-
-        payload = {
-            "satisfaction": 5,
-        }
-
-        response = self.client.post(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}), payload)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_cannot_create_reservation_expe_nonexistent_canteen(self):
-        """
-        Shouldn't be able to create a reservation expe if not the canteen doesn't exist
-        """
-        payload = {
-            "satisfaction": 5,
-        }
-
-        response = self.client.post(reverse("canteen_reservation_expe", kwargs={"canteen_pk": 99}), payload)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(ReservationExpe.objects.get(canteen=self.canteen).leader_email, "test@example.com")
+        self.assertEqual(ReservationExpe.objects.get(canteen=self.canteen).satisfaction, 5)
 
     @authenticate
     def test_cannot_create_duplicate_reservation_expe(self):
         """
         Shouldn't be able to create more than one reservation expe for a canteen
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        reservation_expe = ReservationExpeFactory(canteen=canteen, satisfaction=5)
+        self.canteen.managers.add(authenticate.user)
+        reservation_expe = ReservationExpeFactory(canteen=self.canteen, satisfaction=5)
 
-        response = self.client.post(
-            reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}), {"satisfaction": 0}
-        )
+        payload = {
+            "satisfaction": 0,
+        }
+        response = self.client.post(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         reservation_expe.refresh_from_db()
         self.assertEqual(reservation_expe.satisfaction, 5)
@@ -133,101 +122,112 @@ class ReservationExpeCreateApiTest(APITestCase):
 
 
 class ReservationExpeUpdateApiTest(APITestCase):
-    @authenticate
-    def test_update_reservation_expe(self):
-        """
-        Test that we can update a reservation experiment for a canteen
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        reservation_expe = ReservationExpeFactory(canteen=canteen, leader_email="bad@example.com", satisfaction=1)
-        payload = {"leader_email": "good@example.com", "satisfaction": 3}
-        response = self.client.patch(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}), payload)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        reservation_expe.refresh_from_db()
-        self.assertEqual(reservation_expe.leader_email, "good@example.com")
-        self.assertEqual(reservation_expe.satisfaction, 3)
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.reservation_expe = ReservationExpeFactory(
+            canteen=cls.canteen, leader_email="good@example.com", satisfaction=1, avg_weight_not_served_t2=70
+        )
+        cls.url = reverse("canteen_reservation_expe", kwargs={"canteen_pk": cls.canteen.id})
 
-    def test_cannot_update_reservation_expe_unauthenticated(self):
-        """
-        Shouldn't be able to update a reservation expe if not authenticated
-        """
-        canteen = CanteenFactory()
-        reservation_expe = ReservationExpeFactory(canteen=canteen, leader_email="good@example.com")
+    def test_cannot_update_reservation_expe_if_unauthenticated(self):
         payload = {"leader_email": "bad@example.com"}
-        response = self.client.patch(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}), payload)
+        response = self.client.patch(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        reservation_expe.refresh_from_db()
-        self.assertEqual(reservation_expe.leader_email, "good@example.com")
+        self.reservation_expe.refresh_from_db()
+        self.assertEqual(self.reservation_expe.leader_email, "good@example.com")
 
     @authenticate
-    def test_cannot_update_reservation_expe_not_manager(self):
-        """
-        Shouldn't be able to update a reservation expe if not manager of the canteen
-        """
-        canteen = CanteenFactory()
-        reservation_expe = ReservationExpeFactory(canteen=canteen, leader_email="good@example.com")
+    def test_cannot_update_reservation_expe_if_canteen_does_not_exist(self):
+        url = reverse("canteen_reservation_expe", kwargs={"canteen_pk": 9999})
         payload = {"leader_email": "bad@example.com"}
-        response = self.client.patch(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}), payload)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        reservation_expe.refresh_from_db()
-        self.assertEqual(reservation_expe.leader_email, "good@example.com")
+        response = self.client.patch(url, payload)
 
-    @authenticate
-    def test_cannot_update_nonexistent_reservation_expe(self):
-        """
-        Shouldn't be able to update a reservation expe if it doesn't exist
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        payload = {"leader_email": "bad@example.com"}
-        response = self.client.patch(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}), payload)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(ReservationExpe.objects.count(), 0)
 
     @authenticate
-    def test_cannot_update_canteen_for_reservation_expe(self):
-        """
-        Check that cannot update canteen on a reservation expe
-        """
+    def test_cannot_update_reservation_expe_if_not_canteen_manager(self):
+        payload = {"leader_email": "bad@example.com"}
+        response = self.client.patch(self.url, payload)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        self.reservation_expe.refresh_from_db()
+        self.assertEqual(self.reservation_expe.leader_email, "good@example.com")
+
+    @authenticate
+    def test_cannot_update_reservation_expe_if_reservation_expe_does_not_exist(self):
         canteen = CanteenFactory(managers=[authenticate.user])
-        reservation_expe = ReservationExpeFactory(canteen=canteen)
-        payload = {"canteen": CanteenFactory().id}
-        response = self.client.patch(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}), payload)
+
+        url = reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id})
+        payload = {"leader_email": "bad@example.com"}
+        response = self.client.patch(url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(ReservationExpe.objects.filter(canteen=canteen).count(), 0)
+
+    @authenticate
+    def test_cannot_update_reservation_expe_with_put(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.put(self.url, data={}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @authenticate
+    def test_can_update_reservation_expe(self):
+        self.canteen.managers.add(authenticate.user)
+
+        payload = {"leader_email": "other@example.com", "satisfaction": 3}
+        response = self.client.patch(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        reservation_expe.refresh_from_db()
-        self.assertEqual(reservation_expe.canteen, canteen)
+        self.reservation_expe.refresh_from_db()
+        self.assertEqual(self.reservation_expe.leader_email, "other@example.com")
+        self.assertEqual(self.reservation_expe.satisfaction, 3)
 
     @authenticate
-    def test_updates_bad_data(self):
-        """
-        Check that updates with bad data are rejected
-        """
+    def test_cannot_update_reservation_expe_canteen(self):
+        self.canteen.managers.add(authenticate.user)
         canteen = CanteenFactory(managers=[authenticate.user])
-        reservation_expe = ReservationExpeFactory(canteen=canteen, satisfaction=3, avg_weight_not_served_t2=70)
 
-        response = self.client.patch(
-            reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}),
-            {"satisfaction": 6},
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        reservation_expe.refresh_from_db()
-        self.assertEqual(reservation_expe.satisfaction, 3)
+        payload = {"canteen": canteen.id}
+        response = self.client.patch(self.url, payload)
 
-        response = self.client.patch(
-            reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}),
-            {"avgWeightNotServedT2": -90},
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.reservation_expe.refresh_from_db()
+        self.assertEqual(self.reservation_expe.canteen, self.canteen)  # no change
+
+    @authenticate
+    def test_cannot_update_reservation_expe_with_bad_data(self):
+        self.canteen.managers.add(authenticate.user)
+
+        payload = {"satisfaction": 6}
+        response = self.client.patch(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        reservation_expe.refresh_from_db()
-        self.assertEqual(reservation_expe.avg_weight_not_served_t2, 70)
+        self.reservation_expe.refresh_from_db()
+        self.assertEqual(self.reservation_expe.satisfaction, 1)
+
+        payload = {"avg_weight_not_served_t2": -90}
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.reservation_expe.refresh_from_db()
+        self.assertEqual(self.reservation_expe.avg_weight_not_served_t2, 70)
 
 
 class ReservationExpeDeleteApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.reservation_expe = ReservationExpeFactory(canteen=cls.canteen)
+        cls.url = reverse("canteen_reservation_expe", kwargs={"canteen_pk": cls.canteen.id})
+
     @authenticate
     def test_cannot_delete_reservation_expe(self):
-        """
-        Check that deletion is not allowed
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        ReservationExpeFactory(canteen=canteen)
-        response = self.client.delete(reverse("canteen_reservation_expe", kwargs={"canteen_pk": canteen.id}))
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.delete(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/api/tests/test_reservation_expe.py
+++ b/api/tests/test_reservation_expe.py
@@ -100,20 +100,16 @@ class ReservationExpeCreateApiTest(APITestCase):
         body = response.json()
         self.assertEqual(body["leaderEmail"], "test@example.com")
         self.assertEqual(body["satisfaction"], 5)
-        self.assertEqual(ReservationExpe.objects.get(canteen=self.canteen).leader_email, "test@example.com")
-        self.assertEqual(ReservationExpe.objects.get(canteen=self.canteen).satisfaction, 5)
+        reservation_expe = ReservationExpe.objects.get(canteen=self.canteen)
+        self.assertEqual(reservation_expe.leader_email, "test@example.com")
+        self.assertEqual(reservation_expe.satisfaction, 5)
 
     @authenticate
-    def test_cannot_create_duplicate_reservation_expe(self):
-        """
-        Shouldn't be able to create more than one reservation expe for a canteen
-        """
+    def test_cannot_create_reservation_expe_if_already_exists(self):
         self.canteen.managers.add(authenticate.user)
         reservation_expe = ReservationExpeFactory(canteen=self.canteen, satisfaction=5)
 
-        payload = {
-            "satisfaction": 0,
-        }
+        payload = {"satisfaction": 0}
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -151,8 +147,8 @@ class ReservationExpeUpdateApiTest(APITestCase):
     def test_cannot_update_reservation_expe_if_not_canteen_manager(self):
         payload = {"leader_email": "bad@example.com"}
         response = self.client.patch(self.url, payload)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.reservation_expe.refresh_from_db()
         self.assertEqual(self.reservation_expe.leader_email, "good@example.com")
 

--- a/api/tests/test_reservation_expe.py
+++ b/api/tests/test_reservation_expe.py
@@ -22,6 +22,7 @@ class ReservationExpeListApiTest(APITestCase):
     @authenticate
     def test_cannot_get_reservation_expe_if_canteen_does_not_exist(self):
         url = reverse("canteen_reservation_expe", kwargs={"canteen_pk": 9999})
+
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)  # TODO: should be 404
@@ -42,7 +43,7 @@ class ReservationExpeListApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)  # TODO: should be 404
 
     @authenticate
-    def test_can_get_reservation_expe(self):
+    def test_can_list_reservation_expe(self):
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.get(self.url)

--- a/api/tests/test_resource_actions.py
+++ b/api/tests/test_resource_actions.py
@@ -125,9 +125,9 @@ class CanteenResourceActionGetApiTest(APITestCase):
         ResourceActionFactory(resource=cls.waste_action_2, canteen=cls.canteen_with_resource_action, is_favorite=True)
 
     @authenticate
-    def test_get_single_user_canteen_with_resource_actions(self):
+    def test_get_canteen_with_resource_actions(self):
         self.canteen_with_resource_action.managers.add(authenticate.user)
-        # canteen with resource_actions
+
         url = reverse("single_canteen", kwargs={"pk": self.canteen_with_resource_action.id})
         response = self.client.get(url)
 

--- a/api/tests/test_resource_actions.py
+++ b/api/tests/test_resource_actions.py
@@ -33,7 +33,7 @@ class TestResourceActionsApi(APITestCase):
         response = self.client.post(self.url, data={"is_done": True})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         # user is authenticated and belongs to the canteen, but canteen_id is wrong
-        response = self.client.post(self.url, data={"canteen_id": 999, "is_done": True})
+        response = self.client.post(self.url, data={"canteen_id": 9999, "is_done": True})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_resource_action_success(self):

--- a/api/tests/test_resource_actions.py
+++ b/api/tests/test_resource_actions.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import (
     CanteenFactory,
     ResourceActionFactory,
@@ -11,7 +12,7 @@ from data.factories import (
 from data.models import ResourceAction
 
 
-class TestResourceActionsApi(APITestCase):
+class ResourceActionsCreateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.waste_action = WasteActionFactory()
@@ -20,26 +21,47 @@ class TestResourceActionsApi(APITestCase):
         cls.canteen = CanteenFactory(managers=[cls.user_with_canteen])
         cls.url = reverse("resource_action_create_or_update", kwargs={"resource_pk": cls.waste_action.id})
 
-    def test_create_resource_action_error(self):
-        # user is not authenticated
-        response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": True})
+    def test_cannot_create_resource_action_if_unauthenticated(self):
+        payload = {"canteen_id": self.canteen.id, "is_done": True}
+        response = self.client.post(self.url, data=payload)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        # user does not belong to the canteen
-        self.client.force_login(user=self.user)
-        response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": True})
+
+    @authenticate
+    def test_cannot_create_resource_action_if_user_not_canteen_manager(self):
+        payload = {"canteen_id": self.canteen.id, "is_done": True}
+        response = self.client.post(self.url, data=payload)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        # user is authenticated and belongs to the canteen, but canteen_id missing
-        self.client.force_login(user=self.user_with_canteen)
-        response = self.client.post(self.url, data={"is_done": True})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        # user is authenticated and belongs to the canteen, but canteen_id is wrong
-        response = self.client.post(self.url, data={"canteen_id": 9999, "is_done": True})
+
+    @authenticate
+    def test_cannot_create_resource_action_if_canteen_does_not_exist(self):
+        payload = {"canteen_id": 9999, "is_done": True}
+        response = self.client.post(self.url, data=payload)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_create_resource_action_success(self):
-        # user is authenticated and belongs to the canteen
-        self.client.force_login(user=self.user_with_canteen)
-        response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": True})
+    @authenticate
+    def test_cannot_create_resource_action_if_canteen_id_is_missing(self):
+        payload = {"is_done": True}
+        response = self.client.post(self.url, data=payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @authenticate
+    def test_cannot_create_resource_action_if_canteen_id_is_wrong(self):
+        payload = {"canteen_id": 9999, "is_done": True}
+        response = self.client.post(self.url, data=payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @authenticate
+    def test_can_create_resource_action(self):
+        self.canteen.managers.add(authenticate.user)
+
+        payload = {"canteen_id": self.canteen.id, "is_done": True}
+        response = self.client.post(self.url, data=payload)
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         self.assertEqual(body["resourceId"], self.waste_action.id)
@@ -52,21 +74,36 @@ class TestResourceActionsApi(APITestCase):
         self.assertTrue(ResourceAction.objects.first().is_done)
         self.assertIsNone(ResourceAction.objects.first().is_favorite)
 
+
+class ResourceActionsUpdateApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.waste_action = WasteActionFactory()
+        cls.user = UserFactory()
+        cls.user_with_canteen = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user_with_canteen])
+        cls.url = reverse("resource_action_create_or_update", kwargs={"resource_pk": cls.waste_action.id})
+
+    @authenticate
     def test_update_resource_action(self):
-        # create a ResourceAction
+        self.canteen.managers.add(authenticate.user)
         ResourceActionFactory(resource=self.waste_action, canteen=self.canteen, is_done=True)
-        # user is authenticated and belongs to the canteen
-        self.client.force_login(user=self.user_with_canteen)
+
         # update is_done
-        response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_done": False})
+        payload = {"canteen_id": self.canteen.id, "is_done": False}
+        response = self.client.post(self.url, data=payload)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(ResourceAction.objects.count(), 1)
         self.assertEqual(ResourceAction.objects.first().resource, self.waste_action)
         self.assertEqual(ResourceAction.objects.first().canteen, self.canteen)
         self.assertFalse(ResourceAction.objects.first().is_done)
         self.assertIsNone(ResourceAction.objects.first().is_favorite)
+
         # update is_favorite
-        response = self.client.post(self.url, data={"canteen_id": self.canteen.id, "is_favorite": True})
+        payload = {"canteen_id": self.canteen.id, "is_favorite": True}
+        response = self.client.post(self.url, data=payload)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(ResourceAction.objects.count(), 1)
         self.assertEqual(ResourceAction.objects.first().resource, self.waste_action)
@@ -75,7 +112,7 @@ class TestResourceActionsApi(APITestCase):
         self.assertTrue(ResourceAction.objects.first().is_favorite)
 
 
-class TestCanteenResourceActionApi(APITestCase):
+class CanteenResourceActionGetApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.waste_action_1 = WasteActionFactory()
@@ -87,10 +124,13 @@ class TestCanteenResourceActionApi(APITestCase):
         ResourceActionFactory(resource=cls.waste_action_1, canteen=cls.canteen_with_resource_action, is_done=True)
         ResourceActionFactory(resource=cls.waste_action_2, canteen=cls.canteen_with_resource_action, is_favorite=True)
 
+    @authenticate
     def test_get_single_user_canteen_with_resource_actions(self):
-        self.client.force_login(user=self.user_with_canteen)
+        self.canteen_with_resource_action.managers.add(authenticate.user)
         # canteen with resource_actions
-        response = self.client.get(reverse("single_canteen", kwargs={"pk": self.canteen_with_resource_action.id}))
+        url = reverse("single_canteen", kwargs={"pk": self.canteen_with_resource_action.id})
+        response = self.client.get(url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["id"], self.canteen_with_resource_action.id)
@@ -105,18 +145,24 @@ class TestCanteenResourceActionApi(APITestCase):
         self.assertEqual(body["resourceActions"][1]["resource"]["id"], self.waste_action_2.id)
         self.assertEqual(body["resourceActions"][1]["canteen"]["id"], self.canteen_with_resource_action.id)
 
+    @authenticate
     def test_get_single_published_canteen_with_resource_actions(self):
+        self.canteen.managers.add(authenticate.user)
         # canteen without resource_actions
-        response = self.client.get(reverse("single_published_canteen", kwargs={"pk": self.canteen.id}))
+        url = reverse("single_published_canteen", kwargs={"pk": self.canteen.id})
+        response = self.client.get(url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["id"], self.canteen.id)
         self.assertTrue("resourceActions" in body)
         self.assertEqual(len(body["resourceActions"]), 0)
+
         # canteen with resource_actions
-        response = self.client.get(
-            reverse("single_published_canteen", kwargs={"pk": self.canteen_with_resource_action.id})
-        )
+        self.canteen_with_resource_action.managers.add(authenticate.user)
+        url = reverse("single_published_canteen", kwargs={"pk": self.canteen_with_resource_action.id})
+        response = self.client.get(url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["id"], self.canteen_with_resource_action.id)

--- a/api/tests/test_reviews.py
+++ b/api/tests/test_reviews.py
@@ -7,7 +7,21 @@ from data.factories import CanteenFactory, DiagnosticFactory, ReviewFactory
 from data.models import Review
 
 
-class TestReviews(APITestCase):
+class ReviewCreateApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("create_review")
+
+    def test_cannot_create_review_if_unauthenticated(self):
+        payload = {
+            "page": "CanteensHome",
+            "rating": 3,
+            "suggestion": "Make it read my mind",
+        }
+        response = self.client.post(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     @authenticate
     def test_create_review(self):
         """
@@ -15,12 +29,14 @@ class TestReviews(APITestCase):
         having a canteen/diagnostic is saved automatically.
         """
         CanteenFactory(managers=[authenticate.user])
+
         payload = {
             "page": "CanteensHome",
             "rating": 5,
             "suggestion": "Make it read my mind",
         }
-        response = self.client.post(reverse("create_review"), payload)
+        response = self.client.post(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         review = Review.objects.get(user=authenticate.user)
         self.assertEqual(review.hasCanteen, True)
@@ -41,53 +57,40 @@ class TestReviews(APITestCase):
             "rating": 1,
             "suggestion": "Make it read my mind",
         }
-        response = self.client.post(reverse("create_review"), payload)
+        response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         review = Review.objects.get(user=authenticate.user, page="DiagnosticsHome")
         self.assertEqual(review.hasCanteen, True)
         self.assertEqual(review.hasDiagnostic, True)
 
-    def test_fail_create_review_unauthenticated(self):
-        """
-        Test that unauthenticated user cannot submit a review
-        """
+    @authenticate
+    def test_cannot_create_review_without_rating(self):
         payload = {
             "page": "CanteensHome",
-            "rating": 3,
+            # "rating": 1,
             "suggestion": "Make it read my mind",
         }
-        response = self.client.post(reverse("create_review"), payload)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        response = self.client.post(self.url, payload)
 
-    @authenticate
-    def test_fail_no_rating(self):
-        """
-        Test that user cannot submit a review without the required fields
-        """
-        payload = {
-            "page": "CanteensHome",
-            "suggestion": "Make it read my mind",
-        }  # no rating
-        response = self.client.post(reverse("create_review"), payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         payload = {"rating": 5}  # no page
-        response = self.client.post(reverse("create_review"), payload)
+        response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @authenticate
-    def test_fail_too_high_rating(self):
-        """
-        Test that user cannot submit a review without the required fields
-        """
+    def test_cannot_create_review_with_too_high_rating(self):
         payload = {
             "page": "CanteensHome",
             "rating": 6,
             "suggestion": "Make it read my mind",
         }
-        response = self.client.post(reverse("create_review"), payload)
+        response = self.client.post(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+
+class ReviewInUserFetchApiTest(APITestCase):
     @authenticate
     def test_reviews_in_user_fetch(self):
         """
@@ -95,7 +98,9 @@ class TestReviews(APITestCase):
         """
         ReviewFactory(user=authenticate.user, hasCanteen=True, hasDiagnostic=False)
         ReviewFactory(hasCanteen=False, hasDiagnostic=True)  # should not be fetched
+
         response = self.client.get(reverse("logged_user"))
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(len(body["reviews"]), 1)

--- a/api/tests/test_sectors.py
+++ b/api/tests/test_sectors.py
@@ -4,12 +4,13 @@ from rest_framework.test import APITestCase
 
 
 class SectorApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("sectors_list")
+
     def test_sector_list(self):
-        """
-        The API should return all sectors
-        """
-        response = self.client.get(reverse("sectors_list"))
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-
         self.assertEqual(len(body), 26)

--- a/api/tests/test_subscription.py
+++ b/api/tests/test_subscription.py
@@ -13,22 +13,16 @@ class SubscriptionApiTest(APITestCase):
         cls.url = reverse("subscribe_newsletter")
 
     @patch("api.views.subscription.create_newsletter_contact")
-    def test_newsletter_subscription(self, _, create_newsletter_contact):
-        """
-        When subscribing to the newsletter the email should be sent to Brevo
-        """
+    def test_can_subscribe_newsletter(self, _, create_newsletter_contact):
         payload = {"email": "test@example.com"}
         self.client.post(self.url, payload, format="json")
 
         create_newsletter_contact.assert_called_once_with("test@example.com")
 
     @patch("api.views.subscription.create_newsletter_contact")
-    def test_newsletter_subscription_email_whitespace(self, _, create_newsletter_contact):
-        """
-        When subscribing to the newsletter the email should be stripped before being sent to Brevo
-        """
+    def test_can_subscribe_newsletter_with_email_whitespace(self, _, create_newsletter_contact):
         payload = {"email": "  test@example.com      "}
         response = self.client.post(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        create_newsletter_contact.assert_called_once_with("test@example.com")
+        create_newsletter_contact.assert_called_once_with("test@example.com")  # stripped

--- a/api/tests/test_subscription.py
+++ b/api/tests/test_subscription.py
@@ -7,17 +7,18 @@ from rest_framework.test import APITestCase
 
 
 @requests_mock.Mocker()
-class TestSubscription(APITestCase):
+class SubscriptionApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("subscribe_newsletter")
+
     @patch("api.views.subscription.create_newsletter_contact")
     def test_newsletter_subscription(self, _, create_newsletter_contact):
         """
         When subscribing to the newsletter the email should be sent to Brevo
         """
-        self.client.post(
-            reverse("subscribe_newsletter"),
-            {"email": "test@example.com"},
-            format="json",
-        )
+        payload = {"email": "test@example.com"}
+        self.client.post(self.url, payload, format="json")
 
         create_newsletter_contact.assert_called_once_with("test@example.com")
 
@@ -26,11 +27,8 @@ class TestSubscription(APITestCase):
         """
         When subscribing to the newsletter the email should be stripped before being sent to Brevo
         """
-        response = self.client.post(
-            reverse("subscribe_newsletter"),
-            {"email": "  test@example.com      "},
-            format="json",
-        )
+        payload = {"email": "  test@example.com      "}
+        response = self.client.post(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         create_newsletter_contact.assert_called_once_with("test@example.com")

--- a/api/tests/test_teledeclaration.py
+++ b/api/tests/test_teledeclaration.py
@@ -4,14 +4,24 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 
-class TestTeledeclarationCampaignDatesApi(APITestCase):
-    def test_campaign_dates_list(self):
-        response = self.client.get(reverse("list_teledeclaration_campaign_dates"))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+class TeledeclarationCampaignDatesListApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("list_teledeclaration_campaign_dates")
 
+    def test_campaign_dates_list(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(len(body), 5)
         self.assertEqual(body[-1]["year"], 2025)
+
+
+class TeledeclarationCampaignDatesRetrieveApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("retrieve_teledeclaration_campaign_dates", kwargs={"year": 2024})
 
     def test_campaign_dates_retrieve(self):
         for date_freeze in [
@@ -21,11 +31,9 @@ class TestTeledeclarationCampaignDatesApi(APITestCase):
         ]:
             with self.subTest(DATE=date_freeze["date"]):
                 with freeze_time(date_freeze["date"]):
-                    response = self.client.get(
-                        reverse("retrieve_teledeclaration_campaign_dates", kwargs={"year": 2024})
-                    )
-                    self.assertEqual(response.status_code, status.HTTP_200_OK)
+                    response = self.client.get(self.url)
 
+                    self.assertEqual(response.status_code, status.HTTP_200_OK)
                     body = response.json()
                     self.assertEqual(body["year"], 2024)
                     self.assertEqual(body["inTeledeclaration"], date_freeze["in_teledeclaration"])

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -8,19 +8,15 @@ from api.tests.utils import authenticate, get_oauth2_token
 from data.factories import UserFactory
 
 
-class TestLoggedUserApi(APITestCase):
+class LoggedUserApiTest(APITestCase):
     def test_login_with_email_authenticates_session(self):
         user = UserFactory(email="user@example.com")
         user.set_password("testPw1234#!")
         user.save(update_fields=["password"])
 
-        login_response = self.client.post(
-            reverse("login"),
-            {
-                "username": "USER@example.com",
-                "password": "testPw1234#!",
-            },
-        )
+        url = reverse("login")
+        payload = {"username": "USER@example.com", "password": "testPw1234#!"}
+        login_response = self.client.post(url, payload)
 
         self.assertEqual(login_response.status_code, status.HTTP_302_FOUND)
         self.assertEqual(self.client.session.get("_auth_user_id"), str(user.id))
@@ -34,13 +30,9 @@ class TestLoggedUserApi(APITestCase):
         user.set_password("testPw1234#!")
         user.save(update_fields=["password"])
 
-        login_response = self.client.post(
-            reverse("login"),
-            {
-                "username": "TESTuser",
-                "password": "testPw1234#!",
-            },
-        )
+        url = reverse("login")
+        payload = {"username": "TESTuser", "password": "testPw1234#!"}
+        login_response = self.client.post(url, payload)
 
         self.assertEqual(login_response.status_code, status.HTTP_302_FOUND)
         self.assertEqual(self.client.session.get("_auth_user_id"), str(user.id))

--- a/api/tests/test_vegetarian_expe.py
+++ b/api/tests/test_vegetarian_expe.py
@@ -103,10 +103,7 @@ class VegetarianExpeCreateApiTest(APITestCase):
         self.assertEqual(VegetarianExpe.objects.get(canteen=self.canteen).satisfaction_guests_t0, 5)
 
     @authenticate
-    def test_cannot_create_duplicate_vegetarian_expe(self):
-        """
-        Shouldn't be able to create more than one vegetarian expe for a canteen
-        """
+    def test_cannot_create_vegetarian_expe_if_already_exists(self):
         self.canteen.managers.add(authenticate.user)
         vegetarian_expe = VegetarianExpeFactory(canteen=self.canteen, satisfaction_guests_t0=5)
 
@@ -206,14 +203,14 @@ class VegetarianExpeUpdateApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.vegetarian_expe.refresh_from_db()
-        self.assertEqual(self.vegetarian_expe.satisfaction_guests_t0, 1)
+        self.assertEqual(self.vegetarian_expe.satisfaction_guests_t0, 1)  # no change
 
         payload = {"waste_vegetarian_not_served_t0": -90}
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.vegetarian_expe.refresh_from_db()
-        self.assertEqual(self.vegetarian_expe.waste_vegetarian_not_served_t0, 50)
+        self.assertEqual(self.vegetarian_expe.waste_vegetarian_not_served_t0, 50)  # no change
 
 
 class VegetarianExpeDeleteApiTest(APITestCase):

--- a/api/tests/test_vegetarian_expe.py
+++ b/api/tests/test_vegetarian_expe.py
@@ -62,7 +62,6 @@ class VegetarianExpeCreateApiTest(APITestCase):
         payload = {
             "satisfaction_guests_t0": 5,
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -72,7 +71,6 @@ class VegetarianExpeCreateApiTest(APITestCase):
         payload = {
             "satisfaction_guests_t0": 5,
         }
-
         response = self.client.post(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": 9999}), payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -82,7 +80,6 @@ class VegetarianExpeCreateApiTest(APITestCase):
         payload = {
             "satisfaction_guests_t0": 5,
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -95,7 +92,6 @@ class VegetarianExpeCreateApiTest(APITestCase):
             "vegetarian_menu_percentage_t0": 0.32,
             "satisfaction_guests_t0": 5,
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/api/tests/test_vegetarian_expe.py
+++ b/api/tests/test_vegetarian_expe.py
@@ -8,124 +8,117 @@ from data.models import VegetarianExpe
 
 
 class VegetarianExpeListApiTest(APITestCase):
-    @authenticate
-    def test_get_vegetarian_expe(self):
-        """
-        Test that we can get a vegetarian expe for a canteen
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        VegetarianExpeFactory(canteen=canteen, satisfaction_guests_t0=4)
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.vegetarian_expe = VegetarianExpeFactory(canteen=cls.canteen, satisfaction_guests_t0=5)
+        cls.url = reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": cls.canteen.id})
 
-        response = self.client.get(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}))
+    def test_cannot_get_vegetarian_expe_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_get_vegetarian_expe_if_canteen_does_not_exist(self):
+        url = reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": 9999})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)  # TODO: should be 404
+
+    @authenticate
+    def test_cannot_get_vegetarian_expe_if_not_canteen_manager(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_get_vegetarian_expe_if_vegetarian_expe_does_not_exist(self):
+        canteen = CanteenFactory(managers=[authenticate.user])
+
+        url = reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)  # TODO: should be 404
+
+    @authenticate
+    def test_can_get_vegetarian_expe(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(body["satisfactionGuestsT0"], 4)
-
-    def test_cannot_get_vegetarian_expe_unauthenticated(self):
-        """
-        Shouldn't be able to get a vegetarian expe if not authenticated
-        """
-        canteen = CanteenFactory()
-        VegetarianExpeFactory(canteen=canteen)
-
-        response = self.client.get(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}))
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_cannot_get_vegetarian_expe_not_manager(self):
-        """
-        Shouldn't be able to get a vegetarian expe if not manager of canteen
-        """
-        canteen = CanteenFactory()
-        VegetarianExpeFactory(canteen=canteen)
-
-        response = self.client.get(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}))
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_get_nonexistant_vegetarian_expe(self):
-        """
-        Test attempting to get a vegetarian expe that doesn't exist
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
-
-        response = self.client.get(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}))
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(body["satisfactionGuestsT0"], 5)
 
 
 class VegetarianExpeCreateApiTest(APITestCase):
-    @authenticate
-    def test_create_vegetarian_expe(self):
-        """
-        Test that we can create a new vegetarian experiment for a canteen
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.url = reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": cls.canteen.id})
 
+    def test_cannot_create_vegetarian_expe_if_unauthenticated(self):
         payload = {
-            "vegetarianMenuPercentageT0": 0.32,
-            "satisfactionGuestsT0": 5,
+            "satisfaction_guests_t0": 5,
         }
 
-        response = self.client.post(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), payload)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response = self.client.post(self.url, payload)
 
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_create_vegetarian_expe_if_canteen_does_not_exist(self):
+        payload = {
+            "satisfaction_guests_t0": 5,
+        }
+
+        response = self.client.post(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": 9999}), payload)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_create_vegetarian_expe_if_not_canteen_manager(self):
+        payload = {
+            "satisfaction_guests_t0": 5,
+        }
+
+        response = self.client.post(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_can_create_vegetarian_expe(self):
+        self.canteen.managers.add(authenticate.user)
+
+        payload = {
+            "vegetarian_menu_percentage_t0": 0.32,
+            "satisfaction_guests_t0": 5,
+        }
+
+        response = self.client.post(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         self.assertEqual(body["vegetarianMenuPercentageT0"], 0.32)
         self.assertEqual(body["satisfactionGuestsT0"], 5)
 
-        self.assertEqual(float(VegetarianExpe.objects.get(canteen=canteen).vegetarian_menu_percentage_t0), 0.32)
-        self.assertEqual(VegetarianExpe.objects.get(canteen=canteen).satisfaction_guests_t0, 5)
-
-    def test_cannot_create_vegetarian_expe_not_authenticated(self):
-        """
-        Shouldn't be able to create a vegetarian expe if not authenticated
-        """
-        canteen = CanteenFactory()
-
-        payload = {
-            "satisfactionGuestsT0": 5,
-        }
-
-        response = self.client.post(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), payload)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_cannot_create_vegetarian_expe_not_manager(self):
-        """
-        Shouldn't be able to create a vegetarian expe if not the manager of the canteen
-        """
-        canteen = CanteenFactory()
-
-        payload = {
-            "satisfactionGuestsT0": 5,
-        }
-
-        response = self.client.post(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), payload)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    @authenticate
-    def test_cannot_create_vegetarian_expe_nonexistent_canteen(self):
-        """
-        Shouldn't be able to create a vegetarian expe if not the canteen doesn't exist
-        """
-        payload = {
-            "satisfactionGuestsT0": 5,
-        }
-
-        response = self.client.post(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": 99}), payload)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(float(VegetarianExpe.objects.get(canteen=self.canteen).vegetarian_menu_percentage_t0), 0.32)
+        self.assertEqual(VegetarianExpe.objects.get(canteen=self.canteen).satisfaction_guests_t0, 5)
 
     @authenticate
     def test_cannot_create_duplicate_vegetarian_expe(self):
         """
         Shouldn't be able to create more than one vegetarian expe for a canteen
         """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        vegetarian_expe = VegetarianExpeFactory(canteen=canteen, satisfaction_guests_t0=5)
+        self.canteen.managers.add(authenticate.user)
+        vegetarian_expe = VegetarianExpeFactory(canteen=self.canteen, satisfaction_guests_t0=5)
 
-        response = self.client.post(
-            reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), {"satisfactionGuestsT0": 0}
-        )
+        payload = {
+            "satisfaction_guests_t0": 0,
+        }
+        response = self.client.post(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         vegetarian_expe.refresh_from_db()
         self.assertEqual(vegetarian_expe.satisfaction_guests_t0, 5)
@@ -133,102 +126,111 @@ class VegetarianExpeCreateApiTest(APITestCase):
 
 
 class VegetarianExpeUpdateApiTest(APITestCase):
-    @authenticate
-    def test_update_vegetarian_expe(self):
-        """
-        Test that we can update a vegetarian experiment for a canteen
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        vegetarian_expe = VegetarianExpeFactory(canteen=canteen, satisfaction_guests_t0=1)
-        payload = {"satisfactionGuestsT0": 3}
-        response = self.client.patch(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), payload)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        vegetarian_expe.refresh_from_db()
-        self.assertEqual(vegetarian_expe.satisfaction_guests_t0, 3)
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.vegetarian_expe = VegetarianExpeFactory(
+            canteen=cls.canteen, satisfaction_guests_t0=1, waste_vegetarian_not_served_t0=50
+        )
+        cls.url = reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": cls.canteen.id})
 
-    def test_cannot_update_vegetarian_expe_unauthenticated(self):
-        """
-        Shouldn't be able to update a vegetarian expe if not authenticated
-        """
-        canteen = CanteenFactory()
-        vegetarian_expe = VegetarianExpeFactory(canteen=canteen, satisfaction_guests_t0=1)
-        payload = {"satisfactionGuestsT0": 2}
-        response = self.client.patch(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), payload)
+    def test_cannot_update_vegetarian_expe_if_unauthenticated(self):
+        payload = {"satisfaction_guests_t0": 2}
+        response = self.client.patch(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        vegetarian_expe.refresh_from_db()
-        self.assertEqual(vegetarian_expe.satisfaction_guests_t0, 1)
+        self.vegetarian_expe.refresh_from_db()
+        self.assertEqual(self.vegetarian_expe.satisfaction_guests_t0, 1)
 
     @authenticate
-    def test_cannot_update_vegetarian_expe_not_manager(self):
-        """
-        Shouldn't be able to update a vegetarian expe if not manager of the canteen
-        """
-        canteen = CanteenFactory()
-        vegetarian_expe = VegetarianExpeFactory(canteen=canteen, satisfaction_guests_t0=1)
-        payload = {"satisfactionGuestsT0": 2}
-        response = self.client.patch(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), payload)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        vegetarian_expe.refresh_from_db()
-        self.assertEqual(vegetarian_expe.satisfaction_guests_t0, 1)
+    def test_cannot_update_vegetarian_expe_if_canteen_does_not_exist(self):
+        url = reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": 9999})
+        payload = {"satisfaction_guests_t0": 2}
+        response = self.client.patch(url, payload)
 
-    @authenticate
-    def test_cannot_update_nonexistent_vegetarian_expe(self):
-        """
-        Shouldn't be able to update a vegetarian expe if it doesn't exist
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        payload = {"satisfactionGuestsT0": 2}
-        response = self.client.patch(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), payload)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(VegetarianExpe.objects.count(), 0)
 
     @authenticate
-    def test_cannot_update_canteen_for_vegetarian_expe(self):
-        """
-        Check that cannot update canteen on a reservation expe
-        """
+    def test_cannot_update_vegetarian_expe_if_not_canteen_manager(self):
+        payload = {"satisfaction_guests_t0": 2}
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.vegetarian_expe.refresh_from_db()
+        self.assertEqual(self.vegetarian_expe.satisfaction_guests_t0, 1)
+
+    @authenticate
+    def test_cannot_update_vegetarian_expe_if_vegetarian_expe_does_not_exist(self):
         canteen = CanteenFactory(managers=[authenticate.user])
-        vegetarian_expe = VegetarianExpeFactory(canteen=canteen)
-        payload = {"canteen": CanteenFactory().id}
-        response = self.client.patch(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}), payload)
+
+        url = reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id})
+        payload = {"satisfaction_guests_t0": 2}
+        response = self.client.patch(url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(VegetarianExpe.objects.filter(canteen=canteen).count(), 0)
+
+    @authenticate
+    def test_cannot_update_vegetarian_expe_with_put(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.put(self.url, data={}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @authenticate
+    def test_can_update_vegetarian_expe(self):
+        self.canteen.managers.add(authenticate.user)
+
+        payload = {"satisfaction_guests_t0": 3}
+        response = self.client.patch(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        vegetarian_expe.refresh_from_db()
-        self.assertEqual(vegetarian_expe.canteen, canteen)
+        self.vegetarian_expe.refresh_from_db()
+        self.assertEqual(self.vegetarian_expe.satisfaction_guests_t0, 3)
 
     @authenticate
-    def test_updates_bad_data(self):
-        """
-        Check that updates with bad data are rejected
-        """
+    def test_cannot_update_vegetarian_expe_canteen(self):
+        self.canteen.managers.add(authenticate.user)
         canteen = CanteenFactory(managers=[authenticate.user])
-        vegetarian_expe = VegetarianExpeFactory(
-            canteen=canteen, satisfaction_guests_t0=3, waste_vegetarian_not_served_t0=70
-        )
 
-        response = self.client.patch(
-            reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}),
-            {"satisfactionGuestsT0": 6},
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        vegetarian_expe.refresh_from_db()
-        self.assertEqual(vegetarian_expe.satisfaction_guests_t0, 3)
+        payload = {"canteen": canteen.id}
+        response = self.client.patch(self.url, payload)
 
-        response = self.client.patch(
-            reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}),
-            {"wasteVegetarianNotServedT0": -90},
-        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.vegetarian_expe.refresh_from_db()
+        self.assertEqual(self.vegetarian_expe.canteen, self.canteen)  # no change
+
+    @authenticate
+    def test_cannot_update_vegetarian_expe_with_bad_data(self):
+        self.canteen.managers.add(authenticate.user)
+
+        payload = {"satisfaction_guests_t0": 6}
+        response = self.client.patch(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        vegetarian_expe.refresh_from_db()
-        self.assertEqual(vegetarian_expe.waste_vegetarian_not_served_t0, 70)
+        self.vegetarian_expe.refresh_from_db()
+        self.assertEqual(self.vegetarian_expe.satisfaction_guests_t0, 1)
+
+        payload = {"waste_vegetarian_not_served_t0": -90}
+        response = self.client.patch(self.url, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.vegetarian_expe.refresh_from_db()
+        self.assertEqual(self.vegetarian_expe.waste_vegetarian_not_served_t0, 50)
 
 
 class VegetarianExpeDeleteApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.vegetarian_expe = VegetarianExpeFactory(canteen=cls.canteen)
+        cls.url = reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": cls.canteen.id})
+
     @authenticate
     def test_cannot_delete_vegetarian_expe(self):
-        """
-        Test that we can delete a vegetarian experiment for a canteen
-        """
-        canteen = CanteenFactory(managers=[authenticate.user])
-        VegetarianExpeFactory(canteen=canteen)
-        response = self.client.delete(reverse("canteen_vegetarian_expe", kwargs={"canteen_pk": canteen.id}))
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.delete(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/api/tests/test_waste_actions.py
+++ b/api/tests/test_waste_actions.py
@@ -13,7 +13,7 @@ class WasteActionsListApiTest(APITestCase):
         cls.waste_action = WasteActionFactory()
         cls.url = reverse("waste_actions_list")
 
-    def test_get_waste_actions_list(self):
+    def test_can_get_waste_actions_list(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -87,7 +87,7 @@ class WasteActionsDetailApiTest(APITestCase):
         self.assertTrue("canteenActions" not in body)
 
     @authenticate
-    def test_get_waste_action_detail(self):
+    def test_can_get_waste_action_detail(self):
         # logged in user (without canteen)
         response = self.client.get(self.url)
 

--- a/api/tests/test_waste_actions.py
+++ b/api/tests/test_waste_actions.py
@@ -2,30 +2,38 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.tests.utils import authenticate
 from data.factories import CanteenFactory, ResourceActionFactory, UserFactory, WasteActionFactory
 from data.models import WasteAction
 
 
-class TestWasteActionsListApi(APITestCase):
+class WasteActionsListApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.waste_action = WasteActionFactory()
+        cls.url = reverse("waste_actions_list")
 
     def test_get_waste_actions_list(self):
-        response = self.client.get(reverse("waste_actions_list"))
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 1)
 
 
-class TestWasteActionsListFiltersApi(APITestCase):
+class WasteActionsListFiltersApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("waste_actions_list")
+
     def test_effort_filter(self):
         WasteActionFactory(effort=WasteAction.Effort.LARGE)
         WasteActionFactory(effort=WasteAction.Effort.MEDIUM)
         WasteActionFactory(effort=WasteAction.Effort.SMALL)
 
-        response = self.client.get(
-            f"{reverse('waste_actions_list')}?effort={WasteAction.Effort.SMALL}&effort={WasteAction.Effort.MEDIUM}"
-        )
+        url = f"{self.url}?effort={WasteAction.Effort.SMALL}&effort={WasteAction.Effort.MEDIUM}"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 2)
 
@@ -34,9 +42,12 @@ class TestWasteActionsListFiltersApi(APITestCase):
         WasteActionFactory(waste_origins=[WasteAction.WasteOrigin.PLATE, WasteAction.WasteOrigin.PREP])
         WasteActionFactory(waste_origins=[WasteAction.WasteOrigin.UNSERVED])
 
-        response = self.client.get(
-            f"{reverse('waste_actions_list')}?waste_origins={WasteAction.WasteOrigin.PREP}&waste_origins={WasteAction.WasteOrigin.UNSERVED}"
+        url = (
+            f"{self.url}?waste_origins={WasteAction.WasteOrigin.PREP}&waste_origins={WasteAction.WasteOrigin.UNSERVED}"
         )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 2)
 
@@ -48,12 +59,15 @@ class TestWasteActionsListFiltersApi(APITestCase):
         WasteActionFactory(title="Du texte", subtitle="Faire une évaluation")
         WasteActionFactory(title="Autre texte", subtitle="Ne m'évalue pas")
 
-        response = self.client.get(f"{reverse('waste_actions_list')}?search=evaluation")
+        url = f"{self.url}?search=évaluation"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 2)
 
 
-class TestWasteActionsDetailApi(APITestCase):
+class WasteActionsDetailApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.waste_action = WasteActionFactory()
@@ -62,25 +76,31 @@ class TestWasteActionsDetailApi(APITestCase):
         CanteenFactory()
         cls.canteen = CanteenFactory(managers=[cls.user_with_canteen])
         cls.resource_action = ResourceActionFactory(resource=cls.waste_action, canteen=cls.canteen, is_done=True)
+        cls.url = reverse("waste_action_detail", kwargs={"pk": cls.waste_action.id})
 
-    def test_get_waste_action_detail(self):
-        # anonymous
-        response = self.client.get(reverse("waste_action_detail", kwargs={"pk": self.waste_action.id}))
+    def test_can_get_waste_action_detail_unauthenticated(self):
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["id"], self.waste_action.id)
         self.assertTrue("canteenActions" not in body)
+
+    @authenticate
+    def test_get_waste_action_detail(self):
         # logged in user (without canteen)
-        self.client.force_login(user=self.user)
-        response = self.client.get(reverse("waste_action_detail", kwargs={"pk": self.waste_action.id}))
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["id"], self.waste_action.id)
         self.assertTrue("canteenActions" in body)
         self.assertEqual(len(body["canteenActions"]), 0)
+
         # logged in user with canteen & resource action
-        self.client.force_login(user=self.user_with_canteen)
-        response = self.client.get(reverse("waste_action_detail", kwargs={"pk": self.waste_action.id}))
+        self.canteen.managers.add(authenticate.user)
+        response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["id"], self.waste_action.id)

--- a/api/tests/test_waste_measurements.py
+++ b/api/tests/test_waste_measurements.py
@@ -23,7 +23,7 @@ class WasteMeasurementsListApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_get_waste_measurements_if_canteen_unknown(self):
+    def test_cannot_get_waste_measurements_if_canteen_does_not_exist(self):
         response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": 9999}))
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -159,7 +159,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_create_waste_measurement_if_canteen_unknown(self):
+    def test_cannot_create_waste_measurement_if_canteen_does_not_exist(self):
         payload = {**self.WM_PAYLOAD, "meal_count": 500}
 
         response = self.client.post(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": 9999}), payload)
@@ -464,7 +464,7 @@ class WasteMeasurementsDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_get_waste_measurement_if_canteen_unknown(self):
+    def test_cannot_get_waste_measurement_if_canteen_does_not_exist(self):
         response = self.client.get(
             reverse("canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": 9999})
         )
@@ -558,10 +558,10 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_cannot_update_waste_measurement_if_canteen_unknown(self):
+    def test_cannot_update_waste_measurement_if_canteen_does_not_exist(self):
         payload = {"mealCount": 200}
 
-        response = self.client.get(
+        response = self.client.patch(
             reverse("canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": 9999}),
             payload,
         )
@@ -569,11 +569,11 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_cannot_update_waste_measurement_if_measurement_unknown(self):
+    def test_cannot_update_waste_measurement_if_measurement_does_not_exist(self):
         self.canteen.managers.add(authenticate.user)
         payload = {"mealCount": 200}
 
-        response = self.client.get(
+        response = self.client.patch(
             reverse("canteen_waste_measurement_detail", kwargs={"pk": 9999, "canteen_pk": self.canteen.id}), payload
         )
 

--- a/api/tests/test_waste_measurements.py
+++ b/api/tests/test_waste_measurements.py
@@ -171,7 +171,6 @@ class WasteMeasurementsCreateApiTest(APITestCase):
     @authenticate
     def test_cannot_create_waste_measurement_if_not_canteen_manager(self):
         payload = {**self.WM_PAYLOAD, "meal_count": 500}
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -195,7 +194,6 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "unserved_inedible_mass": "",
             "leftovers_total_mass": 30.3,
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -295,8 +293,8 @@ class WasteMeasurementsCreateApiTest(APITestCase):
 
         # returns a 404 if the creation_source is not valid
         payload = {**self.WM_PAYLOAD, "creation_source": "UNKNOWN"}
-
         response = self.client.post(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @authenticate
@@ -310,7 +308,6 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_start_date": "2024-08-01",
             "period_end_date": "2024-08-01",
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -323,7 +320,6 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         self.canteen.managers.add(authenticate.user)
 
         payload = {}
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -343,7 +339,6 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_start_date": "2024-08-01",
             "period_end_date": "2024-08-20",
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -360,7 +355,6 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_start_date": "2024-08-10",
             "period_end_date": "2024-08-01",
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -385,7 +379,6 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_start_date": "2024-07-03",
             "period_end_date": "2024-08-01",
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -399,7 +392,6 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_start_date": "2024-06-10",
             "period_end_date": "2024-07-03",
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -418,7 +410,6 @@ class WasteMeasurementsCreateApiTest(APITestCase):
             "period_start_date": "2024-06-30",
             "period_end_date": "2024-07-16",
         }
-
         response = self.client.post(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -549,7 +540,6 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
     @authenticate
     def test_cannot_update_waste_measurement_if_unauthenticated(self):
         payload = {"mealCount": 200}
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -576,7 +566,6 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
     @authenticate
     def test_cannot_update_waste_measurement_if_not_canteen_manager(self):
         payload = {"mealCount": 200}
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -590,8 +579,8 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
             period_end_date=datetime.date(2023, 1, 5),
         )
         self.canteen.managers.add(authenticate.user)
-        payload = {"mealCount": 200}
 
+        payload = {"mealCount": 200}
         response = self.client.patch(
             reverse(
                 "canteen_waste_measurement_detail",
@@ -618,8 +607,8 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
     @authenticate
     def test_can_update_waste_measurement(self):
         self.canteen.managers.add(authenticate.user)
-        payload = {"mealCount": 200}
 
+        payload = {"mealCount": 200}
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/tests/test_waste_measurements.py
+++ b/api/tests/test_waste_measurements.py
@@ -16,26 +16,28 @@ class WasteMeasurementsListApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.canteen = CanteenFactory(yearly_meal_count=1000)
+        cls.url = reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": cls.canteen.id})
 
     def test_cannot_get_waste_measurements_if_unauthenticated(self):
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
     def test_cannot_get_waste_measurements_if_canteen_does_not_exist(self):
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": 9999}))
+        url = reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": 9999})
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
     def test_cannot_get_waste_measurements_if_not_canteen_manager(self):
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_get_waste_measurements(self):
+    def test_can_get_waste_measurements(self):
         self.canteen.managers.add(authenticate.user)
         measurement_july = WasteMeasurementFactory(
             canteen=self.canteen,
@@ -49,7 +51,7 @@ class WasteMeasurementsListApiTest(APITestCase):
         )
         WasteMeasurementFactory()  # will not be returned
 
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -57,7 +59,7 @@ class WasteMeasurementsListApiTest(APITestCase):
         self.assertEqual(body[0]["id"], measurement_august.id)  # ordered by period_start_date desc
         self.assertEqual(body[1]["id"], measurement_july.id)
 
-    def test_get_waste_measurements_via_oauth2(self):
+    def test_can_get_waste_measurements_via_oauth2(self):
         user, token = get_oauth2_token("waste_measurements:read")
         self.canteen.managers.add(user)
         measurement_july = WasteMeasurementFactory(
@@ -73,7 +75,7 @@ class WasteMeasurementsListApiTest(APITestCase):
         WasteMeasurementFactory()  # will not be returned
 
         self.client.credentials(Authorization=f"Bearer {token}")
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -90,7 +92,7 @@ class WasteMeasurementsListApiTest(APITestCase):
             period_end_date=datetime.date(2024, 8, 5),
         )
 
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -106,7 +108,7 @@ class WasteMeasurementsListApiTest(APITestCase):
         self.canteen.managers.add(authenticate.user)
         WasteMeasurementFactory(canteen=self.canteen, meal_count=10, total_mass=50)
 
-        response = self.client.get(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id}))
+        response = self.client.get(self.url)
 
         body = response.json()
         self.assertEqual(body[0]["totalYearlyWasteEstimation"], 5000)
@@ -135,8 +137,7 @@ class WasteMeasurementsListApiTest(APITestCase):
         )
 
         query = "?period_start_date_after=2024-07-01&period_end_date_before=2024-09-01"
-        path = reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": self.canteen.id})
-        response = self.client.get(path + query)
+        response = self.client.get(self.url + query)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -162,7 +163,8 @@ class WasteMeasurementsCreateApiTest(APITestCase):
     def test_cannot_create_waste_measurement_if_canteen_does_not_exist(self):
         payload = {**self.WM_PAYLOAD, "meal_count": 500}
 
-        response = self.client.post(reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": 9999}), payload)
+        url = reverse("canteen_waste_measurements_list", kwargs={"canteen_pk": 9999})
+        response = self.client.post(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -175,7 +177,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_create_waste_measurement(self):
+    def test_can_create_waste_measurement(self):
         self.canteen.managers.add(authenticate.user)
 
         payload = {
@@ -216,7 +218,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         self.assertEqual(waste_measurement.leftovers_edible_mass, None)
         self.assertEqual(waste_measurement.leftovers_inedible_mass, None)
 
-    def test_create_waste_measurement_via_oauth2(self):
+    def test_can_create_waste_measurement_via_oauth2(self):
         user, token = get_oauth2_token("waste_measurements:create")
         self.canteen.managers.add(user)
 
@@ -255,6 +257,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
         # from the APP
         payload = {**self.WM_PAYLOAD, "creation_source": "APP"}
         response = self.client.post(self.url, payload)
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         self.assertNotIn("creationUser", body)
@@ -273,6 +276,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
 
         # defaults to API
         response = self.client.post(self.url, self.WM_PAYLOAD)
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         self.assertNotIn("creationUser", body)
@@ -291,6 +295,7 @@ class WasteMeasurementsCreateApiTest(APITestCase):
 
         # returns a 404 if the creation_source is not valid
         payload = {**self.WM_PAYLOAD, "creation_source": "UNKNOWN"}
+
         response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -454,7 +459,7 @@ class WasteMeasurementsDetailApiTest(APITestCase):
             creation_source=CreationSource.APP,
         )
         cls.url = reverse(
-            "canteen_waste_measurement_detail", kwargs={"pk": cls.measurement.id, "canteen_pk": cls.canteen.id}
+            "canteen_waste_measurement_detail", kwargs={"canteen_pk": cls.canteen.id, "pk": cls.measurement.id}
         )
 
     @authenticate
@@ -465,9 +470,8 @@ class WasteMeasurementsDetailApiTest(APITestCase):
 
     @authenticate
     def test_cannot_get_waste_measurement_if_canteen_does_not_exist(self):
-        response = self.client.get(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": 9999})
-        )
+        url = reverse("canteen_waste_measurement_detail", kwargs={"canteen_pk": 9999, "pk": self.measurement.id})
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -485,25 +489,18 @@ class WasteMeasurementsDetailApiTest(APITestCase):
         )
         self.canteen.managers.add(authenticate.user)
 
-        response = self.client.get(
-            reverse(
-                "canteen_waste_measurement_detail",
-                kwargs={"pk": measurement2.id, "canteen_pk": self.canteen.id},
-            )
+        url = reverse(
+            "canteen_waste_measurement_detail",
+            kwargs={"canteen_pk": self.canteen.id, "pk": measurement2.id},
         )
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         # even if user manages the canteen of the measurement
         canteen2.managers.add(authenticate.user)
 
-        response = self.client.get(
-            reverse(
-                "canteen_waste_measurement_detail",
-                kwargs={"pk": measurement2.id, "canteen_pk": self.canteen.id},
-            )
-        )
-
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
@@ -546,7 +543,7 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
             creation_source=CreationSource.APP,
         )
         cls.url = reverse(
-            "canteen_waste_measurement_detail", kwargs={"pk": cls.measurement.id, "canteen_pk": cls.canteen.id}
+            "canteen_waste_measurement_detail", kwargs={"canteen_pk": cls.canteen.id, "pk": cls.measurement.id}
         )
 
     @authenticate
@@ -561,10 +558,8 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
     def test_cannot_update_waste_measurement_if_canteen_does_not_exist(self):
         payload = {"mealCount": 200}
 
-        response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": self.measurement.id, "canteen_pk": 9999}),
-            payload,
-        )
+        url = reverse("canteen_waste_measurement_detail", kwargs={"canteen_pk": 9999, "pk": self.measurement.id})
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -573,9 +568,8 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         self.canteen.managers.add(authenticate.user)
         payload = {"mealCount": 200}
 
-        response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": 9999, "canteen_pk": self.canteen.id}), payload
-        )
+        url = reverse("canteen_waste_measurement_detail", kwargs={"canteen_pk": self.canteen.id, "pk": 9999})
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -601,7 +595,7 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         response = self.client.patch(
             reverse(
                 "canteen_waste_measurement_detail",
-                kwargs={"pk": measurement_other.id, "canteen_pk": self.canteen.id},
+                kwargs={"canteen_pk": self.canteen.id, "pk": measurement_other.id},
             ),
             payload,
         )
@@ -614,7 +608,7 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         response = self.client.patch(
             reverse(
                 "canteen_waste_measurement_detail",
-                kwargs={"pk": measurement_other.id, "canteen_pk": self.canteen.id},
+                kwargs={"canteen_pk": self.canteen.id, "pk": measurement_other.id},
             ),
             payload,
         )
@@ -622,7 +616,7 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @authenticate
-    def test_update_waste_measurement(self):
+    def test_can_update_waste_measurement(self):
         self.canteen.managers.add(authenticate.user)
         payload = {"mealCount": 200}
 
@@ -632,7 +626,7 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         body = response.json()
         self.assertEqual(body["mealCount"], 200)
 
-    def test_update_waste_measurement_via_oauth2(self):
+    def test_can_update_waste_measurement_via_oauth2(self):
         user, token = get_oauth2_token("waste_measurements:write")
         self.canteen.managers.add(user)
         payload = {"mealCount": 200}
@@ -655,7 +649,6 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         self.assertEqual(waste_measurement_history.history_source_api_oauth2_application, None)
 
         payload = {"mealCount": 200, "creationSource": CreationSource.API}
-
         response = self.client.patch(self.url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -681,12 +674,10 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         measurement = WasteMeasurementFactory(
             canteen=self.canteen, period_start_date="2024-08-01", period_end_date="2024-08-05"
         )
-        payload = {"period_end_date": "2024-08-20"}
 
-        response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
-            payload,
-        )
+        url = reverse("canteen_waste_measurement_detail", kwargs={"canteen_pk": self.canteen.id, "pk": measurement.id})
+        payload = {"period_end_date": "2024-08-20"}
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["periodEndDate"][0], "La date de fin ne peut pas être dans le futur")
@@ -704,12 +695,9 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         )
 
         # change start_date to after end_date
+        url = reverse("canteen_waste_measurement_detail", kwargs={"canteen_pk": self.canteen.id, "pk": measurement.id})
         payload = {"period_start_date": "2024-08-10"}
-
-        response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
-            payload,
-        )
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -717,12 +705,9 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         )
 
         # change end_date to before start_date
+        url = reverse("canteen_waste_measurement_detail", kwargs={"canteen_pk": self.canteen.id, "pk": measurement.id})
         payload = {"period_end_date": "2024-07-31"}
-
-        response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
-            payload,
-        )
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -747,12 +732,10 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
             period_start_date=datetime.date(2024, 8, 1),
             period_end_date=datetime.date(2024, 8, 5),
         )
-        payload = {"period_start_date": "2024-07-03"}
 
-        response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
-            payload,
-        )
+        url = reverse("canteen_waste_measurement_detail", kwargs={"canteen_pk": self.canteen.id, "pk": measurement.id})
+        payload = {"period_start_date": "2024-07-03"}
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -766,12 +749,10 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
             period_start_date=datetime.date(2024, 6, 1),
             period_end_date=datetime.date(2024, 6, 5),
         )
-        payload = {"period_end_date": "2024-07-03"}
 
-        response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
-            payload,
-        )
+        url = reverse("canteen_waste_measurement_detail", kwargs={"canteen_pk": self.canteen.id, "pk": measurement.id})
+        payload = {"period_end_date": "2024-07-03"}
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -780,15 +761,12 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
         )
 
         # check a start and end date that encapsulate the periods of existing measurements
+        url = reverse("canteen_waste_measurement_detail", kwargs={"canteen_pk": self.canteen.id, "pk": measurement.id})
         payload = {
             "period_start_date": "2024-01-30",
             "period_end_date": "2024-08-10",
         }
-
-        response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
-            payload,
-        )
+        response = self.client.patch(url, payload)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -808,16 +786,12 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
             period_end_date=datetime.date(2024, 7, 5),
         )
 
+        url = reverse("canteen_waste_measurement_detail", kwargs={"canteen_pk": self.canteen.id, "pk": measurement.id})
         payload = {
             "period_start_date": None,
             "period_end_date": "",
         }
-
-        response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": self.canteen.id}),
-            payload,
-            format="json",
-        )
+        response = self.client.patch(url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["periodStartDate"][0], "Ce champ ne peut être nul.")
@@ -836,13 +810,11 @@ class WasteMeasurementsUpdateApiTest(APITestCase):
             canteen=canteen, period_start_date=datetime.date(2024, 5, 1), period_end_date=datetime.date(2024, 5, 10)
         )
 
+        url = reverse("canteen_waste_measurement_detail", kwargs={"canteen_pk": canteen.id, "pk": measurement.id})
         payload = {"period_start_date": "2024-04-01", "period_end_date": "2024-07-01"}
-        response = self.client.patch(
-            reverse("canteen_waste_measurement_detail", kwargs={"pk": measurement.id, "canteen_pk": canteen.id}),
-            payload,
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.patch(url, payload, format="json")
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         measurement.refresh_from_db()
         self.assertEqual(measurement.period_start_date, datetime.date(2024, 4, 1))
         self.assertEqual(measurement.period_end_date, datetime.date(2024, 7, 1))
@@ -867,9 +839,6 @@ class WasteMeasurementsDeleteApiTest(APITestCase):
 
     @authenticate
     def test_cannot_delete_waste_measurement(self):
-        """
-        Canteen managers cannot delete waste measurements
-        """
         self.canteen.managers.add(authenticate.user)
 
         response = self.client.delete(self.url)

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -258,7 +258,7 @@ class CanteenModelSaveTest(TransactionTestCase):
                     self.assertRaises(
                         IntegrityError, CanteenFactory, production_type=production_type, sector_list=VALUE_NOT_OK
                     )
-            for VALUE_NOT_OK in [[Sector.EDUCATION_PRIMAIRE], [999], ["invalid"], [Sector.EDUCATION_PRIMAIRE, 999]]:
+            for VALUE_NOT_OK in [[Sector.EDUCATION_PRIMAIRE], [9999], ["invalid"], [Sector.EDUCATION_PRIMAIRE, 9999]]:
                 with self.subTest(production_type=production_type, sector_list=VALUE_NOT_OK):
                     self.assertRaises(
                         ValidationError, CanteenFactory, production_type=production_type, sector_list=VALUE_NOT_OK
@@ -298,7 +298,7 @@ class CanteenModelSaveTest(TransactionTestCase):
                 ],
                 [999],
                 ["invalid"],
-                [Sector.EDUCATION_PRIMAIRE, 999],
+                [Sector.EDUCATION_PRIMAIRE, 9999],
             ]:
                 with self.subTest(production_type=production_type, sector_list=VALUE_NOT_OK):
                     self.assertRaises(
@@ -371,7 +371,7 @@ class CanteenModelSaveTest(TransactionTestCase):
                 with self.subTest(groupe=TUPLE_OK[0]):
                     canteen = CanteenFactory(production_type=production_type, groupe=TUPLE_OK[0])
                     self.assertEqual(canteen.groupe, TUPLE_OK[1])
-            for VALUE_NOT_OK in [canteen_groupe.id, canteen_groupe_deleted.id, canteen_site.id, 999, "", "invalid"]:
+            for VALUE_NOT_OK in [canteen_groupe.id, canteen_groupe_deleted.id, canteen_site.id, 9999, "", "invalid"]:
                 with self.subTest(groupe=VALUE_NOT_OK):
                     self.assertRaises(ValueError, CanteenFactory, production_type=production_type, groupe=VALUE_NOT_OK)
         # satellite: can be filled
@@ -384,10 +384,10 @@ class CanteenModelSaveTest(TransactionTestCase):
                 with self.subTest(groupe_id=TUPLE_OK[0]):
                     canteen = CanteenFactory(production_type=production_type, groupe_id=TUPLE_OK[0])
                     self.assertEqual(canteen.groupe, TUPLE_OK[1])
-            for VALUE_NOT_OK in [canteen_site.id, canteen_groupe_deleted.id, 999, "", "invalid"]:
+            for VALUE_NOT_OK in [canteen_site.id, canteen_groupe_deleted.id, 9999, "", "invalid"]:
                 with self.subTest(groupe=VALUE_NOT_OK):
                     self.assertRaises(ValueError, CanteenFactory, production_type=production_type, groupe=VALUE_NOT_OK)
-            for VALUE_NOT_OK in [canteen_site.id, 999]:
+            for VALUE_NOT_OK in [canteen_site.id, 9999]:
                 with self.subTest(groupe_id=VALUE_NOT_OK):
                     self.assertRaises(
                         ValidationError, CanteenFactory, production_type=production_type, groupe_id=VALUE_NOT_OK


### PR DESCRIPTION
### Quoi

Tentative pour homogénéiser les tests API
- `_if_canteen_unknown` --> `_if_canteen_does_not_exist`
  - et toujours utiliser id = 9999 (not 999)
- `_if_canteen_is_filled` --> `_if_canteen_is_valid`
- éviter les commentaires : rendre + explicite les noms des tests
- éviter `force_login`
- prefixer au maximum avec `test_can_` & `test_cannot_`
- `_unauthenticated(self):` --> `_if_unauthenticated(self):`
- `_duplicate` --> `already_exists`
- group payload, url & response together
- `body = response.json()` & `results = body["results"]`
- create dedicated files for schema tests. and purchases_old