### PR TITLE
improve(Achats): Admin: fieldset & nouveau bouton "Restaurer" (si l'achat est archivé)

### DIFF
--- a/data/admin/purchase.py
+++ b/data/admin/purchase.py
@@ -34,20 +34,33 @@ class PurchaseAdmin(SoftDeletionAdmin):
     )
     search_help_text = f"Cherche sur les champs : Cantine (SIRET), {Purchase._meta.get_field('description').verbose_name.capitalize()}, {Purchase._meta.get_field('import_source').verbose_name.capitalize()}"
 
-    fields = (
-        "date",
-        "canteen",
-        "description",
-        "fournisseur",
-        "famille_produits",
-        "category",
-        "caracteristiques",
-        "prix_ht",
-        "definition_local",
-        "definition_local_km",
-        "facture",
-        *Purchase.CREATION_META_FIELDS,
-        "deletion_date",
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "date",
+                    "canteen",
+                    "description",
+                    "fournisseur",
+                    "famille_produits",
+                    "category",
+                    "caracteristiques",
+                    "prix_ht",
+                    "definition_local",
+                    "definition_local_km",
+                )
+            },
+        ),
+        ("Facture", {"fields": ("facture",)}),
+        ("Metadonnées", {"fields": (*Purchase.CREATION_META_FIELDS,)}),
+        (
+            "Supprimer (archiver)",
+            {
+                "description": "Un achat supprimé est un achat 'archivé' : il ne sera plus visible sur la plateforme mais il pourra être restauré à tout moment.",
+                "fields": ("deletion_date",),
+            },
+        ),
     )
 
     def get_queryset(self, request):
@@ -55,10 +68,10 @@ class PurchaseAdmin(SoftDeletionAdmin):
         qs = qs.prefetch_related("canteen")
         return qs
 
-    def get_readonly_fields(self, request, obj=None):
-        return [field for field in self.fields if field not in ("deletion_date",)]
-
     def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
         return False
 
     def save_model(self, request, obj, form, change):

--- a/data/admin/softdeletionadmin.py
+++ b/data/admin/softdeletionadmin.py
@@ -20,7 +20,7 @@ class SoftDeletionAdmin(admin.ModelAdmin):
 
     def delete_model(self, request, obj):
         # Note: it used to call obj.hard_delete()
-        obj.delete()
+        obj.delete(skip_validations=True)
 
     def delete_queryset(self, request, queryset):
         # Note: it used to return queryset.hard_delete()

--- a/data/templates/admin/data/purchase/change_form.html
+++ b/data/templates/admin/data/purchase/change_form.html
@@ -1,0 +1,38 @@
+{% extends "admin/change_form.html" %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const deleteLink = document.querySelector('a.deletelink');
+            if (deleteLink) {
+                // If purchase is deleted (has deletion_date), convert to restore button
+                {% if original.deletion_date %}
+                    const form = deleteLink.closest('form');
+
+                    // Change the link to a button
+                    deleteLink.removeAttribute('href');
+                    deleteLink.setAttribute('type', 'submit');
+                    deleteLink.style.cursor = 'pointer';
+
+                    // Change the text
+                    deleteLink.innerText = '🔄 Restaurer';
+
+                    // Add onclick handler to submit form with restore_action
+                    deleteLink.onclick = function(e) {
+                        e.preventDefault();
+                        const input = document.createElement('input');
+                        input.type = 'hidden';
+                        input.name = 'restore_action';
+                        input.value = '1';
+                        form.appendChild(input);
+                        form.submit();
+                    };
+                {% else %}
+                    // If purchase is active, just rename the Delete button
+                    deleteLink.innerText = '🗑️ Supprimer (archiver)';
+                {% endif %}
+            }
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
### Quoi

Suite à #6952 (même chose mais pour les cantines)
Ici on fait le changement pour les achats
- fieldset pour créer des sections
- formulaire readonly
- et expliciter l'action Supprimer / Restaurer

### Captures d'écran

|état de l'achat|Avant|Après|
|-|-|-|
|Achat actif||<img width="1271" height="622" alt="image" src="https://github.com/user-attachments/assets/206baa7c-46c2-4635-9505-205ca834700a" />|
|Achat supprimé||<img width="1271" height="622" alt="image" src="https://github.com/user-attachments/assets/285a80ea-3dd4-4c9f-8869-fafce604a2be" />|