### PR TITLE
feat(Bilans): API: nouvel endpoint pour récupérer la liste 'recap' des bilans

### DIFF
--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -1,15 +1,17 @@
 from decimal import Decimal
 
+from django.core.management import call_command
 from django.core.exceptions import BadRequest
 from django.db import transaction
 from django.urls import reverse
 from freezegun import freeze_time
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from api.tests.utils import authenticate, get_oauth2_token
 from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
-from data.models import Diagnostic
+from data.models import Diagnostic, Canteen
 from data.models.creation_source import CreationSource
 
 
@@ -871,7 +873,8 @@ class DiagnosticListRecapApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
-        cls.canteen = CanteenFactory(managers=[cls.user])
+        with freeze_time("2021-01-01"):
+            cls.canteen = CanteenFactory(managers=[cls.user])
         cls.diagnostic_2022_cancelled = DiagnosticFactory(canteen=cls.canteen, year=2022)
         with freeze_time("2023-03-30"):  # during the 2022 campaign
             cls.diagnostic_2022_cancelled.teledeclare(applicant=cls.user)
@@ -879,7 +882,6 @@ class DiagnosticListRecapApiTest(APITestCase):
         cls.diagnostic_2021_teledeclared = DiagnosticFactory(canteen=cls.canteen, year=2021)
         with freeze_time("2022-08-30"):  # during the 2021 campaign
             cls.diagnostic_2021_teledeclared.teledeclare(applicant=cls.user)
-        cls.diagnostic_2020 = DiagnosticFactory(canteen=cls.canteen, year=2020)
         cls.url = reverse("diagnostic_list_recap", kwargs={"canteen_pk": cls.canteen.id})
 
     def test_cannot_list_recap_diagnostics_if_unauthenticated(self):
@@ -907,20 +909,24 @@ class DiagnosticListRecapApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(len(body), 5)
+        self.assertEqual(len(body), 5)  # CAMPAIGN_DATES
         # ordered by year ascending
         self.assertEqual(body[0]["year"], 2021)
         self.assertEqual(body[0]["isTeledeclared"], True)
-        self.assertEqual(body[0]["declarationDonnees2021"], True)
+        self.assertEqual(body[0]["declarationDonnees"], True)
         self.assertEqual(body[0]["canteenDiagnosticId"], self.diagnostic_2021_teledeclared.id)
-        self.assertEqual(body[0]["groupeDiagnosticId"], None)
+        self.assertEqual(
+            body[0]["canteenDiagnosticTeledeclarationMode"], self.diagnostic_2021_teledeclared.teledeclaration_mode
+        )
         self.assertEqual(body[0]["generatedFromGroupeDiagnosticId"], None)
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], None)
         self.assertEqual(body[1]["year"], 2022)
         self.assertEqual(body[1]["isTeledeclared"], False)
-        self.assertEqual(body[1]["declarationDonnees2022"], False)
+        self.assertEqual(body[1]["declarationDonnees"], False)
         self.assertEqual(body[1]["canteenDiagnosticId"], self.diagnostic_2022_cancelled.id)
-        self.assertEqual(body[1]["groupeDiagnosticId"], None)
+        self.assertEqual(body[1]["canteenDiagnosticTeledeclarationMode"], None)
         self.assertEqual(body[1]["generatedFromGroupeDiagnosticId"], None)
+        self.assertEqual(body[1]["generatedFromGroupeDiagnosticMode"], None)
 
     def test_cannot_list_recap_diagnostics_via_oauth2(self):
         user, token = get_oauth2_token("canteen:read")
