### PR TITLE
refactor(SEO): bouger la view robots dans une class dédiée

### DIFF
--- a/web/tests/test_robots.py
+++ b/web/tests/test_robots.py
@@ -1,0 +1,20 @@
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+from rest_framework import status
+
+
+class RobotsTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    @override_settings(ENVIRONMENT="prod")
+    def test_robots_prod_allows_indexing(self):
+        response = self.client.get(reverse("robots_txt"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(b"Allow: /", response.content)
+
+    @override_settings(ENVIRONMENT="staging")
+    def test_robots_non_prod_disallows_indexing(self):
+        response = self.client.get(reverse("robots_txt"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(b"Disallow: /", response.content)

--- a/web/urls.py
+++ b/web/urls.py
@@ -15,6 +15,7 @@ from web.views import (
     RegisterInvalidTokenView,
     RegisterSendMailFailedView,
     RegisterUserView,
+    RobotsTxtView,
     SitemapView,
     VueAppDisplayView,
     WidgetView,
@@ -117,14 +118,7 @@ urlpatterns = [
     ),
     path("token-invalide", RegisterInvalidTokenView.as_view(), name="invalid_token"),
     path("sitemap.xml", SitemapView.as_view(), name="sitemap"),
-    path(
-        "robots.txt",
-        TemplateView.as_view(
-            template_name="robots.txt" if settings.ENVIRONMENT == "prod" else "robots-noindex.txt",
-            content_type="text/plain",
-        ),
-        name="robots_txt",
-    ),
+    path("robots.txt", RobotsTxtView.as_view(), name="robots_txt"),
     path(
         "googlefbd6f06a151f47ee.html",
         TemplateView.as_view(template_name="googlefbd6f06a151f47ee.html"),

--- a/web/views.py
+++ b/web/views.py
@@ -68,6 +68,13 @@ class SitemapView(View):
         return sitemap(request, sitemaps)
 
 
+class RobotsTxtView(TemplateView):
+    content_type = "text/plain"
+
+    def get_template_names(self):
+        return ["robots.txt" if settings.ENVIRONMENT == "prod" else "robots-noindex.txt"]
+
+
 class Vue3AppDisplayView(TemplateView):
     """
     This template contains the VueJS app in /frontend


### PR DESCRIPTION
### Quoi

Similaire à #7113 (sitemap), mais pour robots, bouger la logique depuis `web/urls.py` vers `web/views.py`