### PR TITLE
improve(Diagnostics): Règles métiers: s'assurer que les nouveaux valeur_label sont toujours supérieur à chaque valeur_famille_label & à la somme des valeur_famille_label

### DIFF
--- a/data/models/diagnostic.py
+++ b/data/models/diagnostic.py
@@ -621,6 +621,22 @@ class Diagnostic(models.Model):
         "valeur_autres",
     ]
 
+    APPRO_LABEL_FIELDS = [
+        "valeur_bio",
+        "valeur_bio_dont_commerce_equitable",
+        "valeur_europe",
+        "valeur_france",
+        "valeur_circuit_court",
+        "valeur_local",
+    ]
+
+    APPRO_LABEL_GROUPE_FIELDS = [
+        "valeur_bio",
+        "valeur_siqo",
+        "valeur_externalites_performance",
+        "valeur_egalim_autres",
+    ]
+
     APPRO_FIELDS = [
         "valeur_viandes_volailles_bio",
         "valeur_viandes_volailles_bio_dont_commerce_equitable",
@@ -1958,8 +1974,7 @@ class Diagnostic(models.Model):
             diagnostic_validators.validate_valeur_totale(self),
             diagnostic_validators.validate_valeur_famille(self),
             diagnostic_validators.validate_valeur_famille_bio(self),
-            diagnostic_validators.validate_valeur_bio(self),
-            diagnostic_validators.validate_valeur_egalim_autres(self),
+            diagnostic_validators.validate_valeur_label(self),
             diagnostic_validators.validate_viandes_volailles_total(self),
             diagnostic_validators.validate_produits_de_la_mer_total(self),
             diagnostic_validators.validate_viandes_volailles_produits_de_la_mer_egalim(self),

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -328,6 +328,40 @@ class DiagnosticModelSaveTest(TransactionTestCase):
         self.assertRaises(ValidationError, diagnostic.full_clean)
 
     @freeze_time("2026-01-30")  # during the 2025 campaign
+    def test_diagnostic_valeur_bio_dont_commerce_equitable(self):
+        diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2025)
+        # default (None): ok
+        self.assertEqual(diagnostic.valeur_bio, 200)
+        self.assertEqual(diagnostic.valeur_bio_dont_commerce_equitable, None)
+        diagnostic.full_clean()  # should not raise
+        # filled: ok
+        diagnostic.valeur_bio = 50
+        diagnostic.valeur_bio_dont_commerce_equitable = 10
+        diagnostic.save()
+        diagnostic.full_clean()  # should not raise
+        # bio_dont_commerce_equitable cannot be > bio
+        diagnostic.valeur_bio_dont_commerce_equitable = 60
+        diagnostic.save()
+        self.assertRaises(ValidationError, diagnostic.full_clean)
+
+    @freeze_time("2026-01-30")  # during the 2025 campaign
+    def test_diagnostic_valeur_egalim_autres_dont_commerce_equitable(self):
+        diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2025)
+        # default (None): ok
+        self.assertEqual(diagnostic.valeur_egalim_autres, 100)
+        self.assertEqual(diagnostic.valeur_egalim_autres_dont_commerce_equitable, None)
+        diagnostic.full_clean()  # should not raise
+        # filled: ok
+        diagnostic.valeur_egalim_autres = 50
+        diagnostic.valeur_egalim_autres_dont_commerce_equitable = 10
+        diagnostic.save()
+        diagnostic.full_clean()  # should not raise
+        # egalim_autres_dont_commerce_equitable cannot be > egalim_autres
+        diagnostic.valeur_egalim_autres_dont_commerce_equitable = 60
+        diagnostic.save()
+        self.assertRaises(ValidationError, diagnostic.full_clean)
+
+    @freeze_time("2026-01-30")  # during the 2025 campaign
     def test_diagnostic_valeur_viandes_volailles_validation(self):
         VALID_DIAGNOSTIC_WITHOUT_VALEUR_VIANDES_VOLAILLES = VALID_DIAGNOSTIC_SIMPLE_2025.copy()
         VALID_DIAGNOSTIC_WITHOUT_VALEUR_VIANDES_VOLAILLES.pop("valeur_viandes_volailles")

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -63,9 +63,11 @@ VALID_DIAGNOSTIC_SIMPLE_2026 = {
     "valeur_externalites_performance": 100,
     "valeur_egalim_autres": 100,
     "valeur_viandes_volailles": 100,
+    "valeur_viandes_volailles_bio": 30,
     "valeur_viandes_volailles_egalim": 50,
     "valeur_viandes_volailles_france": 20,
     "valeur_produits_de_la_mer": 80,
+    "valeur_produits_de_la_mer_bio": 30,
     "valeur_produits_de_la_mer_egalim": 40,
 }
 
