### PR TITLE
refactor(Admin): restreindre le 2FA aux seuls superuser (v1)

### DIFF
--- a/macantine/admin.py
+++ b/macantine/admin.py
@@ -1,17 +1,39 @@
 from django.contrib import admin
-from django_otp.admin import OTPAdminSite
+from django_otp.admin import OTPAdminAuthenticationForm, OTPAdminSite
 from django.urls import path, reverse
 
 from data.admin.sector import sector_textchoices_admin_view
 from data.admin.textchoices import CANTEEN_TEXTCHOICES_PAGES, canteen_textchoices_admin_view
 
 
+class MaCantineOTPAdminAuthenticationForm(OTPAdminAuthenticationForm):
+    def clean(self):
+        # Skip OTPAdminAuthenticationForm.clean (which always calls clean_otp)
+        self.cleaned_data = super(OTPAdminAuthenticationForm, self).clean()
+        user = self.get_user()
+        if user is not None and user.is_superuser:
+            self.clean_otp(user)
+        return self.cleaned_data
+
+
 class MaCantineAdminSite(OTPAdminSite):
     """
     Custom AdminSite
-    - to use OTPAdminSite (require 2FA for admin login)
+    - to use OTPAdminSite (require 2FA for admin login, superusers only)
     - to inject synthetic, read-only entries in the app list
     """
+
+    login_form = MaCantineOTPAdminAuthenticationForm
+
+    def has_permission(self, request):
+        # Skip OTPAdminSite.has_permission, which requires is_verified() for all staff
+        if not admin.AdminSite.has_permission(self, request):
+            return False
+
+        if not request.user.is_superuser:
+            return True
+
+        return request.user.is_verified()
 
     def get_urls(self):
         custom_urls = [

--- a/macantine/tests/test_admin.py
+++ b/macantine/tests/test_admin.py
@@ -48,19 +48,37 @@ class MaCantineAdminSiteLoginTest(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("/admin/login/", response.url)
 
-    def test_staff_non_superuser_without_otp_redirected_to_login(self):
+    def test_staff_non_superuser_without_otp_can_access_admin(self):
         self.client.force_login(self.staff_not_superuser_no_otp)
         response = self.client.get(reverse("admin:index"))
 
-        self.assertEqual(response.status_code, 302)
-        self.assertIn("/admin/login/", response.url)
+        self.assertEqual(response.status_code, 200)
 
-    def test_staff_superuser_without_otp_redirected_to_setup(self):
+    def test_superuser_without_otp_redirected_to_login(self):
         self.client.force_login(self.superuser_no_otp)
         response = self.client.get(reverse("admin:index"))
 
         self.assertEqual(response.status_code, 302)
         self.assertIn("/admin/login/", response.url)
+
+    def test_staff_non_superuser_can_login_without_otp(self):
+        self.staff_not_superuser_no_otp.set_password("testPw1234#!")
+        self.staff_not_superuser_no_otp.save(update_fields=["password"])
+
+        response = self.client.post(
+            reverse("admin:login"),
+            {
+                "username": self.staff_not_superuser_no_otp.username,
+                "password": "testPw1234#!",
+                "next": reverse("admin:index"),
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/admin/", response.url)
+
+        final_response = self.client.get(response.url)
+        self.assertEqual(final_response.status_code, 200)
 
     def test_staff_user_with_otp_can_access_admin(self):
         # Set user password & device


### PR DESCRIPTION
### Quoi

Suite à #7040 (mise en place du 2FA sur l'admin)
Restreindre à seulement les superuser pour commencer
Ca demande de changer
- le formulaire de login (ignorer le champ otp_token si pas superuser)
- changer les permissions