### PR TITLE
feat(dbt): tâche asynchrone pour lancer toutes les nuits

### DIFF
--- a/macantine/celery.py
+++ b/macantine/celery.py
@@ -45,6 +45,7 @@ nightly_0_10 = crontab(hour=0, minute=10, day_of_week="*")  # Every day at 12:10
 nightly_0_20 = crontab(hour=0, minute=20, day_of_week="*")  # Every day at 12:20AM
 nightly_0_30 = crontab(hour=0, minute=30, day_of_week="*")  # Every day at 12:30AM
 nightly_1 = crontab(hour=1, minute=0, day_of_week="*")  # Every day at 1AM
+nightly_1_30 = crontab(hour=1, minute=30, day_of_week="*")  # Every day at 1:30AM
 nightly_2 = crontab(hour=1, minute=0, day_of_week="*")  # Every day at 2AM
 nightly_3 = crontab(hour=3, minute=0, day_of_week="*")  # Every day at 3AM
 nightly_4 = crontab(hour=4, minute=0, day_of_week="*")  # Every day at 4AM
@@ -94,6 +95,12 @@ app.conf.beat_schedule = {
     "export_dataset_canteen_opendata": {
         "task": "macantine.tasks.export_dataset_canteen_opendata",
         "schedule": nightly_2,  # every_6_hours_20 during campaigns
+    },
+    #########################################################
+    # DBT (Metabase) — depends on export_dataset_raw_analysis (nightly_1)
+    "dbt_run": {
+        "task": "macantine.tasks.dbt_run",
+        "schedule": nightly_1_30,
     },
 }
 

--- a/macantine/tasks.py
+++ b/macantine/tasks.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import redis as r
+from dbt.cli.main import dbtRunner
 from django.conf import settings
 from django.core.management import call_command
 from django.utils import timezone
@@ -339,3 +340,45 @@ def export_dataset_canteen_opendata():
     result = export_datasets(datasets)
 
     return result
+
+
+#########################################################
+# DBT (Metabase)
+
+
+def _invoke_dbt(command: str, dbt_project_dir: str):
+    target = "prod" if settings.ENVIRONMENT == "prod" else "dev"
+    result = dbtRunner().invoke(
+        [
+            command,
+            "--target",
+            target,
+            "--project-dir",
+            dbt_project_dir,
+            "--profiles-dir",
+            dbt_project_dir,
+        ]
+    )
+    if not result.success:
+        raise result.exception or RuntimeError(f"dbt {command} failed")
+
+
+@app.task()
+def dbt_run():
+    """
+    Run dbt models against the analytics data warehouse (Metabase).
+    Depends on export_dataset_raw_analysis having populated the *_raw source tables.
+    """
+    logger.info("Starting dbt_run task")
+    start = time.time()
+
+    dbt_project_dir = str(settings.BASE_DIR / "dbt")
+    # dbt_packages/ isn't committed (see dbt/.gitignore), so packages must be
+    # (re)installed before every run.
+    _invoke_dbt("deps", dbt_project_dir)
+    _invoke_dbt("run", dbt_project_dir)
+
+    end = time.time()
+    message = f"dbt run completed in {end - start:.2f} seconds"
+    logger.info(message)
+    return message

--- a/macantine/tests/test_dbt_run.py
+++ b/macantine/tests/test_dbt_run.py
@@ -1,0 +1,52 @@
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+
+from macantine import tasks
+
+
+class DbtRunTest(SimpleTestCase):
+    @override_settings(ENVIRONMENT="dev")
+    @mock.patch("macantine.tasks.dbtRunner")
+    def test_dbt_run_targets_dev_outside_prod(self, dbt_runner_mock):
+        dbt_runner_mock.return_value.invoke.return_value = mock.Mock(success=True, exception=None)
+
+        result = tasks.dbt_run()
+
+        self.assertIn("dbt run completed", result)
+        calls = dbt_runner_mock.return_value.invoke.call_args_list
+        self.assertEqual(len(calls), 2)
+        deps_args, run_args = calls[0].args[0], calls[1].args[0]
+        self.assertEqual(deps_args[0], "deps")
+        self.assertEqual(run_args[0], "run")
+        self.assertIn("dev", deps_args)
+        self.assertIn("dev", run_args)
+
+    @override_settings(ENVIRONMENT="prod")
+    @mock.patch("macantine.tasks.dbtRunner")
+    def test_dbt_run_targets_prod_in_prod(self, dbt_runner_mock):
+        dbt_runner_mock.return_value.invoke.return_value = mock.Mock(success=True, exception=None)
+
+        tasks.dbt_run()
+
+        run_args = dbt_runner_mock.return_value.invoke.call_args_list[1].args[0]
+        self.assertIn("prod", run_args)
+
+    @mock.patch("macantine.tasks.dbtRunner")
+    def test_dbt_run_raises_dbt_exception_on_failure(self, dbt_runner_mock):
+        dbt_error = RuntimeError("boom")
+        dbt_runner_mock.return_value.invoke.return_value = mock.Mock(success=False, exception=dbt_error)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            tasks.dbt_run()
+        self.assertIs(ctx.exception, dbt_error)
+
+        # "run" should never be attempted if "deps" already failed
+        dbt_runner_mock.return_value.invoke.assert_called_once()
+
+    @mock.patch("macantine.tasks.dbtRunner")
+    def test_dbt_run_raises_generic_error_when_no_exception_attached(self, dbt_runner_mock):
+        dbt_runner_mock.return_value.invoke.return_value = mock.Mock(success=False, exception=None)
+
+        with self.assertRaises(RuntimeError):
+            tasks.dbt_run()


### PR DESCRIPTION
### Quoi

Suite à #6421 (création du projet dbt)
Ici on créé une task + on la rajoute dans celery.
Elle doit tourner APRES `export_dataset_raw_analysis`