### PR TITLE
refactor(Backend): bouger la logique pillow/images dans un fichier dédié (et ajouter des tests)

### DIFF
--- a/common/utils/images.py
+++ b/common/utils/images.py
@@ -1,0 +1,89 @@
+from io import BytesIO
+
+from django.core.files.base import ContentFile
+from PIL import ExifTags
+from PIL import Image as Img
+
+
+def _needs_rotation(pillow_image):
+    orientation_tag = next(filter(lambda x: ExifTags.TAGS[x] == "Orientation", ExifTags.TAGS), None)
+    exif_data = pillow_image._getexif()
+
+    return exif_data and orientation_tag
+
+
+def _rotate_image(pillow_image):
+    needs_rotation = _needs_rotation(pillow_image)
+    if not needs_rotation:
+        return pillow_image
+
+    orientation_tag = next(filter(lambda x: ExifTags.TAGS[x] == "Orientation", ExifTags.TAGS), None)
+    exif_data = pillow_image._getexif()
+    orientation = dict(exif_data.items()).get(orientation_tag)
+
+    if orientation == 3:
+        return pillow_image.rotate(180, expand=True)
+    if orientation == 6:
+        return pillow_image.rotate(270, expand=True)
+    if orientation == 8:
+        return pillow_image.rotate(90, expand=True)
+    return pillow_image
+
+
+def _needs_resize(pillow_image, max_size):
+    return pillow_image.width > max_size or pillow_image.height > max_size
+
+
+def _resize_image(pillow_image, max_size):
+    needs_resize = _needs_resize(pillow_image, max_size)
+    if not needs_resize:
+        return pillow_image
+
+    if pillow_image.width >= pillow_image.height:
+        new_width = max_size
+        new_height = max_size * pillow_image.height / pillow_image.width
+    else:
+        new_width = max_size * pillow_image.width / pillow_image.height
+        new_height = max_size
+
+    return pillow_image.resize((int(new_width), int(new_height)))
+
+
+def _needs_alpha_channel_removal(pillow_image):
+    return pillow_image.mode in ("RGBA", "LA")
+
+
+def _remove_alpha_channel(pillow_image):
+    if _needs_alpha_channel_removal(pillow_image):
+        background = Img.new(pillow_image.mode[:-1], pillow_image.size, "#FFFFFF")
+        background.paste(pillow_image, pillow_image.split()[-1])
+        pillow_image = background
+    return pillow_image
+
+
+def optimize_image(image, name, max_size=1600):
+    try:
+        image_format = "jpeg"
+        pillow_image = Img.open(image)
+
+        if (
+            not _needs_resize(pillow_image, max_size)
+            and not _needs_rotation(pillow_image)
+            and not _needs_alpha_channel_removal(pillow_image)
+        ):
+            return image
+
+        pillow_image = _rotate_image(pillow_image)
+        pillow_image = _resize_image(pillow_image, max_size)
+        pillow_image = _remove_alpha_channel(pillow_image)
+
+        output = BytesIO()
+        pillow_image.save(output, format=image_format)
+        media_content = output.getvalue()
+
+        if media_content:
+            return ContentFile(media_content, name=name)
+        else:
+            return image
+    except Exception:
+        return image

--- a/common/utils/tests/test_images.py
+++ b/common/utils/tests/test_images.py
@@ -1,0 +1,62 @@
+from io import BytesIO
+
+from django.core.files.base import ContentFile
+from django.test import SimpleTestCase
+from PIL import Image
+
+from common.utils.images import optimize_image
+
+ORIENTATION_TAG = 0x0112
+
+
+def _build_image_file(size=(100, 100), mode="RGB", color="red", exif_orientation=None, image_format="JPEG"):
+    image = Image.new(mode, size, color)
+    save_kwargs = {}
+    if exif_orientation is not None:
+        exif = image.getexif()
+        exif[ORIENTATION_TAG] = exif_orientation
+        save_kwargs["exif"] = exif
+
+    buffer = BytesIO()
+    image.save(buffer, format=image_format, **save_kwargs)
+    buffer.seek(0)
+    return buffer
+
+
+class OptimizeImageTest(SimpleTestCase):
+    def test_returns_original_when_no_changes_needed(self):
+        image = _build_image_file(size=(100, 100))
+        result = optimize_image(image, "test.jpg", max_size=1600)
+        self.assertIs(result, image)
+
+    def test_resizes_image_larger_than_max_size(self):
+        image = _build_image_file(size=(2000, 1000))
+        result = optimize_image(image, "test.jpg", max_size=1600)
+        self.assertIsInstance(result, ContentFile)
+        resized = Image.open(result)
+        self.assertEqual(resized.size, (1600, 800))
+
+    def test_resizes_taller_than_wide_image_preserving_ratio(self):
+        image = _build_image_file(size=(1000, 2000))
+        result = optimize_image(image, "test.jpg", max_size=1600)
+        resized = Image.open(result)
+        self.assertEqual(resized.size, (800, 1600))
+
+    def test_removes_alpha_channel(self):
+        image = _build_image_file(size=(100, 100), mode="RGBA", color=(255, 0, 0, 128), image_format="PNG")
+        result = optimize_image(image, "test.png", max_size=1600)
+        self.assertIsInstance(result, ContentFile)
+        cleaned = Image.open(result)
+        self.assertEqual(cleaned.mode, "RGB")
+
+    def test_rotates_image_based_on_exif_orientation(self):
+        image = _build_image_file(size=(200, 100), exif_orientation=6)
+        result = optimize_image(image, "test.jpg", max_size=1600)
+        self.assertIsInstance(result, ContentFile)
+        rotated = Image.open(result)
+        self.assertEqual(rotated.size, (100, 200))
+
+    def test_returns_original_on_invalid_image(self):
+        invalid = BytesIO(b"not an image")
+        result = optimize_image(invalid, "test.jpg", max_size=1600)
+        self.assertIs(result, invalid)

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -17,6 +17,7 @@ from simple_history.utils import update_change_reason
 
 from common.utils import siret as utils_siret
 from common.utils import utils as utils_utils
