### PR TITLE
refactor(Cache): créer une fonction `get_or_set_cache` pour simplifier le code

### DIFF
--- a/api/tests/test_canteen_statistics.py
+++ b/api/tests/test_canteen_statistics.py
@@ -12,7 +12,10 @@ from macantine.tests.test_etl_common import setUpTestData as ETLCommonSetUpTestD
 
 year_data = 2023
 date_in_2023_teledeclaration_campaign = "2024-04-01"  # during the 2023 campaign
-STATS_ENDPOINT_QUERY_COUNT = 7
+STATS_ENDPOINT_QUERY_COUNT = 6
+# The "region" filter changes the queryset shape (an extra query), so the filtered,
+# never-cached path has a different query count than the cacheable year-only path above.
+STATS_ENDPOINT_FILTERED_QUERY_COUNT = 7
 
 
 class CanteenStatsApiTest(APITestCase):
@@ -552,11 +555,11 @@ class CanteenStatsApiTest(APITestCase):
             response = self.client.get(self.url, {"year": year_data - 1})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         # same year, but with extra filters: no cache
-        with self.assertNumQueries(STATS_ENDPOINT_QUERY_COUNT):
+        with self.assertNumQueries(STATS_ENDPOINT_FILTERED_QUERY_COUNT):
             response = self.client.get(self.url, {"year": year_data, "region": "84"})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         # same year, but with extra filters: still no cache
-        with self.assertNumQueries(STATS_ENDPOINT_QUERY_COUNT):
+        with self.assertNumQueries(STATS_ENDPOINT_FILTERED_QUERY_COUNT):
             response = self.client.get(self.url, {"year": year_data, "region": "84"})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/api/views/statistics.py
+++ b/api/views/statistics.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.core.cache import cache
 from django.http import JsonResponse
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
@@ -9,7 +8,7 @@ from rest_framework.views import APIView
 
 from api.serializers import CanteenStatisticsSerializer
 from common.utils.camelize import camelize
-from common.cache.utils import CACHE_TIMEOUT_1_day
+from common.cache.utils import CACHE_TIMEOUT_1_day, get_or_set_cache
 from data.models import Canteen, Diagnostic
 from data.models.sector import Sector
 from data.models.geo import Department, Region
@@ -105,13 +104,19 @@ class CanteenStatisticsView(APIView):
             return JsonResponse({"error": "Expected year"}, status=status.HTTP_400_BAD_REQUEST)
 
         # cache mechanism: only for requests with just the year parameter
-        # TODO: refactor to a dedicated cache config file?
-        if len(request.query_params) == 1 and year:
+        if len(request.query_params) == 1:
             cache_key = f"{CACHE_KEY_PREFIX}_{year}"
-            cached_data = cache.get(cache_key)
-            if cached_data:
-                return JsonResponse(cached_data, status=status.HTTP_200_OK)
+            data = get_or_set_cache(
+                cache_key,
+                lambda: camelize(self._compute_statistics_serializer(request, year).data),
+                CACHE_TIMEOUT_1_day,
+            )
+            return JsonResponse(data, status=status.HTTP_200_OK)
 
+        serializer = self._compute_statistics_serializer(request, year)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def _compute_statistics_serializer(self, request, year):
         filters = self._extract_query_filters(request)
         egalim_group = self._get_egalim_group(filters)
 
@@ -128,15 +133,7 @@ class CanteenStatisticsView(APIView):
         data = self.serializer_class.calculate_statistics(canteens, teledeclarations)
         data["notes"] = self.serializer_class.generate_notes(year, egalim_group)
         data = self.serializer_class.hide_data_if_report_not_published(data, year)
-        serializer = self.serializer_class(data)
-
-        # cache mechanism: store the result if it was not cached (only for requests with just the year parameter)
-        if len(request.query_params) == 1 and year:
-            cache_key = f"{CACHE_KEY_PREFIX}_{year}"
-            if not cache.get(cache_key):
-                cache.set(cache_key, camelize(serializer.data), timeout=CACHE_TIMEOUT_1_day)
-
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return self.serializer_class(data)
 
     def _extract_query_filters(self, request):
         """

--- a/common/api/datagouv.py
+++ b/common/api/datagouv.py
@@ -6,9 +6,8 @@ from datetime import datetime
 
 import requests
 from django.conf import settings
-from django.core.cache import cache
 
-from common.cache.utils import CACHE_TIMEOUT_7_days
+from common.cache.utils import CACHE_TIMEOUT_7_days, get_or_set_cache
 from common.utils.utils import clean_unicode_string
 
 logger = logging.getLogger(__name__)
@@ -138,21 +137,16 @@ def fetch_pats():
     """
     FIELDS_TO_KEEP = ["id", "nom_administratif", "communes_code_insee", "lien_vers_la_fiche_pat"]
 
