### PR TITLE
improve(Utilisateurs): Admin: pouvoir filtrer par 'email confirmé', 'super-utilisateur' et 'groups'

### DIFF
--- a/data/admin/user.py
+++ b/data/admin/user.py
@@ -54,6 +54,7 @@ class MaCanteenUserAdmin(UserAdmin):
         "is_elected_official",
         "is_dev",
         "is_staff",
+        "groups",
         "is_superuser",
         HasTOTPDeviceFilter,
     )

--- a/data/admin/user.py
+++ b/data/admin/user.py
@@ -46,14 +46,15 @@ class MaCanteenUserAdmin(UserAdmin):
         "first_name",
         "last_name",
         "email",
-        "is_staff",
         "email_confirmed",
         "date_joined",
     )
     list_filter = (
+        "email_confirmed",
         "is_elected_official",
         "is_dev",
         "is_staff",
+        "is_superuser",
         HasTOTPDeviceFilter,
     )
     search_fields = (

--- a/data/admin/user.py
+++ b/data/admin/user.py
@@ -46,8 +46,10 @@ class MaCanteenUserAdmin(UserAdmin):
         "first_name",
         "last_name",
         "email",
-        "email_confirmed",
         "date_joined",
+        "email_confirmed",
+        "is_staff",
+        "is_superuser",
     )
     list_filter = (
         "email_confirmed",


### PR DESCRIPTION
### Quoi

Dans l'admin, permettre aux staff de facilement isoler les utilisateurs
- qui ont leur email confirmé ou pas
- qui sont superuser ou pas
- à quel groupe ils appartiennent