### PR TITLE
improve(Diagnostics): Règle métier: s'assurer que le télédéclarant fait partie des gestionnaires

### DIFF
--- a/api/tests/test_canteen_published.py
+++ b/api/tests/test_canteen_published.py
@@ -1140,14 +1140,12 @@ class PublishedCanteenDetailApiTest(APITestCase):
 
     @freeze_time("2024-02-10")  # during the 2023 campaign
     def test_td_diags_not_redacted(self):
-        """
-        A teledeclared diagnostic cannot be redacted
-        """
-        canteen = CanteenFactory(redacted_appro_years=[2022, 2023])
+        user = UserFactory()
+        canteen = CanteenFactory(redacted_appro_years=[2022, 2023], managers=[user])
 
         DiagnosticFactory(canteen=canteen, year=2022)
         diagnostic = DiagnosticFactory(canteen=canteen, year=2023)
-        diagnostic.teledeclare(applicant=UserFactory())
+        diagnostic.teledeclare(applicant=user)
         TeledeclarationFactory(
             diagnostic=diagnostic, status=Teledeclaration.TeledeclarationStatus.SUBMITTED, declared_data={"foo": "bar"}
         )

--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -18,6 +18,7 @@ STATS_ENDPOINT_QUERY_COUNT = 7
 class CanteenStatsApiTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
+        user = UserFactory()
         with freeze_time(date_in_2023_teledeclaration_campaign):
             cls.canteen_1 = CanteenFactory(
                 siret="21010034300016",
@@ -30,6 +31,7 @@ class CanteenStatsApiTest(APITestCase):
                 management_type=Canteen.ManagementType.DIRECT,
                 production_type=Canteen.ProductionType.CENTRAL,
                 economic_model=Canteen.EconomicModel.PUBLIC,
+                managers=[user],
             )
             canteen_diagnostic_1 = DiagnosticFactory(
                 canteen=cls.canteen_1,
@@ -46,7 +48,7 @@ class CanteenStatsApiTest(APITestCase):
                 plastic_tableware_substituted=False,
                 communicates_on_food_quality=False,
             )
-            canteen_diagnostic_1.teledeclare(applicant=UserFactory())
+            canteen_diagnostic_1.teledeclare(applicant=user)
             cls.canteen_2 = CanteenFactory(
                 siret="40419443300078",
                 city_insee_code="69123",
@@ -58,6 +60,7 @@ class CanteenStatsApiTest(APITestCase):
                 management_type=Canteen.ManagementType.DIRECT,
                 production_type=Canteen.ProductionType.CENTRAL_SERVING,
                 economic_model=Canteen.EconomicModel.PUBLIC,
+                managers=[user],
             )
             canteen_diagnostic_2 = DiagnosticFactory(
                 canteen=cls.canteen_2,
@@ -78,7 +81,7 @@ class CanteenStatsApiTest(APITestCase):
                 plastic_tableware_substituted=True,
                 communicates_on_food_quality=True,
             )
-            canteen_diagnostic_2.teledeclare(applicant=UserFactory())
+            canteen_diagnostic_2.teledeclare(applicant=user)
             cls.canteen_3 = CanteenFactory(
                 siret="21380185500015",
                 city_insee_code="38185",
@@ -90,6 +93,7 @@ class CanteenStatsApiTest(APITestCase):
                 management_type=Canteen.ManagementType.CONCEDED,
                 production_type=Canteen.ProductionType.ON_SITE,
                 economic_model=Canteen.EconomicModel.PRIVATE,
+                managers=[user],
             )
             canteen_diagnostic_3 = DiagnosticFactory(
                 canteen=cls.canteen_3,
@@ -106,7 +110,7 @@ class CanteenStatsApiTest(APITestCase):
                 plastic_tableware_substituted=True,
                 communicates_on_food_quality=True,
             )
-            canteen_diagnostic_3.teledeclare(applicant=UserFactory())
+            canteen_diagnostic_3.teledeclare(applicant=user)
             cls.canteen_4 = CanteenFactory(
                 siret="21590350100017",
                 city_insee_code="59350",
@@ -232,7 +236,8 @@ class CanteenStatsApiTest(APITestCase):
         date_in_2022_teledeclaration_campaign = "2022-08-30"
 
         with freeze_time(date_in_2022_teledeclaration_campaign):
-            canteen = CanteenFactory(siret="11007001800012")
+            user = UserFactory()
+            canteen = CanteenFactory(siret="11007001800012", managers=[user])
             # Diagnostic that should display 20% Bio and 45% other EGalim
             canteen_diagnostic = DiagnosticFactory(
                 diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
@@ -250,7 +255,7 @@ class CanteenStatsApiTest(APITestCase):
                 valeur_produits_de_la_mer=10,
                 valeur_produits_de_la_mer_egalim=8,
             )
-            canteen_diagnostic.teledeclare(applicant=UserFactory())
+            canteen_diagnostic.teledeclare(applicant=user)
 
         response = self.client.get(self.url, {"year": past_year})
 
@@ -275,7 +280,8 @@ class CanteenStatsApiTest(APITestCase):
         date_in_2022_teledeclaration_campaign = "2022-08-30"
 
         with freeze_time(date_in_2022_teledeclaration_campaign):
-            canteen = CanteenFactory(siret="11007001800012")
+            user = UserFactory()
+            canteen = CanteenFactory(siret="11007001800012", managers=[user])
             # Diagnostic that should display 20% Bio and 45% other EGalim
             canteen_diagnostic = DiagnosticFactory(
                 diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
@@ -293,7 +299,7 @@ class CanteenStatsApiTest(APITestCase):
                 valeur_produits_de_la_mer=10,
                 valeur_produits_de_la_mer_egalim=8,
             )
-            canteen_diagnostic.teledeclare(applicant=UserFactory())
+            canteen_diagnostic.teledeclare(applicant=user)
 
         response = self.client.get(self.url, {"year": past_year})
 

--- a/api/tests/test_diagnostic_teledeclaration.py
+++ b/api/tests/test_diagnostic_teledeclaration.py
@@ -434,9 +434,9 @@ class DiagnosticTeledeclarationCancelView(APITestCase):
         user = UserFactory()
         self.canteen_site.managers.add(user)
         diagnostic = DiagnosticFactory(canteen=self.canteen_site, year=2024)
-        # authenticate.user is not a manager of the canteen_site
-        diagnostic.teledeclare(authenticate.user)
+        diagnostic.teledeclare(user)
 
+        # teledeclared by user, but authenticate.user is not a manager
         response = self.client.post(
             reverse(
                 "diagnostic_teledeclaration_cancel",
@@ -599,10 +599,12 @@ class DiagnosticTeledeclarationPdfApiTest(APITestCase):
     @freeze_time("2025-03-30")  # during the 2024 campaign
     @authenticate
     def test_cannot_generate_pdf_if_not_canteen_manager(self):
+        user = UserFactory()
         diagnostic = DiagnosticFactory(year=2024)
-        # authenticate.user is not a manager of the canteen
-        diagnostic.teledeclare(authenticate.user)
+        diagnostic.canteen.managers.add(user)
+        diagnostic.teledeclare(user)
 
+        # teledeclared by user, but authenticate.user is not a manager
         response = self.client.get(
             reverse(
                 "diagnostic_teledeclaration_pdf", kwargs={"canteen_pk": diagnostic.canteen.id, "pk": diagnostic.id}

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -2180,7 +2180,8 @@ class Diagnostic(models.Model):
                     raise ValidationError(
                         f"{self.canteen.satellites_missing_data_count} satellites du groupe associée à ce diagnostic ne sont pas remplis"
                     )
-            # TODO: check if the applicant is in the canteen.managers ?
+            if applicant not in self.canteen.managers.all():
+                raise ValidationError("Le déclarant n'est pas un gestionnaire de la cantine associée à ce diagnostic")
             # TODO: run diagnostic.full_clean() (validators) ?
 
         from api.serializers import CanteenTeledeclarationSerializer, SatelliteTeledeclarationSerializer

--- a/data/tests/test_canteen.py
+++ b/data/tests/test_canteen.py
@@ -813,6 +813,7 @@ class CanteenNotDeletedBeforeQuerySetTest(TestCase):
 class CanteenCentralAndSatelliteQuerySetAndPropertyTest(TestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.user = UserFactory()
         cls.canteen_groupe_with_satellite = CanteenFactory(
             siren_unite_legale="756656218", production_type=Canteen.ProductionType.GROUPE, economic_model=None
         )
@@ -902,8 +903,9 @@ class CanteenCentralAndSatelliteQuerySetAndPropertyTest(TestCase):
         self.assertEqual(self.canteen_groupe_with_satellite.satellites_already_teledeclared_count, 0)
         self.assertEqual(self.canteen_groupe_with_satellite.satellites_count, 1)
         # create a diagnostic for the autonomous satellite and teledeclare it
+        self.canteen_satellite_4.managers.add(self.user)
         diagnostic_satellite_4 = DiagnosticFactory(canteen=self.canteen_satellite_4, year=2025)
-        diagnostic_satellite_4.teledeclare(applicant=UserFactory())
+        diagnostic_satellite_4.teledeclare(applicant=self.user)
         self.assertEqual(diagnostic_satellite_4.is_teledeclared, True)
         # link satellite to groupe
         self.canteen_satellite_4.groupe = self.canteen_groupe_with_satellite
@@ -982,9 +984,10 @@ class CanteenPurchaseQuerySetTest(TestCase):
 class CanteenDiagnosticTeledeclarationQuerySetTest(TestCase):
     @classmethod
     def setUpTestData(cls):
+        user = UserFactory()
         CanteenFactory()
-        canteen_with_diagnostic_teledeclared = CanteenFactory()
-        canteen_with_diagnostic_cancelled = CanteenFactory()
+        canteen_with_diagnostic_teledeclared = CanteenFactory(managers=[user])
+        canteen_with_diagnostic_cancelled = CanteenFactory(managers=[user])
         cls.diagnostic_filled_teledeclared = DiagnosticFactory(
             canteen=canteen_with_diagnostic_teledeclared,
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
@@ -1004,8 +1007,8 @@ class CanteenDiagnosticTeledeclarationQuerySetTest(TestCase):
             valeur_totale=None,
         )  # missing data
         with freeze_time("2025-03-30"):  # during the 2024 campaign
-            cls.diagnostic_filled_teledeclared.teledeclare(applicant=UserFactory())
-            cls.diagnostic_filled_cancelled.teledeclare(applicant=UserFactory())
+            cls.diagnostic_filled_teledeclared.teledeclare(applicant=user)
+            cls.diagnostic_filled_cancelled.teledeclare(applicant=user)
             cls.diagnostic_filled_cancelled.cancel()
 
     def test_annotate_with_diagnostic_for_year(self):

--- a/data/tests/test_canteen_action.py
+++ b/data/tests/test_canteen_action.py
@@ -426,9 +426,7 @@ class CanteenActionTestCase(TestCase):
         )
 
         # groupe with satellites and satellite has diagnostic teledeclared
-        canteen_satellite_11_diagnostic_2024.teledeclare(
-            applicant=self.canteen_groupe_1_with_satellites.managers.first()
-        )
+        canteen_satellite_11_diagnostic_2024.teledeclare(applicant=self.canteen_satellite_11.managers.first())
 
         canteen_qs = Canteen.objects.annotate_with_action_for_year(2024)
 

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -107,7 +107,7 @@ class DiagnosticModelSaveTest(TransactionTestCase):
         # CORRECTION diagnostic can be edited during the campaign & correction but not after correction
         with freeze_time("2025-01-20"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2024)
-            diagnostic.teledeclare(applicant=UserFactory(), skip_validations=True)
+            diagnostic.teledeclare(applicant=diagnostic.canteen.managers.first(), skip_validations=True)
         with freeze_time("2025-04-18"):  # during the 2024 correction campaign
             diagnostic.cancel()
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
@@ -119,7 +119,7 @@ class DiagnosticModelSaveTest(TransactionTestCase):
         # SUBMITTED diagnostic can be edited during the campaign & correction but not after campaign
         with freeze_time("2025-01-20"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2024)
-            diagnostic.teledeclare(applicant=UserFactory(), skip_validations=True)
+            diagnostic.teledeclare(applicant=diagnostic.canteen.managers.first(), skip_validations=True)
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.SUBMITTED)
             diagnostic.full_clean()  # should not raise
         with freeze_time("2025-04-18"):  # during the 2024 correction campaign
@@ -413,7 +413,7 @@ class DiagnosticQuerySetTest(TestCase):
                 valeur_egalim_autres=100.00,
             )
             with freeze_time(date_in_teledeclaration_campaign):
-                diagnostic.teledeclare(applicant=UserFactory(), skip_validations=True)
+                diagnostic.teledeclare(applicant=canteen.managers.first(), skip_validations=True)
             diagnostic_last_year = DiagnosticFactory(
                 diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
                 year=year_data - 1,
@@ -423,7 +423,7 @@ class DiagnosticQuerySetTest(TestCase):
                 valeur_bio=200.00,
             )
             with freeze_time(date_in_last_teledeclaration_campaign):
-                diagnostic_last_year.teledeclare(applicant=UserFactory(), skip_validations=True)
+                diagnostic_last_year.teledeclare(applicant=canteen.managers.first(), skip_validations=True)
             setattr(cls, f"diagnostic_canteen_valid_{index + 1}", diagnostic)
             setattr(cls, f"diagnostic_last_year_canteen_valid_{index + 1}", diagnostic_last_year)
 
@@ -437,7 +437,9 @@ class DiagnosticQuerySetTest(TestCase):
             invalid_reason_list=[Diagnostic.InvalidReason.CANTINE_SANS_SIRET_OU_SIREN],
         )
         with freeze_time(date_in_teledeclaration_campaign):
-            cls.diagnostic_canteen_missing_siret.teledeclare(applicant=UserFactory(), skip_validations=True)
+            cls.diagnostic_canteen_missing_siret.teledeclare(
+                applicant=cls.canteen_missing_siret.managers.first(), skip_validations=True
+            )
 
         cls.diagnostic_canteen_cout_repas_aberrant = DiagnosticFactory(
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
@@ -449,7 +451,9 @@ class DiagnosticQuerySetTest(TestCase):
             invalid_reason_list=[],  # not aberrant
         )
         with freeze_time(date_in_teledeclaration_campaign):
-            cls.diagnostic_canteen_cout_repas_aberrant.teledeclare(applicant=UserFactory())
+            cls.diagnostic_canteen_cout_repas_aberrant.teledeclare(
+                applicant=cls.canteen_cout_repas_aberrant.managers.first(), skip_validations=True
+            )
 
         cls.diagnostic_canteen_valeur_totale_aberrant = DiagnosticFactory(
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
@@ -461,7 +465,9 @@ class DiagnosticQuerySetTest(TestCase):
             invalid_reason_list=[],
         )
         with freeze_time(date_in_teledeclaration_campaign):
-            cls.diagnostic_canteen_valeur_totale_aberrant.teledeclare(applicant=UserFactory())
+            cls.diagnostic_canteen_valeur_totale_aberrant.teledeclare(
+                applicant=cls.canteen_valeur_totale_aberrant.managers.first(), skip_validations=True
+            )
 
         cls.diagnostic_canteen_aberrant = DiagnosticFactory(
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
@@ -473,7 +479,9 @@ class DiagnosticQuerySetTest(TestCase):
             invalid_reason_list=[Diagnostic.InvalidReason.VALEURS_ABERRANTES],
         )
         with freeze_time(date_in_teledeclaration_campaign):
-            cls.diagnostic_canteen_aberrant.teledeclare(applicant=UserFactory())
+            cls.diagnostic_canteen_aberrant.teledeclare(
+                applicant=cls.canteen_aberrant.managers.first(), skip_validations=True
+            )
 
         cls.diagnostic_canteen_aberrant_2025 = DiagnosticFactory(
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
@@ -485,7 +493,9 @@ class DiagnosticQuerySetTest(TestCase):
             invalid_reason_list=[Diagnostic.InvalidReason.VALEURS_ABERRANTES],
         )
         with freeze_time("2026-03-15"):  # during the 2025 campaign
-            cls.diagnostic_canteen_aberrant_2025.teledeclare(applicant=UserFactory())
+            cls.diagnostic_canteen_aberrant_2025.teledeclare(
+                applicant=cls.canteen_aberrant.managers.first(), skip_validations=True
+            )
 
         cls.diagnostic_canteen_deleted = DiagnosticFactory(
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
@@ -497,7 +507,9 @@ class DiagnosticQuerySetTest(TestCase):
             invalid_reason_list=[Diagnostic.InvalidReason.CANTINE_SOFT_SUPPRIMEE_PENDANT_CAMPAGNE],
         )
         with freeze_time(date_in_teledeclaration_campaign):
-            cls.diagnostic_canteen_deleted.teledeclare(applicant=UserFactory())
+            cls.diagnostic_canteen_deleted.teledeclare(
+                applicant=cls.canteen_deleted.managers.first(), skip_validations=True
+            )
 
     def test_count(self):
         self.assertEqual(Diagnostic.objects.count(), 18)
@@ -900,11 +912,13 @@ class DiagnosticMealPriceQuerySetAndPropertyTest(TestCase):
                 valeur_totale=Decimal("100000.50"),
                 valeur_bio=2000,
             )
-            cls.diagnostic_groupe_teledeclared.teledeclare(applicant=UserFactory())
+            cls.diagnostic_groupe_teledeclared.teledeclare(applicant=cls.canteen_groupe_teledeclared.managers.first())
             cls.diagnostic_satellite_teledeclared = DiagnosticFactory(
                 canteen=cls.canteen_satellite_teledeclared, year=year_data, valeur_totale=None
             )
-            cls.diagnostic_satellite_teledeclared.teledeclare(applicant=UserFactory())
+            cls.diagnostic_satellite_teledeclared.teledeclare(
+                applicant=cls.canteen_satellite_teledeclared.managers.first()
+            )
             cls.diagnostic_satellite_draft = DiagnosticFactory(
                 canteen=cls.canteen_satellite_draft, year=year_data, valeur_totale=None
             )
@@ -1023,7 +1037,7 @@ class DiagnosticModelDeleteTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
-        cls.canteen_site = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+        cls.canteen_site = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[cls.user])
         cls.diagnostic = DiagnosticFactory(
             canteen=cls.canteen_site,
             year=year_data,

--- a/data/tests/test_diagnostic_teledeclaration.py
+++ b/data/tests/test_diagnostic_teledeclaration.py
@@ -15,6 +15,7 @@ date_in_last_teledeclaration_campaign = "2024-02-01"  # during the 2023 campaign
 class DiagnosticTeledeclaredQuerySetAndPropertyTest(TestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.user = UserFactory()
         cls.diagnostic_not_filled_draft = DiagnosticFactory(
             year=year_data, canteen=CanteenFactory(), valeur_totale=None
         )
@@ -26,8 +27,10 @@ class DiagnosticTeledeclaredQuerySetAndPropertyTest(TestCase):
             year=year_data, canteen=CanteenFactory(), valeur_totale=1000
         )
         with freeze_time(date_in_teledeclaration_campaign):
-            cls.diagnostic_filled_submitted.teledeclare(applicant=UserFactory())
-            cls.diagnostic_filled_cancelled.teledeclare(applicant=UserFactory())
+            cls.diagnostic_filled_submitted.canteen.managers.add(cls.user)
+            cls.diagnostic_filled_submitted.teledeclare(applicant=cls.user)
+            cls.diagnostic_filled_cancelled.canteen.managers.add(cls.user)
+            cls.diagnostic_filled_cancelled.teledeclare(applicant=cls.user)
 
         with freeze_time(date_in_correction_campaign):
             cls.diagnostic_filled_cancelled.cancel()
@@ -78,11 +81,12 @@ class DiagnosticModelTeledeclareMethodTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
-        cls.canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        cls.canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[cls.user])
         cls.canteen_satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             groupe=cls.canteen_groupe,
             sector_list=[Sector.EDUCATION_PRIMAIRE, Sector.SANTE_HOPITAL],
