### PR TITLE
refactor(Backend): bouger la logique camelize dans un fichier dédié (et gérer des strings) (et ajouter des tests)

### DIFF
--- a/api/views/canteen_create_import.py
+++ b/api/views/canteen_create_import.py
@@ -14,7 +14,7 @@ from data.models.creation_source import CreationSource
 from macantine.utils import is_in_teledeclaration_or_correction
 
 from .canteen_managers import AddManagerView
-from .utils import camelize
+from common.utils.camelize import camelize
 
 
 CANTEEN_SCHEMA_FILE_NAME = "cantines_creer.json"

--- a/api/views/canteen_managers_import.py
+++ b/api/views/canteen_managers_import.py
@@ -12,7 +12,7 @@ from common.utils import utils as utils_utils
 from data.models import Canteen, ImportType
 
 from .canteen_managers import AddManagerView
-from .utils import camelize
+from common.utils.camelize import camelize
 
 
 CANTEEN_MANAGERS_SCHEMA_FILE_NAME = "cantines_gestionnaires.json"

--- a/api/views/canteen_update_import.py
+++ b/api/views/canteen_update_import.py
@@ -14,7 +14,7 @@ from data.models import Canteen, ImportType, Sector
 from macantine.utils import is_in_teledeclaration_or_correction
 
 from .canteen_managers import AddManagerView
-from .utils import camelize
+from common.utils.camelize import camelize
 
 
 CANTEEN_UPDATE_SCHEMA_FILE_NAME = "cantines_modifier.json"

--- a/api/views/purchase_import_base.py
+++ b/api/views/purchase_import_base.py
@@ -14,7 +14,7 @@ from common.utils import utils as utils_utils
 from data.models import Canteen, ImportType, Purchase
 from data.models.creation_source import CreationSource
 
-from .utils import camelize
+from common.utils.camelize import camelize
 
 
 class BasePurchasesImportView(BaseImportView):

--- a/api/views/statistics.py
+++ b/api/views/statistics.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from api.serializers import CanteenStatisticsSerializer
-from api.views.utils import camelize
+from common.utils.camelize import camelize
 from data.models import Canteen, Diagnostic
 from data.models.sector import Sector
 from data.models.geo import Department, Region

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -1,19 +1,16 @@
-import json
 import logging
 
-from djangorestframework_camel_case.render import CamelCaseJSONRenderer
+from django.db.models import Model
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
+from oauth2_provider.models import Application
+from rest_framework.request import Request
+from rest_framework.views import APIView
 from simple_history.utils import update_change_reason
 
 logger = logging.getLogger(__name__)
 
 
-def camelize(data):
-    camel_case_bytes = CamelCaseJSONRenderer().render(data)
-    return json.loads(camel_case_bytes.decode("utf-8"))
-
-
-def get_oauth_application(request):
+def get_oauth_application(request: Request) -> Application | None:
     """Extract OAuth Application object from request if authenticated via token"""
     if isinstance(request.successful_authenticator, OAuth2Authentication):
         if request.auth and hasattr(request.auth, "application"):
@@ -21,11 +18,11 @@ def get_oauth_application(request):
     return None
 
 
-def update_change_reason_with_auth(view, object):
+def update_change_reason_with_auth(view: APIView, obj: Model) -> None:
     try:
         update_change_reason(
-            object, f"{view.request.successful_authenticator.__class__.__name__[:100]}"
+            obj, f"{view.request.successful_authenticator.__class__.__name__[:100]}"
         )  # The max allowed chars is 100
     except Exception as e:
-        logger.warning(f"Unable to set reason change on {view.__class__.__name__} for object ID : {object.id}: \n{e}")
-        update_change_reason(object, "Unknown")
+        logger.warning(f"Unable to set reason change on {view.__class__.__name__} for object ID : {obj.id}: \n{e}")
+        update_change_reason(obj, "Unknown")

--- a/common/utils/camelize.py
+++ b/common/utils/camelize.py
@@ -1,0 +1,12 @@
+import json
+import re
+
+from djangorestframework_camel_case.render import CamelCaseJSONRenderer
+from djangorestframework_camel_case.util import camelize_re, underscore_to_camel
+
+
+def camelize(data: str | dict | list) -> str | dict | list:
+    if isinstance(data, str):
+        return re.sub(camelize_re, underscore_to_camel, data)
+    camel_case_bytes = CamelCaseJSONRenderer().render(data)
+    return json.loads(camel_case_bytes.decode("utf-8"))

--- a/common/utils/tests/test_camelize.py
+++ b/common/utils/tests/test_camelize.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+
+from common.utils.camelize import camelize
+
+
+class CamelizeTest(TestCase):
+    def test_camelize_string(self):
+        for TUPLE in [
+            ("some_value", "someValue"),
+            ("already_camel_ish", "alreadyCamelIsh"),
+            ("no_underscores_left_", "noUnderscoresLeft_"),
+            ("nounderscore", "nounderscore"),
+            ("", ""),
+        ]:
+            with self.subTest(text=TUPLE):
+                self.assertEqual(camelize(TUPLE[0]), TUPLE[1])
+
+    def test_camelize_dict(self):
+        self.assertEqual(
+            camelize({"some_key": 1, "another_key": {"nested_key": 2}}),
+            {"someKey": 1, "anotherKey": {"nestedKey": 2}},
+        )
+
+    def test_camelize_list(self):
+        self.assertEqual(
+            camelize([{"some_key": 1}, {"another_key": 2}]),
+            [{"someKey": 1}, {"anotherKey": 2}],
+        )
+
+    def test_camelize_empty_dict(self):
+        self.assertEqual(camelize({}), {})
+
+    def test_camelize_empty_list(self):
+        self.assertEqual(camelize([]), [])


### PR DESCRIPTION
### Quoi

Un peu comme #7095 (pillow)
- je bouge la logique d'un utils obscure vers common
- je gère le camelize de string (je vais en avoir besoin pour un futur test)
- ajout de tests