### PR TITLE
fix(Trouver une cantine): corrige la recherche par commune et siren

### DIFF
--- a/api/tests/test_canteen_published.py
+++ b/api/tests/test_canteen_published.py
@@ -1133,6 +1133,18 @@ class PublishedCanteenDetailApiTest(APITestCase):
         body = response.json()
         self.assertEqual(len(body.get("approDiagnostics")), 1)
 
+    def test_search_by_siren(self):
+        siren = "110070018"
+        canteen_siret = CanteenFactory(siret="11007001800012")
+        canteen_siren = CanteenFactory(siren_unite_legale=siren, siret=None)
+        response = self.client.get(f"{reverse('published_canteens')}?search={siren}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        results = body.get("results")
+        self.assertEqual(body.get("count"), 2)
+        self.assertEqual(results[0]["id"], canteen_siren.id)
+        self.assertEqual(results[1]["id"], canteen_siret.id)
+
 
 class CanteenPreviewDetailApiTest(APITestCase):
     def test_get_single_public_canteen_preview(self):

--- a/api/views/canteen.py
+++ b/api/views/canteen.py
@@ -246,7 +246,7 @@ class PublishedCanteensView(ListAPIView):
         MaCantineOrderingFilter,
     ]
     # TODO: maybe add city/region/department name?
-    search_fields = ["name", "siret"]
+    search_fields = ["name", "siret", "siren_unite_legale"]
     ordering_fields = ["name", "creation_date", "modification_date", "daily_meal_count"]
     filterset_class = PublishedCanteenFilterSet
 

--- a/frontend/src/views/CanteensPage/CanteensHome.vue
+++ b/frontend/src/views/CanteensPage/CanteensHome.vue
@@ -11,7 +11,7 @@
               hide-details="auto"
               ref="search"
               v-model="searchTerm"
-              placeholder="Recherche par nom ou SIRET"
+              placeholder="Recherche par nom ou SIRET ou SIREN"
               @search="search"
               clearable
               @clear="clearSearch"

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -538,6 +538,7 @@ CSP_CONNECT_SRC = (
     "plateforme.adresse.data.gouv.fr",
     "raw.githubusercontent.com/betagouv/ma-cantine/",  # data/schemas/imports/
     "api.iconify.design",  # dsfr icon
+    "api-adresse.data.gouv.fr",  # search "Trouver une cantine"
 )
 if DEBUG:
     CSP_CONNECT_SRC += CSP_DEBUG_DOMAINS


### PR DESCRIPTION
Tickets : 
- https://app.notion.com/p/incubateur-masa/Bug-filtres-g-ographiques-dans-trouver-une-cantine-3b1de24614be80b4840fcd72e460d8be
- https://app.notion.com/p/incubateur-masa/Bug-moteur-de-recherche-les-cantines-SIREN-sont-masqu-es-par-les-cantines-SIRET-3b1de24614be803f9686f23b2b83c5ba