### PR TITLE
feat(Diagnostics): API: nouvel endpoint /check qui renvoi des infos (is_filled, errors)

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -38,6 +38,7 @@ from .diagnostic import (  # noqa: F401
     DiagnosticAndCanteenSerializer,
     PublicApproDiagnosticSerializer,
     PublicServiceDiagnosticSerializer,
+    DiagnosticCheckSerializer,
 )
 from .diagnostic_teledeclaration import (  # noqa: F401
     DiagnosticTeledeclaredAnalysisSerializer,

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -68,6 +68,13 @@ class DiagnosticSerializer(serializers.ModelSerializer):
         return validated_data
 
 
+class DiagnosticCheckSerializer(serializers.Serializer):
+    is_filled = serializers.BooleanField(read_only=True)
+    # infos = serializers.DictField(read_only=True)
+    # warnings = serializers.DictField(read_only=True)
+    errors = serializers.DictField(read_only=True)
+
+
 class CentralKitchenDiagnosticSerializer(DiagnosticSerializer):
     """
     This serializer masks financial data and gives the basic information on appro as percentages

--- a/api/tests/test_canteens.py
+++ b/api/tests/test_canteens.py
@@ -463,10 +463,13 @@ class CanteenDetailApiTest(APITestCase):
 
 
 class CanteenDetailCheckApiTest(APITestCase):
-    def test_cannot_get_canteen_check_if_unauthenticated(self):
-        canteen = CanteenFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.url = reverse("canteen_check", kwargs={"canteen_pk": cls.canteen.id})
 
-        response = self.client.get(reverse("canteen_check", kwargs={"canteen_pk": canteen.id}))
+    def test_cannot_get_canteen_check_if_unauthenticated(self):
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -478,17 +481,27 @@ class CanteenDetailCheckApiTest(APITestCase):
 
     @authenticate
     def test_cannot_get_canteen_check_if_not_manager(self):
-        canteen = CanteenFactory()
-
-        response = self.client.get(reverse("canteen_check", kwargs={"canteen_pk": canteen.id}))
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
-    def test_get_canteen_check_without_errors(self):
-        canteen = CanteenFactory(managers=[authenticate.user])
+    def test_get_canteen_check(self):
+        self.canteen.managers.add(authenticate.user)
 
-        response = self.client.get(reverse("canteen_check", kwargs={"canteen_pk": canteen.id}))
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["isFilled"], True)
+        self.assertEqual(body["errors"], {})
+
+    def test_can_get_canteen_check_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:read")
+        self.canteen.managers.add(user)
+
+        self.client.credentials(Authorization=f"Bearer {token}")
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -497,12 +510,12 @@ class CanteenDetailCheckApiTest(APITestCase):
 
     @authenticate
     def test_get_canteen_check_with_errors(self):
-        canteen = CanteenFactory(managers=[authenticate.user])
-        canteen.siret = "invalid_siret"
-        canteen.sector_list = []
-        canteen.save(skip_validations=True)
+        self.canteen.managers.add(authenticate.user)
+        self.canteen.siret = "invalid_siret"
+        self.canteen.sector_list = []
+        self.canteen.save(skip_validations=True)
 
-        response = self.client.get(reverse("canteen_check", kwargs={"canteen_pk": canteen.id}))
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -1150,3 +1150,73 @@ class DiagnosticListRecapApiTest(APITestCase):
         self.assertEqual(body[0]["canteenDiagnosticId"], None)
         self.assertIsNotNone(body[0]["generatedFromGroupeDiagnosticId"])
         self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], Diagnostic.CentralKitchenDiagnosticMode.ALL)
+
+
+class DiagnosticDetailCheckApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.canteen = CanteenFactory(managers=[cls.user])
+        cls.diagnostic = DiagnosticFactory(year=2019, canteen=cls.canteen)
+        cls.url = reverse(
+            "diagnostic_check",
+            kwargs={"canteen_pk": cls.canteen.id, "pk": cls.diagnostic.id},
+        )
+
+    def test_cannot_get_diagnostic_check_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_get_diagnostic_check_if_canteen_does_not_exist(self):
+        response = self.client.get(
+            reverse(
+                "diagnostic_check",
+                kwargs={"canteen_pk": 9999, "pk": self.diagnostic.id},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_get_diagnostic_check_if_not_canteen_manager(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_get_diagnostic_check_if_diagnostic_does_not_exist(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(
+            reverse(
+                "diagnostic_check",
+                kwargs={"canteen_pk": self.canteen.id, "pk": 9999},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_can_get_diagnostic_check(self):
+        self.canteen.managers.add(authenticate.user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["isFilled"], True)
+        self.assertEqual(body["errors"], {})
+
+    def test_can_get_diagnostic_check_via_oauth2(self):
+        user, token = get_oauth2_token("canteen:read")
+        self.canteen.managers.add(user)
+
+        self.client.credentials(Authorization=f"Bearer {token}")
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["isFilled"], True)
+        self.assertEqual(body["errors"], {})

--- a/api/tests/test_diagnostics.py
+++ b/api/tests/test_diagnostics.py
@@ -484,7 +484,7 @@ class DiagnosticDetailApiTest(APITestCase):
     def setUpTestData(cls):
         cls.user = UserFactory()
         cls.canteen = CanteenFactory(managers=[cls.user])
-        cls.diagnostic = DiagnosticFactory(year=2019, canteen=cls.canteen)
+        cls.diagnostic = DiagnosticFactory(year=2025, canteen=cls.canteen)
         cls.url = reverse(
             "diagnostic_retrieve_update",
             kwargs={"canteen_pk": cls.diagnostic.canteen.id, "pk": cls.diagnostic.id},
@@ -534,7 +534,7 @@ class DiagnosticDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["id"], self.diagnostic.id)
-        self.assertEqual(body["year"], 2019)
+        self.assertEqual(body["year"], 2025)
         self.assertEqual(body["canteenId"], self.canteen.id)
 
     def test_retrieve_diagnostic_via_oauth2(self):
@@ -547,7 +547,7 @@ class DiagnosticDetailApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
         self.assertEqual(body["id"], self.diagnostic.id)
-        self.assertEqual(body["year"], 2019)
+        self.assertEqual(body["year"], 2025)
         self.assertEqual(body["canteenId"], self.canteen.id)
 
 
@@ -557,7 +557,7 @@ class DiagnosticUpdateApiTest(APITestCase):
         cls.user = UserFactory()
         cls.canteen = CanteenFactory(managers=[cls.user])
         cls.diagnostic = DiagnosticFactory(
-            year=2019, canteen=cls.canteen, creation_user=cls.user, creation_source=CreationSource.APP
+            year=2025, canteen=cls.canteen, creation_user=cls.user, creation_source=CreationSource.APP
         )
         cls.url = reverse(
             "diagnostic_retrieve_update",
@@ -580,7 +580,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.diagnostic.refresh_from_db()
-        self.assertEqual(self.diagnostic.year, 2019)
+        self.assertEqual(self.diagnostic.year, 2025)
 
     @authenticate
     def test_cannot_update_diagnostic_if_canteen_unknown(self):
@@ -594,7 +594,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.diagnostic.refresh_from_db()
-        self.assertEqual(self.diagnostic.year, 2019)
+        self.assertEqual(self.diagnostic.year, 2025)
 
     @authenticate
     def test_cannot_update_diagnostic_if_not_canteen_manager(self):
@@ -604,7 +604,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.diagnostic.refresh_from_db()
-        self.assertEqual(self.diagnostic.year, 2019)
+        self.assertEqual(self.diagnostic.year, 2025)
 
     @authenticate
     def test_cannot_update_diagnostic_if_diagnostic_unknown(self):
@@ -620,7 +620,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.diagnostic.refresh_from_db()
-        self.assertEqual(self.diagnostic.year, 2019)
+        self.assertEqual(self.diagnostic.year, 2025)
 
     @authenticate
     def test_cannot_update_diagnostic_if_not_corresponding_canteen(self):
@@ -727,7 +727,7 @@ class DiagnosticUpdateApiTest(APITestCase):
         """
         Do not save edits to a diagnostic which make the sum of the values > total
         """
-        diagnostic = DiagnosticFactory(year=2019, valeur_totale=10, valeur_bio=5, valeur_siqo=2)
+        diagnostic = DiagnosticFactory(year=2025, valeur_totale=10, valeur_bio=5, valeur_siqo=2)
         diagnostic.canteen.managers.add(authenticate.user)
         payload = {"valeur_siqo": 999}
 
@@ -910,7 +910,7 @@ class DiagnosticUpdateApiTest(APITestCase):
 class DiagnosticDeleteApiTest(APITestCase):
     @authenticate
     def test_cannot_delete_diagnostic(self):
-        diagnostic = DiagnosticFactory(year=2019)
+        diagnostic = DiagnosticFactory(year=2025)
         diagnostic.canteen.managers.add(authenticate.user)
 
         response = self.client.delete(
@@ -1152,12 +1152,23 @@ class DiagnosticListRecapApiTest(APITestCase):
         self.assertEqual(body[0]["generatedFromGroupeDiagnosticMode"], Diagnostic.CentralKitchenDiagnosticMode.ALL)
 
 
+@freeze_time("2026-03-30")  # during the 2025 campaign
 class DiagnosticDetailCheckApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
         cls.canteen = CanteenFactory(managers=[cls.user])
-        cls.diagnostic = DiagnosticFactory(year=2019, canteen=cls.canteen)
+        cls.diagnostic = DiagnosticFactory(
+            year=2025,
+            canteen=cls.canteen,
+            diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
+            valeur_totale=1000,
+            valeur_bio=200,
+            valeur_siqo=100,
+            valeur_egalim_autres=100,
+            valeur_viandes_volailles=100,
+            valeur_viandes_volailles_egalim=0,
+        )
         cls.url = reverse(
             "diagnostic_check",
             kwargs={"canteen_pk": cls.canteen.id, "pk": cls.diagnostic.id},
@@ -1220,3 +1231,19 @@ class DiagnosticDetailCheckApiTest(APITestCase):
         body = response.json()
         self.assertEqual(body["isFilled"], True)
         self.assertEqual(body["errors"], {})
+
+    @authenticate
+    def test_can_get_diagnostic_check_with_errors(self):
+        self.canteen.managers.add(authenticate.user)
+        self.diagnostic.valeur_totale = None
+        self.diagnostic.valeur_bio = None
+        self.diagnostic.save()
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["isFilled"], False)
+        self.assertNotEqual(body["errors"], {})
+        self.assertEqual(body["errors"]["valeurTotale"], ["Ce champ est obligatoire pour l'année 2025."])
+        self.assertEqual(body["errors"]["valeurBio"], ["Ce champ est obligatoire pour l'année 2025."])

--- a/api/urls.py
+++ b/api/urls.py
@@ -24,6 +24,7 @@ from api.views import (
     ChangePasswordView,
     ClaimCanteenView,
     CommunityEventsView,
+    DiagnosticCheckView,
     DiagnosticListCreateView,
     DiagnosticListRecapView,
     DiagnosticRetrieveUpdateView,
@@ -173,6 +174,11 @@ urlpatterns = {
         "canteens/<int:canteen_pk>/diagnostics/<int:pk>",
         DiagnosticRetrieveUpdateView.as_view(),
         name="diagnostic_retrieve_update",
+    ),
+    path(
+        "canteens/<int:canteen_pk>/diagnostics/<int:pk>/check",
+        DiagnosticCheckView.as_view(),
+        name="diagnostic_check",
     ),
     path(
         "canteens/<int:canteen_pk>/diagnostics/<int:pk>/teledeclaration/create",

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -44,6 +44,7 @@ from .communityevent import CommunityEventsView  # noqa: F401
 from .diagnostic import (  # noqa: F401
     DiagnosticListCreateView,
     DiagnosticListRecapView,
+    DiagnosticCheckView,
     DiagnosticRetrieveUpdateView,
     DiagnosticsToTeledeclareListView,
     EmailDiagnosticImportFileView,

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -21,6 +21,7 @@ from api.permissions import (
 from api.serializers import (
     DiagnosticAndCanteenSerializer,
     ManagerDiagnosticSerializer,
+    DiagnosticCheckSerializer,
 )
 from api.views.utils import get_oauth_application, update_change_reason_with_auth
 from common.utils import file_import, send_mail
@@ -168,6 +169,28 @@ class DiagnosticListRecapView(APIView):
                 }
             )
         return Response(result)
+
+
+class DiagnosticCheckView(APIView):
+    permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
+    required_scopes = ["canteen"]
+
+    def _get_canteen(self):
+        # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
+        return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
+
+    def get(self, request, canteen_pk, pk):
+        canteen = self._get_canteen()
+        diagnostic = get_object_or_404(Diagnostic, pk=self.kwargs["pk"], canteen=canteen)
+
+        errors = {}
+        try:
+            diagnostic.full_clean()
+        except ValidationError as e:
+            errors = e.message_dict
+
+        response = {"is_filled": diagnostic.is_filled, "errors": errors}
+        return Response(DiagnosticCheckSerializer(response).data)
 
 
 class EmailDiagnosticImportFileView(APIView):

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -40,13 +40,13 @@ class LongPagination(LimitOffsetPagination):
 
 @extend_schema_view(
     get=extend_schema(
-        summary="Lister les diagnostics d'une cantine.",
-        description="Retourne la liste des diagnostics d'une cantine.",
+        summary="Lister les bilans d'une cantine.",
+        description="Retourne la liste des bilans d'une cantine.",
         tags=["Bilans"],
     ),
     post=extend_schema(
-        summary="Créer un nouveau diagnostic.",
-        description="Un diagnostic doit être rattaché à une cantine.",
+        summary="Créer un nouveau bilan.",
+        description="Un bilan doit être rattaché à une cantine.",
         tags=["Bilans"],
     ),
 )
@@ -88,13 +88,13 @@ class DiagnosticListCreateView(ListCreateAPIView):
 
 @extend_schema_view(
     get=extend_schema(
-        summary="Récupérer un diagnostic existant.",
+        summary="Récupérer un bilan existant.",
         description="",
         tags=["Bilans"],
     ),
     patch=extend_schema(
-        summary="Modifier un diagnostic existant.",
-        description="À noter qu'un diagnostic ne peut pas être modifié une fois qu'il a été télédéclaré. Pour ce faire, il faut d'abord annuler la télédéclaration.",
+        summary="Modifier un bilan existant.",
+        description="À noter qu'un bilan ne peut pas être modifié une fois qu'il a été télédéclaré. Pour ce faire, il faut d'abord annuler la télédéclaration.",
         tags=["Bilans"],
     ),
 )
@@ -171,6 +171,14 @@ class DiagnosticListRecapView(APIView):
         return Response(result)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Vérifier les erreurs de validation pour un bilan.",
+        description="Retourne toutes les erreurs de validation potentielles pour un bilan (champs manquants, valeurs invalides, etc.).",
+        tags=["Bilans"],
+        responses=DiagnosticCheckSerializer,
+    )
+)
 class DiagnosticCheckView(APIView):
     permission_classes = [IsAuthenticatedOrTokenHasResourceScope, IsCanteenManagerUrlParam]
     required_scopes = ["canteen"]


### PR DESCRIPTION
### Quoi

Suite à l'endpoint "diagnostic detail" (#6990)
Et similaire à l'endpoint "canteen detail check" (#6914)

Nouvel endpoint "diagnostic detail check"

`canteens/<int:canteen_pk>/diagnostics/<int:pk>/check`

### v1

pour l'instant on renvoi simplement le isFilled et les "errors".
en v2, et après avoir rajouté les nouveaux champs / nouvelles règles, on enrichira avec les blocs fonctionnels