@@ -930,3 +936,102 @@ class DiagnosticListRecapApiTest(APITestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_list_recap_diagnostics_only_return_years_after_canteen_creation(self):
+        self.canteen.managers.add(authenticate.user)
+        with freeze_time("2026-03-15"):  # during the 2025 campaign
+            self.canteen.creation_date = timezone.now()
+            self.canteen.save(skip_validations=True)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 1)  # only the 2025 campaign remains
+        self.assertEqual(body[0]["year"], 2025)
+        self.assertEqual(body[0]["isTeledeclared"], False)
+        self.assertEqual(body[0]["declarationDonnees"], False)
+        self.assertEqual(body[0]["canteenDiagnosticId"], None)
+        self.assertEqual(body[0]["canteenDiagnosticTeledeclarationMode"], None)
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticId"], None)
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], None)
+
+    @freeze_time("2026-03-30")  # during the 2025 campaign
+    @authenticate
+    def test_list_recap_diagnostics_groupe_satellite(self):
+        canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[authenticate.user])
+        canteen_satellite_1 = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe, managers=[authenticate.user]
+        )
+        canteen_satellite_2 = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe, managers=[authenticate.user]
+        )
+        diagnostic_satellite_1 = DiagnosticFactory(
+            canteen=canteen_satellite_1, year=2025, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
+        diagnostic_satellite_1.teledeclare(applicant=authenticate.user)
+        diagnostic_groupe = DiagnosticFactory(
+            canteen=canteen_groupe,
+            year=2025,
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+            central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.APPRO,
+        )
+        diagnostic_groupe.teledeclare(applicant=authenticate.user)
+        diagnostic_satellite_2 = DiagnosticFactory(
+            canteen=canteen_satellite_2,
+            year=2025,
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+        )
+        diagnostic_satellite_2.teledeclare(applicant=authenticate.user)
+
+        call_command("diagnostic_fill_invalid_warning_reason_list", year=2025, apply=True)
+        call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
+
+        # groupe
+        response = self.client.get(reverse("diagnostic_list_recap", kwargs={"canteen_pk": canteen_groupe.id}))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 1)  # only the 2025 campaign remains
+        self.assertEqual(body[0]["year"], 2025)
+        self.assertEqual(body[0]["isTeledeclared"], True)
+        self.assertEqual(body[0]["declarationDonnees"], True)
+        self.assertEqual(body[0]["canteenDiagnosticId"], diagnostic_groupe.id)
+        self.assertEqual(body[0]["canteenDiagnosticTeledeclarationMode"], Diagnostic.TeledeclarationMode.CENTRAL_APPRO)
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticId"], None)
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], None)
+
+        # satellite_1
+        # Teledeclared before the groupe: SITE (100% overriden)
+        response = self.client.get(reverse("diagnostic_list_recap", kwargs={"canteen_pk": canteen_satellite_1.id}))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 1)  # only the 2025 campaign remains
+        self.assertEqual(body[0]["year"], 2025)
+        self.assertEqual(body[0]["isTeledeclared"], True)
+        self.assertEqual(body[0]["declarationDonnees"], True)
+        self.assertEqual(body[0]["canteenDiagnosticId"], diagnostic_satellite_1.id)
+        self.assertEqual(body[0]["canteenDiagnosticTeledeclarationMode"], Diagnostic.TeledeclarationMode.SITE)
+        self.assertIsNotNone(body[0]["generatedFromGroupeDiagnosticId"])
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticTeledeclarationId"], diagnostic_groupe.id)
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], Diagnostic.CentralKitchenDiagnosticMode.APPRO)
+
+        # satellite_2
+        # Teledeclared after the groupe: SATELLITE_WITHOUT_APPRO (partially overriden)
+        response = self.client.get(reverse("diagnostic_list_recap", kwargs={"canteen_pk": canteen_satellite_2.id}))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 1)  # only the 2025 campaign remains
+        self.assertEqual(body[0]["year"], 2025)
+        self.assertEqual(body[0]["isTeledeclared"], True)
+        self.assertEqual(body[0]["declarationDonnees"], True)
+        self.assertEqual(body[0]["canteenDiagnosticId"], diagnostic_satellite_2.id)
+        self.assertEqual(
+            body[0]["canteenDiagnosticTeledeclarationMode"], Diagnostic.TeledeclarationMode.SATELLITE_WITHOUT_APPRO
+        )
+        self.assertIsNotNone(body[0]["generatedFromGroupeDiagnosticId"])
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticTeledeclarationId"], diagnostic_groupe.id)
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], Diagnostic.CentralKitchenDiagnosticMode.APPRO)

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -873,15 +873,7 @@ class DiagnosticListRecapApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
-        with freeze_time("2021-01-01"):
-            cls.canteen = CanteenFactory(managers=[cls.user])
-        cls.diagnostic_2022_cancelled = DiagnosticFactory(canteen=cls.canteen, year=2022)
-        with freeze_time("2023-03-30"):  # during the 2022 campaign
-            cls.diagnostic_2022_cancelled.teledeclare(applicant=cls.user)
-            cls.diagnostic_2022_cancelled.cancel()
-        cls.diagnostic_2021_teledeclared = DiagnosticFactory(canteen=cls.canteen, year=2021)
-        with freeze_time("2022-08-30"):  # during the 2021 campaign
-            cls.diagnostic_2021_teledeclared.teledeclare(applicant=cls.user)
+        cls.canteen = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[cls.user])
         cls.url = reverse("diagnostic_list_recap", kwargs={"canteen_pk": cls.canteen.id})
 
     def test_cannot_list_recap_diagnostics_if_unauthenticated(self):