-    cache_key = f"{CACHE_KEY_PREFIX}_pats"
-    cached_response = cache.get(cache_key)
-    if cached_response:
-        return cached_response
-
-    try:
+    def compute_pats():
         api_url = get_dataset_resource(PAT_DATAGOUV_DATASET_ID, PAT_DATAGOUV_RESOURCE_ID)
         api_response = requests.get(api_url["url"])
         api_response.raise_for_status()
         reader = csv.DictReader(api_response.iter_lines(decode_unicode=True), delimiter=";")
         # the csv is BIG (4+ MB). So we only keep the fields we need.
-        pat_list_filtered = [{field: row[field] for field in FIELDS_TO_KEEP} for row in reader]
-        # cache mechanism: store the result
-        cache.set(cache_key, pat_list_filtered, timeout=CACHE_TIMEOUT_7_days)
-        return pat_list_filtered
+        return [{field: row[field] for field in FIELDS_TO_KEEP} for row in reader]
+
+    try:
+        return get_or_set_cache(f"{CACHE_KEY_PREFIX}_pats", compute_pats, CACHE_TIMEOUT_7_days)
     except requests.HTTPError as e:
         logger.info(e)
         return []

--- a/common/api/decoupage_administratif.py
+++ b/common/api/decoupage_administratif.py
@@ -2,8 +2,7 @@ import logging
 import json
 import requests
 
-from django.core.cache import cache
-from common.cache.utils import CACHE_TIMEOUT_7_days
+from common.cache.utils import CACHE_TIMEOUT_7_days, get_or_set_cache
 
 logger = logging.getLogger(__name__)
 
@@ -43,22 +42,15 @@ def fetch_communes():
     Fields returned: nom, code, codeDepartement, codeRegion, codesPostaux, population
     - missing: siren, codeEpci
     """
-    cache_key = f"{CACHE_KEY_PREFIX}_communes"
-    cached_response = cache.get(cache_key)
-    if cached_response:
-        return cached_response
 
-    api_url = f"{DECOUPAGE_ADMINISTRATIF_API_URL}/communes?type=arrondissement-municipal,commune-actuelle"
-    response = requests.get(api_url, timeout=50)
-    response.raise_for_status()
-    response_json = response.json()
+    def compute_communes():
+        api_url = f"{DECOUPAGE_ADMINISTRATIF_API_URL}/communes?type=arrondissement-municipal,commune-actuelle"
+        response = requests.get(api_url, timeout=50)
+        response.raise_for_status()
+        # order by code
+        return sorted(response.json(), key=lambda x: x["code"])
 
-    # order by code
-    response_json = sorted(response_json, key=lambda x: x["code"])
-
-    # cache mechanism: store the result
-    cache.set(cache_key, response_json, timeout=CACHE_TIMEOUT_7_days)
-    return response_json
+    return get_or_set_cache(f"{CACHE_KEY_PREFIX}_communes", compute_communes, CACHE_TIMEOUT_7_days)
 
 
 def fetch_communes_with_more_fields(with_arrondissements=True):
@@ -67,72 +59,64 @@ def fetch_communes_with_more_fields(with_arrondissements=True):
     - missing: department, region
     - missing: arrondissements (132**, 6938*, 751**)
     """
+
+    def compute_communes_with_more_fields():
+        api_url = f"{DECOUPAGE_ADMINISTRATIF_API_URL}/communes"
+        response = requests.get(api_url, timeout=50)
+        response.raise_for_status()
+        response_json = response.json()
+
+        if with_arrondissements:
+            # we do another query to also get the arrondissements
+            communes_json = fetch_communes()
+            # keep only the arrondissements
+            code_arrondisement_prefix_list = [city["codeArrondissementPrefix"] for city in CITY_WITH_ARRONDISSEMENTS]
+            communes_json_arrondissements = [
+                commune
+                for commune in communes_json
+                if any(commune["code"].startswith(prefix) for prefix in code_arrondisement_prefix_list)
+            ]
+            # set the extra fields
+            for index, arrondissement in enumerate(communes_json_arrondissements):
+                arrondissement_mapping = next(
+                    (
+                        city
+                        for city in CITY_WITH_ARRONDISSEMENTS
+                        if arrondissement["code"].startswith(city["codeArrondissementPrefix"])
+                    ),
+                    None,
+                )
+                commune = next(
+                    (commune for commune in response_json if commune["code"] == arrondissement_mapping["code"]), None
+                )
+                if commune:
+                    communes_json_arrondissements[index]["siren"] = commune["siren"]
+                    communes_json_arrondissements[index]["population"] = None
+                    communes_json_arrondissements[index]["codeEpci"] = commune["codeEpci"]
+                    # communes_json_arrondissements[index]["codeDepartement"] = commune["codeDepartement"]
+                    # communes_json_arrondissements[index]["codeRegion"] = commune["codeRegion"]
+            # merge the two lists (arrondissements at the top, similar to fetch_communes)
+            response_json = communes_json_arrondissements + response_json
+
+        # order by code
+        return sorted(response_json, key=lambda x: x["code"])
+
     cache_key = f"{CACHE_KEY_PREFIX}_communes_with_more_fields"
