### PR TITLE
improve(Bilans): API: nouvel endpoint pour récupérer la liste de ses bilans

### DIFF
--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -13,12 +13,70 @@ from data.models import Diagnostic
 from data.models.creation_source import CreationSource
 
 
+class DiagnosticListApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.diagnostic_2022_cancelled = DiagnosticFactory(canteen=cls.canteen, year=2022)
+        with freeze_time("2023-03-30"):  # during the 2022 campaign
+            cls.diagnostic_2022_cancelled.teledeclare(applicant=cls.user)
+            cls.diagnostic_2022_cancelled.cancel()
+        cls.diagnostic_2021_teledeclared = DiagnosticFactory(canteen=cls.canteen, year=2021)
+        with freeze_time("2022-08-30"):  # during the 2021 campaign
+            cls.diagnostic_2021_teledeclared.teledeclare(applicant=cls.user)
+        cls.diagnostic_2020 = DiagnosticFactory(canteen=cls.canteen, year=2020)
+        cls.url = reverse("diagnostic_list_create", kwargs={"canteen_pk": cls.canteen.id})
+
+    def test_cannot_list_diagnostics_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_list_diagnostics_if_canteen_unknown(self):
+        response = self.client.get(reverse("diagnostic_list_create", kwargs={"canteen_pk": 9999}))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_list_diagnostics_if_not_canteen_manager(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_list_diagnostics(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 3)
+        # ordered by year ascending
+        self.assertEqual(body[0]["id"], self.diagnostic_2020.id)
+        self.assertEqual(body[1]["id"], self.diagnostic_2021_teledeclared.id)
+        self.assertEqual(body[2]["id"], self.diagnostic_2022_cancelled.id)
+
+    def test_list_diagnostics_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:read")
+        self.canteen.managers.add(user)
+
+        self.client.credentials(Authorization=f"Bearer {token}")
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 3)
+
+
 class DiagnosticCreateApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
         cls.canteen = CanteenFactory(managers=[cls.user])
-        cls.url = reverse("diagnostic_creation", kwargs={"canteen_pk": cls.canteen.id})
+        cls.url = reverse("diagnostic_list_create", kwargs={"canteen_pk": cls.canteen.id})
         cls.DIAGNOSTIC_PAYLOAD = {"year": 2020}
 
     def test_cannot_create_diagnostic_if_unauthenticated(self):
@@ -29,7 +87,7 @@ class DiagnosticCreateApiTest(APITestCase):
     @authenticate
     def test_cannot_create_diagnostic_if_canteen_unknown(self):
         response = self.client.post(
-            reverse("diagnostic_creation", kwargs={"canteen_pk": 9999}), self.DIAGNOSTIC_PAYLOAD
+            reverse("diagnostic_list_create", kwargs={"canteen_pk": 9999}), self.DIAGNOSTIC_PAYLOAD
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -725,10 +783,9 @@ class DiagnosticUpdateApiTest(APITestCase):
 
     @authenticate
     def test_cannot_update_diagnostic_teledeclared(self):
-        date_in_2022_teledeclaration_campaign = "2022-08-30"
         diagnostic = DiagnosticFactory(year=2021)
         diagnostic.canteen.managers.add(authenticate.user)
-        with freeze_time(date_in_2022_teledeclaration_campaign):
+        with freeze_time("2022-08-30"):  # during the 2021 campaign
             diagnostic.teledeclare(applicant=authenticate.user)
         payload = {"year": 2020}
 
@@ -746,10 +803,9 @@ class DiagnosticUpdateApiTest(APITestCase):
 
     @authenticate
     def test_update_diagnostic_cancelled(self):
-        date_in_2022_teledeclaration_campaign = "2022-08-30"
         diagnostic = DiagnosticFactory(year=2021)
         diagnostic.canteen.managers.add(authenticate.user)
-        with freeze_time(date_in_2022_teledeclaration_campaign):
+        with freeze_time("2022-08-30"):  # during the 2021 campaign
             diagnostic.teledeclare(applicant=authenticate.user)
             diagnostic.cancel()
         payload = {"year": 2020}

--- a/api/urls.py
+++ b/api/urls.py
@@ -24,7 +24,7 @@ from api.views import (
     ChangePasswordView,
     ClaimCanteenView,
     CommunityEventsView,
-    DiagnosticCreateView,
+    DiagnosticListCreateView,
     DiagnosticsCompleteImportView,
     DiagnosticsFromPurchasesView,
     DiagnosticsSimpleImportView,
@@ -160,8 +160,8 @@ urlpatterns = {
     ),
     path(
         "canteens/<int:canteen_pk>/diagnostics/",
-        DiagnosticCreateView.as_view(),
-        name="diagnostic_creation",
+        DiagnosticListCreateView.as_view(),
+        name="diagnostic_list_create",
     ),
     path(
         "canteens/<int:canteen_pk>/diagnostics/<int:pk>",

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -24,7 +24,11 @@ from .canteen_groupe import (  # noqa: F401
     CanteenGroupeSatellitesListView,
     CanteenGroupeSatelliteUnlinkView,
 )  # noqa: F401
-from .canteen_images import UserCanteenLogoView, UserCanteenImagesListView, UserCanteenImagesRetrieveUpdateDestroyView  # noqa: F401
+from .canteen_images import (  # noqa: F401
+    UserCanteenImagesListView,
+    UserCanteenImagesRetrieveUpdateDestroyView,
+    UserCanteenLogoView,
+)
 from .canteen_managers import (  # noqa: F401
     AddManagerView,
     ClaimCanteenView,
@@ -38,7 +42,7 @@ from .canteen_managers_import import CanteensManagersImportView  # noqa: F401
 from .canteen_update_import import CanteensUpdateImportView  # noqa: F401
 from .communityevent import CommunityEventsView  # noqa: F401
 from .diagnostic import (  # noqa: F401
-    DiagnosticCreateView,
+    DiagnosticListCreateView,
     DiagnosticsToTeledeclareListView,
     DiagnosticUpdateView,
     EmailDiagnosticImportFileView,

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -7,7 +7,7 @@ from django.db.models import Exists, OuterRef
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseServerError
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.generics import CreateAPIView, ListAPIView, UpdateAPIView, get_object_or_404
+from rest_framework.generics import ListCreateAPIView, ListAPIView, UpdateAPIView, get_object_or_404
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.views import APIView
 
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
         tags=["Bilans"],
     )
 )
-class DiagnosticCreateView(CreateAPIView):
+class DiagnosticListCreateView(ListCreateAPIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     required_scopes = ["canteen"]
     model = Diagnostic
@@ -47,6 +47,10 @@ class DiagnosticCreateView(CreateAPIView):
     def _get_canteen(self):
         # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
         return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
+
+    def get_queryset(self):
+        canteen = self._get_canteen()
+        return canteen.diagnostics.all().order_by("year")
 
     def perform_create(self, serializer):
         try:


### PR DESCRIPTION
### Quoi

(En parallèle du nouvel endpoint qui listera des infos "recap" des bilans par année : #6975)
On ouvre cet endpoint qui liste les bilans créés par cantine par an.

`canteens/<int:canteen_pk>/diagnostics`

### Note

Pas de 1TD1Site pour l'instant : il faudrait regarder coté serializer pour ajouter des champs qui permette de bien diférencier les bilans créés de générés