@@ -908,25 +900,6 @@ class DiagnosticListRecapApiTest(APITestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-        self.assertEqual(len(body), 5)  # CAMPAIGN_DATES
-        # ordered by year ascending
-        self.assertEqual(body[0]["year"], 2021)
-        self.assertEqual(body[0]["isTeledeclared"], True)
-        self.assertEqual(body[0]["declarationDonnees"], True)
-        self.assertEqual(body[0]["canteenDiagnosticId"], self.diagnostic_2021_teledeclared.id)
-        self.assertEqual(
-            body[0]["canteenDiagnosticTeledeclarationMode"], self.diagnostic_2021_teledeclared.teledeclaration_mode
-        )
-        self.assertEqual(body[0]["generatedFromGroupeDiagnosticId"], None)
-        self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], None)
-        self.assertEqual(body[1]["year"], 2022)
-        self.assertEqual(body[1]["isTeledeclared"], False)
-        self.assertEqual(body[1]["declarationDonnees"], False)
-        self.assertEqual(body[1]["canteenDiagnosticId"], self.diagnostic_2022_cancelled.id)
-        self.assertEqual(body[1]["canteenDiagnosticTeledeclarationMode"], None)
-        self.assertEqual(body[1]["generatedFromGroupeDiagnosticId"], None)
-        self.assertEqual(body[1]["generatedFromGroupeDiagnosticMode"], None)
 
     def test_cannot_list_recap_diagnostics_via_oauth2(self):
         user, token = get_oauth2_token("canteen:read")
@@ -950,27 +923,44 @@ class DiagnosticListRecapApiTest(APITestCase):
         body = response.json()
         self.assertEqual(len(body), 1)  # only the 2025 campaign remains
         self.assertEqual(body[0]["year"], 2025)
-        self.assertEqual(body[0]["isTeledeclared"], False)
-        self.assertEqual(body[0]["declarationDonnees"], False)
-        self.assertEqual(body[0]["canteenDiagnosticId"], None)
-        self.assertEqual(body[0]["canteenDiagnosticTeledeclarationMode"], None)
+
+    @freeze_time("2026-03-30")  # during the 2025 campaign
+    @authenticate
+    def test_list_recap_diagnostics_site(self):
+        self.canteen.managers.add(authenticate.user)
+        self.canteen.creation_date = timezone.now()
+        self.canteen.save(skip_validations=True)
+        diagnostic = DiagnosticFactory(
+            canteen=self.canteen, year=2025, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
+        diagnostic.teledeclare(applicant=authenticate.user)
+
+        response = self.client.get(reverse("diagnostic_list_recap", kwargs={"canteen_pk": self.canteen.id}))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 1)  # only the 2025 campaign remains
+        self.assertEqual(body[0]["year"], 2025)
+        self.assertEqual(body[0]["isTeledeclared"], True)
+        self.assertEqual(body[0]["declarationDonnees"], True)
+        self.assertEqual(body[0]["canteenDiagnosticId"], diagnostic.id)
         self.assertEqual(body[0]["generatedFromGroupeDiagnosticId"], None)
         self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], None)
 
     @freeze_time("2026-03-30")  # during the 2025 campaign
     @authenticate
-    def test_list_recap_diagnostics_groupe_satellite(self):
+    def test_list_recap_diagnostics_groupe_appro_only_with_satellite(self):
         canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[authenticate.user])
