### PR TITLE
improve(Diagnostics): Admin: empecher la création

### DIFF
--- a/data/admin/diagnostic.py
+++ b/data/admin/diagnostic.py
@@ -235,6 +235,9 @@ class DiagnosticAdmin(SimpleHistoryAdmin):
             obj.creation_source = CreationSource.ADMIN
         super().save_model(request, obj, form, change)
 
+    def has_add_permission(self, request):
+        return False
+
     def has_change_permission(self, request, obj=None):
         return obj and not obj.is_teledeclared
 


### PR DESCRIPTION
### Quoi

Dans #7108 on commence à afficher des champs différents en fonction de l'année.
Coté admin, et pour éviter de se creuser la tête sur le formulaire "nouveau" (quels champs afficher pour quelle année ?), on disable la création.
De toute facon les bilans ne peuvent être créé que par formulaire/API/Import