+from common.utils.images import optimize_image
 from data.fields import ChoiceArrayField
 from data.models import AuthenticationMethodHistoricalRecords
 from data.models.creation_source import CreationSource
@@ -32,7 +33,6 @@ from data.utils import (
     get_diagnostic_lowest_limit_year,
     get_diagnostic_upper_limit_year,
     has_charfield_missing_query,
-    optimize_image,
 )
 from data.validators import canteen as canteen_validators
 from macantine.utils import (

--- a/data/models/partner.py
+++ b/data/models/partner.py
@@ -4,8 +4,8 @@ from ckeditor_uploader.fields import RichTextUploadingField
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from common.utils.images import optimize_image
 from data.fields import ChoiceArrayField
-from data.utils import optimize_image
 from data.models.partnertype import PartnerType
 from data.models.sector import SectorM2M, SectorCategory
 from data.models.geo import Department

--- a/data/models/user.py
+++ b/data/models/user.py
@@ -11,9 +11,9 @@ from django.dispatch import receiver
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from common.utils import utils as utils_utils
+from common.utils.images import optimize_image
 from data.fields import ChoiceArrayField
 from data.models.geo import Department
-from data.utils import optimize_image
 from data.validators import user as user_validators
 from macantine import brevo
 

--- a/data/utils.py
+++ b/data/utils.py
@@ -2,15 +2,11 @@ import csv
 import datetime
 import json
 from decimal import Decimal
-from io import BytesIO
 
-from django.core.files.base import ContentFile
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
 from django.db.models import Q
-from PIL import ExifTags
-from PIL import Image as Img
 
 
 class CustomJSONEncoder(DjangoJSONEncoder):
@@ -37,90 +33,6 @@ def array_overlap_query(field_name: str, values: list):
     for value in values:
         query |= Q(**{f"{field_name}__contains": [value]})
     return query
-
-
-def _needs_rotation(pillow_image):
-    orientation_tag = next(filter(lambda x: ExifTags.TAGS[x] == "Orientation", ExifTags.TAGS), None)
-    exif_data = pillow_image._getexif()
-
-    return exif_data and orientation_tag
-
-
-def _rotate_image(pillow_image):
-    needs_rotation = _needs_rotation(pillow_image)
-    if not needs_rotation:
-        return pillow_image
-
-    orientation_tag = next(filter(lambda x: ExifTags.TAGS[x] == "Orientation", ExifTags.TAGS), None)
-    exif_data = pillow_image._getexif()
-    orientation = dict(exif_data.items()).get(orientation_tag)
-
-    if orientation == 3:
-        return pillow_image.rotate(180, expand=True)
-    if orientation == 6:
-        return pillow_image.rotate(270, expand=True)
-    if orientation == 8:
-        return pillow_image.rotate(90, expand=True)
-    return pillow_image
-
-
-def _needs_resize(pillow_image, max_size):
-    return pillow_image.width > max_size or pillow_image.height > max_size
-
-
-def _resize_image(pillow_image, max_size):
-    needs_resize = _needs_resize(pillow_image, max_size)
-    if not needs_resize:
-        return pillow_image
-
-    if pillow_image.width >= pillow_image.height:
-        new_width = max_size
-        new_height = max_size * pillow_image.height / pillow_image.width
-    else:
-        new_width = max_size * pillow_image.width / pillow_image.height
-        new_height = max_size
-
-    return pillow_image.resize((int(new_width), int(new_height)))
-
-
-def _needs_alpha_channel_removal(pillow_image):
-    return pillow_image.mode in ("RGBA", "LA")
-
-
-def _remove_alpha_channel(pillow_image):
-    if _needs_alpha_channel_removal(pillow_image):
-        background = Img.new(pillow_image.mode[:-1], pillow_image.size, "#FFFFFF")
-        background.paste(pillow_image, pillow_image.split()[-1])
-        pillow_image = background
-    return pillow_image
-
-
-def optimize_image(image, name, max_size=1600):
-    try:
-        image_format = "jpeg"
-        pillow_image = Img.open(image)
-
-        if (
-            not _needs_resize(pillow_image, max_size)
-            and not _needs_rotation(pillow_image)
-            and not _needs_alpha_channel_removal(pillow_image)
-        ):
-            return image
-
-        pillow_image = _rotate_image(pillow_image)
-        pillow_image = _resize_image(pillow_image, max_size)
-        pillow_image = _remove_alpha_channel(pillow_image)
-
-        output = BytesIO()
-        pillow_image.save(output, format=image_format)
-        media_content = output.getvalue()
-
-        if media_content:
-            return ContentFile(media_content, name=name)
-        else:
-            return image
-    except Exception:
-        return image
 
 
 def get_diagnostic_lowest_limit_year():


### PR DESCRIPTION
### Quoi

Suite à #7093 on a mis à jour `pillow`.
mais ce n'est pas toujours simple de savoir si cela va casser notre utilisation du package ou non.
J'en profite pour refactorer le code & rajouter des tests justement.