### PR TITLE
improve(Télédéclaration): CAMPAIGN_DATES: ne rendre visible que les années qui sont "validées" (ont un lien `legifrance_url` vers l'arrêté)

### DIFF
--- a/api/serializers/statistics.py
+++ b/api/serializers/statistics.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from rest_framework import serializers
 
 from data.models import Canteen, SectorCategory
-from macantine.utils import CAMPAIGN_DATES, EGALIM_OBJECTIVES, get_year_campaign_end_date_or_today_date
+from macantine.utils import CAMPAIGN_DATES_VALID, EGALIM_OBJECTIVES, get_year_campaign_end_date_or_today_date
 
 logger = logging.getLogger(__name__)
 
@@ -174,7 +174,7 @@ class CanteenStatisticsSerializer(serializers.Serializer):
         Hide data if the report for the given year is not published yet.
         """
         year = int(year)
-        if year not in CAMPAIGN_DATES.keys():
+        if year not in CAMPAIGN_DATES_VALID.keys():
             for field in CanteenStatisticsSerializer.FIELDS_TO_HIDE_IF_CAMPAIGN_NOT_FOUND:
                 data[field] = None
             # TODO: ajouter le cas où la campagne de TD n'a pas commencé mais dont on connait les dates
@@ -186,7 +186,7 @@ class CanteenStatisticsSerializer(serializers.Serializer):
                 data["notes"]["campaign_info"] = (
                     f"Aucune campagne de télédéclaration trouvée pour l'année {year}. Veuillez vérifier l'année saisie."
                 )
-        elif not CAMPAIGN_DATES[year].get("rapport_parlement_url"):
+        elif not CAMPAIGN_DATES_VALID[year].get("rapport_parlement_url"):
             for field in CanteenStatisticsSerializer.FIELDS_TO_HIDE_IF_REPORT_NOT_PUBLISHED:
                 data[field] = None
             data["notes"]["campaign_info"] = (

--- a/api/views/diagnostic.py
+++ b/api/views/diagnostic.py
@@ -29,7 +29,7 @@ from common.utils import file_import, send_mail
 from data.models import Canteen, Teledeclaration
 from data.models.creation_source import CreationSource
 from data.models.diagnostic import Diagnostic
-from macantine.utils import CAMPAIGN_DATES, is_in_correction
+from macantine.utils import CAMPAIGN_DATES_VALID, is_in_correction
 
 logger = logging.getLogger(__name__)
 
@@ -142,9 +142,9 @@ class DiagnosticListRecapView(APIView):
         canteen = self._get_canteen()
         canteen_diagnostics = Diagnostic.all_objects.filter(canteen=canteen)
         result = []
-        for year in CAMPAIGN_DATES.keys():
+        for year in CAMPAIGN_DATES_VALID.keys():
             # skip years where the canteen was not yet created
-            if canteen.creation_date > CAMPAIGN_DATES[year]["teledeclaration_end_date"]:
+            if canteen.creation_date > CAMPAIGN_DATES_VALID[year]["teledeclaration_end_date"]:
                 continue
             # is_teledeclared: if at least 1 of the canteen's diagnostics is SUBMITTED
             is_teledeclared = any(d.year == year and d.is_teledeclared for d in canteen_diagnostics)

--- a/api/views/diagnostic_teledeclaration.py
+++ b/api/views/diagnostic_teledeclaration.py
@@ -21,7 +21,7 @@ from api.permissions import (
 )
 from api.serializers import DiagnosticTeledeclaredAnalysisSerializer, DiagnosticTeledeclaredOpenDataSerializer
 from data.models import Canteen, Diagnostic, Teledeclaration
-from macantine.utils import CAMPAIGN_DATES
+from macantine.utils import CAMPAIGN_DATES_VALID
 
 logger = logging.getLogger(__name__)
 
@@ -330,7 +330,7 @@ class DiagnosticTeledeclaredAnalysisListView(ListAPIView):
     ordering_fields = ["creation_date"]
 
     def get_queryset(self):
-        return Diagnostic.objects.valid_td_all_years(CAMPAIGN_DATES.keys()).order_by("teledeclaration_date")
+        return Diagnostic.objects.valid_td_all_years(CAMPAIGN_DATES_VALID.keys()).order_by("teledeclaration_date")
 
 
 class DiagnosticTeledeclaredOpenDataListView(ListAPIView):

--- a/api/views/teledeclaration.py
+++ b/api/views/teledeclaration.py
@@ -5,7 +5,7 @@ from rest_framework.generics import ListAPIView, RetrieveAPIView
 
 from api.serializers import CampaignDatesSerializer, CampaignDatesFullSerializer
 from macantine.utils import (
-    CAMPAIGN_DATES,
+    CAMPAIGN_DATES_VALID,
     is_in_correction,
     is_in_teledeclaration,
 )
@@ -23,8 +23,8 @@ class TeledeclarationCampaignDatesListView(ListAPIView):
 
     def get(self, request, format=None):
         campaign_dates = []
-        for year in CAMPAIGN_DATES.keys():
-            campaign_dates.append({"year": year, **CAMPAIGN_DATES[year]})
+        for year in CAMPAIGN_DATES_VALID.keys():
+            campaign_dates.append({"year": year, **CAMPAIGN_DATES_VALID[year]})
         return Response(self.get_serializer(campaign_dates, many=True).data)
 
 
@@ -39,11 +39,11 @@ class TeledeclarationCampaignDatesRetrieveView(RetrieveAPIView):
     serializer_class = CampaignDatesFullSerializer
 
     def get(self, request, year, format=None):
-        if not CAMPAIGN_DATES.get(year):
+        if not CAMPAIGN_DATES_VALID.get(year):
             return Response(status=status.HTTP_404_NOT_FOUND)
         campaign_dates_for_year = {
             "year": year,
-            **CAMPAIGN_DATES[year],
+            **CAMPAIGN_DATES_VALID[year],
             "in_teledeclaration": is_in_teledeclaration(),
             "in_correction": is_in_correction(),
         }

--- a/macantine/etl/analysis.py
+++ b/macantine/etl/analysis.py
@@ -11,7 +11,7 @@ from data.models import Canteen, Diagnostic, Purchase, User, WasteMeasurement
 from data.models.sector import get_category_lib_list_from_canteen_snapshot, get_sector_lib_list_from_canteen_snapshot
 from macantine.etl import etl, utils
 from macantine.etl.data_ware_house import DataWareHouse
-from macantine.utils import CAMPAIGN_DATES
+from macantine.utils import CAMPAIGN_DATES_VALID
 from data.models.geo import Department, Region
 
 logger = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ class ETL_ANALYSIS_TELEDECLARATIONS(etl.EXTRACTOR, ANALYSIS):
     def __init__(self):
         super().__init__()
         self.warehouse = DataWareHouse()
-        self.years = CAMPAIGN_DATES.keys()
+        self.years = CAMPAIGN_DATES_VALID.keys()
         self.dataset_name = "teledeclarations"
         self.schema = json.load(open("data/schemas/export_analysis/schema_teledeclarations.json"))
         self.columns = [field["name"] for field in self.schema["fields"]]

--- a/macantine/utils.py
+++ b/macantine/utils.py
@@ -175,6 +175,10 @@ CAMPAIGN_DATES = {
 }
 
 
+# keep only years with legifrance_url (arrêté publié)
+CAMPAIGN_DATES_VALID = {year: dates for year, dates in CAMPAIGN_DATES.items() if dates.get("legifrance_url")}
+
+
 def is_in_teledeclaration(year=None):
     """
     Check if the current date is within a teledeclaration period.


### PR DESCRIPTION
### Quoi

Suite à #7014 (ajout de `legifrance_url`)
on créé un `CAMPAIGN_DATES_VALID` à partir de `CAMPAIGN_DATES`
- CAMPAIGN_DATES_VALID est pour les données envoyées au grand public (endpoint dédié, stats)
- CAMPAIGN_DATES reste en interne et permet de commencer à tester les modifications sur le modèle de données sans casser