### PR TITLE
refactor(Achats): Facture: simplifier les serializer

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -59,8 +59,7 @@ from .purchase import (  # noqa: F401
     PurchaseSerializer,
     PurchaseOldSerializer,
     PurchaseSummarySerializer,
-    PurchaseFactureUploadSerializer,
-    PurchaseFactureResponseSerializer,
+    PurchaseFactureSerializer,
     PurchasePercentageSummarySerializer,
     PurchaseExportSerializer,
 )

--- a/api/serializers/purchase.py
+++ b/api/serializers/purchase.py
@@ -194,21 +194,13 @@ class PurchaseSerializer(serializers.ModelSerializer):
         return internal_value
 
 
-class PurchaseFactureUploadSerializer(serializers.Serializer):
-    facture = Base64FileField(required=True, allow_null=False)
+class PurchaseFactureSerializer(serializers.ModelSerializer):
+    id = serializers.IntegerField(read_only=True)
+    facture = Base64FileField()
 
     class Meta:
-        fields = ("facture",)
-
-
-class PurchaseFactureResponseSerializer(serializers.Serializer):
-    id = serializers.IntegerField()
-    facture = serializers.SerializerMethodField()
-
-    def get_facture(self, obj):
-        if obj.facture:
-            return self.context["request"].build_absolute_uri(obj.facture.url)
-        return None
+        model = Purchase
+        fields = ("id", "facture")
 
 
 # NB: these names reflect the names in the diagnostic model

--- a/api/views/canteen_images.py
+++ b/api/views/canteen_images.py
@@ -16,11 +16,13 @@ from data.models import Canteen, CanteenImage
         summary="Obtenir le logo d'une cantine.",
         description="",
         tags=["Cantines"],
+        responses=CanteenLogoSerializer,
     ),
     post=extend_schema(
         summary="Ajouter le logo d'une cantine.",
         description="",
         tags=["Cantines"],
+        responses=CanteenLogoSerializer,
     ),
     delete=extend_schema(
         summary="Supprimer le logo d'une cantine.",

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -16,14 +16,13 @@ from rest_framework.views import APIView
 from api.filters.utils import UnaccentSearchFilter
 from api.permissions import (
     IsAuthenticated,
-    IsCanteenManager,
     IsAuthenticatedOrTokenHasResourceScope,
+    IsCanteenManager,
     IsCanteenManagerUrlParam,
     IsLinkedCanteenManager,
 )
 from api.serializers import (
-    PurchaseFactureResponseSerializer,
-    PurchaseFactureUploadSerializer,
+    PurchaseFactureSerializer,
     PurchaseOldSerializer,
     PurchasePercentageSummarySerializer,
     PurchaseSerializer,
@@ -267,19 +266,19 @@ class PurchaseFactureView(APIView):
         if not purchase.facture:
             raise NotFound()
 
-        serializer = PurchaseFactureResponseSerializer(purchase, context={"request": request})
+        serializer = PurchaseFactureSerializer(purchase, context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def post(self, request, *args, **kwargs):
         purchase = self.get_object()
 
-        serializer = PurchaseFactureUploadSerializer(data=request.data, context={"request": request})
+        serializer = PurchaseFactureSerializer(purchase, data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
 
         purchase.facture = serializer.validated_data["facture"]
         purchase.save(skip_validations=True)
 
-        response_serializer = PurchaseFactureResponseSerializer(purchase, context={"request": request})
+        response_serializer = PurchaseFactureSerializer(purchase, context={"request": request})
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 
     def delete(self, request, *args, **kwargs):

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -893,7 +893,7 @@ class Canteen(DirtyFieldsMixin, SoftDeletionModel):
         return False
 
     @property
-    def logo_full_url(self):
+    def logo_full_url(self) -> str | None:
         if self.logo:
             return self.logo.url
         return None

--- a/data/models/purchase.py
+++ b/data/models/purchase.py
@@ -342,6 +342,12 @@ class Purchase(SoftDeletionModel):
                 pass
         return ", ".join(caracteristiques_display) if caracteristiques_display else ""
 
+    @property
+    def facture_full_url(self) -> str | None:
+        if self.facture:
+            return self.facture.url
+        return None
+
     @classmethod
     def canteen_summary_for_year(cls, canteen, year):
         purchases = cls.objects.filter_for_stats(canteen, year)


### PR DESCRIPTION
### Quoi

Suite au nouvel endpoint dédié dans #6840
Et au travail dans #6932 (Canteen.logo)

Ca me permet de
- regrouper les 2 serializer Upload & Response ensemble
- les passer en ModelSerializer
- même field que pour logo
- ajouter aussi une property `facture_full_url` pour documentation

### Objet retourné

```
{
"id": 12345,
"facture": "<CELLAR_HOST>/<CELLAR_BUCKET_NAME>/media/invoices/2026/<hash>.pdf"
}
```