### PR TITLE
refactor(Télédéclaration): faire la validation du champ year sur CAMPAIGN_DATES

### DIFF
--- a/api/tests/test_canteen_published.py
+++ b/api/tests/test_canteen_published.py
@@ -980,9 +980,7 @@ class PublishedCanteenDetailApiTest(APITestCase):
         The published endpoint returns all diagnostic "service" data in one property,
         and the appro data in another. The latter should be filtered on the redacted years.
         """
-        canteen = CanteenFactory(
-            production_type=Canteen.ProductionType.ON_SITE, redacted_appro_years=[2020, 2021, 2023]
-        )
+        canteen = CanteenFactory(production_type=Canteen.ProductionType.ON_SITE, redacted_appro_years=[2021, 2023])
 
         DiagnosticFactory(canteen=canteen, year=2021)
         published_appro_diag = DiagnosticFactory(canteen=canteen, year=2022)

--- a/api/tests/test_diagnostics_simple_import.py
+++ b/api/tests/test_diagnostics_simple_import.py
@@ -186,7 +186,7 @@ class DiagnosticsSimpleImportApiErrorTest(APITestCase):
         body = response.json()
         errors = body["errors"]
         self.assertEqual(body["count"], 0)
-        self.assertEqual(len(errors), 23)
+        self.assertEqual(len(errors), 22)
         self.assertEqual(errors[0]["row"], 2)
         self.assertEqual(errors[0]["status"], 400)
         self.assertEqual(
@@ -200,89 +200,85 @@ class DiagnosticsSimpleImportApiErrorTest(APITestCase):
         )
         self.assertEqual(
             errors[2]["message"],
-            "Champ 'année' : L'année doit être dans l'année de campagne en cours (2024, 2025).",
-        )
-        self.assertEqual(
-            errors[3]["message"],
             "Champ 'Nombre de repas par an' : Ce champ est obligatoire pour l'année 2150.",
         )
         self.assertEqual(
-            errors[4]["message"],
+            errors[3]["message"],
             "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la valeur (HT) valeur_bio, 1500",
         )
         self.assertEqual(
-            errors[5]["message"],
+            errors[4]["message"],
             "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la somme des valeurs d'approvisionnement, 1500",
         )
         self.assertEqual(
-            errors[6]["message"],
+            errors[5]["message"],
             "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la somme des valeurs d'approvisionnement, 2000",
         )
         self.assertEqual(
-            errors[7]["message"],
+            errors[6]["message"],
             "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la somme des valeurs d'approvisionnement pour le label france, 1600",
         )
         self.assertEqual(
-            errors[8]["message"],
+            errors[7]["message"],
             "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, EGalim, 100, est plus que la valeur totale (HT) viandes et volailles, 50",
         )
         self.assertEqual(
-            errors[9]["message"],
+            errors[8]["message"],
             "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur (HT) viandes_volailles, 50, est moins que la valeur (HT) viandes_volailles_france, 100",
         )
         self.assertEqual(
-            errors[10]["message"],
+            errors[9]["message"],
             "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, Origine France, 100, est plus que la valeur totale (HT) viandes et volailles, 50",
         )
         self.assertEqual(
-            errors[11]["message"],
+            errors[10]["message"],
             "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, EGalim, 100, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
         )
         self.assertEqual(
-            errors[12]["message"],
+            errors[11]["message"],
             "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur (HT) produits_de_la_mer, 50, est moins que la valeur (HT) produits_de_la_mer_france, 100",
         )
         self.assertEqual(
-            errors[13]["message"],
+            errors[12]["message"],
             "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, Origine France, 100, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
         )
         self.assertEqual(
-            errors[14]["message"],
+            errors[13]["message"],
             # TODO: is this the best field to point to as being wrong? hors bio could be confusing
             "Champ 'Produits SIQO (hors bio) - Valeur annuelle HT' : La somme des valeurs viandes et poissons, EGalim, 300, est plus que la somme des valeurs bio, SIQO, environnementales et autres EGalim, 200",
         )
         self.assertEqual(
-            errors[15]["message"],
+            errors[14]["message"],
             "Champ 'Bio - Valeur annuelle HT' : La valeur (HT) bio dont commerce équitable, 150, est plus que la valeur totale (HT) bio, 50",
         )
         self.assertEqual(
-            errors[16]["message"],
+            errors[15]["message"],
             "Champ 'Valeur totale (HT) des autres achats EGalim' : La valeur (HT) achats commerce équitable (hors bio), 150, est plus que la valeur totale (HT) des autres achats EGalim, 50",
         )
         # Both totals meat are greater than the total return 2 errors
         self.assertEqual(
-            errors[17]["message"],
+            errors[16]["message"],
             "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur (HT) viandes_volailles, 50, est moins que la valeur (HT) viandes_volailles_france, 60",
         )
         self.assertEqual(
-            errors[18]["message"],
+            errors[17]["message"],
             "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, EGalim, 60, est plus que la valeur totale (HT) viandes et volailles, 50",
         )
         self.assertEqual(
-            errors[19]["message"],
+            errors[18]["message"],
             "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, Origine France, 60, est plus que la valeur totale (HT) viandes et volailles, 50",
         )
         # Both totals meat are greater than the total return 2 errors
         self.assertEqual(
-            errors[20]["message"],
+            errors[19]["message"],
             "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur (HT) produits_de_la_mer, 50, est moins que la valeur (HT) produits_de_la_mer_france, 60",
         )
         self.assertEqual(
-            errors[21]["message"],
+            errors[20]["message"],
             "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, EGalim, 60, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
         )
         self.assertEqual(
-            errors[22]["message"],
+            errors[21]["message"],
             "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, Origine France, 60, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
         )
 

--- a/api/tests/test_diagnostics_simple_import.py
+++ b/api/tests/test_diagnostics_simple_import.py
@@ -186,7 +186,7 @@ class DiagnosticsSimpleImportApiErrorTest(APITestCase):
         body = response.json()
         errors = body["errors"]
         self.assertEqual(body["count"], 0)
-        self.assertEqual(len(errors), 22)
+        self.assertEqual(len(errors), 23)
         self.assertEqual(errors[0]["row"], 2)
         self.assertEqual(errors[0]["status"], 400)
         self.assertEqual(
@@ -196,89 +196,93 @@ class DiagnosticsSimpleImportApiErrorTest(APITestCase):
         )
         self.assertEqual(
             errors[1]["message"],
-            "Champ 'année' : L'année doit être comprise entre 2024 et 2026.",
+            "Champ 'année' : L'année doit être parmi 2021, 2022, 2023, 2024, 2025, 2026.",
         )
         self.assertEqual(
             errors[2]["message"],
-            "Champ 'Nombre de repas par an' : Ce champ est obligatoire pour l'année 2150.",
+            "Champ 'année' : L'année doit être dans l'année de campagne en cours (2024, 2025).",
         )
         self.assertEqual(
             errors[3]["message"],
-            "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la valeur (HT) valeur_bio, 1500",
+            "Champ 'Nombre de repas par an' : Ce champ est obligatoire pour l'année 2150.",
         )
         self.assertEqual(
             errors[4]["message"],
-            "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la somme des valeurs d'approvisionnement, 1500",
+            "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la valeur (HT) valeur_bio, 1500",
         )
         self.assertEqual(
             errors[5]["message"],
-            "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la somme des valeurs d'approvisionnement, 2000",
+            "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la somme des valeurs d'approvisionnement, 1500",
         )
         self.assertEqual(
             errors[6]["message"],
-            "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la somme des valeurs d'approvisionnement pour le label france, 1600",
+            "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la somme des valeurs d'approvisionnement, 2000",
         )
         self.assertEqual(
             errors[7]["message"],
-            "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, EGalim, 100, est plus que la valeur totale (HT) viandes et volailles, 50",
+            "Champ 'Valeur totale annuelle HT' : La valeur totale (HT), 1000, est moins que la somme des valeurs d'approvisionnement pour le label france, 1600",
         )
         self.assertEqual(
             errors[8]["message"],
-            "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur (HT) viandes_volailles, 50, est moins que la valeur (HT) viandes_volailles_france, 100",
+            "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, EGalim, 100, est plus que la valeur totale (HT) viandes et volailles, 50",
         )
         self.assertEqual(
             errors[9]["message"],
-            "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, Origine France, 100, est plus que la valeur totale (HT) viandes et volailles, 50",
+            "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur (HT) viandes_volailles, 50, est moins que la valeur (HT) viandes_volailles_france, 100",
         )
         self.assertEqual(
             errors[10]["message"],
-            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, EGalim, 100, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
+            "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, Origine France, 100, est plus que la valeur totale (HT) viandes et volailles, 50",
         )
         self.assertEqual(
             errors[11]["message"],
-            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur (HT) produits_de_la_mer, 50, est moins que la valeur (HT) produits_de_la_mer_france, 100",
+            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, EGalim, 100, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
         )
         self.assertEqual(
             errors[12]["message"],
-            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, Origine France, 100, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
+            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur (HT) produits_de_la_mer, 50, est moins que la valeur (HT) produits_de_la_mer_france, 100",
         )
         self.assertEqual(
             errors[13]["message"],
+            "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, Origine France, 100, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
+        )
+        self.assertEqual(
+            errors[14]["message"],
             # TODO: is this the best field to point to as being wrong? hors bio could be confusing
             "Champ 'Produits SIQO (hors bio) - Valeur annuelle HT' : La somme des valeurs viandes et poissons, EGalim, 300, est plus que la somme des valeurs bio, SIQO, environnementales et autres EGalim, 200",
         )
         self.assertEqual(
-            errors[14]["message"],
+            errors[15]["message"],
             "Champ 'Bio - Valeur annuelle HT' : La valeur (HT) bio dont commerce équitable, 150, est plus que la valeur totale (HT) bio, 50",
         )
         self.assertEqual(
-            errors[15]["message"],
+            errors[16]["message"],
             "Champ 'Valeur totale (HT) des autres achats EGalim' : La valeur (HT) achats commerce équitable (hors bio), 150, est plus que la valeur totale (HT) des autres achats EGalim, 50",
         )
         # Both totals meat are greater than the total return 2 errors
         self.assertEqual(
-            errors[16]["message"],
+            errors[17]["message"],
             "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur (HT) viandes_volailles, 50, est moins que la valeur (HT) viandes_volailles_france, 60",
         )
         self.assertEqual(
-            errors[17]["message"],
+            errors[18]["message"],
             "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, EGalim, 60, est plus que la valeur totale (HT) viandes et volailles, 50",
         )
         self.assertEqual(
-            errors[18]["message"],
+            errors[19]["message"],
             "Champ 'Valeur totale (HT) viandes et volailles fraiches ou surgelées' : La valeur totale (HT) viandes et volailles fraiches ou surgelées, Origine France, 60, est plus que la valeur totale (HT) viandes et volailles, 50",
         )
         # Both totals meat are greater than the total return 2 errors
         self.assertEqual(
-            errors[19]["message"],
+            errors[20]["message"],
             "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur (HT) produits_de_la_mer, 50, est moins que la valeur (HT) produits_de_la_mer_france, 60",
         )
         self.assertEqual(
-            errors[20]["message"],
+            errors[21]["message"],
             "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, EGalim, 60, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
         )
         self.assertEqual(
-            errors[21]["message"],
+            errors[22]["message"],
             "Champ 'Valeur totale (HT) poissons et produits aquatiques' : La valeur totale (HT) poissons et produits aquatiques, Origine France, 60, est plus que la valeur totale (HT) poissons et produits aquatiques, 50",
         )
 

--- a/data/models/canteen.py
+++ b/data/models/canteen.py
@@ -29,13 +29,10 @@ from data.models.sector import (
     SectorM2M,
     annotate_with_sector_category_list,
 )
-from data.utils import (
-    get_diagnostic_lowest_limit_year,
-    get_diagnostic_upper_limit_year,
-    has_charfield_missing_query,
-)
+from data.utils import has_charfield_missing_query
 from data.validators import canteen as canteen_validators
 from data.models.diagnostic_teledeclaration_dates import (
+    CAMPAIGN_DATES,
     get_year_campaign_end_date_or_today_date,
     is_in_correction,
     is_in_teledeclaration,
@@ -46,7 +43,7 @@ from .softdeletionmodel import SoftDeletionManager, SoftDeletionModel, SoftDelet
 
 
 def get_diagnostic_year_choices():
-    return [(y, str(y)) for y in range(get_diagnostic_lowest_limit_year(), get_diagnostic_upper_limit_year())]
+    return [(y, str(y)) for y in CAMPAIGN_DATES.keys()]
 
 
 def list_properties(queryset, property):

--- a/data/tests/test_diagnostic.py
+++ b/data/tests/test_diagnostic.py
@@ -78,7 +78,7 @@ class DiagnosticModelSaveTest(TransactionTestCase):
         VALID_DIAGNOSTIC_WITHOUT_YEAR = VALID_DIAGNOSTIC_SIMPLE_2026.copy()
         VALID_DIAGNOSTIC_WITHOUT_YEAR.pop("year")
         # on save
-        for VALUE_OK_ON_SAVE in [None, -2000, 0, 1991, 2024, "2023"]:
+        for VALUE_OK_ON_SAVE in [None, -2000, 0, 1991, "2023", 2024]:
             with self.subTest(year=VALUE_OK_ON_SAVE):
                 diagnostic = DiagnosticFactory(year=VALUE_OK_ON_SAVE, **VALID_DIAGNOSTIC_WITHOUT_YEAR)
                 self.assertEqual(diagnostic.year, VALUE_OK_ON_SAVE)
@@ -88,24 +88,12 @@ class DiagnosticModelSaveTest(TransactionTestCase):
                     ValueError, Diagnostic.objects.create, year=VALUE_NOT_OK_ON_SAVE, **VALID_DIAGNOSTIC_WITHOUT_YEAR
                 )
         # on full_clean
-        this_year = datetime.now().date().year
-        last_year = datetime.now().date().year - 1
-        next_year = datetime.now().date().year + 1
-        last_two_years = datetime.now().date().year - 2
-        next_two_years = datetime.now().date().year + 2
-        for TUPLE_OK_ON_FULL_CLEAN in [
-            (this_year, this_year),
-            (f"{this_year}", this_year),
-            (last_year, last_year),
-            (f"{last_year}", last_year),
-            (next_year, next_year),
-            (f"{next_year}", next_year),
-        ]:
+        for TUPLE_OK_ON_FULL_CLEAN in [(2025, 2025), ("2026", 2026)]:
             with self.subTest(year=TUPLE_OK_ON_FULL_CLEAN[0]):
                 diagnostic = DiagnosticFactory(year=TUPLE_OK_ON_FULL_CLEAN[0], **VALID_DIAGNOSTIC_WITHOUT_YEAR)
                 diagnostic.full_clean()
                 self.assertEqual(diagnostic.year, TUPLE_OK_ON_FULL_CLEAN[1])
-        for VALUE_NOT_OK_ON_FULL_CLEAN in [None, 1991, last_two_years, next_two_years, 2222]:
+        for VALUE_NOT_OK_ON_FULL_CLEAN in [None, 1991, 2024, 2027, 2222]:
             with self.subTest(year=VALUE_NOT_OK_ON_FULL_CLEAN):
                 diagnostic = DiagnosticFactory(year=VALUE_NOT_OK_ON_FULL_CLEAN, **VALID_DIAGNOSTIC_WITHOUT_YEAR)
                 self.assertRaises(ValidationError, diagnostic.full_clean)

--- a/data/utils.py
+++ b/data/utils.py
@@ -1,5 +1,4 @@
 import csv
-import datetime
 import json
 from decimal import Decimal
 
@@ -33,18 +32,6 @@ def array_overlap_query(field_name: str, values: list):
     for value in values:
         query |= Q(**{f"{field_name}__contains": [value]})
     return query
-
-
-def get_diagnostic_lowest_limit_year():
-    return 2019
-
-
-def get_diagnostic_lower_limit_year():
-    return datetime.datetime.now().date().year - 1
-
-
-def get_diagnostic_upper_limit_year():
-    return datetime.datetime.now().date().year + 1
 
 
 def make_optional_positive_integer_field(**kwargs):

--- a/data/validators/diagnostic.py
+++ b/data/validators/diagnostic.py
@@ -16,6 +16,7 @@ def validate_year_and_can_edit(instance):
         - year must be filled
         - year must be an integer
         - year must be in CAMPAIGN_DATES
+        - year must be in the current campaign year (now.year - 1 & now.year)
         - if year is valid:
             - after teledeclaration end date, DRAFT diagnostic cannot be edited anymore
             - after correction end date, any diagnostic cannot be edited anymore
@@ -29,7 +30,17 @@ def validate_year_and_can_edit(instance):
         utils_utils.add_validation_error(errors, field_name, "Le champ doit être un nombre entier.")
     else:
         if not isinstance(value, int) or value not in CAMPAIGN_DATES:
-            utils_utils.add_validation_error(errors, "year", f"L'année doit être parmi {list(CAMPAIGN_DATES.keys())}.")
+            utils_utils.add_validation_error(
+                errors, "year", f"L'année doit être parmi {', '.join(map(str, CAMPAIGN_DATES.keys()))}."
+            )
+        now = timezone.now()
+        current_campaign_years = [now.year - 1, now.year]
+        if int(value) not in current_campaign_years:
+            utils_utils.add_validation_error(
+                errors,
+                "year",
+                f"L'année doit être dans l'année de campagne en cours ({', '.join(map(str, current_campaign_years))}).",
+            )
         else:  # valid year, check can_edit validation
             if instance.pk:
                 now = timezone.now()

--- a/data/validators/diagnostic.py
+++ b/data/validators/diagnostic.py
@@ -29,19 +29,21 @@ def validate_year_and_can_edit(instance):
     elif not (isinstance(value, int) or (isinstance(value, str) and value.isdigit())):
         utils_utils.add_validation_error(errors, field_name, "Le champ doit être un nombre entier.")
     else:
+        # year is an integer
+        now = timezone.now()
+        current_campaign_years = [now.year - 1, now.year]
         if not isinstance(value, int) or value not in CAMPAIGN_DATES:
             utils_utils.add_validation_error(
                 errors, "year", f"L'année doit être parmi {', '.join(map(str, CAMPAIGN_DATES.keys()))}."
             )
-        now = timezone.now()
-        current_campaign_years = [now.year - 1, now.year]
-        if int(value) not in current_campaign_years:
+        elif int(value) not in current_campaign_years:
             utils_utils.add_validation_error(
                 errors,
                 "year",
                 f"L'année doit être dans l'année de campagne en cours ({', '.join(map(str, current_campaign_years))}).",
             )
-        else:  # valid year, check can_edit validation
+        # year is valid, check can_edit validation
+        else:
             if instance.pk:
                 now = timezone.now()
                 if now > get_year_campaign_end_date_or_today_date(value):

--- a/data/validators/diagnostic.py
+++ b/data/validators/diagnostic.py
@@ -3,11 +3,11 @@ from decimal import Decimal
 from django.utils import timezone
 
 from data.models.diagnostic_teledeclaration_dates import (
+    CAMPAIGN_DATES,
     get_year_campaign_end_date_or_today_date,
     get_year_correction_end_date_or_campaign_end_date_or_today_date,
 )
 from common.utils import utils as utils_utils
-from data.utils import get_diagnostic_lower_limit_year, get_diagnostic_upper_limit_year
 
 
 def validate_year_and_can_edit(instance):
@@ -15,7 +15,7 @@ def validate_year_and_can_edit(instance):
     - extra validation:
         - year must be filled
         - year must be an integer
-        - year must be between lower and upper limit years
+        - year must be in CAMPAIGN_DATES
         - if year is valid:
             - after teledeclaration end date, DRAFT diagnostic cannot be edited anymore
             - after correction end date, any diagnostic cannot be edited anymore
@@ -28,12 +28,8 @@ def validate_year_and_can_edit(instance):
     elif not (isinstance(value, int) or (isinstance(value, str) and value.isdigit())):
         utils_utils.add_validation_error(errors, field_name, "Le champ doit être un nombre entier.")
     else:
-        lower_limit_year = get_diagnostic_lower_limit_year()
-        upper_limit_year = get_diagnostic_upper_limit_year()
-        if not isinstance(value, int) or value < lower_limit_year or value > upper_limit_year:
-            utils_utils.add_validation_error(
-                errors, "year", f"L'année doit être comprise entre {lower_limit_year} et {upper_limit_year}."
-            )
+        if not isinstance(value, int) or value not in CAMPAIGN_DATES:
+            utils_utils.add_validation_error(errors, "year", f"L'année doit être parmi {list(CAMPAIGN_DATES.keys())}.")
         else:  # valid year, check can_edit validation
             if instance.pk:
                 now = timezone.now()


### PR DESCRIPTION
### Quoi

Suite à #7103

On continue le ménage autour de CAMPAIGN_DATES
- plus de upper & lower limits
- on se base seulement sur les années de CAMPAIGN_DATES