### PR TITLE
improve(Diagnostics): Règles métiers: s'assurer que valeur_famille est toujours supérieur ou égale à chaque valeur_famille_label & à la somme des valeur_famille_label

### DIFF
--- a/api/tests/test_diagnostics_simple_import.py
+++ b/api/tests/test_diagnostics_simple_import.py
@@ -186,7 +186,7 @@ class DiagnosticsSimpleImportApiErrorTest(APITestCase):
         body = response.json()
         errors = body["errors"]
         self.assertEqual(body["count"], 0)
-        self.assertEqual(len(errors), 17)
+        self.assertEqual(len(errors), 21)
         self.assertEqual(errors[0]["row"], 2)
         self.assertEqual(errors[0]["status"], 400)
         self.assertEqual(
@@ -220,45 +220,61 @@ class DiagnosticsSimpleImportApiErrorTest(APITestCase):
         )
         self.assertEqual(
             errors[7]["message"],
-            "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, Origine France, 100, est plus que la valeur totale (HT) viandes et volailles, 50",
+            "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur (HT) viandes_volailles, 50, est moins que la valeur (HT) viandes_volailles_france, 100",
         )
         self.assertEqual(
             errors[8]["message"],
-            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, EGalim, 100, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
+            "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, Origine France, 100, est plus que la valeur totale (HT) viandes et volailles, 50",
         )
         self.assertEqual(
             errors[9]["message"],
-            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, Origine France, 100, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
+            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, EGalim, 100, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
         )
         self.assertEqual(
             errors[10]["message"],
+            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur (HT) produits_de_la_mer, 50, est moins que la valeur (HT) produits_de_la_mer_france, 100",
+        )
+        self.assertEqual(
+            errors[11]["message"],
+            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, Origine France, 100, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
+        )
+        self.assertEqual(
+            errors[12]["message"],
             # TODO: is this the best field to point to as being wrong? hors bio could be confusing
             "Champ 'Produits SIQO (hors bio) - Valeur annuelle HT' : La somme des valeurs viandes et poissons, EGalim, 300, est plus que la somme des valeurs bio, SIQO, environnementales et autres EGalim, 200",
         )
         self.assertEqual(
-            errors[11]["message"],
+            errors[13]["message"],
             "Champ 'Bio - Valeur annuelle HT' : La valeur (HT) bio dont commerce équitable, 150, est plus que la valeur totale (HT) bio, 50",
         )
         self.assertEqual(
-            errors[12]["message"],
+            errors[14]["message"],
             "Champ 'Valeur totale (HT) des autres achats EGalim' : La valeur (HT) achats commerce équitable (hors bio), 150, est plus que la valeur totale (HT) des autres achats EGalim, 50",
         )
         # Both totals meat are greater than the total return 2 errors
         self.assertEqual(
-            errors[13]["message"],
+            errors[15]["message"],
+            "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur (HT) viandes_volailles, 50, est moins que la valeur (HT) viandes_volailles_france, 60",
+        )
+        self.assertEqual(
+            errors[16]["message"],
             "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, EGalim, 60, est plus que la valeur totale (HT) viandes et volailles, 50",
         )
         self.assertEqual(
-            errors[14]["message"],
+            errors[17]["message"],
             "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, Origine France, 60, est plus que la valeur totale (HT) viandes et volailles, 50",
         )
         # Both totals meat are greater than the total return 2 errors
         self.assertEqual(
-            errors[15]["message"],
+            errors[18]["message"],
+            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur (HT) produits_de_la_mer, 50, est moins que la valeur (HT) produits_de_la_mer_france, 60",
+        )
+        self.assertEqual(
+            errors[19]["message"],
             "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, EGalim, 60, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
         )
         self.assertEqual(
-            errors[16]["message"],
+            errors[20]["message"],
             "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, Origine France, 60, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
         )
 

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1854,6 +1854,7 @@ class Diagnostic(models.Model):
             diagnostic_validators.validate_diagnostic_type(self),
             diagnostic_validators.validate_appro_fields_required(self),
             diagnostic_validators.validate_valeur_totale(self),
+            diagnostic_validators.validate_valeur_famille(self),
             diagnostic_validators.validate_valeur_bio(self),
             diagnostic_validators.validate_valeur_egalim_autres(self),
             diagnostic_validators.validate_viandes_volailles_total(self),

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -253,6 +253,48 @@ class DiagnosticModelSaveTest(TransactionTestCase):
                 self.assertRaises(ValidationError, diagnostic.full_clean)
 
     @freeze_time("2026-01-30")  # during the 2025 campaign
