### PR TITLE
refactor(Achats): API: permettre de sauvegarder ou supprimer une facture sur un achat 'non valide'

### DIFF
--- a/api/tests/test_purchase_facture.py
+++ b/api/tests/test_purchase_facture.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from api.tests.utils import authenticate
+from data.models import Purchase
 from data.factories import CanteenFactory, PurchaseFactory
 
 
@@ -80,6 +81,25 @@ class PurchaseFactureUploadTest(APITestCase):
     @authenticate
     def test_can_upload_facture(self):
         self.canteen.managers.add(authenticate.user)
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+
+        response = self.client.post(self.url, {"facture": file}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["id"], self.purchase.id)
+        self.assertIsNotNone(data["facture"])
+
+        # Verify file was saved
+        self.purchase.refresh_from_db()
+        self.assertTrue(self.purchase.facture)
+        self.assertIn("facture", self.purchase.facture.name)
+
+    @authenticate
+    def test_can_upload_even_if_purchase_not_valid(self):
+        self.canteen.managers.add(authenticate.user)
+        self.purchase.caracteristiques = [Purchase.Characteristic.EUROPE, Purchase.Characteristic.FRANCE]
+        self.purchase.save(skip_validations=True)
         file = SimpleUploadedFile("facture.pdf", b"pdf content")
 
         response = self.client.post(self.url, {"facture": file}, format="multipart")
@@ -280,6 +300,19 @@ class PurchaseFactureDeleteTest(APITestCase):
     @authenticate
     def test_can_delete_facture(self):
         self.canteen.managers.add(authenticate.user)
+        self.assertTrue(self.purchase.facture)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.purchase.refresh_from_db()
+        self.assertFalse(self.purchase.facture)
+
+    @authenticate
+    def test_can_delete_facture_even_if_purchase_not_valid(self):
+        self.canteen.managers.add(authenticate.user)
+        self.purchase.caracteristiques = [Purchase.Characteristic.EUROPE, Purchase.Characteristic.FRANCE]
+        self.purchase.save(skip_validations=True)
         self.assertTrue(self.purchase.facture)
 
         response = self.client.delete(self.url)

--- a/api/tests/test_purchase_facture.py
+++ b/api/tests/test_purchase_facture.py
@@ -96,7 +96,28 @@ class PurchaseFactureUploadTest(APITestCase):
         self.assertIn("facture", self.purchase.facture.name)
 
     @authenticate
-    def test_can_upload_even_if_purchase_not_valid(self):
+    def test_can_upload_facture_even_if_canteen_not_filled(self):
+        self.canteen.managers.add(authenticate.user)
+        self.canteen.siret = None
+        self.canteen.save(skip_validations=True)
+        self.assertIsNone(self.canteen.siret)
+        self.assertFalse(self.canteen.is_filled)
+        file = SimpleUploadedFile("facture.pdf", b"pdf content")
+
+        response = self.client.post(self.url, {"facture": file}, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["id"], self.purchase.id)
+        self.assertIsNotNone(data["facture"])
+
+        # Verify file was saved
+        self.purchase.refresh_from_db()
+        self.assertTrue(self.purchase.facture)
+        self.assertIn("facture", self.purchase.facture.name)
+
+    @authenticate
+    def test_can_upload_even_if_purchase_not_filled(self):
         self.canteen.managers.add(authenticate.user)
         self.purchase.caracteristiques = [Purchase.Characteristic.EUROPE, Purchase.Characteristic.FRANCE]
         self.purchase.save(skip_validations=True)
@@ -309,7 +330,22 @@ class PurchaseFactureDeleteTest(APITestCase):
         self.assertFalse(self.purchase.facture)
 
     @authenticate
-    def test_can_delete_facture_even_if_purchase_not_valid(self):
+    def test_can_delete_facture_even_if_canteen_not_filled(self):
+        self.canteen.managers.add(authenticate.user)
+        self.canteen.siret = None
+        self.canteen.save(skip_validations=True)
+        self.assertIsNone(self.canteen.siret)
+        self.assertFalse(self.canteen.is_filled)
+        self.assertTrue(self.purchase.facture)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.purchase.refresh_from_db()
+        self.assertFalse(self.purchase.facture)
+
+    @authenticate
+    def test_can_delete_facture_even_if_purchase_not_filled(self):
         self.canteen.managers.add(authenticate.user)
         self.purchase.caracteristiques = [Purchase.Characteristic.EUROPE, Purchase.Characteristic.FRANCE]
         self.purchase.save(skip_validations=True)

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -277,7 +277,7 @@ class PurchaseFactureView(APIView):
         serializer.is_valid(raise_exception=True)
 
         purchase.facture = serializer.validated_data["facture"]
-        purchase.save()
+        purchase.save(skip_validations=True)
 
         response_serializer = PurchaseFactureResponseSerializer(purchase, context={"request": request})
         return Response(response_serializer.data, status=status.HTTP_200_OK)
@@ -288,9 +288,10 @@ class PurchaseFactureView(APIView):
         if not purchase.facture:
             raise NotFound()
 
-        purchase.facture.delete()
+        purchase.facture.delete(skip_validations=True)
         purchase.facture = None
         purchase.save()
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -288,9 +288,9 @@ class PurchaseFactureView(APIView):
         if not purchase.facture:
             raise NotFound()
 
-        purchase.facture.delete(skip_validations=True)
+        purchase.facture.delete(save=False)
         purchase.facture = None
-        purchase.save()
+        purchase.save(skip_validations=True)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
### Quoi

Dans #6840 on avait créé un endpoint dédié à la gestion de la facture d'un achat
Dans #6936 & #6937 on a rajouté `skip_validations` au model `Purchase` pour être plus flexible sur le save & le delete

Ici on revient sur l'endpoint dédié à la facture, pour s'assurer que l'on peut la manipuler même sur un objet achat qui ne serait pas valide