### PR TITLE
refactor(TD): nouveau queryset 'has_invalid_reason' pour facilement exclure les TD non valides [1TD1Site]

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -28,6 +28,7 @@ from macantine.utils import (
     CAMPAIGN_DATES,
     EGALIM_OBJECTIVES,
     TELEDECLARATION_CURRENT_VERSION,
+    YEARS_WITH_1TD1SITE,
     is_in_correction,
     is_in_teledeclaration_or_correction,
     objectifs_egalim_atteints,
@@ -184,6 +185,10 @@ def commerce_equitable_sup_bio_query():
     )
 
 
+def has_invalid_reason_list_query():
+    return ~has_arrayfield_missing_query("invalid_reason_list")
+
+
 def is_teledeclared_query():
     return Q(status=Diagnostic.DiagnosticStatus.SUBMITTED)
 
@@ -197,6 +202,9 @@ class DiagnosticQuerySet(models.QuerySet):
 
     def teledeclared(self):
         return self.filter(is_teledeclared_query())
+
+    def has_invalid_reason(self):
+        return self.filter(has_invalid_reason_list_query())
 
     def in_year(self, year):
         return self.filter(year=int(year))
@@ -301,10 +309,8 @@ class DiagnosticQuerySet(models.QuerySet):
     def valid_td_site_by_year(self, year):
         year = int(year)
         if year in CAMPAIGN_DATES.keys():
-            if year in [2024, 2025]:
-                return self.teledeclared_site_for_year(year).filter(
-                    has_arrayfield_missing_query("invalid_reason_list")
-                )
+            if year in YEARS_WITH_1TD1SITE:
+                return self.teledeclared_site_for_year(year).exclude(has_invalid_reason_list_query())
             else:
                 return self.valid_td_by_year(year)
         else:
@@ -1993,6 +1999,10 @@ class Diagnostic(models.Model):
     @property
     def is_filled(self):
         return self.is_filled_simple or self.is_filled_complete
+
+    @property
+    def has_invalid_reason(self):
+        return self.invalid_reason_list and len(self.invalid_reason_list) > 0
 
     @property
     def is_teledeclared(self):

--- a/data/tests/test_diagnostic_teledeclaration.py
+++ b/data/tests/test_diagnostic_teledeclaration.py
@@ -47,6 +47,33 @@ class DiagnosticTeledeclaredQuerySetAndPropertyTest(TestCase):
         self.assertFalse(self.diagnostic_filled_cancelled.is_teledeclared)
 
 
+@freeze_time(date_in_last_teledeclaration_campaign)
+class DiagnosticInvalidReasonListQuerySetAndPropertyTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.diagnostic_invalid_reason_none = DiagnosticFactory(
+            year=year_data, canteen=CanteenFactory(), valeur_totale=1000, invalid_reason_list=None
+        )
+        cls.diagnostic_invalid_reason_empty = DiagnosticFactory(
+            year=year_data, canteen=CanteenFactory(), valeur_totale=1000, invalid_reason_list=[]
+        )
+        cls.diagnostic_invalid_reason_not_empty = DiagnosticFactory(
+            year=year_data,
+            canteen=CanteenFactory(),
+            valeur_totale=1000,
+            invalid_reason_list=[Diagnostic.InvalidReason.CANTINE_SOFT_SUPPRIMEE_PENDANT_CAMPAGNE],
+        )
+
+    def test_has_invalid_reason_queryset(self):
+        self.assertEqual(Diagnostic.objects.all().count(), 3)
+        self.assertEqual(Diagnostic.objects.has_invalid_reason().count(), 1)
+
+    def test_has_invalid_reason_property(self):
+        self.assertFalse(self.diagnostic_invalid_reason_none.has_invalid_reason)
+        self.assertFalse(self.diagnostic_invalid_reason_empty.has_invalid_reason)
+        self.assertTrue(self.diagnostic_invalid_reason_not_empty.has_invalid_reason)
+
+
 class DiagnosticModelTeledeclareMethodTest(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -16,6 +16,7 @@ redis = r.from_url(settings.REDIS_URL, decode_responses=True)
 # increment this when the teledeclaration format changes
 # and update docs/teledeclaration_versions.md
 TELEDECLARATION_CURRENT_VERSION = 16
+YEARS_WITH_1TD1SITE = [2024, 2025]
 
 
 def convert_date_string_to_datetime(date_string, time_start_or_end="start"):


### PR DESCRIPTION
### Quoi

Quelques nouveaux helpers sur le model `Diagnostic`
- nouveau queryset `has_invalid_reason()`
- nouvelle property `has_invalid_reason`
- nouvelle constant `YEARS_WITH_1TD1SITE`

### Pourquoi

Simplifier la gestion de ce champ, qui est parfois None ou []