+            managers=[cls.user],
         )
         cls.diagnostic_groupe = DiagnosticFactory(
             canteen=cls.canteen_groupe,
@@ -91,7 +95,7 @@ class DiagnosticModelTeledeclareMethodTest(TestCase):
             central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
             valeur_totale=0,
         )
-        cls.canteen_site = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+        cls.canteen_site = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[cls.user])
         cls.diagnostic_site = DiagnosticFactory(
             canteen=cls.canteen_site,
             year=year_data,
@@ -145,7 +149,17 @@ class DiagnosticModelTeledeclareMethodTest(TestCase):
         self.assertRaises(ValidationError, self.diagnostic_groupe.teledeclare, applicant=self.user)
 
     @freeze_time(date_in_teledeclaration_campaign)
-    def test_groupe_can_teledeclare(self):
+    def test_cannot_teledeclare_a_diagnostic_if_applicant_not_canteen_manager(self):
+        user = UserFactory()
+        # site
+        self.assertFalse(self.diagnostic_site.canteen.managers.filter(id=user.id).exists())
+        self.assertRaises(ValidationError, self.diagnostic_site.teledeclare, applicant=user)
+        # groupe
+        self.assertFalse(self.diagnostic_groupe.canteen.managers.filter(id=user.id).exists())
+        self.assertRaises(ValidationError, self.diagnostic_groupe.teledeclare, applicant=user)
+
+    @freeze_time(date_in_teledeclaration_campaign)
+    def test_can_teledeclare_groupe(self):
         self.assertIsNone(self.diagnostic_groupe.applicant)
         self.assertIsNone(self.diagnostic_groupe.canteen_snapshot)
         self.assertIsNone(self.diagnostic_groupe.satellites_snapshot)
@@ -223,10 +237,12 @@ class DiagnosticModelTeledeclareMethodTest(TestCase):
 class DiagnosticModelCancelMethodTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        cls.user = UserFactory()
+        cls.canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[cls.user])
         cls.canteen_satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             groupe=cls.canteen_groupe,
+            managers=[cls.user],
         )
         cls.canteen_groupe_diagnostic = DiagnosticFactory(
             canteen=cls.canteen_groupe,
@@ -247,7 +263,7 @@ class DiagnosticModelCancelMethodTest(TestCase):
     @freeze_time(date_in_teledeclaration_campaign)
     def test_cancel(self):
         # teledeclare the diagnostic
-        self.canteen_groupe_diagnostic.teledeclare(applicant=UserFactory())
+        self.canteen_groupe_diagnostic.teledeclare(applicant=self.user)
         self.assertEqual(self.canteen_groupe_diagnostic.status, Diagnostic.DiagnosticStatus.SUBMITTED)
         self.assertIsNotNone(self.canteen_groupe_diagnostic.applicant)
         self.assertIsNotNone(self.canteen_groupe_diagnostic.teledeclaration_date)
@@ -267,7 +283,7 @@ class DiagnosticModelCancelMethodTest(TestCase):
 
     def test_cancel_in_correction_campaign(self):
         with freeze_time(date_in_teledeclaration_campaign):
-            self.canteen_groupe_diagnostic.teledeclare(applicant=UserFactory())
+            self.canteen_groupe_diagnostic.teledeclare(applicant=self.user)
 
         with freeze_time(date_in_correction_campaign):
             self.canteen_groupe_diagnostic.cancel()
@@ -276,7 +292,7 @@ class DiagnosticModelCancelMethodTest(TestCase):
     @freeze_time(date_in_teledeclaration_campaign)
     def test_cancel_post_save_declaration_donnees_year(self):
         # teledeclare the diagnostic
-        self.canteen_groupe_diagnostic.teledeclare(applicant=UserFactory())
+        self.canteen_groupe_diagnostic.teledeclare(applicant=self.user)
         self.canteen_groupe.refresh_from_db()
         self.assertTrue(getattr(self.canteen_groupe, f"declaration_donnees_{year_data}"))
 
@@ -288,12 +304,12 @@ class DiagnosticModelCancelMethodTest(TestCase):
 
     def test_cancelled_diagnostic_can_be_teledeclare_again(self):
         with freeze_time(date_in_teledeclaration_campaign):
-            self.canteen_groupe_diagnostic.teledeclare(applicant=UserFactory())
+            self.canteen_groupe_diagnostic.teledeclare(applicant=self.user)
 
         with freeze_time(date_in_correction_campaign):
             self.canteen_groupe_diagnostic.cancel()
             self.canteen_groupe.name = "New Name"
-            self.canteen_groupe_diagnostic.teledeclare(applicant=UserFactory())
+            self.canteen_groupe_diagnostic.teledeclare(applicant=self.user)
 
             self.canteen_groupe.refresh_from_db()
             self.canteen_satellite.refresh_from_db()
@@ -306,7 +322,7 @@ class DiagnosticTeledeclaredSnapshotsTest(TestCase):
     def setUpTestData(cls):
         cls.user = UserFactory()
         # groupe + satellite
-        cls.canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        cls.canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[cls.user])
         cls.canteen_satellite_1 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=cls.canteen_groupe, yearly_meal_count=550
         )
