### PR TITLE
fix(Stockage): répare la config S3 suite à la mise à jour de boto3

### DIFF
--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -205,21 +205,9 @@ default_file_storage = os.getenv("DEFAULT_FILE_STORAGE")
 STORAGES = {
     "default": {
         "BACKEND": default_file_storage,
-        # see https://github.com/jschneier/django-storages/issues/1482
-        "OPTIONS": {
-            "client_config": BotoConfig(
-                request_checksum_calculation="when_required", response_checksum_validation="when_required"
-            )
-        },
     },
     "staticfiles": {
         "BACKEND": os.getenv("STATICFILES_STORAGE"),
-        # see https://github.com/jschneier/django-storages/issues/1482
-        "OPTIONS": {
-            "client_config": BotoConfig(
-                request_checksum_calculation="when_required", response_checksum_validation="when_required"
-            )
-        },
     },
 }
 
@@ -230,6 +218,12 @@ if default_file_storage == "storages.backends.s3.S3Storage":
     AWS_STORAGE_BUCKET_NAME = os.getenv("CELLAR_BUCKET_NAME")
     AWS_LOCATION = "media"
     AWS_QUERYSTRING_AUTH = False
+    # see https://github.com/jschneier/django-storages/issues/1482
+    client_config = BotoConfig(
+        request_checksum_calculation="when_required", response_checksum_validation="when_required"
+    )
+    STORAGES["default"]["OPTIONS"] = {"client_config": client_config}
+    STORAGES["staticfiles"]["OPTIONS"] = {"client_config": client_config}
 
 MEDIA_ROOT = os.getenv("MEDIA_ROOT", os.path.join(BASE_DIR, "media"))
 MEDIA_URL = "/media/"

--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -19,6 +19,7 @@ import dotenv  # noqa
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
+from botocore.config import Config as BotoConfig
 
 from macantine.sentry import before_send
 
@@ -204,9 +205,21 @@ default_file_storage = os.getenv("DEFAULT_FILE_STORAGE")
 STORAGES = {
     "default": {
         "BACKEND": default_file_storage,
+        # see https://github.com/jschneier/django-storages/issues/1482
+        "OPTIONS": {
+            "client_config": BotoConfig(
+                request_checksum_calculation="when_required", response_checksum_validation="when_required"
+            )
+        },
     },
     "staticfiles": {
         "BACKEND": os.getenv("STATICFILES_STORAGE"),
+        # see https://github.com/jschneier/django-storages/issues/1482
+        "OPTIONS": {
+            "client_config": BotoConfig(
+                request_checksum_calculation="when_required", response_checksum_validation="when_required"
+            )
+        },
     },
 }
 


### PR DESCRIPTION
### Quoi

Dans #6791 on a fait le ménage dans nos dépendances.
Mais on a aussi mis à jour quelques packages au passage
```
boto3 / botocore : de 1.35.57 à 1.43.67
```

Sauf que... https://github.com/jschneier/django-storages/issues/1482
la v1.36 de boto3 change la config, django-storages n'est pas à jour, et ca buggait