### PR TITLE
fix(Stockage): répare la config S3 suite à la mise à jour de boto3 (v2)

### DIFF
--- a/macantine/settings.py
+++ b/macantine/settings.py
@@ -217,11 +217,9 @@ if default_file_storage == "storages.backends.s3.S3Storage":
     AWS_LOCATION = "media"
     AWS_QUERYSTRING_AUTH = False
     # see https://github.com/jschneier/django-storages/issues/1482
-    client_config = BotoConfig(
+    AWS_S3_CLIENT_CONFIG = BotoConfig(
         request_checksum_calculation="when_required", response_checksum_validation="when_required"
     )
-    STORAGES["default"]["OPTIONS"] = {"client_config": client_config}
-    STORAGES["staticfiles"]["OPTIONS"] = {"client_config": client_config}
 
 MEDIA_ROOT = os.getenv("MEDIA_ROOT", os.path.join(BASE_DIR, "media"))
 MEDIA_URL = "/media/"


### PR DESCRIPTION
### Quoi

v2 de #7028

En fait le "client_config" était deprecated... j'aurais du tester en local j'avais en effet une erreur
```
File "...ma-cantine/.venv/lib/python3.12/site-packages/django/contrib/staticfiles/storage.py", line 30, in __init__
    super().__init__(location, base_url, *args, **kwargs)
TypeError: FileSystemStorage.__init__() got an unexpected keyword argument 'client_config'
```

J'ai changé pour la bonne facon :crossed_fingers: 