-        canteen_satellite_1 = CanteenFactory(
+        canteen_satellite_1_before = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe, managers=[authenticate.user]
         )
-        canteen_satellite_2 = CanteenFactory(
+        canteen_satellite_2_after = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe, managers=[authenticate.user]
         )
-        diagnostic_satellite_1 = DiagnosticFactory(
-            canteen=canteen_satellite_1, year=2025, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        diagnostic_satellite_1_before = DiagnosticFactory(
+            canteen=canteen_satellite_1_before, year=2025, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
         )
-        diagnostic_satellite_1.teledeclare(applicant=authenticate.user)
+        diagnostic_satellite_1_before.teledeclare(applicant=authenticate.user)
         diagnostic_groupe = DiagnosticFactory(
             canteen=canteen_groupe,
             year=2025,
@@ -978,17 +968,17 @@ class DiagnosticListRecapApiTest(APITestCase):
             central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.APPRO,
         )
         diagnostic_groupe.teledeclare(applicant=authenticate.user)
-        diagnostic_satellite_2 = DiagnosticFactory(
-            canteen=canteen_satellite_2,
-            year=2025,
-            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+        diagnostic_satellite_2_after = DiagnosticFactory(
+            canteen=canteen_satellite_2_after, year=2025, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
         )
-        diagnostic_satellite_2.teledeclare(applicant=authenticate.user)
+        diagnostic_satellite_2_after.teledeclare(applicant=authenticate.user)
 
         call_command("diagnostic_fill_invalid_warning_reason_list", year=2025, apply=True)
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
 
         # groupe
+        self.assertEqual(diagnostic_groupe.teledeclaration_mode, Diagnostic.TeledeclarationMode.CENTRAL_APPRO)
+
         response = self.client.get(reverse("diagnostic_list_recap", kwargs={"canteen_pk": canteen_groupe.id}))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -998,13 +988,15 @@ class DiagnosticListRecapApiTest(APITestCase):
         self.assertEqual(body[0]["isTeledeclared"], True)
         self.assertEqual(body[0]["declarationDonnees"], True)
         self.assertEqual(body[0]["canteenDiagnosticId"], diagnostic_groupe.id)
-        self.assertEqual(body[0]["canteenDiagnosticTeledeclarationMode"], Diagnostic.TeledeclarationMode.CENTRAL_APPRO)
         self.assertEqual(body[0]["generatedFromGroupeDiagnosticId"], None)
         self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], None)
 
-        # satellite_1
-        # Teledeclared before the groupe: SITE (100% overriden)
-        response = self.client.get(reverse("diagnostic_list_recap", kwargs={"canteen_pk": canteen_satellite_1.id}))
+        # satellite_1_before (teledeclared before the groupe)
+        self.assertEqual(diagnostic_satellite_1_before.teledeclaration_mode, Diagnostic.TeledeclarationMode.SITE)
+
+        response = self.client.get(
+            reverse("diagnostic_list_recap", kwargs={"canteen_pk": canteen_satellite_1_before.id})
+        )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -1012,14 +1004,87 @@ class DiagnosticListRecapApiTest(APITestCase):
         self.assertEqual(body[0]["year"], 2025)
         self.assertEqual(body[0]["isTeledeclared"], True)
         self.assertEqual(body[0]["declarationDonnees"], True)
-        self.assertEqual(body[0]["canteenDiagnosticId"], diagnostic_satellite_1.id)
-        self.assertEqual(body[0]["canteenDiagnosticTeledeclarationMode"], Diagnostic.TeledeclarationMode.SITE)
+        self.assertEqual(body[0]["canteenDiagnosticId"], diagnostic_satellite_1_before.id)
         self.assertIsNotNone(body[0]["generatedFromGroupeDiagnosticId"])
-        self.assertEqual(body[0]["generatedFromGroupeDiagnosticTeledeclarationId"], diagnostic_groupe.id)
         self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], Diagnostic.CentralKitchenDiagnosticMode.APPRO)
 
