### PR TITLE
refactor(Achats): API: spliter l'endpoint `/summary` en 2 (avec et sans year)

### DIFF
--- a/api/tests/test_purchases.py
+++ b/api/tests/test_purchases.py
@@ -691,6 +691,58 @@ class CanteenPurchasesSummaryApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
+    def test_can_get_canteen_purchases_summary(self):
+        self.canteen.managers.add(authenticate.user)
+
+        PurchaseFactory(canteen=self.canteen, prix_ht=100, date="2020-01-01")
+        PurchaseFactory(canteen=self.canteen, prix_ht=50, date="2020-12-31")
+        PurchaseFactory(canteen=self.canteen, prix_ht=300, date="2021-01-01")
+        PurchaseFactory(canteen=self.canteen, prix_ht=150, date="2021-12-31")
+        other_canteen = CanteenFactory(managers=[authenticate.user])
+        PurchaseFactory(canteen=other_canteen, prix_ht=999, date="2021-01-01")
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("results", body)
+        self.assertEqual(len(body["results"]), 2)  # multi year
+        self.assertEqual(body["results"][0]["year"], 2020)
+        self.assertEqual(body["results"][0]["valeurTotale"], 150)
+        self.assertIn("valeurBio", body["results"][0])
+        self.assertEqual(body["results"][1]["year"], 2021)
+        self.assertEqual(body["results"][1]["valeurTotale"], 450)
+
+
+class CanteenPurchasesSummaryForYearApiTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.canteen = CanteenFactory()
+        cls.year = 2020
+        cls.url = reverse(
+            "canteen_purchases_summary_for_year", kwargs={"canteen_pk": cls.canteen.id, "year": cls.year}
+        )
+
+    def test_cannot_get_canteen_purchases_summary_for_year_if_unauthenticated(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_cannot_get_canteen_purchases_summary_for_year_if_canteen_does_not_exist(self):
+        response = self.client.get(
+            reverse("canteen_purchases_summary_for_year", kwargs={"canteen_pk": 9999, "year": self.year})
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @authenticate
+    def test_cannot_get_canteen_purchases_summary_for_year_if_not_canteen_manager(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
     def test_can_get_purchase_total_summary(self):
         """
         Given a year, return spending by category
@@ -781,8 +833,7 @@ class CanteenPurchasesSummaryApiTest(APITestCase):
             canteen=self.canteen, date="2019-01-01", caracteristiques=[Purchase.Characteristic.BIO], prix_ht=666
         )
 
-        payload = {"year": 2020}
-        response = self.client.get(self.url, payload)
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -890,8 +941,7 @@ class CanteenPurchasesSummaryApiTest(APITestCase):
             canteen=self.canteen, date="2019-01-01", caracteristiques=[Purchase.Characteristic.BIO], prix_ht=666
         )
 
-        payload = {"year": 2020}
-        response = self.client.get(self.url, payload)
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -971,8 +1021,7 @@ class CanteenPurchasesSummaryApiTest(APITestCase):
             prix_ht=10,
         )
 
-        payload = {"year": 2020}
-        response = self.client.get(self.url, payload)
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -1043,8 +1092,7 @@ class CanteenPurchasesSummaryApiTest(APITestCase):
             prix_ht=10,
         )
 
-        payload = {"year": 2020}
-        response = self.client.get(self.url, payload)
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         body = response.json()
@@ -1052,29 +1100,6 @@ class CanteenPurchasesSummaryApiTest(APITestCase):
         self.assertEqual(body["valeurProduitsDeLaMerEgalim"], 55 + 40 + 30)
         self.assertEqual(body["valeurProduitsDeLaMerFrance"], 55 + 15)
         self.assertEqual(body["valeurProduitsDeLaMerLocal"], 0)
-
-    @authenticate
-    def test_can_get_multi_year_purchase_statistics(self):
-        self.canteen.managers.add(authenticate.user)
-
-        PurchaseFactory(canteen=self.canteen, prix_ht=100, date="2020-01-01")
-        PurchaseFactory(canteen=self.canteen, prix_ht=50, date="2020-12-31")
-        PurchaseFactory(canteen=self.canteen, prix_ht=300, date="2021-01-01")
-        PurchaseFactory(canteen=self.canteen, prix_ht=150, date="2021-12-31")
-        other_canteen = CanteenFactory(managers=[authenticate.user])
-        PurchaseFactory(canteen=other_canteen, prix_ht=999, date="2021-01-01")
-
-        response = self.client.get(self.url)  # no payload
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        body = response.json()
-        self.assertIn("results", body)
-        self.assertEqual(len(body["results"]), 2)
-        self.assertEqual(body["results"][0]["year"], 2020)
-        self.assertEqual(body["results"][0]["valeurTotale"], 150)
-        self.assertIn("valeurBio", body["results"][0])
-        self.assertEqual(body["results"][1]["year"], 2021)
-        self.assertEqual(body["results"][1]["valeurTotale"], 450)
 
 
 class PurchaseOptionsApiTest(APITestCase):

--- a/api/urls.py
+++ b/api/urls.py
@@ -13,6 +13,7 @@ from api.views import (
     CanteenMinistriesView,
     CanteenPurchasesPercentageSummaryView,
     CanteenPurchasesSummaryView,
+    CanteenPurchasesSummaryForYearView,
     CanteensCreateImportView,
     CanteensManagersImportView,
     CanteenStatisticsView,
@@ -154,6 +155,11 @@ urlpatterns = {
         "canteens/<int:canteen_pk>/purchases/summary",
         CanteenPurchasesSummaryView.as_view(),
         name="canteen_purchases_summary",
+    ),
+    path(
+        "canteens/<int:canteen_pk>/purchases/summary/<int:year>",
+        CanteenPurchasesSummaryForYearView.as_view(),
+        name="canteen_purchases_summary_for_year",
     ),
     path(
         "canteens/<int:canteen_pk>/purchases/percentageSummary",

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -63,6 +63,7 @@ from .partnertype import PartnerTypeListView  # noqa: F401
 from .purchase import (  # noqa: F401
     CanteenPurchasesPercentageSummaryView,
     CanteenPurchasesSummaryView,
+    CanteenPurchasesSummaryForYearView,
     DiagnosticsFromPurchasesView,
     PurchaseCreateView,
     PurchaseFactureView,

--- a/api/views/purchase.py
+++ b/api/views/purchase.py
@@ -303,9 +303,22 @@ class CanteenPurchasesSummaryView(APIView):
 
     def get(self, request, *args, **kwargs):
         canteen = self._get_canteen()
-        year = request.query_params.get("year")
-        data = Purchase.canteen_summary_for_year(canteen, year) if year else Purchase.canteen_summary(canteen)
-        return Response(PurchaseSummarySerializer(data).data if year else data)
+        data = Purchase.canteen_summary(canteen)
+        return Response(data)
+
+
+class CanteenPurchasesSummaryForYearView(APIView):
+    permission_classes = [IsCanteenManagerUrlParam]
+
+    def _get_canteen(self):
+        # IsCanteenManagerUrlParam will raise a 404 if the canteen doesn't exist
+        return Canteen.objects.get(pk=self.kwargs["canteen_pk"])
+
+    def get(self, request, *args, **kwargs):
+        canteen = self._get_canteen()
+        year = self.kwargs["year"]
+        data = Purchase.canteen_summary_for_year(canteen, year)
+        return Response(PurchaseSummarySerializer(data).data)
 
 
 class CanteenPurchasesPercentageSummaryView(APIView):

--- a/frontend/src/components/DiagnosticSummary/PurchasesSummary.vue
+++ b/frontend/src/components/DiagnosticSummary/PurchasesSummary.vue
@@ -83,7 +83,7 @@ export default {
       this.purchasesSummary = null
       this.purchasesFetchingError = false
       if (this.canteen?.id) {
-        return fetch(`/api/v1/canteens/${this.canteen.id}/purchases/summary?year=${this.year}`)
+        return fetch(`/api/v1/canteens/${this.canteen.id}/purchases/summary/${this.year}`)
           .then((response) => (response.ok ? response.json() : {}))
           .then((response) => (this.purchasesSummary = response))
           .catch(() => {

--- a/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/index.vue
+++ b/frontend/src/views/DiagnosticTunnel/QualityMeasureSteps/index.vue
@@ -188,7 +188,7 @@ export default {
       this.$emit("tunnel-autofill", e)
     },
     fetchPurchasesSummary() {
-      fetch(`/api/v1/canteens/${this.canteen.id}/purchases/summary?year=${this.diagnostic.year}`)
+      fetch(`/api/v1/canteens/${this.canteen.id}/purchases/summary/${this.diagnostic.year}`)
         .then((response) => (response.ok ? response.json() : {}))
         .then((response) => {
           if (Object.values(response).some((x) => !!x)) {

--- a/frontend/src/views/PurchasesSummary.vue
+++ b/frontend/src/views/PurchasesSummary.vue
@@ -314,7 +314,7 @@ export default {
       this.summary = null
       if (!this.vizCanteenId || !this.vizYear) return
       this.loading = true
-      fetch(`/api/v1/canteens/${this.vizCanteenId}/purchases/summary?year=${this.vizYear}`)
+      fetch(`/api/v1/canteens/${this.vizCanteenId}/purchases/summary/${this.vizYear}`)
         .then((response) => (response.ok ? response.json() : {}))
         .then((response) => {
           this.summary = response


### PR DESCRIPTION
### Quoi

Suite à un premier ménage dans #7024
Ici on va un peu plus loin et on split en 2 endpoints : CanteenPurchasesSummaryView & CanteenPurchasesSummaryForYearView
- pour mieux s'y retrouver
- splitter aussi les tests
- voir ce qui manque pour que les 2 soient "homogènes", voir créer un nouvel endpoint "diagnostic"