@@ -327,9 +329,30 @@ class DiagnosticModelSaveTest(TransactionTestCase):
         diagnostic.save()
         self.assertRaises(ValidationError, diagnostic.full_clean)
 
-    @freeze_time("2026-01-30")  # during the 2025 campaign
+    @freeze_time("2027-01-30")  # during the 2026 campaign
+    def test_diagnostic_valeur_label(self):
+        VALID_DIAGNOSTIC_COMPLETE_2026 = VALID_DIAGNOSTIC_SIMPLE_2026.copy()
+        # default: ok
+        diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_COMPLETE_2026)
+        self.assertEqual(diagnostic.valeur_bio, 200)
+        self.assertEqual(diagnostic.label_sum("bio"), 60)
+        # 1 valeur_famille_label cannot be > valeur_label
+        diagnostic.valeur_viandes_volailles_bio = 200
+        diagnostic.save()
+        self.assertEqual(diagnostic.valeur_bio, 200)
+        self.assertRaises(ValidationError, diagnostic.full_clean)
+        # sum of valeur_famille_label cannot be > valeur_label
+        diagnostic.valeur_viandes_volailles_bio = 30
+        diagnostic.valeur_fruits_et_legumes = 150
+        diagnostic.valeur_fruits_et_legumes_bio = 150
+        diagnostic.save()
+        self.assertEqual(diagnostic.valeur_bio, 200)
+        self.assertEqual(diagnostic.label_sum("bio"), 210)
+        self.assertRaises(ValidationError, diagnostic.full_clean)
+
+    @freeze_time("2027-01-30")  # during the 2026 campaign
     def test_diagnostic_valeur_bio_dont_commerce_equitable(self):
-        diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2025)
+        diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2026)
         # default (None): ok
         self.assertEqual(diagnostic.valeur_bio, 200)
         self.assertEqual(diagnostic.valeur_bio_dont_commerce_equitable, None)
@@ -344,9 +367,9 @@ class DiagnosticModelSaveTest(TransactionTestCase):
         diagnostic.save()
         self.assertRaises(ValidationError, diagnostic.full_clean)
 
-    @freeze_time("2026-01-30")  # during the 2025 campaign
+    @freeze_time("2027-01-30")  # during the 2026 campaign
     def test_diagnostic_valeur_egalim_autres_dont_commerce_equitable(self):
-        diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2025)
+        diagnostic = DiagnosticFactory(**VALID_DIAGNOSTIC_SIMPLE_2026)
         # default (None): ok
         self.assertEqual(diagnostic.valeur_egalim_autres, 100)
         self.assertEqual(diagnostic.valeur_egalim_autres_dont_commerce_equitable, None)

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -358,12 +358,11 @@ class DiagnosticModelSaveTest(TransactionTestCase):
         self.assertEqual(diagnostic.valeur_bio_dont_commerce_equitable, None)
         diagnostic.full_clean()  # should not raise
         # filled: ok
-        diagnostic.valeur_bio = 50
         diagnostic.valeur_bio_dont_commerce_equitable = 10
         diagnostic.save()
         diagnostic.full_clean()  # should not raise
         # bio_dont_commerce_equitable cannot be > bio
-        diagnostic.valeur_bio_dont_commerce_equitable = 60
+        diagnostic.valeur_bio_dont_commerce_equitable = 210
         diagnostic.save()
         self.assertRaises(ValidationError, diagnostic.full_clean)
 
@@ -375,12 +374,11 @@ class DiagnosticModelSaveTest(TransactionTestCase):
         self.assertEqual(diagnostic.valeur_egalim_autres_dont_commerce_equitable, None)
         diagnostic.full_clean()  # should not raise
         # filled: ok
-        diagnostic.valeur_egalim_autres = 50
         diagnostic.valeur_egalim_autres_dont_commerce_equitable = 10
         diagnostic.save()
         diagnostic.full_clean()  # should not raise
         # egalim_autres_dont_commerce_equitable cannot be > egalim_autres
