### PR TITLE
improve(Diagnostics): Règles métiers: s'assurer que valeur_famille_bio est toujours supérieur ou égale à valeur_famille_bio_dont_commerce_equitable

### DIFF
--- a/api/tests/test_diagnostics_simple_import.py
+++ b/api/tests/test_diagnostics_simple_import.py
@@ -186,7 +186,7 @@ class DiagnosticsSimpleImportApiErrorTest(APITestCase):
         body = response.json()
         errors = body["errors"]
         self.assertEqual(body["count"], 0)
-        self.assertEqual(len(errors), 21)
+        self.assertEqual(len(errors), 22)
         self.assertEqual(errors[0]["row"], 2)
         self.assertEqual(errors[0]["status"], 400)
         self.assertEqual(

--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -1865,6 +1865,7 @@ class Diagnostic(models.Model):
             diagnostic_validators.validate_appro_fields_required(self),
             diagnostic_validators.validate_valeur_totale(self),
             diagnostic_validators.validate_valeur_famille(self),
+            diagnostic_validators.validate_valeur_famille_bio(self),
             diagnostic_validators.validate_valeur_bio(self),
             diagnostic_validators.validate_valeur_egalim_autres(self),
             diagnostic_validators.validate_viandes_volailles_total(self),

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -311,6 +311,23 @@ class DiagnosticModelSaveTest(TransactionTestCase):
         self.assertRaises(ValidationError, diagnostic.full_clean)
 
     @freeze_time("2026-01-30")  # during the 2025 campaign
+    def test_diagnostic_valeur_famille_bio(self):
+        diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2025)
+        # default (None): ok
+        self.assertEqual(diagnostic.valeur_viandes_volailles_bio, None)
+        self.assertEqual(diagnostic.valeur_viandes_volailles_bio_dont_commerce_equitable, None)
+        diagnostic.full_clean()  # should not raise
+        # filled: ok
+        diagnostic.valeur_viandes_volailles_bio = 50
+        diagnostic.valeur_viandes_volailles_bio_dont_commerce_equitable = 10
+        diagnostic.save()
+        diagnostic.full_clean()  # should not raise
+        # bio_dont_commerce_equitable cannot be > bio
+        diagnostic.valeur_viandes_volailles_bio_dont_commerce_equitable = 60
+        diagnostic.save()
+        self.assertRaises(ValidationError, diagnostic.full_clean)
+
+    @freeze_time("2026-01-30")  # during the 2025 campaign
     def test_diagnostic_valeur_viandes_volailles_validation(self):
         VALID_DIAGNOSTIC_WITHOUT_VALEUR_VIANDES_VOLAILLES = VALID_DIAGNOSTIC_SIMPLE_2025.copy()
         VALID_DIAGNOSTIC_WITHOUT_VALEUR_VIANDES_VOLAILLES.pop("valeur_viandes_volailles")

--- a/data/validators/diagnostic.py
+++ b/data/validators/diagnostic.py
@@ -190,6 +190,30 @@ def validate_valeur_famille(instance):
     return errors
 
 
+def validate_valeur_famille_bio(instance):
+    """
+    - extra validation:
+        - valeur_famille_bio must be >= valeur_famille_bio_dont_commerce_equitable
+    """
+    errors = {}
+    for family in instance.APPRO_FAMILIES:
+        field_name = f"valeur_{family}_bio"
+        field_value = getattr(instance, field_name)
+        if field_value is not None:
+            bio_dont_commerce_equitable_field_name = f"{field_name}_dont_commerce_equitable"
+            bio_dont_commerce_equitable_field_value = getattr(instance, bio_dont_commerce_equitable_field_name)
+            if (
+                bio_dont_commerce_equitable_field_value is not None
+                and bio_dont_commerce_equitable_field_value > field_value
+            ):
+                utils_utils.add_validation_error(
+                    errors,
+                    field_name,
+                    f"La valeur (HT) bio dont commerce équitable, {bio_dont_commerce_equitable_field_value}, est plus que la valeur totale (HT) bio, {field_value}",
+                )
+    return errors
+
+
 def validate_valeur_bio(instance):
     """
     - extra validation:


### PR DESCRIPTION
### Quoi

Dans la continuité de #7007
Nouvelles validations spécifiques à valeur_*famille_bio : doit toujours être >= à valeur_*famille_bio_dont_commerce_equitable