### PR TITLE
refactor(SEO): bouger la view sitemap dans une class dédiée

### DIFF
--- a/web/tests/test_registration.py
+++ b/web/tests/test_registration.py
@@ -9,7 +9,7 @@ from rest_framework.test import APITestCase
 from web.forms import RegisterUserForm
 
 
-class TestRegistration(APITestCase):
+class RegistrationTest(APITestCase):
     def test_cannot_register_with_email_as_username(self):
         payload = {
             "first_name": "Tester",

--- a/web/tests/test_sitemap.py
+++ b/web/tests/test_sitemap.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from rest_framework import status
 
 
-class TestSitemaps(TestCase):
+class SitemapTest(TestCase):
     def setUp(self):
         self.client = Client()
 

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,14 +1,10 @@
 from django.conf import settings
 from django.contrib.auth import views as auth_views
-from django.contrib.sitemaps.views import sitemap
 from django.urls import path, re_path
-from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
-from common.cache.utils import CACHE_TIMEOUT_1_day
-from web.sitemaps import BlogPostSitemap, CanteenSitemap, PartnerSitemap, WebSitemap
 from web.views import (
     AccountActivationView,
     ActivationTokenView,
@@ -19,16 +15,10 @@ from web.views import (
     RegisterInvalidTokenView,
     RegisterSendMailFailedView,
     RegisterUserView,
+    SitemapView,
     VueAppDisplayView,
     WidgetView,
 )
-
-sitemaps = {
-    "canteens": CanteenSitemap,
-    "blog": BlogPostSitemap,
-    "partners": PartnerSitemap,
-    "other": WebSitemap,
-}
 
 urlpatterns = [
     re_path(r"^widgets/.*$", WidgetView.as_view(), name="widget_app"),
@@ -126,12 +116,7 @@ urlpatterns = [
         name="activate",
     ),
     path("token-invalide", RegisterInvalidTokenView.as_view(), name="invalid_token"),
-    path(
-        "sitemap.xml",
-        cache_page(CACHE_TIMEOUT_1_day, key_prefix="sitemap")(sitemap),
-        {"sitemaps": sitemaps},
-        name="sitemap",
-    ),
+    path("sitemap.xml", SitemapView.as_view(), name="sitemap"),
     path(
         "robots.txt",
         TemplateView.as_view(

--- a/web/views.py
+++ b/web/views.py
@@ -5,18 +5,22 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model, login, tokens
 from django.contrib.auth import views as auth_views
+from django.contrib.sitemaps.views import sitemap
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
 from django.utils.encoding import force_bytes
-from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from django.utils.http import url_has_allowed_host_and_scheme, urlsafe_base64_decode, urlsafe_base64_encode
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import FormView, TemplateView, View
-from django.utils.http import url_has_allowed_host_and_scheme
 
+from common.cache.utils import CACHE_TIMEOUT_1_day
 from common.utils import send_mail
 from web.forms import LoginUserForm, RegisterUserForm
+from web.sitemaps import BlogPostSitemap, CanteenSitemap, PartnerSitemap, WebSitemap
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +52,20 @@ class VueAppDisplayView(TemplateView):
     """
 
     template_name = "vue-app.html"
+
+
+sitemaps = {
+    "canteens": CanteenSitemap,
+    "blog": BlogPostSitemap,
+    "partners": PartnerSitemap,
+    "other": WebSitemap,
+}
+
+
+@method_decorator(cache_page(CACHE_TIMEOUT_1_day, key_prefix="sitemap"), name="get")
+class SitemapView(View):
+    def get(self, request, *args, **kwargs):
+        return sitemap(request, sitemaps)
 
 
 class Vue3AppDisplayView(TemplateView):


### PR DESCRIPTION
### Quoi

bouger la logique "sitemap" depuis `web/urls.py` vers `web/views.py`