@@ -325,6 +341,7 @@ class DiagnosticTeledeclaredSnapshotsTest(TestCase):
             siret="21640122400011",
             production_type=Canteen.ProductionType.ON_SITE,
             sector_list=[Sector.EDUCATION_PRIMAIRE, Sector.SANTE_HOPITAL],
+            managers=[cls.user],
         )
         cls.diagnostic_site = DiagnosticFactory(
             canteen=cls.canteen_site,

--- a/macantine/tests/test_canteen_fill_declaration_donnees_year_field.py
+++ b/macantine/tests/test_canteen_fill_declaration_donnees_year_field.py
@@ -9,8 +9,9 @@ from data.models import Canteen, Diagnostic
 class CanteenFillDeclarationDonneesYearFieldCommandTest(TestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.user = UserFactory()
         cls.canteen_site_with_diagnostic_not_teledeclared = CanteenFactory(
-            production_type=Canteen.ProductionType.ON_SITE
+            production_type=Canteen.ProductionType.ON_SITE, managers=[cls.user]
         )
         cls.canteen_site_diagnostic_not_teledeclared = DiagnosticFactory(
             canteen=cls.canteen_site_with_diagnostic_not_teledeclared,
@@ -19,7 +20,7 @@ class CanteenFillDeclarationDonneesYearFieldCommandTest(TestCase):
             valeur_totale=1000,
         )  # filled (2024)
         cls.canteen_satellite_with_diagnostic_teledeclared = CanteenFactory(
-            production_type=Canteen.ProductionType.ON_SITE_CENTRAL
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, managers=[cls.user]
         )
         cls.canteen_satellite_diagnostic_teledeclared = DiagnosticFactory(
             canteen=cls.canteen_satellite_with_diagnostic_teledeclared,
@@ -27,10 +28,13 @@ class CanteenFillDeclarationDonneesYearFieldCommandTest(TestCase):
             year=2024,
             valeur_totale=1000,
         )  # filled (2024)
-        cls.canteen_groupe_with_diagnostic_teledeclared = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        cls.canteen_groupe_with_diagnostic_teledeclared = CanteenFactory(
+            production_type=Canteen.ProductionType.GROUPE, managers=[cls.user]
+        )
         cls.canteen_satellite_with_groupe_diagnostic_teledeclared = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             groupe=cls.canteen_groupe_with_diagnostic_teledeclared,
+            managers=[cls.user],
         )
         cls.canteen_groupe_diagnostic_teledeclared = DiagnosticFactory(
             canteen=cls.canteen_groupe_with_diagnostic_teledeclared,
@@ -39,8 +43,8 @@ class CanteenFillDeclarationDonneesYearFieldCommandTest(TestCase):
             valeur_totale=1000,
         )  # filled (2024)
         with freeze_time("2025-03-30"):  # during the 2024 campaign
-            cls.canteen_satellite_diagnostic_teledeclared.teledeclare(applicant=UserFactory())
-            cls.canteen_groupe_diagnostic_teledeclared.teledeclare(applicant=UserFactory())
+            cls.canteen_satellite_diagnostic_teledeclared.teledeclare(applicant=cls.user)
+            cls.canteen_groupe_diagnostic_teledeclared.teledeclare(applicant=cls.user)
 
     def test_command(self):
         # Note: since the addition of Diagnositc post_save signal, the declaration_donnees_YEAR field is automatically filled

--- a/macantine/tests/test_diagnostic_fill_invalid_warning_reason_list.py
+++ b/macantine/tests/test_diagnostic_fill_invalid_warning_reason_list.py
@@ -18,11 +18,13 @@ date_in_last_teledeclaration_campaign = "2024-02-01"
 class DiagnosticFillInvalidWarningReasonListTest(TestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.user = UserFactory()
         cls.canteen_deleted = CanteenFactory(
             siret="21730065600014",
             deletion_date=timezone.make_aware(
                 datetime.strptime(date_in_teledeclaration_campaign, "%Y-%m-%d")
             ),  # soft deleted
+            managers=[cls.user],
         )
         cls.diagnostic_canteen_deleted = DiagnosticFactory(
             diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
@@ -33,7 +35,7 @@ class DiagnosticFillInvalidWarningReasonListTest(TestCase):
             valeur_bio=200.00,
         )
         with freeze_time(date_in_teledeclaration_campaign):  # during the 2024 campaign
-            cls.diagnostic_canteen_deleted.teledeclare(applicant=UserFactory())
+            cls.diagnostic_canteen_deleted.teledeclare(applicant=cls.user)
 
     def test_command_should_not_add_if_other_year(self):
         self.diagnostic_canteen_deleted.refresh_from_db()

--- a/macantine/tests/test_etl_analysis.py
+++ b/macantine/tests/test_etl_analysis.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from freezegun import freeze_time
 
 from api.serializers import DiagnosticTeledeclaredAnalysisSerializer
-from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
+from data.factories import CanteenFactory, DiagnosticFactory
 from data.models import Canteen, Diagnostic, Sector
 from macantine.etl.analysis import ETL_ANALYSIS_CANTEEN, ETL_ANALYSIS_TELEDECLARATIONS
 from macantine.etl.utils import format_td_sector_column, get_objectif_zone_geo
@@ -258,7 +258,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
                     valeur_externalites_performance=tc["data"]["valeur_externalites_performance_agg"],
                     valeur_egalim_autres=tc["data"]["valeur_egalim_autres_agg"],
                 )
-                diagnostic.teledeclare(applicant=UserFactory())
+                diagnostic.teledeclare(applicant=canteen.managers.first())
 
                 self.serializer_data = {
                     "valeur_totale": tc["data"]["valeur_totale"],
@@ -322,7 +322,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
         with freeze_time("2023-03-30"):  # during the 2022 campaign
             canteen_ok = CanteenFactory(daily_meal_count=10, yearly_meal_count=2000)
             diagnostic = DiagnosticFactory(canteen=canteen_ok, year=2022, valeur_totale=1000)
-            diagnostic.teledeclare(applicant=UserFactory())
+            diagnostic.teledeclare(applicant=canteen_ok.managers.first())
 
             self.serializer_data = {
                 "yearly_meal_count": canteen_ok.yearly_meal_count,
@@ -341,7 +341,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
             canteen_invalid_yearly_meal_count.save(skip_validations=True)
             canteen_invalid_yearly_meal_count.refresh_from_db()
             diagnostic = DiagnosticFactory(canteen=canteen_invalid_yearly_meal_count, year=2021, valeur_totale=1000)
-            diagnostic.teledeclare(applicant=UserFactory(), skip_validations=True)
+            diagnostic.teledeclare(applicant=canteen_invalid_yearly_meal_count.managers.first(), skip_validations=True)
 
             self.serializer_data = {
                 "yearly_meal_count": canteen_invalid_yearly_meal_count.yearly_meal_count,
@@ -370,7 +370,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
                 epci_lib="Grenoble-Alpes-Métropole",
             )
             diagnostic = DiagnosticFactory(canteen=canteen_with_geo_data, year=2022)
-            diagnostic.teledeclare(applicant=UserFactory())
+            diagnostic.teledeclare(applicant=canteen_with_geo_data.managers.first())
 
         self.serializer = DiagnosticTeledeclaredAnalysisSerializer(instance=Diagnostic.objects.get(id=diagnostic.id))
         data = self.serializer.data
@@ -394,7 +394,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
                 region_lib=None,
             )
             diagnostic_half_geo = DiagnosticFactory(canteen=canteen_half_geo_data, year=2022)
-            diagnostic_half_geo.teledeclare(applicant=UserFactory())
+            diagnostic_half_geo.teledeclare(applicant=canteen_half_geo_data.managers.first())
 
         self.serializer_half_geo = DiagnosticTeledeclaredAnalysisSerializer(
             instance=Diagnostic.objects.get(id=diagnostic_half_geo.id)
@@ -420,7 +420,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
                 region_lib=None,
             )
             diagnostic_without_geo = DiagnosticFactory(canteen=canteen_without_geo_data, year=2022)
-            diagnostic_without_geo.teledeclare(applicant=UserFactory())
+            diagnostic_without_geo.teledeclare(applicant=canteen_without_geo_data.managers.first())
 
         self.serializer_without_geo = DiagnosticTeledeclaredAnalysisSerializer(
             instance=Diagnostic.objects.get(id=diagnostic_without_geo.id)
@@ -442,7 +442,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
                 economic_model=Canteen.EconomicModel.PUBLIC,
             )
             diagnostic = DiagnosticFactory(canteen=canteen_with_line_ministry, year=2022)
-            diagnostic.teledeclare(applicant=UserFactory())
+            diagnostic.teledeclare(applicant=canteen_with_line_ministry.managers.first())
 
         self.serializer = DiagnosticTeledeclaredAnalysisSerializer(instance=Diagnostic.objects.get(id=diagnostic.id))
         data = self.serializer.data
@@ -453,7 +453,7 @@ class TeledeclarationETLAnalysisTest(TestCase):
         with freeze_time("2023-03-30"):  # during the 2022 campaign
             canteen_without_line_ministry = CanteenFactory(line_ministry=None)
             diagnostic_without_line_ministry = DiagnosticFactory(canteen=canteen_without_line_ministry, year=2022)
-            diagnostic_without_line_ministry.teledeclare(applicant=UserFactory())
+            diagnostic_without_line_ministry.teledeclare(applicant=canteen_without_line_ministry.managers.first())
 
         self.serializer_without_line_ministry = DiagnosticTeledeclaredAnalysisSerializer(
             instance=Diagnostic.objects.get(id=diagnostic_without_line_ministry.id)

--- a/macantine/tests/test_teledeclaration_generate_1td1site_2024.py
+++ b/macantine/tests/test_teledeclaration_generate_1td1site_2024.py
@@ -3,14 +3,18 @@ from django.db.models.signals import post_save
 from django.test import TestCase
 from freezegun import freeze_time
 
-from api.tests.utils import assert_almost_equal, authenticate
-from data.factories import CanteenFactory, DiagnosticFactory
+from api.tests.utils import assert_almost_equal
+from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 from data.models import Diagnostic
 from data.models.canteen import Canteen, fill_geo_fields_from_siret
 from data.models.sector import Sector
 
 
 class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
     def setUp(self):
         post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
         return super().setUp()
@@ -19,12 +23,11 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
         post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
         return super().tearDown()
 
-    @authenticate
     def test_correct_number_of_diagnostics_generated_for_central(self):
         """
         The script should generate one diagnostic for each satellite saved in snapshot.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret)
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret)
 
@@ -35,7 +38,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Before the script is run
         self.assertEqual(Canteen.objects.count(), 3)
@@ -55,12 +58,11 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
             2,
         )
 
-    @authenticate
     def test_correct_number_of_diagnostics_generated_for_central_serving(self):
         """
         The script should generate one diagnostic for each satellite saved in snapshot (the central serving is already in the snapshot)
         """
-        central_serving = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL_SERVING)
+        central_serving = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL_SERVING, managers=[self.user])
         CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central_serving.siret
         )
@@ -72,7 +74,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_serving_diagnostic.teledeclare(applicant=authenticate.user)
+            central_serving_diagnostic.teledeclare(applicant=self.user)
             # Need to add satellites to the snapshot with groupe migration
             call_command("canteen_migrate_central_to_groupe", apply=True)
 
@@ -93,13 +95,12 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
             2,
         )
 
-    @authenticate
     def test_when_script_run_again_delete_previous_generated_diagnostics(self):
         """
         Test that when the script is run again, it deletes the previous generated diagnostics and create one.
         """
-        central_1 = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
-        central_2 = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
+        central_1 = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
+        central_2 = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
         satellite_1 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central_1.siret
         )
@@ -123,8 +124,8 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_1_diagnostic.teledeclare(applicant=authenticate.user)
-            central_2_diagnostic.teledeclare(applicant=authenticate.user)
+            central_1_diagnostic.teledeclare(applicant=self.user)
+            central_2_diagnostic.teledeclare(applicant=self.user)
 
         # Before the script is run
         self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 2)
@@ -165,13 +166,14 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
             first_time_generated_diagnostic_satellite_2.id, second_time_generated_diagnostic_satellite_2.id
         )
 
-    @authenticate
     def test_tag_satellites_with_teledeclaration_and_teledeclare_by_central_mode_all(self):
         """
         Test when a satellite canteen has a teledeclaration, and it's also teledeclared by the central the script tags it as doublon.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
-        satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=None)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
+        satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=None, managers=[self.user]
+        )
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             satellite_diagnostic = DiagnosticFactory(
                 canteen=satellite,
@@ -179,7 +181,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            satellite_diagnostic.teledeclare(applicant=authenticate.user)
+            satellite_diagnostic.teledeclare(applicant=self.user)
 
         self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
 
@@ -194,7 +196,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_bio=2000,
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 2)
 
@@ -206,13 +208,14 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
         self.assertFalse(satellite_diagnostic.generated_from_groupe_diagnostic)
         self.assertIn(Diagnostic.InvalidReason.DOUBLON_1TD1SITE, satellite_diagnostic.invalid_reason_list)
 
-    @authenticate
     def test_tag_satellites_with_teledeclaration_and_teledeclare_by_central_mode_appro(self):
         """
         Test when a satellite canteen has a teledeclaration, and it's also teledeclared by the central with mode "appro only" the script does not tag it as doublon.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
-        satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=None)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
+        satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=None, managers=[self.user]
+        )
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             satellite_diagnostic = DiagnosticFactory(
                 canteen=satellite,
@@ -220,7 +223,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            satellite_diagnostic.teledeclare(applicant=authenticate.user)
+            satellite_diagnostic.teledeclare(applicant=self.user)
 
         self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
 
@@ -235,7 +238,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_bio=2000,
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.APPRO,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 2)
 
@@ -247,13 +250,14 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
         self.assertFalse(satellite_diagnostic.generated_from_groupe_diagnostic)
         self.assertIn(Diagnostic.InvalidReason.DOUBLON_1TD1SITE, satellite_diagnostic.invalid_reason_list)
 
-    @authenticate
     def test_when_script_run_again_remove_tag_doublon(self):
         """
         If a satellite has the tag "DOUBLON_1TD1SITE" when the script is re-run, it should be removed.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
-        satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=None)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
+        satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=None, managers=[self.user]
+        )
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             satellite_diagnostic = DiagnosticFactory(
                 canteen=satellite,
@@ -261,7 +265,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            satellite_diagnostic.teledeclare(applicant=authenticate.user)
+            satellite_diagnostic.teledeclare(applicant=self.user)
             satellite.central_producer_siret = central.siret
             satellite.save(skip_validations=True)
             central_diagnostic = DiagnosticFactory(
@@ -270,7 +274,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -299,7 +303,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
 
         # Teledeclare the central again but without the satellite
         with freeze_time("2025-03-30"):  # during the 2024 campaign
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Re-run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -312,12 +316,11 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
             0,
         )
 
-    @authenticate
     def test_when_central_is_deleted_has_satellite_teledeclarations(self):
         """
         Test when a central is deleted after the teledeclaration, the script still generates diagnostics for its satellites.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret)
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret)
         with freeze_time("2025-03-30"):  # during the 2024 campaign
@@ -328,7 +331,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         central.delete()
 
@@ -349,12 +352,11 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
             2,
         )
 
-    @authenticate
     def test_when_satellite_is_deleted_has_teledeclaration(self):
         """
         Test when a satellite is deleted after the teledeclaration, it still has a generated diagnostic.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
         satellite_1 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
         )