+    def test_diagnostic_valeur_famille(self):
+        VALID_DIAGNOSTIC_COMPLETE_2025 = VALID_DIAGNOSTIC_SIMPLE_2025.copy()
+        # default: ok
+        diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_COMPLETE_2025)
+        self.assertEqual(diagnostic.valeur_viandes_volailles, 100)
+        self.assertEqual(diagnostic.family_sum("viandes_volailles"), 0)  # only APPRO_LABELS
+        diagnostic.full_clean()  # should not raise
+        # 1 valeur_famille_label cannot be > valeur_famille
+        diagnostic.valeur_viandes_volailles_bio = 200
+        diagnostic.valeur_viandes_volailles_fermier = 50
+        diagnostic.save()
+        self.assertEqual(diagnostic.valeur_viandes_volailles, 100)
+        self.assertRaises(ValidationError, diagnostic.full_clean)
+        # even for non-egalim labels
+        diagnostic.valeur_viandes_volailles_bio = 10
+        diagnostic.valeur_viandes_volailles_fermier = 10
+        diagnostic.valeur_viandes_volailles_europe = 200
+        diagnostic.save()
+        self.assertEqual(diagnostic.valeur_viandes_volailles, 100)
+        self.assertRaises(ValidationError, diagnostic.full_clean)
+        # sum of valeur_famille_label cannot be > valeur_famille
+        diagnostic.valeur_viandes_volailles_bio = 10
+        diagnostic.valeur_viandes_volailles_label_rouge = 10
+        diagnostic.valeur_viandes_volailles_aocaop_igp_stg = 10
+        diagnostic.valeur_viandes_volailles_hve = 10
+        diagnostic.valeur_viandes_volailles_peche_durable = 10
+        diagnostic.valeur_viandes_volailles_rup = 10
+        diagnostic.valeur_viandes_volailles_commerce_equitable = 10
+        diagnostic.valeur_viandes_volailles_fermier = 10
+        diagnostic.valeur_viandes_volailles_externalites = 10
+        diagnostic.valeur_viandes_volailles_performance = 10
+        diagnostic.valeur_viandes_volailles_non_egalim = 10
+        diagnostic.valeur_viandes_volailles_europe = 10
+        diagnostic.valeur_viandes_volailles_france = 10
+        diagnostic.valeur_viandes_volailles_circuit_court = 10
+        diagnostic.valeur_viandes_volailles_local = 10
+        diagnostic.save()
+        self.assertEqual(diagnostic.valeur_viandes_volailles, 100)
+        self.assertEqual(diagnostic.family_sum("viandes_volailles"), 110)  # only APPRO_LABELS
+        self.assertRaises(ValidationError, diagnostic.full_clean)
+
+    @freeze_time("2026-01-30")  # during the 2025 campaign
     def test_diagnostic_valeur_viandes_volailles_validation(self):
         VALID_DIAGNOSTIC_WITHOUT_VALEUR_VIANDES_VOLAILLES = VALID_DIAGNOSTIC_SIMPLE_2025.copy()
         VALID_DIAGNOSTIC_WITHOUT_VALEUR_VIANDES_VOLAILLES.pop("valeur_viandes_volailles")

--- a/data/validators/diagnostic.py
+++ b/data/validators/diagnostic.py
@@ -139,6 +139,38 @@ def validate_valeur_totale(instance):
     return errors
 
 
+def validate_valeur_famille(instance):
+    """
+    - clean_fields() (called by full_clean()) already does some checks
+    - extra validation:
+        - for each family field:
+            - valeur_famille must be >= each of the valeur_famille_label fields
+            - valeur_famille must be >= sum of each label for that family
+    """
+    errors = {}
+    for family in instance.APPRO_FAMILIES:
+        field_name = f"valeur_{family}"
+        field_value = getattr(instance, field_name)
+        if field_value is not None:
+            for label in instance.APPRO_LABELS_ALL:
+                family_label_field_name = f"valeur_{family}_{label}"
+                family_label_field_value = getattr(instance, family_label_field_name)
+                if family_label_field_value and family_label_field_value > field_value:
+                    utils_utils.add_validation_error(
+                        errors,
+                        field_name,
+                        f"La valeur (HT) {family}, {field_value}, est moins que la valeur (HT) {family_label_field_name}, {family_label_field_value}",
+                    )
+            family_sum = instance.family_sum(family)
+            if family_sum and family_sum > field_value:
+                utils_utils.add_validation_error(
+                    errors,
+                    field_name,
+                    f"La valeur (HT) {family}, {field_value}, est moins que la somme des valeurs d'approvisionnement de tous les labels, {family_sum}",
+                )
+    return errors
+
+
 def validate_valeur_bio(instance):
     """
     - extra validation:

--- a/data/validators/diagnostic.py
+++ b/data/validators/diagnostic.py
@@ -159,7 +159,7 @@ def validate_valeur_famille(instance):
                     utils_utils.add_validation_error(
                         errors,
                         field_name,
-                        f"La valeur (HT) {family}, {field_value}, est moins que la valeur (HT) {family_label_field_name}, {family_label_field_value}",
+                        f"La valeur (HT) {family}, {field_value}, est moins que la valeur (HT) {family}_{label}, {family_label_field_value}",
                     )
             family_sum = instance.family_sum(family)
             if family_sum and family_sum > field_value:


### PR DESCRIPTION
### Quoi

Suite à l'ajout des champs `valeur_*famille*` dans #7005

On rajoute ici des règles de validation/cohérences pour s'assurer que les TD sont de bonnes qualités
Pour chaque famille
- valeur_famille > chacun des valeur_famille_label
- valeur_famille > somme des valeur_famille_label (seulement ceux sommables / appro / egalim)