### PR TITLE
improve(Cantines): Admin: remettre le bouton 'Supprimer' (cela va l'archiver) + nouveau bouton "Restaurer" (si la cantine est archivée)

### DIFF
--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -142,7 +142,7 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         ),
         ("Metadonnées", {"fields": Canteen.CREATION_META_FIELDS}),
         (
-            "Archiver la cantine",
+            "Supprimer (archiver)",
             {
                 "description": "Une cantine archivée est une cantine 'supprimée' : elle ne sera plus visible sur la plateforme mais elle pourra être restaurée à tout moment.",
                 "fields": ("deletion_date",),
@@ -184,9 +184,6 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
             obj.creation_user = request.user
             obj.creation_source = CreationSource.ADMIN
         super().save_model(request, obj, form, change)
-
-    def has_delete_permission(self, request, obj=None):
-        return obj is not None and not obj.deletion_date
 
     @admin.display(description="Siret (ou Siren)")
     def siret_or_siren_unite_legale_display(self, obj):

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -144,7 +144,7 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         (
             "Supprimer (archiver)",
             {
-                "description": "Une cantine archivée est une cantine 'supprimée' : elle ne sera plus visible sur la plateforme mais elle pourra être restaurée à tout moment.",
+                "description": "Une cantine supprimée est une cantine 'archivée' : elle ne sera plus visible sur la plateforme mais elle pourra être restaurée à tout moment.",
                 "fields": ("deletion_date",),
             },
         ),

--- a/data/admin/canteen.py
+++ b/data/admin/canteen.py
@@ -160,18 +160,13 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         *Canteen.TD_FIELDS,
         *Canteen.MATOMO_FIELDS,
         *Canteen.CREATION_META_FIELDS,
+        "deletion_date",
     )
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         qs = qs.select_related("groupe").annotate_with_image_count()
         return qs
-
-    def get_actions(self, request):
-        actions = super().get_actions(request)
-        if "delete_selected" in actions:
-            del actions["delete_selected"]
-        return actions
 
     def get_inlines(self, request, obj):
         # to avoid circular import error
@@ -191,7 +186,7 @@ class CanteenAdmin(SoftDeletionHistoryAdmin):
         super().save_model(request, obj, form, change)
 
     def has_delete_permission(self, request, obj=None):
-        return False
+        return obj is not None and not obj.deletion_date
 
     @admin.display(description="Siret (ou Siren)")
     def siret_or_siren_unite_legale_display(self, obj):

--- a/data/admin/softdeletionadmin.py
+++ b/data/admin/softdeletionadmin.py
@@ -1,8 +1,9 @@
 from django.contrib import admin
+from django.http import HttpResponseRedirect
 from simple_history.admin import SimpleHistoryAdmin
 
 
-@admin.action(description="Restaurer les objets supprimés par l'utilisateur")
+@admin.action(description="Restaurer les objets supprimés")
 def restore_objects(modeladmin, request, queryset):
     queryset.update(deletion_date=None)
 
@@ -32,6 +33,23 @@ class SoftDeletionAdmin(admin.ModelAdmin):
     @admin.display(description="Statut de suppression")
     def deletion_status(self, obj):
         return "🗑️ Supprimée" if obj.deletion_date else "✔️ Active"
+
+    def response_change(self, request, obj):
+        """
+        Override the response_change method to handle the restore_action.
+        - the restore button replaces the deletion link
+        - see the change_form.html template
+        """
+        if "restore_action" in request.POST:
+            obj.deletion_date = None
+            try:
+                obj.save(skip_validations=True)
+            except TypeError:
+                obj.save()
+            self.message_user(request, "Objet restauré avec succès.")
+            # Redirect to the same page to show the updated object
+            return HttpResponseRedirect(request.path)
+        return super().response_change(request, obj)
 
 
 class SoftDeletionHistoryAdmin(SoftDeletionAdmin, SimpleHistoryAdmin):

--- a/data/templates/admin/data/canteen/change_form.html
+++ b/data/templates/admin/data/canteen/change_form.html
@@ -1,0 +1,36 @@
+{% extends "admin/change_form.html" %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {% if original.deletion_date %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            // Find the delete link and convert it to a restore button
+            const deleteLink = document.querySelector('a.deletelink');
+            if (deleteLink) {
+                // Get the form
+                const form = deleteLink.closest('form');
+
+                // Change the link to a button
+                deleteLink.removeAttribute('href');
+                deleteLink.setAttribute('type', 'submit');
+                deleteLink.style.cursor = 'pointer';
+
+                // Change the text
+                deleteLink.innerText = '🔄 Restaurer cette cantine';
+
+                // Add onclick handler to submit form with restore_action
+                deleteLink.onclick = function(e) {
+                    e.preventDefault();
+                    const input = document.createElement('input');
+                    input.type = 'hidden';
+                    input.name = 'restore_action';
+                    input.value = '1';
+                    form.appendChild(input);
+                    form.submit();
+                };
+            }
+        });
+    </script>
+    {% endif %}
+{% endblock %}

--- a/data/templates/admin/data/canteen/change_form.html
+++ b/data/templates/admin/data/canteen/change_form.html
@@ -2,35 +2,37 @@
 
 {% block extrahead %}
     {{ block.super }}
-    {% if original.deletion_date %}
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            // Find the delete link and convert it to a restore button
             const deleteLink = document.querySelector('a.deletelink');
             if (deleteLink) {
-                // Get the form
-                const form = deleteLink.closest('form');
+                // If canteen is deleted (has deletion_date), convert to restore button
+                {% if original.deletion_date %}
+                    const form = deleteLink.closest('form');
 
-                // Change the link to a button
-                deleteLink.removeAttribute('href');
-                deleteLink.setAttribute('type', 'submit');
-                deleteLink.style.cursor = 'pointer';
+                    // Change the link to a button
+                    deleteLink.removeAttribute('href');
+                    deleteLink.setAttribute('type', 'submit');
+                    deleteLink.style.cursor = 'pointer';
 
-                // Change the text
-                deleteLink.innerText = '🔄 Restaurer cette cantine';
+                    // Change the text
+                    deleteLink.innerText = '🔄 Restaurer';
 
-                // Add onclick handler to submit form with restore_action
-                deleteLink.onclick = function(e) {
-                    e.preventDefault();
-                    const input = document.createElement('input');
-                    input.type = 'hidden';
-                    input.name = 'restore_action';
-                    input.value = '1';
-                    form.appendChild(input);
-                    form.submit();
-                };
+                    // Add onclick handler to submit form with restore_action
+                    deleteLink.onclick = function(e) {
+                        e.preventDefault();
+                        const input = document.createElement('input');
+                        input.type = 'hidden';
+                        input.name = 'restore_action';
+                        input.value = '1';
+                        form.appendChild(input);
+                        form.submit();
+                    };
+                {% else %}
+                    // If canteen is active, just rename the Delete button
+                    deleteLink.innerText = '🗑️ Supprimer (archiver)';
+                {% endif %}
             }
         });
     </script>
-    {% endif %}
 {% endblock %}


### PR DESCRIPTION
### Quoi

Tentative d'amélioration de l'admin cantines concernant la suppression/archivage
- mettre le champ `deletion_date` en readonly
- remettre le bouton "Supprimer"
- remplacer le bouton (et l'action) "Supprimer" par "Restaurer"

### Captures d'écran

|état de la cantine|Avant|Après|
|-|-|-|
|Cantine active||<img width="1271" height="520" alt="image" src="https://github.com/user-attachments/assets/3151ff4d-3b82-4ce6-8fa7-0203c2e6ad6e" />|
|Cantine supprimée||<img width="1271" height="521" alt="image" src="https://github.com/user-attachments/assets/bb605f8c-771d-49d0-8655-10015a88b525" />|