@@ -367,7 +369,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         satellite_1.delete()
 
@@ -388,13 +390,12 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
             2,
         )
 
-    @authenticate
     def test_when_satellite_is_hard_deleted_has_teledeclaration(self):
         """
         Test when a satellite is hard deleted after the teledeclaration, it still has a generated diagnostic.
         Note: hard delete is not possible anymore
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
         satellite_1 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
         )
@@ -407,7 +408,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         satellite_1.hard_delete()
 
@@ -430,13 +431,19 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
 
 
 class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
-    @authenticate
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
     def test_set_correct_creation_date(self):
         """
         The creation date of the generated diagnostics should be the date of the teledeclaration of the central diagnostic.
         """
         central = CanteenFactory(
-            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.CENTRAL,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
@@ -449,7 +456,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -458,13 +465,15 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         diagnostic_generated = Diagnostic.all_objects.in_year(2024).teledeclared().get(canteen=satellite)
         self.assertEqual(diagnostic_generated.creation_date, central_diagnostic.teledeclaration_date)
 
-    @authenticate
     def test_groupe_snapshot_filled(self):
         """
         The groupe_snapshot should be filled with the canteen snapshot of the central diagnostic.
         """
         central = CanteenFactory(
-            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.CENTRAL,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
@@ -477,7 +486,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -487,13 +496,15 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         self.assertIsNotNone(diagnostic_generated.groupe_snapshot)
         self.assertEqual(diagnostic_generated.groupe_snapshot["siret"], central.siret)
 
-    @authenticate
     def test_satellites_snapshot_empty(self):
         """
         The satellites_snapshot should be empty for the generated diagnostics.
         """
         central = CanteenFactory(
-            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.CENTRAL,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
@@ -506,7 +517,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -515,12 +526,11 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         diagnostic_generated = Diagnostic.all_objects.in_year(2024).teledeclared().get(canteen=satellite)
         self.assertIsNone(diagnostic_generated.satellites_snapshot)
 
-    @authenticate
     def test_update_teledeclaration_mode(self):
         """
         Test the teledeclaration_mode value is updated in the generated diagnostics.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL_SERVING)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL_SERVING, managers=[self.user])
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret)
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             central_diagnostic = DiagnosticFactory(
@@ -531,7 +541,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -543,13 +553,15 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         for diagnostic in diagnostic_generated:
             self.assertEqual(diagnostic.teledeclaration_mode, Diagnostic.TeledeclarationMode.SITE)
 
-    @authenticate
     def test_copy_teledeclaration_metadata(self):
         """
         The metadata from the central diagnostic are copied in the generated diagnostics.
         """
         central = CanteenFactory(
-            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.CENTRAL,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
@@ -562,7 +574,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -574,13 +586,15 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         self.assertEqual(diagnostic_generated.teledeclaration_date, diagnostic_central.teledeclaration_date)
         self.assertEqual(diagnostic_generated.teledeclaration_version, diagnostic_central.teledeclaration_version)
 
-    @authenticate
     def test_copy_applicant_informations(self):
         """
         The applicant informations from the central diagnostic are copied in the generated diagnostics.
         """
         central = CanteenFactory(
-            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.CENTRAL,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
@@ -593,7 +607,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -604,12 +618,11 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         self.assertEqual(diagnostic_generated.applicant_snapshot, diagnostic_central.applicant_snapshot)
         self.assertEqual(diagnostic_generated.applicant, diagnostic_central.applicant)
 
-    @authenticate
     def test_copy_invalid_reason_list(self):
         """
         The invalid reason list from the central diagnostic are copied in the generated diagnostics.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
         satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
         )
@@ -623,7 +636,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                     Diagnostic.InvalidReason.VALEURS_INCOHERENTES
                 ],  # Fake invalid reason list is added
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -638,6 +651,10 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
 
 
 class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
     def setUp(self):
         post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
         return super().setUp()
@@ -646,7 +663,6 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
         post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
         return super().tearDown()
 
-    @authenticate
     def test_keep_history_canteen_fields(self):
         """
         The historical values of the canteen when the teledeclaration is done are kept in the generated diagnostics (don't use the current values).
@@ -657,6 +673,7 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
                 siret="21340172201787", production_type=Canteen.ProductionType.CENTRAL, city_insee_code="34172"
             )
             central.save()
+            central.managers.add(self.user)
             satellite_siret = CanteenFactory.build(
                 name="Mon premier nom SIRET",
                 siret="33533639200154",
@@ -683,7 +700,7 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Change satellite informations
         satellite_siret.name = "Mon nouveau nom SIRET"
@@ -723,7 +740,6 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
         siren_canteen_snapshot = diagnostic_satellite_siren.canteen_snapshot
         self.assertEqual(siren_canteen_snapshot["siren_unite_legale"], "123456789")
 
-    @authenticate
     def test_copy_central_fields(self):
         """
         Some informations from the central are copied in the canteen_snapshot of the generated diagnostics: geodata, sector and line ministry.
@@ -736,6 +752,7 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
             pat_list=["1294", "1295"],
             department="38",
             region="84",
+            managers=[self.user],
         )
         central.sector_list = [Sector.ADMINISTRATION_INTER_ADMINISTRATIF]
         central.line_ministry = Canteen.Ministries.AFFAIRES_ETRANGERES
@@ -763,7 +780,7 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -788,12 +805,13 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
             with self.subTest(field=field):
                 self.assertEqual(diagnostic_generated.canteen_snapshot[field], getattr(central, field))
 
-    @authenticate
     def test_divide_yearly_meal_count_by_number_of_satellites(self):
         """
         The yearly meal count is divided by the number of satellites (and converted to integer)
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011)
+        central = CanteenFactory(
+            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, managers=[self.user]
+        )
         satellite_1 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             central_producer_siret=central.siret,
@@ -813,7 +831,7 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -838,13 +856,15 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
         self.assertEqual(int(satellite_1_diagnostic.canteen_snapshot["yearly_meal_count"]), expected_yearly_meal_count)
         self.assertEqual(int(satellite_2_diagnostic.canteen_snapshot["yearly_meal_count"]), expected_yearly_meal_count)
 
-    @authenticate
     def test_keep_history_yearly_meal_count(self):
         """
         If the central changes its yearly meal count after the teledeclaraiont, the script uses the old value.
         """
         central = CanteenFactory(
-            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, daily_meal_count=100
+            production_type=Canteen.ProductionType.CENTRAL,
+            yearly_meal_count=1011,
+            daily_meal_count=100,
+            managers=[self.user],
         )
         satellite_1 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
@@ -864,7 +884,7 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Change the meal count of the central
         central.yearly_meal_count = 9999
@@ -893,12 +913,11 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
         self.assertEqual(satellite_1_diagnostic.canteen_snapshot["yearly_meal_count"], expected_yearly_meal_count)
         self.assertEqual(satellite_2_diagnostic.canteen_snapshot["yearly_meal_count"], expected_yearly_meal_count)
 
-    @authenticate
     def test_yearly_meal_count_is_none(self):
         """
         Test that when the central has a None yearly meal count, the script generates a diagnostic with a None value.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
         central.yearly_meal_count = None
         central.save(skip_validations=True)
         satellite = CanteenFactory(
@@ -908,7 +927,7 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
         )
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             central_diagnostic = DiagnosticFactory(canteen=central, year=2024, valeur_totale=10000, valeur_bio=2000)
-            central_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            central_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -923,18 +942,14 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
 
 
 class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
-    def setUp(self):
-        post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
-        return super().setUp()
-
-    def tearDown(self):
-        post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
-        return super().tearDown()
-
     @classmethod
     def setUpTestData(cls):
+        cls.user = UserFactory()
         cls.central = CanteenFactory(
-            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.CENTRAL,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[cls.user],
         )
         cls.satellite_1 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
@@ -953,6 +968,14 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
         for field in Diagnostic.COMPLETE_APPRO_FIELDS:
             cls.appro_fields[field] = 500.75
 
+    def setUp(self):
+        post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
+        return super().setUp()
+
+    def tearDown(self):
+        post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
+        return super().tearDown()
+
     def verify_appro_fields_divided(self, fields, satellite_diagnostic, central_diagnostic, divisor):
         for field in fields:
             with self.subTest(field=field):
@@ -963,7 +986,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 self.assertIsNotNone(diagnostic_value)
                 assert_almost_equal(self, diagnostic_value, expected_value)
 
-    @authenticate
     def test_total_value_divided_by_number_of_satellites(self):
         """
         Test that the total value is divided by the number of satellites.
@@ -975,7 +997,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 year=2024,
                 valeur_totale=total_value,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            central_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -986,7 +1008,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
         assert_almost_equal(self, satellite_1_diagnostic.valeur_totale, total_value / 2)
         assert_almost_equal(self, satellite_2_diagnostic.valeur_totale, total_value / 2)
 
-    @authenticate
     def test_central_type_simple(self):
         """
         Test that when a central canteen teledeclares with mode ALL.
@@ -999,7 +1020,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
                 **self.appro_fields,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            central_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -1020,7 +1041,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                     number_of_generated_diagnostics,
                 )
 
-    @authenticate
     def test_central_serving_type_simple(self):
         """
         Test that when a central serving canteen teledeclares with mode ALL.
@@ -1037,7 +1057,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
                 **self.appro_fields,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            central_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
             # Need to add satellites to the snapshot with groupe migration
             call_command("canteen_migrate_central_to_groupe", apply=True)
             # Save satellite canteen created
@@ -1066,7 +1086,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                     number_of_generated_diagnostics,
                 )
 
-    @authenticate
     def test_central_type_complete(self):
         """
         Test that when a central canteen teledeclares in mode ALL with COMPLETE type.
@@ -1079,7 +1098,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
                 **self.appro_fields,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            central_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -1100,7 +1119,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                     number_of_generated_diagnostics,
                 )
 
-    @authenticate
     def test_central_serving_type_complete(self):
         """
         Test that when a central serving canteen teledeclares with mode ALL.
@@ -1117,7 +1135,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
                 **self.appro_fields,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            central_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
             # Need to add satellites to the snapshot with groupe migration
             call_command("canteen_migrate_central_to_groupe", apply=True)
             # Save satellite canteen created
@@ -1146,7 +1164,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                     number_of_generated_diagnostics,
                 )
 
-    @authenticate
     def test_central_no_type(self):
         """
         Test that when a central canteen teledeclares without mode.
@@ -1159,7 +1176,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
                 **self.appro_fields,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            central_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -1180,7 +1197,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                     number_of_generated_diagnostics,
                 )
 
-    @authenticate
     def test_central_serving_no_type(self):
         """
         Test that when a central serving canteen teledeclares with no type.
@@ -1197,7 +1213,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
                 **self.appro_fields,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            central_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
             # Need to add satellites to the snapshot with groupe migration
             call_command("canteen_migrate_central_to_groupe", apply=True)
             # Save satellite canteen created
@@ -1226,7 +1242,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                     number_of_generated_diagnostics,
                 )
 
