### PR TITLE
refactor(Diagnostics): API: ajouter un serializer à l'endpoint `/recap` (et mieux documenter)

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -39,6 +39,7 @@ from .diagnostic import (  # noqa: F401
     PublicApproDiagnosticSerializer,
     PublicServiceDiagnosticSerializer,
     DiagnosticCheckSerializer,
+    DiagnosticRecapSerializer,
 )
 from .diagnostic_teledeclaration import (  # noqa: F401
     DiagnosticTeledeclaredAnalysisSerializer,

--- a/api/serializers/diagnostic.py
+++ b/api/serializers/diagnostic.py
@@ -246,3 +246,12 @@ class DiagnosticAndCanteenSerializer(FullDiagnosticSerializer):
         from .canteen import FullCanteenSerializer
 
         return FullCanteenSerializer(obj.canteen).data
+
+
+class DiagnosticRecapSerializer(serializers.Serializer):
+    year = serializers.IntegerField(read_only=True)
+    is_teledeclared = serializers.BooleanField(read_only=True)
+    declaration_donnees = serializers.JSONField(read_only=True)
+    canteen_diagnostic_id = serializers.IntegerField(read_only=True)
+    generated_from_groupe_diagnostic_id = serializers.IntegerField(read_only=True)
+    generated_from_groupe_diagnostic_mode = serializers.CharField(read_only=True)

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -22,6 +22,7 @@ from api.serializers import (
     DiagnosticAndCanteenSerializer,
     ManagerDiagnosticSerializer,
     DiagnosticCheckSerializer,
+    DiagnosticRecapSerializer,
 )
 from api.views.utils import get_oauth_application, update_change_reason_with_auth
 from common.utils import file_import, send_mail
@@ -122,6 +123,14 @@ class DiagnosticRetrieveUpdateView(RetrieveUpdateAPIView):
         update_change_reason_with_auth(self, diagnostic)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        summary="Récupérer le récapitulatif par année des bilans d'une cantine.",
+        description="",
+        tags=["Bilans"],
+        responses=DiagnosticRecapSerializer(many=True),
+    ),
+)
 class DiagnosticListRecapView(APIView):
     permission_classes = [IsAuthenticated, IsCanteenManagerUrlParam]
 
@@ -168,7 +177,7 @@ class DiagnosticListRecapView(APIView):
                     "generated_from_groupe_diagnostic_mode": generated_from_groupe_diagnostic_mode,
                 }
             )
-        return Response(result)
+        return Response(DiagnosticRecapSerializer(result, many=True).data)
 
 
 @extend_schema_view(


### PR DESCRIPTION
### Quoi

Dans #6975 on a créé un endpoint `/recap` coté Diagnostic
Ici je repasse dessus rapido pour lui ajouter un serializer

### Pourquoi

Dans l'idée d'avoir un endpoint `/recap` aussi coté Achats 