### PR TITLE
refactor(Bilans): API: renvoyer des champs supplémentaire + ajouter de la pagination sur le nouvel endpoint 'liste'

### DIFF
--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -19,7 +19,13 @@ FIELDS = (
 )
 REQUIRED_FIELDS = ("year",)
 CREATE_ONLY_FIELDS = ("creation_source", *Diagnostic.MATOMO_FIELDS)
-READ_ONLY_FIELDS = ("id",)
+READ_ONLY_FIELDS = (
+    "id",
+    "status",
+    *Diagnostic.TELEDECLARATION_FIELDS,
+    "generated_from_groupe_diagnostic",
+    *Diagnostic.TELEDECLARATION_DATA_QUALITY_FIELDS,
+)
 
 
 class DiagnosticSerializer(serializers.ModelSerializer):
@@ -117,6 +123,9 @@ class ManagerDiagnosticSerializer(DiagnosticSerializer):
             + Diagnostic.MATOMO_FIELDS
             + ["creation_source", "creation_date", "modification_date"]
             + Diagnostic.TUNNEL_PROGRESS_FIELDS
+            + Diagnostic.TELEDECLARATION_FIELDS
+            + Diagnostic.TELEDECLARATION_DATA_QUALITY_FIELDS
+            + ["status", "generated_from_groupe_diagnostic", "creation_source", "creation_date", "modification_date"]
         )
 
     def get_fields(self):

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -55,11 +55,12 @@ class DiagnosticListApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(len(body), 3)
+        results = body["results"]
+        self.assertEqual(len(results), 3)
         # ordered by year ascending
-        self.assertEqual(body[0]["id"], self.diagnostic_2020.id)
-        self.assertEqual(body[1]["id"], self.diagnostic_2021_teledeclared.id)
-        self.assertEqual(body[2]["id"], self.diagnostic_2022_cancelled.id)
+        self.assertEqual(results[0]["id"], self.diagnostic_2020.id)
+        self.assertEqual(results[1]["id"], self.diagnostic_2021_teledeclared.id)
+        self.assertEqual(results[2]["id"], self.diagnostic_2022_cancelled.id)
 
     def test_list_diagnostics_via_oauth2(self):
         user, token = get_oauth2_token("canteen:read")
@@ -70,7 +71,8 @@ class DiagnosticListApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
-        self.assertEqual(len(body), 3)
+        results = body["results"]
+        self.assertEqual(len(results), 3)
 
 
 class DiagnosticCreateApiTest(APITestCase):

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -32,18 +32,29 @@ from macantine.utils import is_in_correction, CAMPAIGN_DATES
 logger = logging.getLogger(__name__)
 
 
+class LongPagination(LimitOffsetPagination):
+    default_limit = 100
+    max_limit = 100
+
+
 @extend_schema_view(
+    get=extend_schema(
+        summary="Lister les diagnostics d'une cantine.",
+        description="Retourne la liste des diagnostics d'une cantine.",
+        tags=["Bilans"],
+    ),
     post=extend_schema(
         summary="Créer un nouveau diagnostic.",
         description="Un diagnostic doit être rattaché à une cantine.",
         tags=["Bilans"],
-    )
+    ),
 )
 class DiagnosticListCreateView(ListCreateAPIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     required_scopes = ["canteen"]
     model = Diagnostic
     serializer_class = ManagerDiagnosticSerializer
+    pagination_class = LongPagination
 
     def _get_canteen(self):
         # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
@@ -190,16 +201,11 @@ class EmailDiagnosticImportFileView(APIView):
         return HttpResponse()
 
 
-class DiagnosticsToTeledeclarePagination(LimitOffsetPagination):
-    default_limit = 100
-    max_limit = 100
-
-
 class DiagnosticsToTeledeclareListView(ListAPIView):
     permission_classes = [IsAuthenticated]
     model = Diagnostic
     serializer_class = DiagnosticAndCanteenSerializer
-    pagination_class = DiagnosticsToTeledeclarePagination
+    pagination_class = LongPagination
     ordering = "modification_date"
 
     def get_queryset(self):

--- a/data/admin/diagnostic.py
+++ b/data/admin/diagnostic.py
@@ -188,8 +188,7 @@ class DiagnosticAdmin(SimpleHistoryAdmin):
             "Metadonnées",
             {
                 "fields": (
-                    "invalid_reason_list",
-                    "warning_reason_list",
+                    *Diagnostic.TELEDECLARATION_DATA_QUALITY_FIELDS,
                     *Diagnostic.CREATION_META_FIELDS,
                 )
             },
@@ -208,8 +207,7 @@ class DiagnosticAdmin(SimpleHistoryAdmin):
         "satellites_snapshot_pretty",
         "applicant_snapshot_pretty",
         "groupe_snapshot_pretty",
-        "invalid_reason_list",
-        "warning_reason_list",
+        *Diagnostic.TELEDECLARATION_DATA_QUALITY_FIELDS,
         *Diagnostic.CREATION_META_FIELDS,
     )
 

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -914,6 +914,10 @@ class Diagnostic(models.Model):
         "generated_from_groupe_diagnostic",
         "groupe_snapshot",
     ]
+    TELEDECLARATION_DATA_QUALITY_FIELDS = [
+        "invalid_reason_list",
+        "warning_reason_list",
+    ]
 
     APPRO_PERCENTAGE_PROPERTY_FIELDS = [
         "percentage_valeur_totale",


### PR DESCRIPTION
### Quoi

Dans #6974 on a créé un nouvel endpoint `canteens/<int:canteen_pk>/diagnostics`
Ici on rajoute
- de la pagination
- des champs supplémentaires dans le serializer (en lien avec la TD)