-    @authenticate
     def test_mode_all_non_appro_fields_are_copied(self):
         """
         Test that when a central canteen teledeclares in mode ALL with non appro fields, the values are copied in the generated diagnostics.
@@ -1238,7 +1253,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            central_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
@@ -1260,10 +1275,13 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
     Test the teledeclaration of canteen or diagnostic not concerned by the 1td1site script are not modified when the command is run.
     """
 
-    @authenticate
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
     def test_canteen_site(self):
-        site_1 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
-        site_2 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+        site_1 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[self.user])
+        site_2 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic_site_1 = DiagnosticFactory(
@@ -1276,8 +1294,8 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 year=2024,
                 diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
             )
-            diagnostic_site_1.teledeclare(applicant=authenticate.user)
-            diagnostic_site_2.teledeclare(applicant=authenticate.user)
+            diagnostic_site_1.teledeclare(applicant=self.user)
+            diagnostic_site_2.teledeclare(applicant=self.user)
 
         diagnostic_site_1_before_script = diagnostic_site_1
         diagnostic_site_2_before_script = diagnostic_site_2
@@ -1304,10 +1322,11 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
         self.assertEqual(diagnostic_site_1, diagnostic_site_1_before_script)
         self.assertEqual(diagnostic_site_2, diagnostic_site_2_before_script)
 
-    @authenticate
     def test_satellite_with_central_siret_unknown(self):
         satellite = CanteenFactory(
-            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret="21380185500015"
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
+            central_producer_siret="21380185500015",
+            managers=[self.user],
         )
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             satellite_diagnostic = DiagnosticFactory(
@@ -1315,7 +1334,7 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 year=2024,
                 diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
             )
-            satellite_diagnostic.teledeclare(applicant=authenticate.user)
+            satellite_diagnostic.teledeclare(applicant=self.user)
 
         satellite_diagnostic_before_script = satellite_diagnostic
 
@@ -1342,16 +1361,17 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
         )
         self.assertEqual(satellite_diagnostic, satellite_diagnostic_before_script)
 
-    @authenticate
     def test_satellite_with_central_siret_empty(self):
-        satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret="")
+        satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret="", managers=[self.user]
+        )
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             satellite_diagnostic = DiagnosticFactory(
                 canteen=satellite,
                 year=2024,
                 diagnostic_type=Diagnostic.DiagnosticType.SIMPLE,
             )
-            satellite_diagnostic.teledeclare(applicant=authenticate.user)
+            satellite_diagnostic.teledeclare(applicant=self.user)
 
         satellite_snapshot_canteen_before_script = satellite_diagnostic.canteen_snapshot
         satellite_snapshot_satellites_before_script = satellite_diagnostic.satellites_snapshot
@@ -1377,10 +1397,12 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
         self.assertEqual(satellite_diagnostic.canteen_snapshot, satellite_snapshot_canteen_before_script)
         self.assertEqual(satellite_diagnostic.satellites_snapshot, satellite_snapshot_satellites_before_script)
 
-    @authenticate
     def test_teledeclaration_other_year_are_not_generated(self):
         central = CanteenFactory(
-            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.CENTRAL,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret)
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret)
@@ -1392,7 +1414,7 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic_2023.teledeclare(applicant=authenticate.user)
+            central_diagnostic_2023.teledeclare(applicant=self.user)
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             central_diagnostic_2024 = DiagnosticFactory(
@@ -1401,7 +1423,7 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic_2024.teledeclare(applicant=authenticate.user)
+            central_diagnostic_2024.teledeclare(applicant=self.user)
 
         with freeze_time("2026-03-30"):  # during the 2025 campaign
             central_diagnostic_2025 = DiagnosticFactory(
@@ -1410,7 +1432,7 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic_2025.teledeclare(applicant=authenticate.user)
+            central_diagnostic_2025.teledeclare(applicant=self.user)
 
         # Before the script is run
         self.assertEqual(Diagnostic.all_objects.count(), 3)
@@ -1427,12 +1449,11 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
         self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 3)
         self.assertEqual(Diagnostic.all_objects.in_year(2025).teledeclared().count(), 1)
 
-    @authenticate
     def test_central_without_satellites(self):
         """
         Test that when a central canteen has no satellites, the script does not generate any diagnostic.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             central_diagnostic = DiagnosticFactory(
                 canteen=central,
@@ -1440,18 +1461,17 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
         call_command("teledeclaration_generate_1td1site", year=2024, apply=True)
         self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
 
-    @authenticate
     def test_central_with_diagnostic_not_teledeclared(self):
         """
         Test that when a diagnostic is draft, it is not modified when the script is run.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret)
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             DiagnosticFactory(
@@ -1468,12 +1488,11 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
         self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 0)
         self.assertEqual(Diagnostic.all_objects.in_year(2024).filter(generated_from_groupe_diagnostic=True).count(), 0)
 
-    @authenticate
     def test_cancelled_central_diagnostics(self):
         """
         If a teledeclaration is cancelled, no diagnostics should be generated.
         """