-        # satellite_2
-        # Teledeclared after the groupe: SATELLITE_WITHOUT_APPRO (partially overriden)
+        # satellite_2_after (teledeclared after the groupe)
+        self.assertEqual(
+            diagnostic_satellite_2_after.teledeclaration_mode, Diagnostic.TeledeclarationMode.SATELLITE_WITHOUT_APPRO
+        )
+
+        response = self.client.get(
+            reverse("diagnostic_list_recap", kwargs={"canteen_pk": canteen_satellite_2_after.id})
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 1)  # only the 2025 campaign remains
+        self.assertEqual(body[0]["year"], 2025)
+        self.assertEqual(body[0]["isTeledeclared"], True)
+        self.assertEqual(body[0]["declarationDonnees"], True)
+        self.assertEqual(body[0]["canteenDiagnosticId"], diagnostic_satellite_2_after.id)
+        self.assertIsNotNone(body[0]["generatedFromGroupeDiagnosticId"])
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], Diagnostic.CentralKitchenDiagnosticMode.APPRO)
+
+    @freeze_time("2026-03-30")  # during the 2025 campaign
+    @authenticate
+    def test_list_recap_diagnostics_groupe_all_with_satellite(self):
+        canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[authenticate.user])
+        canteen_satellite_1_before = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe, managers=[authenticate.user]
+        )
+        canteen_satellite_2 = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe, managers=[authenticate.user]
+        )
+        diagnostic_satellite_1_before = DiagnosticFactory(
+            canteen=canteen_satellite_1_before, year=2025, diagnostic_type=Diagnostic.DiagnosticType.SIMPLE
+        )
+        diagnostic_satellite_1_before.teledeclare(applicant=authenticate.user)
+        diagnostic_groupe = DiagnosticFactory(
+            canteen=canteen_groupe,
+            year=2025,
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+            central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
+        )
+        diagnostic_groupe.teledeclare(applicant=authenticate.user)
+
+        call_command("diagnostic_fill_invalid_warning_reason_list", year=2025, apply=True)
+        call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
+
+        # groupe
+        self.assertEqual(diagnostic_groupe.teledeclaration_mode, Diagnostic.TeledeclarationMode.CENTRAL_ALL)
+
+        response = self.client.get(reverse("diagnostic_list_recap", kwargs={"canteen_pk": canteen_groupe.id}))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 1)  # only the 2025 campaign remains
+        self.assertEqual(body[0]["year"], 2025)
+        self.assertEqual(body[0]["isTeledeclared"], True)
+        self.assertEqual(body[0]["declarationDonnees"], True)
+        self.assertEqual(body[0]["canteenDiagnosticId"], diagnostic_groupe.id)
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticId"], None)
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], None)
+
+        # satellite_1_before (teledeclared before the groupe)
+        self.assertEqual(diagnostic_satellite_1_before.teledeclaration_mode, Diagnostic.TeledeclarationMode.SITE)
+
+        response = self.client.get(
+            reverse("diagnostic_list_recap", kwargs={"canteen_pk": canteen_satellite_1_before.id})
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 1)  # only the 2025 campaign remains
+        self.assertEqual(body[0]["year"], 2025)
+        self.assertEqual(body[0]["isTeledeclared"], True)
+        self.assertEqual(body[0]["declarationDonnees"], True)
+        self.assertEqual(body[0]["canteenDiagnosticId"], diagnostic_satellite_1_before.id)
+        self.assertIsNotNone(body[0]["generatedFromGroupeDiagnosticId"])
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], Diagnostic.CentralKitchenDiagnosticMode.ALL)
+
+        # satellite_2 (did not teledeclare)
         response = self.client.get(reverse("diagnostic_list_recap", kwargs={"canteen_pk": canteen_satellite_2.id}))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1028,10 +1093,6 @@ class DiagnosticListRecapApiTest(APITestCase):
         self.assertEqual(body[0]["year"], 2025)
         self.assertEqual(body[0]["isTeledeclared"], True)
         self.assertEqual(body[0]["declarationDonnees"], True)
-        self.assertEqual(body[0]["canteenDiagnosticId"], diagnostic_satellite_2.id)
-        self.assertEqual(
-            body[0]["canteenDiagnosticTeledeclarationMode"], Diagnostic.TeledeclarationMode.SATELLITE_WITHOUT_APPRO
-        )
+        self.assertEqual(body[0]["canteenDiagnosticId"], None)
         self.assertIsNotNone(body[0]["generatedFromGroupeDiagnosticId"])