-    cached_response = cache.get(cache_key)
-    if cached_response:
-        return cached_response
-
-    api_url = f"{DECOUPAGE_ADMINISTRATIF_API_URL}/communes"
-    response = requests.get(api_url, timeout=50)
-    response.raise_for_status()
-    response_json = response.json()
-
-    if with_arrondissements:
-        # we do another query to also get the arrondissements
-        communes_json = fetch_communes()
-        # keep only the arrondissements
-        code_arrondisement_prefix_list = [city["codeArrondissementPrefix"] for city in CITY_WITH_ARRONDISSEMENTS]
-        communes_json_arrondissements = [
-            commune
-            for commune in communes_json
-            if any(commune["code"].startswith(prefix) for prefix in code_arrondisement_prefix_list)
-        ]
-        # set the extra fields
-        for index, arrondissement in enumerate(communes_json_arrondissements):
-            arrondissement_mapping = next(
-                (
-                    city
-                    for city in CITY_WITH_ARRONDISSEMENTS
-                    if arrondissement["code"].startswith(city["codeArrondissementPrefix"])
-                ),
-                None,
-            )
-            commune = next(
-                (commune for commune in response_json if commune["code"] == arrondissement_mapping["code"]), None
-            )
-            if commune:
-                communes_json_arrondissements[index]["siren"] = commune["siren"]
-                communes_json_arrondissements[index]["population"] = None
-                communes_json_arrondissements[index]["codeEpci"] = commune["codeEpci"]
-                # communes_json_arrondissements[index]["codeDepartement"] = commune["codeDepartement"]
-                # communes_json_arrondissements[index]["codeRegion"] = commune["codeRegion"]
-        # merge the two lists (arrondissements at the top, similar to fetch_communes)
-        response_json = communes_json_arrondissements + response_json
-
-    # order by code
-    response_json = sorted(response_json, key=lambda x: x["code"])
-
-    # cache mechanism: store the result
-    cache.set(cache_key, response_json, timeout=CACHE_TIMEOUT_7_days)
-    return response_json
+    return get_or_set_cache(cache_key, compute_communes_with_more_fields, CACHE_TIMEOUT_7_days)
 
 
 def fetch_epcis():
     """
     Fields returned: nom, code (codesDepartements, codesRegions, population)
     """
-    cache_key = f"{CACHE_KEY_PREFIX}_epcis"
-    cached_response = cache.get(cache_key)
-    if cached_response:
-        return cached_response
 
-    api_url = f"{DECOUPAGE_ADMINISTRATIF_API_URL}/epcis?fields=nom,code"
-    response = requests.get(api_url, timeout=50)
-    response.raise_for_status()
+    def compute_epcis():
+        api_url = f"{DECOUPAGE_ADMINISTRATIF_API_URL}/epcis?fields=nom,code"
+        response = requests.get(api_url, timeout=50)
+        response.raise_for_status()
+        return response.json()
 
-    # cache mechanism: store the result
-    cache.set(cache_key, response.json(), timeout=CACHE_TIMEOUT_7_days)
-    return response.json()
+    return get_or_set_cache(f"{CACHE_KEY_PREFIX}_epcis", compute_epcis, CACHE_TIMEOUT_7_days)
 
 
 def fetch_communes_from_epci(epci):
@@ -149,36 +133,28 @@ def fetch_departements():
     """
     Fields returned: nom, code, codeRegion
     """
-    cache_key = f"{CACHE_KEY_PREFIX}_departements"
-    cached_response = cache.get(cache_key)
-    if cached_response:
-        return cached_response
 
-    api_url = f"{DECOUPAGE_ADMINISTRATIF_API_URL}/departements?zone=metro,drom,com"
-    response = requests.get(api_url, timeout=5)
-    response.raise_for_status()
+    def compute_departements():
+        api_url = f"{DECOUPAGE_ADMINISTRATIF_API_URL}/departements?zone=metro,drom,com"
+        response = requests.get(api_url, timeout=5)
+        response.raise_for_status()
+        return response.json()
 
-    # cache mechanism: store the result
-    cache.set(cache_key, response.json(), timeout=CACHE_TIMEOUT_7_days)
-    return response.json()
+    return get_or_set_cache(f"{CACHE_KEY_PREFIX}_departements", compute_departements, CACHE_TIMEOUT_7_days)
 
 
 def fetch_regions():
     """
     Fields returned: nom, code
     """