-        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL)
+        central = CanteenFactory(production_type=Canteen.ProductionType.CENTRAL, managers=[self.user])
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret)
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             central_diagnostic = DiagnosticFactory(
@@ -1482,7 +1501,7 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
             central_diagnostic.cancel()
 
         # Run the script

--- a/macantine/tests/test_teledeclaration_generate_1td1site_2025.py
+++ b/macantine/tests/test_teledeclaration_generate_1td1site_2025.py
@@ -6,13 +6,17 @@ from django.test import TestCase
 from django.utils import timezone
 from freezegun import freeze_time
 
-from api.tests.utils import assert_almost_equal, authenticate
-from data.factories import CanteenFactory, DiagnosticFactory
+from api.tests.utils import assert_almost_equal
+from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 from data.models import Diagnostic
 from data.models.canteen import Canteen, fill_geo_fields_from_siret
 
 
 class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
     def setUp(self):
         post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
         return super().setUp()
@@ -21,12 +25,11 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
         post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
         return super().tearDown()
 
-    @authenticate
     def test_correct_number_of_diagnostics_generated_for_groupe(self):
         """
         The script should generate one diagnostic for each satellite saved in snapshot.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
 
@@ -37,7 +40,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Before the script is run
         self.assertEqual(Canteen.objects.count(), 3)
@@ -57,13 +60,12 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
             2,
         )
 
-    @authenticate
     def test_when_script_run_again_delete_previous_generated_diagnostics(self):
         """
         Test that when the script is run again, it deletes the previous generated diagnostics and create one.
         """
-        groupe_1 = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
-        groupe_2 = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        groupe_1 = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
+        groupe_2 = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         satellite_1 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe_1)
         satellite_2 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe_2)
         with freeze_time("2026-03-30"):  # during the 2025 campaign
@@ -83,8 +85,8 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_1_diagnostic.teledeclare(applicant=authenticate.user)
-            groupe_2_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_1_diagnostic.teledeclare(applicant=self.user)
+            groupe_2_diagnostic.teledeclare(applicant=self.user)
 
         # Before the script is run
         self.assertEqual(Diagnostic.all_objects.in_year(2025).teledeclared().count(), 2)
@@ -125,13 +127,14 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
             first_time_generated_diagnostic_satellite_2.id, second_time_generated_diagnostic_satellite_2.id
         )
 
-    @authenticate
     def test_tag_satellites_with_teledeclaration_and_teledeclare_by_groupe_mode_all(self):
         """
         Test when a satellite canteen has a teledeclaration, and it's also teledeclared by the groupe the script tags it as doublon.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
-        satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=None)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
+        satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=None, managers=[self.user]
+        )
         with freeze_time("2026-03-30"):  # during the 2025 campaign
             satellite_diagnostic = DiagnosticFactory(
                 canteen=satellite,
@@ -139,7 +142,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            satellite_diagnostic.teledeclare(applicant=authenticate.user)
+            satellite_diagnostic.teledeclare(applicant=self.user)
 
         self.assertEqual(Diagnostic.all_objects.in_year(2025).teledeclared().count(), 1)
 
@@ -154,7 +157,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_bio=2000,
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         self.assertEqual(Diagnostic.all_objects.in_year(2025).teledeclared().count(), 2)
 
@@ -166,13 +169,14 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
         self.assertFalse(satellite_diagnostic.generated_from_groupe_diagnostic)
         self.assertIn(Diagnostic.InvalidReason.DOUBLON_1TD1SITE, satellite_diagnostic.invalid_reason_list)
 
-    @authenticate
     def test_tag_satellites_with_teledeclaration_and_teledeclare_by_groupe_mode_appro(self):
         """
         Test when a satellite canteen has a teledeclaration, and it's also teledeclared by the groupe with mode "appro only" the script does not tag it as doublon.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
-        satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=None)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
+        satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=None, managers=[self.user]
+        )
         with freeze_time("2026-03-30"):  # during the 2025 campaign
             satellite_diagnostic = DiagnosticFactory(
                 canteen=satellite,
@@ -180,7 +184,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            satellite_diagnostic.teledeclare(applicant=authenticate.user)
+            satellite_diagnostic.teledeclare(applicant=self.user)
 
         self.assertEqual(Diagnostic.all_objects.in_year(2025).teledeclared().count(), 1)
 
@@ -195,7 +199,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_bio=2000,
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.APPRO,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         self.assertEqual(Diagnostic.all_objects.in_year(2025).teledeclared().count(), 2)
 
@@ -207,13 +211,14 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
         self.assertFalse(satellite_diagnostic.generated_from_groupe_diagnostic)
         self.assertIn(Diagnostic.InvalidReason.DOUBLON_1TD1SITE, satellite_diagnostic.invalid_reason_list)
 
-    @authenticate
     def test_when_script_run_again_remove_tag_doublon(self):
         """
         If a satellite has the tag "DOUBLON_1TD1SITE" when the script is re-run, it should be removed.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
-        satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=None)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
+        satellite = CanteenFactory(
+            production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=None, managers=[self.user]
+        )
         with freeze_time("2026-03-30"):  # during the 2025 campaign
             satellite_diagnostic = DiagnosticFactory(
                 canteen=satellite,
@@ -221,7 +226,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            satellite_diagnostic.teledeclare(applicant=authenticate.user)
+            satellite_diagnostic.teledeclare(applicant=self.user)
             satellite.groupe = groupe
             satellite.save(skip_validations=True)
             groupe_diagnostic = DiagnosticFactory(
@@ -230,7 +235,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -260,7 +265,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
         # Commented because a groupe without satellite cannot teledeclare
         # # Teledeclare the groupe again but without the satellite
         # with freeze_time("2026-03-30"):  # during the 2025 campaign
-        #     groupe_diagnostic.teledeclare(applicant=authenticate.user)
+        #     groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Re-run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -273,12 +278,11 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
             0,
         )
 
-    @authenticate
     def test_when_groupe_is_deleted_has_satellite_teledeclarations(self):
         """
         Test when a groupe is deleted after the teledeclaration, the script still generates diagnostics for its satellites.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         with freeze_time("2026-03-30"):  # during the 2025 campaign
@@ -289,7 +293,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # groupe.delete()
         Canteen.objects.filter(id=groupe.id).update(deletion_date=timezone.now())
@@ -311,12 +315,11 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
             2,
         )
 
-    @authenticate
     def test_when_satellite_is_deleted_has_teledeclaration(self):
         """
         Test when a satellite is deleted after the teledeclaration, it still has a generated diagnostic.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         satellite_1 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         with freeze_time("2026-03-30"):  # during the 2025 campaign
@@ -327,7 +330,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         satellite_1.delete()
 
@@ -348,13 +351,12 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
             2,
         )
 