-        diagnostic.valeur_egalim_autres_dont_commerce_equitable = 60
+        diagnostic.valeur_egalim_autres_dont_commerce_equitable = 110
         diagnostic.save()
         self.assertRaises(ValidationError, diagnostic.full_clean)
 

--- a/data/validators/diagnostic.py
+++ b/data/validators/diagnostic.py
@@ -75,7 +75,7 @@ def validate_canteen_fields_required(instance):
     """
     - clean_fields() (called by full_clean()) already does some checks
     - extra validation: depending on the year of the diagnostic
-        - in 2026 and after, nombre_repas_an is required
+        - [NEW in 2026] nombre_repas_an is required
     """
     errors = {}
     if instance.year:
@@ -163,8 +163,8 @@ def validate_valeur_famille(instance):
     - clean_fields() (called by full_clean()) already does some checks
     - extra validation:
         - for each family field:
-            - valeur_famille must be >= each of the valeur_famille_label fields
-            - valeur_famille must be >= sum of each label for that family
+            - valeur_*famille* must be >= each of the valeur_*famille*_*label* fields
+            - valeur_*famille* must be >= sum of each label for that family
     """
     errors = {}
     for family in instance.APPRO_FAMILIES:
@@ -193,7 +193,7 @@ def validate_valeur_famille(instance):
 def validate_valeur_famille_bio(instance):
     """
     - extra validation:
-        - valeur_famille_bio must be >= valeur_famille_bio_dont_commerce_equitable
+        - valeur_*famille*_bio must be >= valeur_*famille*_bio_dont_commerce_equitable
     """
     errors = {}
     for family in instance.APPRO_FAMILIES:
@@ -214,12 +214,37 @@ def validate_valeur_famille_bio(instance):
     return errors
 
 
-def validate_valeur_bio(instance):
+def validate_valeur_label(instance):
     """
     - extra validation:
+        - for each (existing) label field:
+            - [NEW in 2026] valeur_*label* must be >= each of the valeur_*famille*_*label* fields
+            - [NEW in 2026] valeur_*label* must be >= sum of each family for that label
         - valeur_bio_dont_commerce_equitable must be <= valeur_bio
+        - valeur_egalim_autres_dont_commerce_equitable must be <= valeur_egalim_autres
     """
     errors = {}
+    if instance.year and int(instance.year) >= 2026:
+        for label in instance.APPRO_LABELS_ALL:
+            field_name = f"valeur_{label}"
+            field_value = getattr(instance, field_name, None)  # some don't exist
+            if field_value is not None:
+                for family in instance.APPRO_FAMILIES:
+                    family_label_field_name = f"valeur_{family}_{label}"
+                    family_label_field_value = getattr(instance, family_label_field_name)
+                    if family_label_field_value and family_label_field_value > field_value:
+                        utils_utils.add_validation_error(
+                            errors,
+                            field_name,
+                            f"La valeur (HT) {label}, {field_value}, est moins que la valeur (HT) {family}_{label}, {family_label_field_value}",
+                        )
+                label_sum = instance.label_sum(label)
+                if label_sum and label_sum > field_value:
+                    utils_utils.add_validation_error(
+                        errors,
+                        field_name,
+                        f"La valeur (HT) {label}, {field_value}, est moins que la somme des valeurs d'approvisionnement de toutes les familles, {label_sum}",
+                    )
     if instance.valeur_bio is not None:
         if (
             instance.valeur_bio_dont_commerce_equitable is not None
@@ -230,15 +255,6 @@ def validate_valeur_bio(instance):
                 "valeur_bio",
                 f"La valeur (HT) bio dont commerce équitable, {instance.valeur_bio_dont_commerce_equitable}, est plus que la valeur totale (HT) bio, {instance.valeur_bio}",
             )
-    return errors
-
-
-def validate_valeur_egalim_autres(instance):
-    """
-    - extra validation:
-        - valeur_egalim_autres_dont_commerce_equitable must be <= valeur_egalim_autres
-    """
-    errors = {}
     if instance.valeur_egalim_autres is not None:
         if (
             instance.valeur_egalim_autres_dont_commerce_equitable is not None


### PR DESCRIPTION
### Quoi

Similaire à #7007

Dans #7019 on a créé de nouveaux champs `valeur_france`, `valeur_europe`, `valeur_circuit_court` & `valeur_local`

On rajoute ici des règles de validation/cohérences pour s'assurer que les TD sont de bonnes qualités
Pour chaque label
- valeur_label > chacun des valeur_famille_label
- valeur_label > somme des valeur_famille_label