-    cache_key = f"{CACHE_KEY_PREFIX}_regions"
-    cached_response = cache.get(cache_key)
-    if cached_response:
-        return cached_response
 
-    api_url = f"{DECOUPAGE_ADMINISTRATIF_API_URL}/regions?zone=metro,drom,com"
-    response = requests.get(api_url, timeout=5)
-    response.raise_for_status()
+    def compute_regions():
+        api_url = f"{DECOUPAGE_ADMINISTRATIF_API_URL}/regions?zone=metro,drom,com"
+        response = requests.get(api_url, timeout=5)
+        response.raise_for_status()
+        return response.json()
 
-    # cache mechanism: store the result
-    cache.set(cache_key, response.json(), timeout=CACHE_TIMEOUT_7_days)
-    return response.json()
+    return get_or_set_cache(f"{CACHE_KEY_PREFIX}_regions", compute_regions, CACHE_TIMEOUT_7_days)
 
 
 def map_communes_infos():

--- a/common/cache/utils.py
+++ b/common/cache/utils.py
@@ -1,3 +1,5 @@
+from django.core.cache import cache
+
 # When calling cache.get(key), the following queries are executed:
 # 1. SELECT "cache_key", "value", "expires" FROM "cache" WHERE "cache_key" IN (':1:canteen_statistics_2024')
 CACHE_GET_QUERY_COUNT = 1
@@ -16,3 +18,15 @@ CACHE_SET_QUERY_COUNT = 6
 CACHE_TIMEOUT_1_day = 60 * 60 * 24
 CACHE_TIMEOUT_7_days = 60 * 60 * 24 * 7
 CACHE_TIMEOUT_30_days = 60 * 60 * 24 * 30
+
+
+def get_or_set_cache(cache_key, compute_value, timeout):
+    """
+    Return the cached value for `cache_key`, computing and storing it via
+    `compute_value()` on a cache miss.
+    """
+    value = cache.get(cache_key)
+    if value is None:
+        value = compute_value()
+        cache.set(cache_key, value, timeout=timeout)
+    return value

--- a/web/tests/test_sitemap.py
+++ b/web/tests/test_sitemap.py
@@ -1,12 +1,22 @@
+from django.core.cache import cache
 from django.test import Client, TestCase
 from django.urls import reverse
 from rest_framework import status
+
+from web.views import SITEMAP_CACHE_KEY
 
 
 class SitemapTest(TestCase):
     def setUp(self):
         self.client = Client()
+        cache.clear()
 
     def test_sitemap_status(self):
         response = self.client.get(reverse("sitemap"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_sitemap_is_cached(self):
+        self.assertIsNone(cache.get(SITEMAP_CACHE_KEY))
+        response = self.client.get(reverse("sitemap"))
+        self.assertIsNotNone(cache.get(SITEMAP_CACHE_KEY))
+        self.assertIn("Cache-Control", response)

--- a/web/views.py
+++ b/web/views.py
@@ -7,17 +7,16 @@ from django.contrib.auth import get_user_model, login, tokens
 from django.contrib.auth import views as auth_views
 from django.contrib.sitemaps.views import sitemap
 from django.core.exceptions import ObjectDoesNotExist
-from django.http import HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
+from django.utils.cache import patch_response_headers
 from django.utils.encoding import force_bytes
 from django.utils.http import url_has_allowed_host_and_scheme, urlsafe_base64_decode, urlsafe_base64_encode
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import FormView, TemplateView, View
 
-from common.cache.utils import CACHE_TIMEOUT_1_day
+from common.cache.utils import CACHE_TIMEOUT_1_day, get_or_set_cache
 from common.utils import send_mail
 from web.forms import LoginUserForm, RegisterUserForm
 from web.sitemaps import BlogPostSitemap, CanteenSitemap, PartnerSitemap, WebSitemap
@@ -61,11 +60,20 @@ sitemaps = {
     "other": WebSitemap,
 }
 
+SITEMAP_CACHE_KEY = "sitemap_xml"
 
-@method_decorator(cache_page(CACHE_TIMEOUT_1_day, key_prefix="sitemap"), name="get")
+
 class SitemapView(View):
     def get(self, request, *args, **kwargs):
-        return sitemap(request, sitemaps)
+        def compute_sitemap_content():
+            response = sitemap(request, sitemaps)
+            response.render()
+            return response.content
+
+        content = get_or_set_cache(SITEMAP_CACHE_KEY, compute_sitemap_content, CACHE_TIMEOUT_1_day)
+        response = HttpResponse(content, content_type="application/xml")
+        patch_response_headers(response, cache_timeout=CACHE_TIMEOUT_1_day)
+        return response
 
 
 class RobotsTxtView(TemplateView):


### PR DESCRIPTION
### Quoi

On utilise le cache à plusieurs endroits : statistics, datagouv, decoupage_administratif, sitemap
Simplifier le code get/set dans une fonction unique.