-    @authenticate
     def test_when_satellite_is_hard_deleted_has_teledeclaration(self):
         """
         Test when a satellite is hard deleted after the teledeclaration, it still has a generated diagnostic.
         Note: hard delete is not possible anymore
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         satellite_1 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         with freeze_time("2026-03-30"):  # during the 2025 campaign
@@ -365,7 +367,7 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         satellite_1.hard_delete()
 
@@ -388,13 +390,19 @@ class Teledeclaration1Td1SiteScriptGenerationTest(TestCase):
 
 
 class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
-    @authenticate
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
     def test_set_correct_creation_date(self):
         """
         The creation date of the generated diagnostics should be the date of the teledeclaration of the central diagnostic.
         """
         central = CanteenFactory(
-            production_type=Canteen.ProductionType.CENTRAL, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.CENTRAL,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, central_producer_siret=central.siret
@@ -407,7 +415,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            central_diagnostic.teledeclare(applicant=authenticate.user)
+            central_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -416,13 +424,15 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         diagnostic_generated = Diagnostic.all_objects.in_year(2025).teledeclared().get(canteen=satellite)
         self.assertEqual(diagnostic_generated.creation_date, central_diagnostic.teledeclaration_date)
 
-    @authenticate
     def test_groupe_snapshot_filled(self):
         """
         The groupe_snapshot should be filled for the generated diagnostics.
         """
         groupe = CanteenFactory(
-            production_type=Canteen.ProductionType.GROUPE, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.GROUPE,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
 
@@ -433,7 +443,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -444,13 +454,15 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         self.assertEqual(diagnostic_generated.groupe_snapshot["id"], groupe.id)
         self.assertEqual(diagnostic_generated.groupe_snapshot["name"], groupe.name)
 
-    @authenticate
     def test_satellites_snapshot_empty(self):
         """
         The satellites_snapshot should be empty for the generated diagnostics.
         """
         groupe = CanteenFactory(
-            production_type=Canteen.ProductionType.GROUPE, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.GROUPE,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
 
@@ -461,7 +473,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -470,12 +482,11 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         diagnostic_generated = Diagnostic.all_objects.in_year(2025).teledeclared().get(canteen=satellite)
         self.assertIsNone(diagnostic_generated.satellites_snapshot)
 
-    @authenticate
     def test_update_teledeclaration_mode(self):
         """
         Test the teledeclaration_mode value is updated in the generated diagnostics.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         with freeze_time("2026-03-30"):  # during the 2025 campaign
             groupe_diagnostic = DiagnosticFactory(
@@ -486,7 +497,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -498,13 +509,15 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         for diagnostic in diagnostic_generated:
             self.assertEqual(diagnostic.teledeclaration_mode, Diagnostic.TeledeclarationMode.SITE)
 
-    @authenticate
     def test_copy_teledeclaration_metadata(self):
         """
         The metadata from the groupe diagnostic are copied in the generated diagnostics.
         """
         groupe = CanteenFactory(
-            production_type=Canteen.ProductionType.GROUPE, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.GROUPE,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
 
@@ -515,7 +528,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -527,13 +540,15 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         self.assertEqual(diagnostic_generated.teledeclaration_date, diagnostic_groupe.teledeclaration_date)
         self.assertEqual(diagnostic_generated.teledeclaration_version, diagnostic_groupe.teledeclaration_version)
 
-    @authenticate
     def test_copy_applicant_informations(self):
         """
         The applicant informations from the groupe diagnostic are copied in the generated diagnostics.
         """
         groupe = CanteenFactory(
-            production_type=Canteen.ProductionType.GROUPE, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.GROUPE,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
 
@@ -544,7 +559,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -555,12 +570,11 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
         self.assertEqual(diagnostic_generated.applicant_snapshot, diagnostic_groupe.applicant_snapshot)
         self.assertEqual(diagnostic_generated.applicant, diagnostic_groupe.applicant)
 
-    @authenticate
     def test_copy_invalid_reason_list(self):
         """
         The invalid reason list from the groupe diagnostic are copied in the generated diagnostics.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         with freeze_time("2026-03-30"):  # during the 2025 campaign
             groupe_diagnostic = DiagnosticFactory(
@@ -572,7 +586,7 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
                     Diagnostic.InvalidReason.VALEURS_INCOHERENTES
                 ],  # Fake invalid reason list is added
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -587,6 +601,10 @@ class Teledeclaration1Td1SiteTeledeclarationFieldsTest(TestCase):
 
 
 class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
     def setUp(self):
         post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
         return super().setUp()
@@ -595,7 +613,6 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
         post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
         return super().tearDown()
 
-    @authenticate
     def test_keep_history_canteen_fields(self):
         """
         The historical values of the canteen when the teledeclaration is done are kept in the generated diagnostics (don't use the current values).
@@ -604,6 +621,7 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
             # factory build + save: to circumvent the factory and create a history entry
             groupe = CanteenFactory.build(production_type=Canteen.ProductionType.GROUPE)
             groupe.save()
+            groupe.managers.add(self.user)
             satellite_siret = CanteenFactory.build(
                 name="Mon premier nom SIRET",
                 siret="33533639200154",
@@ -630,7 +648,7 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Change satellite informations
         satellite_siret.name = "Mon nouveau nom SIRET"
@@ -670,13 +688,12 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
         siren_canteen_snapshot = diagnostic_satellite_siren.canteen_snapshot
         self.assertEqual(siren_canteen_snapshot["siren_unite_legale"], "123456789")
 
-    @authenticate
     def test_dont_copy_groupe_fields(self):
         """
         Before, some informations from the groupe were copied in the canteen_snapshot of the generated diagnostics: geodata, sector and line ministry.
         We don't do this anymore.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             economic_model=Canteen.EconomicModel.PRIVATE,  # Private economic model for the satellite
@@ -697,7 +714,7 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -722,13 +739,14 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
             with self.subTest(field=field):
                 self.assertEqual(diagnostic_generated.canteen_snapshot[field], getattr(satellite, field))
 
-    @authenticate
     def test_dont_divide_yearly_meal_count_by_number_of_satellites(self):
         """
         Before, the yearly meal count is divided by the number of satellites (and converted to integer)
         We don't do this anymore.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, yearly_meal_count=1011)
+        groupe = CanteenFactory(
+            production_type=Canteen.ProductionType.GROUPE, yearly_meal_count=1011, managers=[self.user]
+        )
         satellite_1 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL,
             groupe=groupe,
@@ -747,7 +765,7 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -773,18 +791,14 @@ class Teledeclaration1Td1SiteCanteenFieldsTest(TestCase):
 
 
 class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
-    def setUp(self):
-        post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
-        return super().setUp()
-
-    def tearDown(self):
-        post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
-        return super().tearDown()
-
     @classmethod
     def setUpTestData(cls):
+        cls.user = UserFactory()
         cls.groupe = CanteenFactory(
-            production_type=Canteen.ProductionType.GROUPE, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.GROUPE,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[cls.user],
         )
         cls.satellite_1 = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=cls.groupe, yearly_meal_count=450
@@ -806,6 +820,14 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
         for field in Diagnostic.COMPLETE_APPRO_FIELDS:
             cls.appro_fields[field] = 500.75
 
+    def setUp(self):
+        post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
+        return super().setUp()
+
+    def tearDown(self):
+        post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
+        return super().tearDown()
+
     def verify_appro_fields_divided(self, fields, satellite_diagnostic, groupe_diagnostic, divisor):
         for field in fields:
             with self.subTest(field=field):
@@ -814,7 +836,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 expected_value = groupe_value / divisor
                 assert_almost_equal(self, diagnostic_value, expected_value)
 
-    @authenticate
     def test_total_value_divided_by_satellite_yearly_meal_count(self):
         """
         Before, we divided the total value by the number of satellites.
@@ -827,7 +848,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 year=2025,
                 valeur_totale=total_value,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            groupe_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -846,7 +867,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
             total_value / (self.groupe_satellites_yearly_meal_count_sum / self.satellite_2.yearly_meal_count),
         )
 
-    @authenticate
     def test_cout_repas_computed_per_satellite(self):
         """
         cout_repas depends on the satellite's yearly_meal_count.
@@ -860,7 +880,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 year=2025,
                 valeur_totale=total_value,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            groupe_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Before the script is run
         groupe_diagnostic = Diagnostic.all_objects.in_year(2025).teledeclared().get(canteen=self.groupe)
@@ -877,7 +897,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
         self.assertEqual(satellite_1_diagnostic.cout_repas, Decimal("4.04"))
         self.assertEqual(satellite_2_diagnostic.cout_repas, Decimal("4.04"))
 
-    @authenticate
     def test_groupe_type_simple(self):
         """
         Test that when a groupe canteen teledeclares with mode ALL.
@@ -890,7 +909,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
                 **self.appro_fields,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            groupe_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -911,7 +930,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                     / satellite_diagnostic.canteen_snapshot["yearly_meal_count"],
                 )
 
-    @authenticate
     def test_groupe_type_complete(self):
         """
         Test that when a groupe canteen teledeclares in mode ALL with COMPLETE type.
@@ -924,7 +942,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
                 **self.appro_fields,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            groupe_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -945,7 +963,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                     / satellite_diagnostic.canteen_snapshot["yearly_meal_count"],
                 )
 
-    @authenticate
     def test_groupe_no_type(self):
         """
         Test that when a groupe canteen teledeclares without mode.
@@ -958,7 +975,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
                 **self.appro_fields,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            groupe_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -979,7 +996,6 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                     / satellite_diagnostic.canteen_snapshot["yearly_meal_count"],
                 )
 
-    @authenticate
     def test_mode_all_non_appro_fields_are_copied(self):
         """
         Test that when a groupe canteen teledeclares in mode ALL with non appro fields, the values are copied in the generated diagnostics.
@@ -991,7 +1007,7 @@ class Teledeclaration1Td1SiteTunnelFieldsValuesTest(TestCase):
                 diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
                 central_kitchen_diagnostic_mode=Diagnostic.CentralKitchenDiagnosticMode.ALL,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user, skip_validations=True)
+            groupe_diagnostic.teledeclare(applicant=self.user, skip_validations=True)
 
         # Run the script
         call_command("teledeclaration_generate_1td1site", year=2025, apply=True)
@@ -1013,10 +1029,13 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
     Test the teledeclaration of canteen or diagnostic not concerned by the 1td1site script are not modified when the command is run.
     """
 
-    @authenticate
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
     def test_canteen_site(self):
-        site_1 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
-        site_2 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+        site_1 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[self.user])
+        site_2 = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[self.user])
 
         with freeze_time("2026-03-30"):  # during the 2025 campaign
             diagnostic_site_1 = DiagnosticFactory(
@@ -1029,8 +1048,8 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 year=2025,
                 diagnostic_type=Diagnostic.DiagnosticType.COMPLETE,
             )
-            diagnostic_site_1.teledeclare(applicant=authenticate.user)
-            diagnostic_site_2.teledeclare(applicant=authenticate.user)
+            diagnostic_site_1.teledeclare(applicant=self.user)
+            diagnostic_site_2.teledeclare(applicant=self.user)
 
         diagnostic_site_1_before_script = diagnostic_site_1
         diagnostic_site_2_before_script = diagnostic_site_2
@@ -1057,10 +1076,12 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
         self.assertEqual(diagnostic_site_1, diagnostic_site_1_before_script)
         self.assertEqual(diagnostic_site_2, diagnostic_site_2_before_script)
 
-    @authenticate
     def test_teledeclaration_other_year_are_not_generated(self):
         groupe = CanteenFactory(
-            production_type=Canteen.ProductionType.GROUPE, yearly_meal_count=1011, daily_meal_count=3
+            production_type=Canteen.ProductionType.GROUPE,
+            yearly_meal_count=1011,
+            daily_meal_count=3,
+            managers=[self.user],
         )
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
@@ -1072,7 +1093,7 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic_2023.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic_2023.teledeclare(applicant=self.user)
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             groupe_diagnostic_2024 = DiagnosticFactory(
@@ -1081,7 +1102,7 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic_2024.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic_2024.teledeclare(applicant=self.user)
 
         with freeze_time("2026-03-30"):  # during the 2025 campaign
             groupe_diagnostic_2025 = DiagnosticFactory(
@@ -1090,7 +1111,7 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic_2025.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic_2025.teledeclare(applicant=self.user)
 
         # Before the script is run
         self.assertEqual(Diagnostic.all_objects.count(), 3)
@@ -1107,12 +1128,11 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
         self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
         self.assertEqual(Diagnostic.all_objects.in_year(2025).teledeclared().count(), 3)
 
-    @authenticate
     def test_groupe_with_diagnostic_not_teledeclared(self):
         """
         Test that when a diagnostic is draft, it is not modified when the script is run.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         with freeze_time("2026-03-30"):  # during the 2025 campaign
             DiagnosticFactory(
@@ -1129,12 +1149,11 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
         self.assertEqual(Diagnostic.all_objects.in_year(2025).teledeclared().count(), 0)
         self.assertEqual(Diagnostic.all_objects.in_year(2025).filter(generated_from_groupe_diagnostic=True).count(), 0)
 
-    @authenticate
     def test_cancelled_groupe_diagnostics(self):
         """
         If a teledeclaration is cancelled, no diagnostics should be generated.
         """
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
         with freeze_time("2026-03-30"):  # during the 2025 campaign
             groupe_diagnostic = DiagnosticFactory(
@@ -1143,7 +1162,7 @@ class Teledeclaration1Td1SiteNotConcernedByScriptTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            groupe_diagnostic.teledeclare(applicant=authenticate.user)
+            groupe_diagnostic.teledeclare(applicant=self.user)
             groupe_diagnostic.cancel()
 
         # Run the script

--- a/macantine/tests/test_teledeclaration_resubmit.py
+++ b/macantine/tests/test_teledeclaration_resubmit.py
@@ -5,11 +5,14 @@ from django.db.models.signals import post_save
 
 from data.models.canteen import Canteen, fill_geo_fields_from_siret
 from data.models import Diagnostic
-from api.tests.utils import authenticate
 from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 
 
 class TeledeclarationResubmitScriptTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
     def setUp(self):
         post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
         return super().setUp()
@@ -18,9 +21,8 @@ class TeledeclarationResubmitScriptTest(TestCase):
         post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
         return super().tearDown()
 
-    @authenticate
     def test_resubmit_single_diagnostic(self):
-        canteen = CanteenFactory(name="First name", city_insee_code="38185")
+        canteen = CanteenFactory(name="First name", city_insee_code="38185", managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(
@@ -29,7 +31,7 @@ class TeledeclarationResubmitScriptTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            diagnostic.teledeclare(applicant=authenticate.user)
+            diagnostic.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -56,20 +58,19 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertEqual(diagnostic.canteen_snapshot["name"], "New name")
             self.assertEqual(diagnostic.canteen_snapshot["city_insee_code"], "34172")
 
-    @authenticate
     def test_resubmit_multiple_diagnostics(self):
-        canteen_1 = CanteenFactory()
-        canteen_2 = CanteenFactory()
-        canteen_3 = CanteenFactory()
+        canteen_1 = CanteenFactory(managers=[self.user])
+        canteen_2 = CanteenFactory(managers=[self.user])
+        canteen_3 = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic_1 = DiagnosticFactory(canteen=canteen_1, year=2024, valeur_totale=10000, valeur_bio=2000)
             diagnostic_2 = DiagnosticFactory(canteen=canteen_2, year=2024, valeur_totale=10000, valeur_bio=2000)
             diagnostic_3 = DiagnosticFactory(canteen=canteen_3, year=2024, valeur_totale=10000, valeur_bio=2000)
 
-            diagnostic_1.teledeclare(applicant=authenticate.user)
-            diagnostic_2.teledeclare(applicant=authenticate.user)
-            diagnostic_3.teledeclare(applicant=authenticate.user)
+            diagnostic_1.teledeclare(applicant=self.user)
+            diagnostic_2.teledeclare(applicant=self.user)
+            diagnostic_3.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 3)
@@ -88,17 +89,16 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertTrue(diagnostic_2.is_teledeclared)
             self.assertTrue(diagnostic_3.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_from_different_year(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic_2024 = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic_2024.teledeclare(applicant=authenticate.user)
+            diagnostic_2024.teledeclare(applicant=self.user)
 
         with freeze_time("2026-04-15"):  # during the 2025 campaign
             diagnostic_2025 = DiagnosticFactory(canteen=canteen, year=2025, valeur_totale=10000, valeur_bio=2000)
-            diagnostic_2025.teledeclare(applicant=authenticate.user)
+            diagnostic_2025.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -112,16 +112,15 @@ class TeledeclarationResubmitScriptTest(TestCase):
             diagnostic_2025.refresh_from_db()
             self.assertTrue(diagnostic_2025.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_not_teledeclared(self):
-        canteen_1 = CanteenFactory()
-        canteen_2 = CanteenFactory()
+        canteen_1 = CanteenFactory(managers=[self.user])
+        canteen_2 = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic_teledeclared = DiagnosticFactory(
                 canteen=canteen_1, year=2024, valeur_totale=10000, valeur_bio=2000
             )
-            diagnostic_teledeclared.teledeclare(applicant=authenticate.user)
+            diagnostic_teledeclared.teledeclare(applicant=self.user)
 
             # Create a diagnostic that is not teledeclared
             diagnostic_not_teledeclared = DiagnosticFactory(
@@ -144,13 +143,12 @@ class TeledeclarationResubmitScriptTest(TestCase):
             self.assertTrue(diagnostic_teledeclared.is_teledeclared)
             self.assertFalse(diagnostic_not_teledeclared.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_not_found(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=authenticate.user)
+            diagnostic.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -165,13 +163,12 @@ class TeledeclarationResubmitScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertTrue(diagnostic.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_if_diagnostic_validation_error(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=authenticate.user)
+            diagnostic.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -189,13 +186,12 @@ class TeledeclarationResubmitScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertTrue(diagnostic.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_if_canteen_validation_error(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=authenticate.user)
+            diagnostic.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -213,16 +209,17 @@ class TeledeclarationResubmitScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertTrue(diagnostic.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_if_canteen_satellite_validation_error(self):
-        canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         canteen_satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe
         )
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
-            diagnostic = DiagnosticFactory(canteen=canteen_groupe, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=authenticate.user)
+            diagnostic_groupe = DiagnosticFactory(
+                canteen=canteen_groupe, year=2024, valeur_totale=10000, valeur_bio=2000
+            )
+            diagnostic_groupe.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -234,27 +231,25 @@ class TeledeclarationResubmitScriptTest(TestCase):
 
         with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Run the script
-            call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic.id))
+            call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic_groupe.id))
 
             # After running the script, the diagnostic should still be teledeclared (resubmission failed)
-            diagnostic.refresh_from_db()
-            self.assertTrue(diagnostic.is_teledeclared)
+            diagnostic_groupe.refresh_from_db()
+            self.assertTrue(diagnostic_groupe.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_if_canteen_applicant_deleted(self):
-        canteen = CanteenFactory()
-        user = UserFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=user)
+            diagnostic.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
 
         with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Delete the user
-            user.delete()
+            self.user.delete()
 
             # Run the script
             call_command("teledeclaration_resubmit", year=2024, teledeclaration_id_list=str(diagnostic.id))

--- a/macantine/tests/test_teledeclaration_submit_correction.py
+++ b/macantine/tests/test_teledeclaration_submit_correction.py
@@ -5,11 +5,14 @@ from django.db.models.signals import post_save
 
 from data.models.canteen import Canteen, fill_geo_fields_from_siret
 from data.models import Diagnostic
-from api.tests.utils import authenticate
 from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 
 
 class TeledeclarationSubmitCorrectionScriptTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
     def setUp(self):
         post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
         return super().setUp()
@@ -18,9 +21,8 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
         post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
         return super().tearDown()
 
-    @authenticate
     def test_submit_single_diagnostic_in_correction(self):
-        canteen = CanteenFactory(name="First name", city_insee_code="38185")
+        canteen = CanteenFactory(name="First name", city_insee_code="38185", managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(
@@ -29,7 +31,7 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
                 valeur_totale=10000,
                 valeur_bio=2000,
             )
-            diagnostic.teledeclare(applicant=authenticate.user)
+            diagnostic.teledeclare(applicant=self.user)
 
         with freeze_time("2025-04-17"):  # during the 2024 correction campaign
             # Before running the script
@@ -56,25 +58,24 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertEqual(diagnostic.id, original_diagnostic_id)
             self.assertTrue(diagnostic.is_teledeclared)
-            self.assertEqual(diagnostic.applicant, authenticate.user)
+            self.assertEqual(diagnostic.applicant, self.user)
             self.assertNotEqual(diagnostic.teledeclaration_date, original_teledeclaration_date)
             self.assertEqual(diagnostic.canteen_snapshot["name"], "New name")
             self.assertEqual(diagnostic.canteen_snapshot["city_insee_code"], "34172")
 
-    @authenticate
     def test_submit_multiple_diagnostics_in_correction(self):
-        canteen_1 = CanteenFactory()
-        canteen_2 = CanteenFactory()
-        canteen_3 = CanteenFactory()
+        canteen_1 = CanteenFactory(managers=[self.user])
+        canteen_2 = CanteenFactory(managers=[self.user])
+        canteen_3 = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic_1 = DiagnosticFactory(canteen=canteen_1, year=2024, valeur_totale=10000, valeur_bio=2000)
             diagnostic_2 = DiagnosticFactory(canteen=canteen_2, year=2024, valeur_totale=10000, valeur_bio=2000)
             diagnostic_3 = DiagnosticFactory(canteen=canteen_3, year=2024, valeur_totale=10000, valeur_bio=2000)
 
-            diagnostic_1.teledeclare(applicant=authenticate.user)
-            diagnostic_2.teledeclare(applicant=authenticate.user)
-            diagnostic_3.teledeclare(applicant=authenticate.user)
+            diagnostic_1.teledeclare(applicant=self.user)
+            diagnostic_2.teledeclare(applicant=self.user)
+            diagnostic_3.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 3)
@@ -96,15 +97,14 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             self.assertTrue(diagnostic_2.is_teledeclared)
             self.assertTrue(diagnostic_3.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_teledeclared(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic_teledeclared = DiagnosticFactory(
                 canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000
             )
-            diagnostic_teledeclared.teledeclare(applicant=authenticate.user)
+            diagnostic_teledeclared.teledeclare(applicant=self.user)
             original_teledeclaration_date = diagnostic_teledeclared.teledeclaration_date
 
             # Before running the script
@@ -120,9 +120,8 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             self.assertTrue(diagnostic_teledeclared.is_teledeclared)
             self.assertEqual(diagnostic_teledeclared.teledeclaration_date, original_teledeclaration_date)
 
-    @authenticate
     def test_skip_diagnostic_in_draft(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic_draft = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
@@ -139,13 +138,12 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             diagnostic_draft.refresh_from_db()
             self.assertFalse(diagnostic_draft.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_if_diagnostic_validation_error(self):
-        canteen = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE)
+        canteen = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=authenticate.user)
+            diagnostic.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -167,13 +165,12 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
-    @authenticate
     def test_skip_diagnostic_if_canteen_validation_error(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=authenticate.user)
+            diagnostic.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -195,16 +192,15 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
-    @authenticate
     def test_skip_diagnostic_if_canteen_satellite_validation_error(self):
-        canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        canteen_groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         canteen_satellite = CanteenFactory(
             production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=canteen_groupe
         )
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen_groupe, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=authenticate.user)
+            diagnostic.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -226,14 +222,12 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
-    @authenticate
     def test_skip_diagnostic_if_canteen_applicant_deleted(self):
-        canteen = CanteenFactory()
-        user = UserFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=user)
+            diagnostic.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -244,7 +238,7 @@ class TeledeclarationSubmitCorrectionScriptTest(TestCase):
             self.assertEqual(diagnostic.status, Diagnostic.DiagnosticStatus.CORRECTION)
 
             # Delete the user
-            user.delete()
+            self.user.delete()
 
             # Run the script
             call_command("teledeclaration_submit_correction", year=2024)

--- a/macantine/tests/test_teledeclaration_submit_outside_of_campaign.py
+++ b/macantine/tests/test_teledeclaration_submit_outside_of_campaign.py
@@ -5,11 +5,14 @@ from django.db.models.signals import post_save
 
 from data.models.canteen import Canteen, fill_geo_fields_from_siret
 from data.models import Diagnostic
-from api.tests.utils import authenticate
-from data.factories import CanteenFactory, DiagnosticFactory
+from data.factories import CanteenFactory, DiagnosticFactory, UserFactory
 
 
 class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
     def setUp(self):
         post_save.disconnect(fill_geo_fields_from_siret, sender=Canteen)
         return super().setUp()
@@ -18,9 +21,8 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
         post_save.connect(fill_geo_fields_from_siret, sender=Canteen)
         return super().tearDown()
 
-    @authenticate
     def test_submit_single_diagnostic_after_campaign(self):
-        canteen = CanteenFactory(name="First name", city_insee_code="38185")
+        canteen = CanteenFactory(name="First name", city_insee_code="38185", managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(
@@ -39,20 +41,19 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 "teledeclaration_submit_outside_of_campaign",
                 year=2024,
                 diagnostic_id_list=str(diagnostic.id),
-                applicant_id=authenticate.user.id,
+                applicant_id=self.user.id,
                 apply=True,
             )
 
             # After running the script
             diagnostic.refresh_from_db()
             self.assertTrue(diagnostic.is_teledeclared)
-            self.assertEqual(diagnostic.applicant, authenticate.user)
+            self.assertEqual(diagnostic.applicant, self.user)
 
-    @authenticate
     def test_submit_multiple_diagnostics_after_campaign(self):
-        canteen_1 = CanteenFactory()
-        canteen_2 = CanteenFactory()
-        canteen_3 = CanteenFactory()
+        canteen_1 = CanteenFactory(managers=[self.user])
+        canteen_2 = CanteenFactory(managers=[self.user])
+        canteen_3 = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic_1 = DiagnosticFactory(canteen=canteen_1, year=2024, valeur_totale=10000, valeur_bio=2000)
@@ -69,7 +70,7 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 "teledeclaration_submit_outside_of_campaign",
                 year=2024,
                 diagnostic_id_list=diagnostic_ids,
-                applicant_id=authenticate.user.id,
+                applicant_id=self.user.id,
                 apply=True,
             )
 
@@ -82,9 +83,8 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             self.assertTrue(diagnostic_2.is_teledeclared)
             self.assertTrue(diagnostic_3.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_from_different_year(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
 
@@ -101,7 +101,7 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 "teledeclaration_submit_outside_of_campaign",
                 year=2024,
                 diagnostic_id_list=str(diagnostic_2025.id),
-                applicant_id=authenticate.user.id,
+                applicant_id=self.user.id,
                 apply=True,
             )
 
@@ -109,16 +109,15 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             diagnostic_2025.refresh_from_db()
             self.assertFalse(diagnostic_2025.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_teledeclared(self):
-        canteen_1 = CanteenFactory()
-        canteen_2 = CanteenFactory()
+        canteen_1 = CanteenFactory(managers=[self.user])
+        canteen_2 = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic_teledeclared = DiagnosticFactory(
                 canteen=canteen_1, year=2024, valeur_totale=10000, valeur_bio=2000
             )
-            diagnostic_teledeclared.teledeclare(applicant=authenticate.user)
+            diagnostic_teledeclared.teledeclare(applicant=self.user)
             diagnostic_not_teledeclared = DiagnosticFactory(
                 canteen=canteen_2, year=2024, valeur_totale=10000, valeur_bio=2000
             )
@@ -134,7 +133,7 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 "teledeclaration_submit_outside_of_campaign",
                 year=2024,
                 diagnostic_id_list=diagnostic_ids,
-                applicant_id=authenticate.user.id,
+                applicant_id=self.user.id,
                 apply=True,
             )
 
@@ -145,9 +144,8 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             self.assertTrue(diagnostic_teledeclared.is_teledeclared)
             self.assertTrue(diagnostic_not_teledeclared.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_not_found(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
@@ -163,7 +161,7 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 "teledeclaration_submit_outside_of_campaign",
                 year=2024,
                 diagnostic_id_list=diagnostic_ids,
-                applicant_id=authenticate.user.id,
+                applicant_id=self.user.id,
                 apply=True,
             )
 
@@ -171,9 +169,8 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertTrue(diagnostic.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_if_before_campaign(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-01-01"):  # before the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
@@ -186,7 +183,7 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 "teledeclaration_submit_outside_of_campaign",
                 year=2024,
                 diagnostic_id_list=str(diagnostic.id),
-                applicant_id=authenticate.user.id,
+                applicant_id=self.user.id,
                 apply=True,
             )
 
@@ -194,9 +191,8 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertFalse(diagnostic.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_draft_if_during_campaign(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
@@ -209,7 +205,7 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 "teledeclaration_submit_outside_of_campaign",
                 year=2024,
                 diagnostic_id_list=str(diagnostic.id),
-                applicant_id=authenticate.user.id,
+                applicant_id=self.user.id,
                 apply=True,
             )
 
@@ -217,13 +213,12 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertFalse(diagnostic.is_teledeclared)
 
-    @authenticate
     def test_skip_diagnostic_correction_if_during_correction_campaign(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=authenticate.user)
+            diagnostic.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -237,7 +232,7 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 "teledeclaration_submit_outside_of_campaign",
                 year=2024,
                 diagnostic_id_list=str(diagnostic.id),
-                applicant_id=authenticate.user.id,
+                applicant_id=self.user.id,
                 apply=True,
             )
 
@@ -245,9 +240,8 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertFalse(diagnostic.is_teledeclared)
 
-    @authenticate
     def test_submit_diagnostic_even_if_diagnostic_validation_error(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
@@ -266,7 +260,7 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 "teledeclaration_submit_outside_of_campaign",
                 year=2024,
                 diagnostic_id_list=str(diagnostic.id),
-                applicant_id=authenticate.user.id,
+                applicant_id=self.user.id,
                 apply=True,
             )
 
@@ -274,13 +268,12 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertTrue(diagnostic.is_teledeclared)
 
-    @authenticate
     def test_submit_diagnostic_even_if_canteen_validation_error(self):
-        canteen = CanteenFactory()
+        canteen = CanteenFactory(managers=[self.user])
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
             diagnostic = DiagnosticFactory(canteen=canteen, year=2024, valeur_totale=10000, valeur_bio=2000)
-            diagnostic.teledeclare(applicant=authenticate.user)
+            diagnostic.teledeclare(applicant=self.user)
 
             # Before running the script
             self.assertEqual(Diagnostic.all_objects.in_year(2024).teledeclared().count(), 1)
@@ -296,7 +289,7 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 "teledeclaration_submit_outside_of_campaign",
                 year=2024,
                 diagnostic_id_list=str(diagnostic.id),
-                applicant_id=authenticate.user.id,
+                applicant_id=self.user.id,
                 apply=True,
             )
 
@@ -304,9 +297,8 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
             diagnostic.refresh_from_db()
             self.assertTrue(diagnostic.is_teledeclared)
 
-    @authenticate
     def test_submit_diagnostic_even_if_satellite_validation_error(self):
-        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE)
+        groupe = CanteenFactory(production_type=Canteen.ProductionType.GROUPE, managers=[self.user])
         satellite = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE_CENTRAL, groupe=groupe)
 
         with freeze_time("2025-03-30"):  # during the 2024 campaign
@@ -326,7 +318,7 @@ class TeledeclarationSubmitOutsideOfCampaignScriptTest(TestCase):
                 "teledeclaration_submit_outside_of_campaign",
                 year=2024,
                 diagnostic_id_list=str(diagnostic.id),
-                applicant_id=authenticate.user.id,
+                applicant_id=self.user.id,
                 apply=True,
             )
 


### PR DESCRIPTION
### Quoi

- Ajoute une règle supplémentaire dans la méthode `Diagnostic.teledeclare()`
- ajout de tests + réparer les ~200 tests qui cassaient :sweat_smile: 