### PR TITLE
feat(Diagnostics): API: nouvel endpoint pour récupérer 1 de ses bilans

### DIFF
--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -486,17 +486,69 @@ class DiagnosticDetailApiTest(APITestCase):
         cls.canteen = CanteenFactory(managers=[cls.user])
         cls.diagnostic = DiagnosticFactory(year=2019, canteen=cls.canteen)
         cls.url = reverse(
-            "diagnostic_update",
+            "diagnostic_retrieve_update",
             kwargs={"canteen_pk": cls.diagnostic.canteen.id, "pk": cls.diagnostic.id},
         )
 
+    def test_cannot_retrieve_diagnostic_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     @authenticate
-    def test_cannot_get_diagnostic(self):
-        self.canteen.managers.add(authenticate.user)
+    def test_cannot_retrieve_diagnostic_if_canteen_unknown(self):
+        response = self.client.get(
+            reverse(
+                "diagnostic_retrieve_update",
+                kwargs={"canteen_pk": 9999, "pk": self.diagnostic.id},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_retrieve_diagnostic_if_not_canteen_manager(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_retrieve_diagnostic_if_diagnostic_unknown(self):
+        self.diagnostic.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(
+            reverse(
+                "diagnostic_retrieve_update",
+                kwargs={"canteen_pk": self.diagnostic.canteen.id, "pk": 9999},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_retrieve_diagnostic(self):
+        self.diagnostic.canteen.managers.add(authenticate.user)
 
         response = self.client.get(self.url)
 
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["id"], self.diagnostic.id)
+        self.assertEqual(body["year"], 2019)
+        self.assertEqual(body["canteenId"], self.canteen.id)
+
+    def test_retrieve_diagnostic_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:read")
+        self.diagnostic.canteen.managers.add(user)
+
+        self.client.credentials(Authorization=f"Bearer {token}")
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["id"], self.diagnostic.id)
+        self.assertEqual(body["year"], 2019)
+        self.assertEqual(body["canteenId"], self.canteen.id)
 
 
 class DiagnosticUpdateApiTest(APITestCase):
@@ -508,7 +560,7 @@ class DiagnosticUpdateApiTest(APITestCase):
             year=2019, canteen=cls.canteen, creation_user=cls.user, creation_source=CreationSource.APP
         )
         cls.url = reverse(
-            "diagnostic_update",
+            "diagnostic_retrieve_update",
             kwargs={"canteen_pk": cls.diagnostic.canteen.id, "pk": cls.diagnostic.id},
         )
 
@@ -534,7 +586,7 @@ class DiagnosticUpdateApiTest(APITestCase):
     def test_cannot_update_diagnostic_if_canteen_unknown(self):
         response = self.client.patch(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": 9999, "pk": self.diagnostic.id},
             ),
             {"year": 2020},
@@ -560,7 +612,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         response = self.client.patch(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": self.diagnostic.canteen.id, "pk": 9999},
             ),
             {"year": 2020},
@@ -578,7 +630,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         response = self.client.patch(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": self.diagnostic.canteen.id, "pk": diagnostic_other.id},
             ),
             {"year": 2020},
@@ -591,7 +643,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         response = self.client.patch(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": self.diagnostic.canteen.id, "pk": diagnostic_other.id},
             ),
             {"year": 2020},
@@ -681,7 +733,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         response = self.client.patch(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
@@ -704,7 +756,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         response = self.client.patch(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
@@ -728,7 +780,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         response = self.client.patch(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
@@ -752,7 +804,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         response = self.client.patch(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
@@ -773,7 +825,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         response = self.client.patch(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
@@ -795,7 +847,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         response = self.client.patch(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
@@ -816,7 +868,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         response = self.client.patch(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             ),
             payload,
@@ -844,7 +896,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
             response = self.client.patch(
                 reverse(
-                    "diagnostic_update",
+                    "diagnostic_retrieve_update",
                     kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
                 ),
                 payload,
@@ -863,7 +915,7 @@ class DiagnosticDeleteApiTest(APITestCase):
 
         response = self.client.delete(
             reverse(
-                "diagnostic_update",
+                "diagnostic_retrieve_update",
                 kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id},
             )
         )

--- a/api/urls.py
+++ b/api/urls.py
@@ -26,6 +26,7 @@ from api.views import (
     CommunityEventsView,
     DiagnosticListCreateView,
     DiagnosticListRecapView,
+    DiagnosticRetrieveUpdateView,
     DiagnosticsCompleteImportView,
     DiagnosticsFromPurchasesView,
     DiagnosticsSimpleImportView,
@@ -33,7 +34,6 @@ from api.views import (
     DiagnosticTeledeclarationCancelView,
     DiagnosticTeledeclarationCreateView,
     DiagnosticTeledeclarationPdfView,
-    DiagnosticUpdateView,
     EmailDiagnosticImportFileView,
     InitialDataView,
     InquiryView,
@@ -166,8 +166,8 @@ urlpatterns = {
     ),
     path(
         "canteens/<int:canteen_pk>/diagnostics/<int:pk>",
-        DiagnosticUpdateView.as_view(),
-        name="diagnostic_update",
+        DiagnosticRetrieveUpdateView.as_view(),
+        name="diagnostic_retrieve_update",
     ),
     path(
         "canteens/<int:canteen_pk>/diagnostics/recap",

--- a/api/urls.py
+++ b/api/urls.py
@@ -165,14 +165,14 @@ urlpatterns = {
         name="diagnostic_list_create",
     ),
     path(
-        "canteens/<int:canteen_pk>/diagnostics/<int:pk>",
-        DiagnosticRetrieveUpdateView.as_view(),
-        name="diagnostic_retrieve_update",
-    ),
-    path(
         "canteens/<int:canteen_pk>/diagnostics/recap",
         DiagnosticListRecapView.as_view(),
         name="diagnostic_list_recap",
+    ),
+    path(
+        "canteens/<int:canteen_pk>/diagnostics/<int:pk>",
+        DiagnosticRetrieveUpdateView.as_view(),
+        name="diagnostic_retrieve_update",
     ),
     path(
         "canteens/<int:canteen_pk>/diagnostics/<int:pk>/teledeclaration/create",

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -44,8 +44,8 @@ from .communityevent import CommunityEventsView  # noqa: F401
 from .diagnostic import (  # noqa: F401
     DiagnosticListCreateView,
     DiagnosticListRecapView,
+    DiagnosticRetrieveUpdateView,
     DiagnosticsToTeledeclareListView,
-    DiagnosticUpdateView,
     EmailDiagnosticImportFileView,
 )
 from .diagnostic_import import DiagnosticsCompleteImportView, DiagnosticsSimpleImportView  # noqa: F401

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -7,10 +7,10 @@ from django.db.models import Exists, OuterRef
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseServerError
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.generics import ListCreateAPIView, ListAPIView, UpdateAPIView, get_object_or_404
+from rest_framework.generics import ListAPIView, ListCreateAPIView, RetrieveUpdateAPIView, get_object_or_404
 from rest_framework.pagination import LimitOffsetPagination
-from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from api.exceptions import DuplicateException
 from api.permissions import (
@@ -27,7 +27,7 @@ from common.utils import file_import, send_mail
 from data.models import Canteen, Teledeclaration
 from data.models.creation_source import CreationSource
 from data.models.diagnostic import Diagnostic
-from macantine.utils import is_in_correction, CAMPAIGN_DATES
+from macantine.utils import CAMPAIGN_DATES, is_in_correction
 
 logger = logging.getLogger(__name__)
 
@@ -86,16 +86,21 @@ class DiagnosticListCreateView(ListCreateAPIView):
 
 
 @extend_schema_view(
+    get=extend_schema(
+        summary="Récupérer un diagnostic existant.",
+        description="",
+        tags=["Bilans"],
+    ),
     patch=extend_schema(
         summary="Modifier un diagnostic existant.",
         description="À noter qu'un diagnostic ne peut pas être modifié une fois qu'il a été télédéclaré. Pour ce faire, il faut d'abord annuler la télédéclaration.",
         tags=["Bilans"],
     ),
 )
-class DiagnosticUpdateView(UpdateAPIView):
+class DiagnosticRetrieveUpdateView(RetrieveUpdateAPIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     required_scopes = ["canteen"]
-    http_method_names = ["patch"]  # disable "put"
+    http_method_names = ["get", "patch"]  # disable "put"
     model = Diagnostic
     serializer_class = ManagerDiagnosticSerializer
 


### PR DESCRIPTION
### Quoi

Après avoir rajouté l'endpoint qui permettait de récupérer tout ses bilans: #6974
Ici on ouvre l'endpoint existant "update" à "retrieve"

`canteens/<int:canteen_pk>/diagnostics/<int:pk>`