-        self.assertEqual(body[0]["generatedFromGroupeDiagnosticTeledeclarationId"], diagnostic_groupe.id)
-        self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], Diagnostic.CentralKitchenDiagnosticMode.APPRO)
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], Diagnostic.CentralKitchenDiagnosticMode.ALL)

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -865,3 +865,68 @@ class DiagnosticDeleteApiTest(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+
+class DiagnosticListRecapApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.diagnostic_2022_cancelled = DiagnosticFactory(canteen=cls.canteen, year=2022)
+        with freeze_time("2023-03-30"):  # during the 2022 campaign
+            cls.diagnostic_2022_cancelled.teledeclare(applicant=cls.user)
+            cls.diagnostic_2022_cancelled.cancel()
+        cls.diagnostic_2021_teledeclared = DiagnosticFactory(canteen=cls.canteen, year=2021)
+        with freeze_time("2022-08-30"):  # during the 2021 campaign
+            cls.diagnostic_2021_teledeclared.teledeclare(applicant=cls.user)
+        cls.diagnostic_2020 = DiagnosticFactory(canteen=cls.canteen, year=2020)
+        cls.url = reverse("diagnostic_list_recap", kwargs={"canteen_pk": cls.canteen.id})
+
+    def test_cannot_list_recap_diagnostics_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_list_recap_diagnostics_if_canteen_unknown(self):
+        response = self.client.get(reverse("diagnostic_list_recap", kwargs={"canteen_pk": 9999}))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_list_recap_diagnostics_if_not_canteen_manager(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_list_recap_diagnostics(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 5)
+        # ordered by year ascending
+        self.assertEqual(body[0]["year"], 2021)
+        self.assertEqual(body[0]["isTeledeclared"], True)
+        self.assertEqual(body[0]["declarationDonnees2021"], True)
+        self.assertEqual(body[0]["canteenDiagnosticId"], self.diagnostic_2021_teledeclared.id)
+        self.assertEqual(body[0]["groupeDiagnosticId"], None)
+        self.assertEqual(body[0]["generatedFromGroupeDiagnosticId"], None)
+        self.assertEqual(body[1]["year"], 2022)
+        self.assertEqual(body[1]["isTeledeclared"], False)
+        self.assertEqual(body[1]["declarationDonnees2022"], False)
+        self.assertEqual(body[1]["canteenDiagnosticId"], self.diagnostic_2022_cancelled.id)
+        self.assertEqual(body[1]["groupeDiagnosticId"], None)
+        self.assertEqual(body[1]["generatedFromGroupeDiagnosticId"], None)
+
+    def test_cannot_list_recap_diagnostics_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:read")
+        self.canteen.managers.add(user)
+
+        self.client.credentials(Authorization=f"Bearer {token}")
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/api/urls.py
+++ b/api/urls.py
@@ -25,6 +25,7 @@ from api.views import (
     ClaimCanteenView,
     CommunityEventsView,
     DiagnosticListCreateView,
+    DiagnosticListRecapView,
     DiagnosticsCompleteImportView,
     DiagnosticsFromPurchasesView,
     DiagnosticsSimpleImportView,
@@ -167,6 +168,11 @@ urlpatterns = {
         "canteens/<int:canteen_pk>/diagnostics/<int:pk>",
         DiagnosticUpdateView.as_view(),
         name="diagnostic_update",
+    ),
+    path(
+        "canteens/<int:canteen_pk>/diagnostics/recap",
+        DiagnosticListRecapView.as_view(),
+        name="diagnostic_list_recap",
     ),
     path(
         "canteens/<int:canteen_pk>/diagnostics/<int:pk>/teledeclaration/create",

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -43,6 +43,7 @@ from .canteen_update_import import CanteensUpdateImportView  # noqa: F401
 from .communityevent import CommunityEventsView  # noqa: F401
 from .diagnostic import (  # noqa: F401
     DiagnosticListCreateView,
+    DiagnosticListRecapView,
     DiagnosticsToTeledeclareListView,
     DiagnosticUpdateView,
     EmailDiagnosticImportFileView,

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import ListCreateAPIView, ListAPIView, UpdateAPIView, get_object_or_404
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.views import APIView
+from rest_framework.response import Response
 
 from api.exceptions import DuplicateException
 from api.permissions import (
@@ -26,7 +27,7 @@ from common.utils import file_import, send_mail
 from data.models import Canteen, Teledeclaration
 from data.models.creation_source import CreationSource
 from data.models.diagnostic import Diagnostic
-from macantine.utils import is_in_correction
+from macantine.utils import is_in_correction, CAMPAIGN_DATES
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +103,50 @@ class DiagnosticUpdateView(UpdateAPIView):
         serializer.is_valid(raise_exception=True)
         diagnostic = serializer.save()
         update_change_reason_with_auth(self, diagnostic)
+
+
+class DiagnosticListRecapView(APIView):
+    permission_classes = [IsAuthenticated, IsCanteenManagerUrlParam]
+
+    def _get_canteen(self):
+        # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
+        return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
+
+    def get(self, request, canteen_pk):
+        canteen = self._get_canteen()
+        canteen_diagnostics = Diagnostic.all_objects.filter(canteen=canteen)
+        result = []
+        for year in CAMPAIGN_DATES.keys():
+            # skip years where the canteen was not yet created
+            if canteen.creation_date < CAMPAIGN_DATES[year]["teledeclaration_start_date"]:
+                continue
+            # is_teledeclared: at least 1 diagnostic is SUBMITTED
+            is_teledeclared = any(d.year == year and d.is_teledeclared for d in canteen_diagnostics)
+            canteen_diagnostic_id = next(
+                (d.id for d in canteen_diagnostics if d.year == year and not d.generated_from_groupe_diagnostic), None
+            )
+            groupe_diagnostic_id = next(
+                (
+                    d.teledeclaration_id
+                    for d in canteen_diagnostics
+                    if d.year == year and d.generated_from_groupe_diagnostic
+                ),
+                None,
+            )
+            generated_from_groupe_diagnostic_id = next(
+                (d.id for d in canteen_diagnostics if d.year == year and d.generated_from_groupe_diagnostic), None
+            )
+            result.append(
+                {
+                    "year": year,
+                    "is_teledeclared": is_teledeclared,
+                    f"declaration_donnees_{year}": getattr(canteen, f"declaration_donnees_{year}", None),
+                    "canteen_diagnostic_id": canteen_diagnostic_id,
+                    "groupe_diagnostic_id": groupe_diagnostic_id,
+                    "generated_from_groupe_diagnostic_id": generated_from_groupe_diagnostic_id,
+                }
+            )
+        return Response(result)
 
 
 class EmailDiagnosticImportFileView(APIView):

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -129,18 +129,12 @@ class DiagnosticListRecapView(APIView):
                 (d for d in canteen_diagnostics if d.year == year and not d.generated_from_groupe_diagnostic), None
             )
             canteen_diagnostic_id = canteen_diagnostic.id if canteen_diagnostic else None
-            canteen_diagnostic_teledeclaration_mode = (
-                canteen_diagnostic.teledeclaration_mode if canteen_diagnostic else None
-            )
             # generated_from_groupe_diagnostic: the canteen's generated diagnostic (from its groupe) (if it exists)
             generated_from_groupe_diagnostic = next(
                 (d for d in canteen_diagnostics if d.year == year and d.generated_from_groupe_diagnostic), None
             )
             generated_from_groupe_diagnostic_id = (
                 generated_from_groupe_diagnostic.id if generated_from_groupe_diagnostic else None
-            )
-            generated_from_groupe_diagnostic_teledeclaration_id = (
-                generated_from_groupe_diagnostic.teledeclaration_id if generated_from_groupe_diagnostic else None
             )
             generated_from_groupe_diagnostic_mode = (
                 generated_from_groupe_diagnostic.central_kitchen_diagnostic_mode
@@ -153,9 +147,7 @@ class DiagnosticListRecapView(APIView):
                     "is_teledeclared": is_teledeclared,
                     "declaration_donnees": declaration_donnees,
                     "canteen_diagnostic_id": canteen_diagnostic_id,
-                    "canteen_diagnostic_teledeclaration_mode": canteen_diagnostic_teledeclaration_mode,
                     "generated_from_groupe_diagnostic_id": generated_from_groupe_diagnostic_id,
-                    "generated_from_groupe_diagnostic_teledeclaration_id": generated_from_groupe_diagnostic_teledeclaration_id,
                     "generated_from_groupe_diagnostic_mode": generated_from_groupe_diagnostic_mode,
                 }
             )

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -118,32 +118,45 @@ class DiagnosticListRecapView(APIView):
         result = []
         for year in CAMPAIGN_DATES.keys():
             # skip years where the canteen was not yet created
-            if canteen.creation_date < CAMPAIGN_DATES[year]["teledeclaration_start_date"]:
+            if canteen.creation_date > CAMPAIGN_DATES[year]["teledeclaration_end_date"]:
                 continue
-            # is_teledeclared: at least 1 diagnostic is SUBMITTED
+            # is_teledeclared: if at least 1 of the canteen's diagnostics is SUBMITTED
             is_teledeclared = any(d.year == year and d.is_teledeclared for d in canteen_diagnostics)
-            canteen_diagnostic_id = next(
-                (d.id for d in canteen_diagnostics if d.year == year and not d.generated_from_groupe_diagnostic), None
+            # declaration_donnees: copy the canteeen's field value
+            declaration_donnees = getattr(canteen, f"declaration_donnees_{year}", None)
+            # canteen_diagnostic: the canteen's own diagnostic (if it exists)
+            canteen_diagnostic = next(
+                (d for d in canteen_diagnostics if d.year == year and not d.generated_from_groupe_diagnostic), None
             )
-            groupe_diagnostic_id = next(
-                (
-                    d.teledeclaration_id
-                    for d in canteen_diagnostics
-                    if d.year == year and d.generated_from_groupe_diagnostic
-                ),
-                None,
+            canteen_diagnostic_id = canteen_diagnostic.id if canteen_diagnostic else None
+            canteen_diagnostic_teledeclaration_mode = (
+                canteen_diagnostic.teledeclaration_mode if canteen_diagnostic else None
             )
-            generated_from_groupe_diagnostic_id = next(
-                (d.id for d in canteen_diagnostics if d.year == year and d.generated_from_groupe_diagnostic), None
+            # generated_from_groupe_diagnostic: the canteen's generated diagnostic (from its groupe) (if it exists)
+            generated_from_groupe_diagnostic = next(
+                (d for d in canteen_diagnostics if d.year == year and d.generated_from_groupe_diagnostic), None
+            )
+            generated_from_groupe_diagnostic_id = (
+                generated_from_groupe_diagnostic.id if generated_from_groupe_diagnostic else None
+            )
+            generated_from_groupe_diagnostic_teledeclaration_id = (
+                generated_from_groupe_diagnostic.teledeclaration_id if generated_from_groupe_diagnostic else None
+            )
+            generated_from_groupe_diagnostic_mode = (
+                generated_from_groupe_diagnostic.central_kitchen_diagnostic_mode
+                if generated_from_groupe_diagnostic
+                else None
             )
             result.append(
                 {
                     "year": year,
                     "is_teledeclared": is_teledeclared,
-                    f"declaration_donnees_{year}": getattr(canteen, f"declaration_donnees_{year}", None),
+                    "declaration_donnees": declaration_donnees,
                     "canteen_diagnostic_id": canteen_diagnostic_id,
-                    "groupe_diagnostic_id": groupe_diagnostic_id,
+                    "canteen_diagnostic_teledeclaration_mode": canteen_diagnostic_teledeclaration_mode,
                     "generated_from_groupe_diagnostic_id": generated_from_groupe_diagnostic_id,
+                    "generated_from_groupe_diagnostic_teledeclaration_id": generated_from_groupe_diagnostic_teledeclaration_id,
+                    "generated_from_groupe_diagnostic_mode": generated_from_groupe_diagnostic_mode,
                 }
             )
         return Response(result)


### PR DESCRIPTION
### Quoi

API interne qui va plus loin que #6974 (liste des bilans)

Renvoi une liste, avec pour chaque année
- year
- is_teledeclared
- declaration_donnees_year
- canteen_diagnostic_id
- groupe_diagnostic_id
- generated_from_groupe_diagnostic_id